### PR TITLE
Fixed some animations which were based on frame counting

### DIFF
--- a/Source Main 5.2/source/CSPetSystem.cpp
+++ b/Source Main 5.2/source/CSPetSystem.cpp
@@ -24,7 +24,6 @@
 
 extern bool g_PetEnableDuel;
 
-extern  int     MoveSceneFrame;
 extern  float   WorldTime;
 extern	char    TextList[50][100];
 extern	int     TextListColor[50];
@@ -120,7 +119,7 @@ void CSPetSystem::CreatePetPointer(int Type, unsigned char PositionX, unsigned c
     o->Position[0] = (float)(PositionX * TERRAIN_SCALE) + 0.5f * TERRAIN_SCALE;
     o->Position[1] = (float)(PositionY * TERRAIN_SCALE) + 0.5f * TERRAIN_SCALE;
 
-    o->InitialSceneFrame = MoveSceneFrame;
+    o->InitialSceneTime = WorldTime;
     o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
 
     Vector(0.f, 0.f, Rotation, o->Angle);
@@ -567,7 +566,7 @@ void CSPetDarkSpirit::MovePet(void)
             c->AttackTime = 15;
         }
     }
-    if ((rand() % 100) == 0 && (MoveSceneFrame % 60) == 0)
+    if ((rand() % 100) == 0 && (rand() % 60) == 0)
     {
         PlayBuffer(SOUND_DSPIRIT_SHOUT, o);
     }

--- a/Source Main 5.2/source/CSWaterTerrain.cpp
+++ b/Source Main 5.2/source/CSWaterTerrain.cpp
@@ -19,7 +19,6 @@
 #include "MapManager.h"
 
 extern  float   WorldTime;
-extern  int     MoveSceneFrame;
 extern  float   TerrainMappingAlpha[TERRAIN_SIZE * TERRAIN_SIZE];
 extern  float   g_chrome[MAX_VERTICES][2];
 

--- a/Source Main 5.2/source/GMBattleCastle.cpp
+++ b/Source Main 5.2/source/GMBattleCastle.cpp
@@ -51,6 +51,18 @@ namespace battleCastle
     static  bool    g_bBattleCastleStartBackup = false;
     static  float   g_iMp3PlayTime = 0.f;
 
+    static float LastHealingParticle = 0.0f;
+    static constexpr float HealingParticleInterval = 400; // every 400 ms
+
+    static float LastStoneFlyEffect = 0.0f;
+    static constexpr float StoneFlyEffectInterval = 800; // every 800 ms
+
+    static float LastArrowEffectOnBattlefield = 0.0f;
+    static constexpr float ArrowEffectOnBattlefieldInterval = 2400; // every 2400 ms
+
+    static float LastArrowEffectInStampRoom = 0.0f;
+    static constexpr float ArrowEffectInStampRoomInterval = 400; // every 400 ms
+
     std::queue<BuildTime>   g_qBuildTimeLocation;
 
     enum
@@ -728,8 +740,9 @@ namespace battleCastle
 
         if (IsBattleCastleStart())
         {
-            if ((MoveSceneFrame % 20) == 0)
+            if (LastStoneFlyEffect < WorldTime - StoneFlyEffectInterval)
             {
+                LastStoneFlyEffect = WorldTime;
                 int HeroY = (Hero->PositionY);
                 if (rand() % 3)
                 {
@@ -792,8 +805,9 @@ namespace battleCastle
             int HeroY = (Hero->PositionY);
             if ((HeroY > 58 && HeroY < 113) || (HeroY > 117 && HeroY < 159))
             {
-                if ((MoveSceneFrame % 60) == 0)
+                if (LastArrowEffectOnBattlefield < WorldTime - ArrowEffectOnBattlefieldInterval)
                 {
+                    LastArrowEffectOnBattlefield = WorldTime;
                     int length = (rand() % 4 + 2) / 2;
                     int dx = (rand() % 1400 - 700) - 60.f * length;
 
@@ -839,8 +853,9 @@ namespace battleCastle
                 }
             }
 
-            if ((MoveSceneFrame % 10) == 0)
+            if (LastArrowEffectInStampRoom < WorldTime - ArrowEffectInStampRoomInterval)
             {
+                LastArrowEffectInStampRoom = WorldTime;
                 if (HeroY > 58 && HeroY < 159)
                 {
                     vec3_t Position;
@@ -1734,8 +1749,9 @@ namespace battleCastle
             }
         }
 
-        if (bHealing && MoveSceneFrame % 10 == 0)
+        if (bHealing && LastHealingParticle < WorldTime - HealingParticleInterval)
         {
+            LastHealingParticle = WorldTime;
             CreateParticle(BITMAP_PLUS, o->Position, o->Angle, o->Light);
         }
     }

--- a/Source Main 5.2/source/GMHellas.cpp
+++ b/Source Main 5.2/source/GMHellas.cpp
@@ -297,13 +297,21 @@ void RenderObjectDescription()
     }
 }
 
+float LastAmbientSoundPlay = 0.0f;
+const float AmbientSoundInterval = 4000.0f; // every 4 seconds.
+
+float LastKundunSoundPlay = 0.0f;
+const float KundunSoundInterval = 2000.0f; // every 2 seconds.
+
 bool MoveHellasObjectSetting(int& objCount, int object)
 {
     if (gMapManager.InHellas() == false) return false;
 
     PlayBuffer(SOUND_KALIMA_AMBIENT);
-    if ((MoveSceneFrame % 100) == 0)
+    
+    if (LastAmbientSoundPlay < WorldTime - AmbientSoundInterval)
     {
+        LastAmbientSoundPlay = WorldTime;
         PlayBuffer(SOUND_KALIMA_AMBIENT2 + rand() % 2);
     }
 
@@ -312,8 +320,9 @@ bool MoveHellasObjectSetting(int& objCount, int object)
         int CurrX = (Hero->PositionX);
         int CurrY = (Hero->PositionY);
 
-        if ((CurrX >= 25 && CurrY >= 44) && (CurrX <= 51 && CurrY <= 119) && (MoveSceneFrame % 50) == 0)
+        if ((CurrX >= 25 && CurrY >= 44) && (CurrX <= 51 && CurrY <= 119) && (LastKundunSoundPlay < WorldTime - KundunSoundInterval))
         {
+            LastKundunSoundPlay = WorldTime;
             PlayBuffer(SOUND_KUNDUN_AMBIENT1 + rand() % 2);
         }
     }
@@ -615,12 +624,16 @@ bool RenderHellasObjectMesh(OBJECT* o, BMD* b)
     return false;
 }
 
+float LastBigMonCreation = 0.0f;
+const float BigMonInterval = 4000.0f; // every 4 seconds.
+
 int CreateBigMon(OBJECT* o)
 {
     if (gMapManager.InHellas() == false) return 0;
 
-    if ((MoveSceneFrame % 100) == 0)
+    if (LastBigMonCreation < WorldTime - BigMonInterval)
     {
+        LastBigMonCreation = WorldTime;
         o->Live = true;
         OpenMonsterModel(33);
         o->Type = MODEL_MONSTER01 + 33;

--- a/Source Main 5.2/source/GOBoid.cpp
+++ b/Source Main 5.2/source/GOBoid.cpp
@@ -713,23 +713,26 @@ void RenderBugs()
     }
 }
 
+constexpr float HorseEffectInterval = 10 * (1000.f / 25.f); // every 10 frames on a 25fps basis (400 ms)
+
 void RenderDarkHorseSkill(OBJECT* o, BMD* b)
 {
     if (o == NULL)	return;
     if (b == NULL)	return;
-    float  Matrix[3][4];
-    vec3_t Angle, p, Position;
 
     o->WeaponLevel++;
-    if ((MoveSceneFrame % 10) == 0)
+    if (o->LastHorseWaveEffect < WorldTime - HorseEffectInterval)
     {
         CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, o->Light);
+        o->LastHorseWaveEffect = WorldTime;
     }
 
     if (o->AnimationFrame >= 8.f && o->AnimationFrame <= 9.5f)
     {
         if ((o->WeaponLevel % 2) == 1)
         {
+            float  Matrix[3][4];
+            vec3_t Angle, p, Position;
             Vector(0.f, 150.f * (o->WeaponLevel / 2), 0.f, p);
             Vector(0.f, 0.f, (float)(rand() % 360), Angle);
             for (int i = 0; i < 6; ++i)
@@ -991,7 +994,7 @@ void MoveBird(OBJECT* o)
 
 void MoveHeavenBug(OBJECT* o, int index)
 {
-    int iFrame = MoveSceneFrame;
+    const float iFrame = WorldTime / 40.0f;
 
     o->Position[0] += o->Velocity * (float)sinf(o->Angle[2]);
     o->Position[1] -= o->Velocity * (float)cosf(o->Angle[2]);

--- a/Source Main 5.2/source/PhysicsManager.cpp
+++ b/Source Main 5.2/source/PhysicsManager.cpp
@@ -46,8 +46,6 @@ void CPhysicsVertex::Init(float fXPos, float fYPos, float fZPos, BOOL bFixed)
     }
 }
 
-extern int MoveSceneFrame;
-
 void CPhysicsVertex::UpdateForce(unsigned int iKey, DWORD dwType, float fWind)
 {
     if (PVS_FIXEDPOS & m_byState)
@@ -625,7 +623,7 @@ BOOL CPhysicsCloth::Move(float fTime)
 
 void CPhysicsCloth::InitForces(void)
 {
-    int iSeed = ((MoveSceneFrame / 10) * 101) % m_iNumVertices;
+    const int iSeed = static_cast<int>(WorldTime / 400.f) * 101 % m_iNumVertices;
 
     for (int iVertex = 0; iVertex < m_iNumVertices; ++iVertex)
     {
@@ -1160,7 +1158,7 @@ void CPhysicsClothMesh::InitForces(void)
         return;
     }
 
-    int iSeed = ((MoveSceneFrame / 10) * 101) % m_iNumVertices;
+    const int iSeed = static_cast<int>(WorldTime / 400.f) * 101 % m_iNumVertices;
 
     for (int iVertex = 0; iVertex < m_iNumVertices; ++iVertex)
     {

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -765,10 +765,12 @@ float   DeltaT = 0.1f;
 float   FPS;
 float   WorldTime = 0.f;
 
+float WorldTimeWrapOffset = 0.f;
+
 void CalcFPS()
 {
     static int timeinit = 0;
-    static int start, start2, current, last;
+    static long start, start2, current, last;
     static int frame = 0, frame2 = 0;
     if (!timeinit)
     {
@@ -778,8 +780,19 @@ void CalcFPS()
     }
     frame++;
     frame2++;
-    WorldTime = (float)(timeGetTime());
+
     current = timeGetTime(); // found in winmm.
+
+    auto currentFloat = static_cast<float>(current);
+    if (WorldTime > (currentFloat + WorldTimeWrapOffset))
+    {
+        // every 49,71 days without reboot, the value gets wrapped around 0 again.
+        // so we simply add this to an offset.
+        WorldTimeWrapOffset += 4294967295.0f;
+    }
+
+    WorldTime = currentFloat + WorldTimeWrapOffset;
+
     int    difTime = current - last;
     double dif = (double)(current - start) / CLOCKS_PER_SEC;
     double rv = (dif) ? (double)frame / (double)dif : -1.0;

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -905,7 +905,6 @@ void BMD::EndRender()
 
 extern float WorldTime;
 extern int WaterTextureNumber;
-extern int MoveSceneFrame;
 
 void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float BlendMeshLight, float BlendMeshTexCoordU, float BlendMeshTexCoordV, int MeshTexture)
 {

--- a/Source Main 5.2/source/ZzzCharacter.cpp
+++ b/Source Main 5.2/source/ZzzCharacter.cpp
@@ -9629,7 +9629,8 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
     {
         if (!g_isCharacterBuff(o, eBuff_Cloaking))
         {
-            if (g_isCharacterBuff(o, eBuff_AddCriticalDamage) && o->Kind == KIND_PLAYER && o->Type == MODEL_PLAYER && (MoveSceneFrame % 30) == 0)
+            constexpr float CritDamageEffectInterval = 1200.0f;
+            if (g_isCharacterBuff(o, eBuff_AddCriticalDamage) && o->Kind == KIND_PLAYER && o->Type == MODEL_PLAYER && (c->LastCritDamageEffect < WorldTime - CritDamageEffectInterval))
             {
                 bool    renderSkillWave = (rand() % 20) ? true : false;
                 short   weaponType = -1;
@@ -10692,25 +10693,25 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 12)
                         {
-                            if ((MoveSceneFrame % 6) == 0)
+                            if ((rand() % 6) == 0)
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 0);
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 1);
                             }
-                            else if ((MoveSceneFrame % 3) == 0)
+                            else if ((rand() % 3) == 0)
                             {
                                 CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
                             }
                         }
                         else if (EquipmentLevelSet == 13)
                         {
-                            if ((MoveSceneFrame % 6) == 0)
+                            if ((rand() % 6) == 0)
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 0);
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 1);
                             }
 
-                            if ((MoveSceneFrame % 4) == 0)
+                            if ((rand() % 4) == 0)
                             {
                                 CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
                                 CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 7, o, 20, 40, 1);
@@ -10718,13 +10719,13 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 14)
                         {
-                            if ((MoveSceneFrame % 6) == 0)
+                            if ((rand() % 6) == 0)
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 0);
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 1);
                             }
 
-                            if ((MoveSceneFrame % 4) == 0)
+                            if ((rand() % 4) == 0)
                             {
                                 CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
                                 CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 7, o, 20, 40, 1);
@@ -10732,13 +10733,13 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 15)
                         {
-                            if ((MoveSceneFrame % 6) == 0)
+                            if ((rand() % 6) == 0)
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 0);
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 1);
                             }
 
-                            if ((MoveSceneFrame % 4) == 0)
+                            if ((rand() % 4) == 0)
                             {
                                 CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
                                 CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 7, o, 20, 40, 1);
@@ -11338,7 +11339,7 @@ void CreateCharacterPointer(CHARACTER* c, int Type, unsigned char PositionX, uns
     o->Position[0] = (float)((c->PositionX) * TERRAIN_SCALE) + 0.5f * TERRAIN_SCALE;
     o->Position[1] = (float)((c->PositionY) * TERRAIN_SCALE) + 0.5f * TERRAIN_SCALE;
 
-    o->InitialSceneFrame = MoveSceneFrame;
+    o->InitialSceneTime = WorldTime;
 
     if (gMapManager.WorldActive == -1 || c->Helper.Type != MODEL_HELPER + 3 || c->SafeZone)
     {

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -33,8 +33,6 @@ PARTICLE  Leaves[MAX_LEAVES];
 #endif // DEVIAS_XMAS_EVENT
 JOINT     Joints[MAX_JOINTS];
 
-extern int MoveSceneFrame;
-
 BYTE    g_byUpperBoneLocation[7] = { 25, 26, 27, 20, 34, 35, 36 };
 
 OBJECT Effects[MAX_EFFECTS];

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -4509,7 +4509,7 @@ void MoveJoint(JOINT* o, int iIndex)
                         VectorAdd(o->Tails[j][k], o->TargetPosition, o->Tails[j][k]);
                 }
             }
-            int iFrame = MoveSceneFrame;
+            int iFrame = static_cast<int>(WorldTime / 40.f);
 
             iFrame = ((iIndex % 2) ? iFrame : -iFrame) + iIndex * 53731;
 
@@ -5640,7 +5640,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
             }
 
-            int iFrame = MoveSceneFrame;
+            int iFrame = static_cast<int>(WorldTime / 40.f);
 
             iFrame = ((iIndex % 2) ? iFrame : -iFrame) + iIndex * 53731;
 
@@ -7388,7 +7388,7 @@ void RenderJoints(BYTE bRenderOneMore)
 
 void GetMagicScrew(int iParam, vec3_t vResult, float fSpeedRate)
 {
-    iParam += MoveSceneFrame;
+    iParam += static_cast<int>(WorldTime / 40.f);
 
     vec3_t vDirTemp;
     float fSpeed[3] = { 0.048f, 0.0613f, 0.1113f };

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -1391,7 +1391,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                                                     else if (o->Type == MODEL_MONSTER01 + 60)
                                                     {
                                                         if (o->CurrentAction == MONSTER01_DIE ||
-                                                            (MoveSceneFrame - o->InitialSceneFrame) < 25
+                                                            (WorldTime - o->InitialSceneTime) < 1000
                                                             )
                                                         {
                                                             if (o->CurrentAction == MONSTER01_DIE)

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -115,8 +115,6 @@ int  SceneFlag = MOVIE_SCENE;
 int  SceneFlag = WEBZEN_SCENE;
 #endif // MOVIE_DIRECTSHOW
 
-int  MoveSceneFrame = 0;
-
 extern int g_iKeyPadEnable;
 
 CPhysicsManager g_PhysicsManager;
@@ -2262,6 +2260,7 @@ constexpr int target_fps = 30;
 constexpr int ms_per_frame = 1000 / target_fps;
 
 uint64_t current_tick_count = GetTickCount64();
+uint64_t last_water_change = GetTickCount64();
 
 void MainScene(HDC hDC)
 {
@@ -2314,11 +2313,16 @@ void MainScene(HDC hDC)
         }
 
         constexpr int NumberOfWaterTextures = 32;
-        constexpr double timePerFrame = NumberOfWaterTextures / 25.0;
-        WaterTextureNumber = static_cast<uint64_t>(timeGetTime() * timePerFrame) % NumberOfWaterTextures;
-        // TODO: Refactor the depending code of these frame counting things
-        //       so they use the actual time instead. See also 'WorldTime'.
-        MoveSceneFrame++;
+        constexpr double timePerFrame = 1000 / 25.0;
+        int64_t time_since_last_render = current_tick_count - last_water_change;
+
+        while (time_since_last_render > timePerFrame)
+        {
+            WaterTextureNumber++;
+            WaterTextureNumber %= NumberOfWaterTextures;
+            time_since_last_render -= timePerFrame;
+            last_water_change = current_tick_count;
+        }
     }
 
     if (Destroy) {

--- a/Source Main 5.2/source/ZzzScene.h
+++ b/Source Main 5.2/source/ZzzScene.h
@@ -5,7 +5,6 @@
 extern int MenuStateCurrent;
 extern int MenuStateNext;
 extern int  SceneFlag;
-extern int  MoveSceneFrame;
 //extern bool EnableEdit;
 extern int  ErrorMessage;
 extern bool InitServerList;

--- a/Source Main 5.2/source/w_CharacterInfo.cpp
+++ b/Source Main 5.2/source/w_CharacterInfo.cpp
@@ -95,6 +95,7 @@ void CHARACTER::Initialize()
     PositionY = 0;
     m_iDeleteTime = 0;
     m_iFenrirSkillTarget = -1;
+    LastCritDamageEffect = 0;
 
     ProtectGuildMarkWorldTime = 0.0f;
     AttackRange = 0.0f;

--- a/Source Main 5.2/source/w_CharacterInfo.h
+++ b/Source Main 5.2/source/w_CharacterInfo.h
@@ -198,6 +198,7 @@ public:
     int         PositionY;
     int         m_iDeleteTime;
     int			m_iFenrirSkillTarget;
+    float       LastCritDamageEffect;
 
     float		ProtectGuildMarkWorldTime;
     float		AttackRange;

--- a/Source Main 5.2/source/w_ObjectInfo.cpp
+++ b/Source Main 5.2/source/w_ObjectInfo.cpp
@@ -133,7 +133,7 @@ void OBJECT::Initialize()
     AttackPoint[0] = 0;
     AttackPoint[1] = 0;
     RenderType = 0;
-    InitialSceneFrame = 0;
+    InitialSceneTime = 0;
     LinkBone = 0;
 
     m_dwTime = 0;

--- a/Source Main 5.2/source/w_ObjectInfo.h
+++ b/Source Main 5.2/source/w_ObjectInfo.h
@@ -165,7 +165,7 @@ public:
     int           BlendMesh;
     int           AttackPoint[2];
     int           RenderType;
-    int			  InitialSceneFrame;
+    int			  InitialSceneTime;
     int           LinkBone;
 
 public:
@@ -187,6 +187,9 @@ public:
     float         PriorAnimationFrame;
     float	      AlphaTarget;
     float         Alpha;
+
+
+    float       LastHorseWaveEffect;
 
 public:
     vec3_t        Light;


### PR DESCRIPTION
They are now based on WorldTime.
At some places, the frame counter was just used as a randomizer. Removed the MoveSceneFrame variable in this process. There are still a lot of places which need to be adjusted, this was just the tip of the iceberg. E.g. there are a lot of code lines like
```
float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
float fSpeedPerFrame = fActionSpeed / 10.f;
float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
```

or places like in CSParts where the animation speed is defined as Velocity, which gets applied on each frame.