### PR TITLE
Dynamic frame rate (above 25~30 fps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MU Online Client Sources
+﻿# MU Online Client Sources
 
 This is my special fork of the Season 5.2 client sources [uploaded by Luois](https://github.com/LouisEmulator/Main5.2).
 
@@ -6,17 +6,16 @@ The ultimate goal is to clean it up and make it compatible and feature complete
 to Season 6 Episode 3.
 
 What I have done so far:
-  * Replaced the network stack with MUnique.OpenMU.Network to make it easier to
+  * 🔥 The framerate has been increased to 60 fps and can be adjusted with the chat
+    command `$fps <value>`. The options menu includes a checkbox to reduce effects.
+  * 🔥 Added inventory and vault extensions.
+  * 🔥 Replaced the network stack with MUnique.OpenMU.Network to make it easier to
     apply changes. I included a .NET 7 runtime for this and had to change some
     code to allow async networking.
-  * The network protocol has been adapted for Season 6 Episode 3 - there is probably
+  * 🔥 The network protocol has been adapted for Season 6 Episode 3 - there is probably
     still some work to do, but it connects to [OpenMU](https://github.com/MUnique/OpenMU)
     and is playable.
-  * The framerate has been increased to 30 fps. However, some further adjustments
-    so that some animations (which rely on frame counting) can run at normal speed.
-    Once that's fixed, we can go even higher.
-  * Added inventory and vault extensions.
-  * Significant changes from Qubit have been incorporated, such as
+  * 🔥 Significant changes from Qubit have been incorporated, such as
     * Rage Fighter class
     * Visual bug when Dark Lord walks with Raven
     * Item equipping with right mouse click

--- a/Source Main 5.2/Main.sln.DotSettings.user
+++ b/Source Main 5.2/Main.sln.DotSettings.user
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=83C6A8DE_002D5418_002D41B5_002DBD9C_002D471F99FEAAA0_002Fd_003Asource_002Ff_003AZzzEffectParticle_002Ecpp/@EntryIndexedValue">ForceIncluded</s:String></wpf:ResourceDictionary>

--- a/Source Main 5.2/source/CDirection.cpp
+++ b/Source Main 5.2/source/CDirection.cpp
@@ -425,7 +425,7 @@ void CDirection::SetNextDirectionPosition(int x, int y, int z, float Speed)
 
 bool CDirection::GetTimeCheck(int DelayTime)
 {
-    int PresentTime = timeGetTime();
+    int PresentTime = WorldTime;
 
     if (m_bTimeCheck)
     {

--- a/Source Main 5.2/source/CSChaosCastle.cpp
+++ b/Source Main 5.2/source/CSChaosCastle.cpp
@@ -448,7 +448,7 @@ bool RenderChaosCastleVisual(OBJECT* o, BMD* b)
         {
             Vector(0.f, 0.f, 0.f, p);
             b->TransformPosition(BoneTransform[1], p, Position);
-            if (o->LifeTime == 10)
+            if ((int)o->LifeTime == 10)
             {
                 CreateJoint(BITMAP_JOINT_THUNDER + 1, Position, Position, o->Angle, 2, NULL, 60.f + rand() % 10);
 
@@ -462,7 +462,7 @@ bool RenderChaosCastleVisual(OBJECT* o, BMD* b)
             }
             else
             {
-                o->LifeTime--;
+                o->LifeTime -= FPS_ANIMATION_FACTOR;
             }
         }
     case    4:

--- a/Source Main 5.2/source/CSChaosCastle.cpp
+++ b/Source Main 5.2/source/CSChaosCastle.cpp
@@ -93,13 +93,13 @@ bool MoveChaosCastleObjectSetting(int& objCount, int object)
 {
     if (gMapManager.InChaosCastle() == false) return false;
 
-    if ((rand() % 10) == 0 && object)
+    if (rand_fps_check(10) && object)
     {
         objCount = rand() % object;
         return true;
     }
 
-    if (!Hero->SafeZone && (rand() % 10) == 0)
+    if (!Hero->SafeZone && rand_fps_check(10))
     {
         vec3_t Position;
 
@@ -527,7 +527,7 @@ void RenderTerrainVisual(int xi, int yi)
         Position[2] = Hero->Object.Position[2];
         CreateParticle(BITMAP_SMOKE + 4, Position, Angle, Light, 0, 1.5f);
 
-        if (rand() % 5 == 0)
+        if (rand_fps_check(5))
         {
             EarthQuake = (float)(rand() % 3 - 3) * 0.1f;
         }

--- a/Source Main 5.2/source/CSItemOption.cpp
+++ b/Source Main 5.2/source/CSItemOption.cpp
@@ -918,7 +918,7 @@ void CSItemOption::getAllAddOptionStatesbyCompare(WORD* Strength, WORD* Dexterit
 void CSItemOption::CheckItemSetOptions(void)
 {
     BYTE byOptionList[30] = { 0, };
-    ITEM* itemTmp = NULL;
+    ITEM* itemRight = NULL;
 
     ZeroMemory(m_bySetOptionList, sizeof(BYTE) * 16);
 
@@ -936,7 +936,8 @@ void CSItemOption::CheckItemSetOptions(void)
             continue;
         }
 
-        if ((i == EQUIPMENT_WEAPON_LEFT || i == EQUIPMENT_RING_LEFT) && itemTmp->Type == ip->Type && itemTmp->ExtOption == (ip->ExtOption % 0x04))
+        if ((i == EQUIPMENT_WEAPON_LEFT || i == EQUIPMENT_RING_LEFT)
+            && itemRight != nullptr && itemRight->Type == ip->Type && (itemRight->ExtOption % 0x04) == (ip->ExtOption % 0x04))
         {
             continue;
         }
@@ -948,10 +949,7 @@ void CSItemOption::CheckItemSetOptions(void)
 
         if (i == EQUIPMENT_WEAPON_RIGHT || i == EQUIPMENT_RING_RIGHT)
         {
-            // TODO: How logical is that? In the end, you're just modifying ip?
-            itemTmp = ip;
-            itemTmp->Type = ip->Type;
-            itemTmp->ExtOption = (ip->ExtOption % 0x04);
+            itemRight = ip;
         }
     }
 
@@ -981,7 +979,8 @@ void CSItemOption::CheckItemSetOptions(void)
             continue;
         }
 
-        if (((i == EQUIPMENT_WEAPON_LEFT || i == EQUIPMENT_RING_LEFT) && itemTmp->Type == ip->Type && itemTmp->ExtOption == (ip->ExtOption % 0x04)))
+        if (((i == EQUIPMENT_WEAPON_LEFT || i == EQUIPMENT_RING_LEFT)
+            && itemRight != nullptr && itemRight->Type == ip->Type && (itemRight->ExtOption % 0x04) == (ip->ExtOption % 0x04)))
         {
             continue;
         }
@@ -993,10 +992,7 @@ void CSItemOption::CheckItemSetOptions(void)
 
         if (i == EQUIPMENT_WEAPON_RIGHT || i == EQUIPMENT_RING_RIGHT)
         {
-            // TODO: How logical is that? In the end, you're just modifying ip?
-            itemTmp = ip;
-            itemTmp->Type = ip->Type;
-            itemTmp->ExtOption = (ip->ExtOption % 0x04);
+            itemRight = ip;
         }
     }
 

--- a/Source Main 5.2/source/CSPetSystem.cpp
+++ b/Source Main 5.2/source/CSPetSystem.cpp
@@ -24,7 +24,7 @@
 
 extern bool g_PetEnableDuel;
 
-extern  float   WorldTime;
+extern  double   WorldTime;
 extern	char    TextList[50][100];
 extern	int     TextListColor[50];
 extern	int     TextBold[50];

--- a/Source Main 5.2/source/CSPetSystem.cpp
+++ b/Source Main 5.2/source/CSPetSystem.cpp
@@ -448,7 +448,7 @@ void CSPetDarkSpirit::MovePet(void)
         }
 
         float Speed = 0;
-        if (rand() % speedRandom == 0)
+        if (rand_fps_check(speedRandom))
         {
             if (Distance >= FlyRange * FlyRange)
             {
@@ -566,7 +566,7 @@ void CSPetDarkSpirit::MovePet(void)
             c->AttackTime = 15;
         }
     }
-    if ((rand() % 100) == 0 && (rand() % 60) == 0)
+    if (rand_fps_check(100) && rand_fps_check(60))
     {
         PlayBuffer(SOUND_DSPIRIT_SHOUT, o);
     }

--- a/Source Main 5.2/source/CSPetSystem.cpp
+++ b/Source Main 5.2/source/CSPetSystem.cpp
@@ -457,10 +457,10 @@ void CSPetDarkSpirit::MovePet(void)
             else
             {
                 Speed = -(float)(rand() % 8 + 32) * 0.1f;
-                o->Angle[2] += (float)(rand() % 60);
+                o->Angle[2] += (float)(rand() % 60) * FPS_ANIMATION_FACTOR;
             }
 
-            Speed += o->Direction[1];
+            Speed += o->Direction[1] * FPS_ANIMATION_FACTOR;
             Speed = Speed / 2.f;
 
             o->Direction[0] = 0.f;
@@ -491,7 +491,7 @@ void CSPetDarkSpirit::MovePet(void)
 
         if (o->AI == PET_ATTACK)
         {
-            TargetPosition[2] += 50.f;
+            TargetPosition[2] += 50.f * FPS_ANIMATION_FACTOR;
             float Distance = MoveHumming(o->Position, o->Angle, TargetPosition, o->Velocity);
             if (Distance < 20 || o->LifeTime>20)
             {
@@ -502,9 +502,9 @@ void CSPetDarkSpirit::MovePet(void)
                     o->m_bActionStart = false;
                 }
             }
-            o->Velocity += o->Gravity;
-            o->Gravity += 0.2f;
-            o->LifeTime++;
+            o->Velocity += o->Gravity * FPS_ANIMATION_FACTOR;
+            o->Gravity += 0.2f * FPS_ANIMATION_FACTOR;
+            o->LifeTime+= FPS_ANIMATION_FACTOR;
         }
         else if (o->AI == PET_ESCAPE)
         {
@@ -513,7 +513,7 @@ void CSPetDarkSpirit::MovePet(void)
             {
                 SetAI(PET_FLYING);
             }
-            o->Velocity -= 1.f;
+            o->Velocity -= 1.f * FPS_ANIMATION_FACTOR;
         }
         SetAction(o, 3);
     }
@@ -560,7 +560,7 @@ void CSPetDarkSpirit::MovePet(void)
     }
     if (o->AI >= PET_ATTACK && o->AI <= PET_ATTACK_MAGIC)
     {
-        c->AttackTime++;
+        c->AttackTime += FPS_ANIMATION_FACTOR;
         if (c->AttackTime >= 15)
         {
             c->AttackTime = 15;
@@ -576,13 +576,13 @@ void CSPetDarkSpirit::MovePet(void)
     float Distance = Range[0] * Range[0] + Range[1] * Range[1];
     if (o->Position[2] < (TargetPosition[2] - 200.f) || Distance>409600.f)
     {
-        o->LifeTime++;
+        o->LifeTime += FPS_ANIMATION_FACTOR;
     }
     if (o->LifeTime > 90)
     {
         o->LifeTime = 0;
         VectorCopy(TargetPosition, o->Position);
-        o->Position[2] += 250.f;
+        o->Position[2] += 250.f * FPS_ANIMATION_FACTOR;
     }
 }
 
@@ -719,7 +719,7 @@ void CSPetDarkSpirit::AttackEffect(CHARACTER* c, OBJECT* o)
                 CreateEffect(MODEL_DARKLORD_SKILL, o->Position, Angle, Light, 3);
             }
         }
-        if (c->AttackTime > 3 && c->AttackTime % 2)
+        if (c->AttackTime > 3 && (int)c->AttackTime % 2)
         {
             if (o->Position[2] > (m_PetOwner->Object.Position[2] + 100.f))
             {
@@ -732,7 +732,7 @@ void CSPetDarkSpirit::AttackEffect(CHARACTER* c, OBJECT* o)
         break;
 
     case PET_ATTACK_MAGIC:
-        if (c->AttackTime <= 14)
+        if (c->AttackTime < 15)
         {
             if (o->BoneTransform != NULL)
             {
@@ -748,7 +748,7 @@ void CSPetDarkSpirit::AttackEffect(CHARACTER* c, OBJECT* o)
                 }
             }
         }
-        else if (c->AttackTime == 15)
+        else if (c->AttackTime >= 15)
         {
             if (c->TargetCharacter != -1)
             {

--- a/Source Main 5.2/source/CSPetSystem.cpp
+++ b/Source Main 5.2/source/CSPetSystem.cpp
@@ -487,7 +487,7 @@ void CSPetDarkSpirit::MovePet(void)
         AngleMatrix(o->Angle, o->Matrix);
         Vector(0.f, -o->Velocity, 0.f, p);
         VectorRotate(p, o->Matrix, Pos);
-        VectorAdd(o->Position, Pos, o->Position);
+        VectorAddScaled(o->Position, Pos, o->Position, FPS_ANIMATION_FACTOR);
 
         if (o->AI == PET_ATTACK)
         {
@@ -546,7 +546,7 @@ void CSPetDarkSpirit::MovePet(void)
         {
             Vector(0.f, -o->Velocity, 0.f, p);
             VectorRotate(p, o->Matrix, Pos);
-            VectorAdd(o->Position, Pos, o->Position);
+            VectorAddScaled(o->Position, Pos, o->Position, FPS_ANIMATION_FACTOR);
         }
         Vector(0.f, 0.f, 0.f, p);
         b->TransformPosition(Owner->BoneTransform[42], p, Pos, true);
@@ -710,7 +710,7 @@ void CSPetDarkSpirit::AttackEffect(CHARACTER* c, OBJECT* o)
             {
                 CreateJoint(BITMAP_LIGHT, o->Position, o->Position, o->Angle, 1, NULL, (float)(rand() % 40 + 20));
             }
-            if (c->AttackTime == 1)
+            if ((int)c->AttackTime == 1)
             {
                 vec3_t Angle, Light;
 

--- a/Source Main 5.2/source/CSWaterTerrain.cpp
+++ b/Source Main 5.2/source/CSWaterTerrain.cpp
@@ -226,7 +226,7 @@ void CSWaterTerrain::addSineWave(int x, int y, int radiusX, int radiusY, int hei
 void    CSWaterTerrain::calcBaseWave(void)
 {
     /*
-        if ( (rand()%10)==0 )
+        if ( rand_fps_check(10) )
         {
             m_iSelectWaveX = rand()%WATER_TERRAIN_SIZE;
             m_iSelectWaveY = rand()%WATER_TERRAIN_SIZE;

--- a/Source Main 5.2/source/CSWaterTerrain.cpp
+++ b/Source Main 5.2/source/CSWaterTerrain.cpp
@@ -18,7 +18,7 @@
 #include "GMHellas.h"
 #include "MapManager.h"
 
-extern  float   WorldTime;
+extern  double   WorldTime;
 extern  float   TerrainMappingAlpha[TERRAIN_SIZE * TERRAIN_SIZE];
 extern  float   g_chrome[MAX_VERTICES][2];
 

--- a/Source Main 5.2/source/CameraMove.h
+++ b/Source Main 5.2/source/CameraMove.h
@@ -30,7 +30,7 @@ class CCameraMove
 
     float m_CameraStartPos[3];
     float m_fCameraStartDistanceLevel;
-    int m_iDelayCount;
+    double m_iDelayCount;
 
     DWORD m_dwCameraWalkState;
     float m_CurrentCameraPos[3];

--- a/Source Main 5.2/source/Event.cpp
+++ b/Source Main 5.2/source/Event.cpp
@@ -278,12 +278,12 @@ bool CNewYearsDayEvent::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
         if (o->CurrentAction >= MONSTER01_STOP1 && o->CurrentAction <= MONSTER01_ATTACK2)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 Vector(1.0f, 0.4f, 0.0f, vLight);
                 CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, vLight, 0, 0.28f);
 
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     Vector(0.8f, 0.6f, 0.1f, vLight);
                 }
@@ -302,7 +302,7 @@ bool CNewYearsDayEvent::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         }
         else if (o->CurrentAction == MONSTER01_SHOCK || o->CurrentAction == MONSTER01_DIE)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 Vector(1.0f, 0.4f, 0.0f, vLight);
                 float fScale;
@@ -313,7 +313,7 @@ bool CNewYearsDayEvent::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
                 for (int i = 0; i < 5; ++i)
                 {
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         Vector(0.8f, 0.6f, 0.1f, vLight);
                     }
@@ -330,7 +330,7 @@ bool CNewYearsDayEvent::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     CreateParticle(BITMAP_SHINY, vWorldPos, o->Angle, vLight, 4, 0.8f);
                 }
             }
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Vector(0.3f, 0.3f, 0.8f, vLight);
                 CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, vLight, 1, 1.f);
@@ -343,7 +343,7 @@ bool CNewYearsDayEvent::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 o->m_iAnimation = rand() % 6 + MODEL_NEWYEARSDAY_EVENT_BEKSULKI;
                 CreateParticle(BITMAP_EXPLOTION, vWorldPos, o->Angle, vLight, 0, 0.5f);
-                if (rand() % 4 == 0) o->m_iAnimation = MODEL_NEWYEARSDAY_EVENT_PIG;
+                if (rand_fps_check(4)) o->m_iAnimation = MODEL_NEWYEARSDAY_EVENT_PIG;
 
                 PlayBuffer(SOUND_NEWYEARSDAY_DIE);
             }
@@ -351,7 +351,7 @@ bool CNewYearsDayEvent::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             if (o->AnimationFrame >= 4.5f)
                 CreateEffect(MODEL_NEWYEARSDAY_EVENT_MONEY, vWorldPos, o->Angle, vLight);
 
-            if (o->m_iAnimation != 0 && rand() % 3 == 0)
+            if (o->m_iAnimation != 0 && rand_fps_check(3))
             {
                 if (o->AnimationFrame >= 4.5f)
                     CreateEffect(o->m_iAnimation, vWorldPos, o->Angle, vLight);

--- a/Source Main 5.2/source/GM3rdChangeUp.cpp
+++ b/Source Main 5.2/source/GM3rdChangeUp.cpp
@@ -126,14 +126,14 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     switch (pObject->Type)
     {
     case 2:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, pObject->Position, pObject->Angle, Light, 13, pObject->Scale);
         }
         break;
     case 3:
-        if (rand() % 3 == 0) {
+        if (rand_fps_check(3)) {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, pObject->Position, pObject->Angle, Light, 0, pObject->Scale);
         }
@@ -141,14 +141,14 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     case 5:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 2 == 0) {
+        if (rand_fps_check(2)) {
             if ((int)((pObject->Timer++) + 2) % 4 == 0)
             {
                 CreateParticle(BITMAP_ADV_SMOKE + 1, pObject->Position, pObject->Angle, Light);
                 CreateParticle(BITMAP_ADV_SMOKE, pObject->Position, pObject->Angle, Light, 0);
             }
         }
-        if (rand() % 2 == 0) {
+        if (rand_fps_check(2)) {
             if ((int)(pObject->Timer++) % 4 == 0)
             {
                 CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 6);
@@ -173,12 +173,12 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     break;
     case 58:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_WATERFALL_1, pObject->Position, pObject->Angle, Light, 2, pObject->Scale);
         break;
     case 59:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
             CreateParticle(BITMAP_WATERFALL_2, pObject->Position, pObject->Angle, Light, 1, pObject->Scale);
         break;
     case 60:
@@ -186,11 +186,11 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         CreateParticle(BITMAP_WATERFALL_3, pObject->Position, pObject->Angle, Light, 3, pObject->Scale);
         break;
     case 85:
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             if ((int)((pObject->Timer++) + 2) % 4 == 0)
             {
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     Vector(0.f, 0.0f, 0.0f, Light);
                     CreateParticle(BITMAP_ADV_SMOKE + 1, pObject->Position, pObject->Angle, Light, 1, pObject->Scale);
@@ -200,7 +200,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
             }
         }
         Vector(1.f, 0.4f, 0.4f, Light);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             if ((int)(pObject->Timer++) % 4 == 0)
             {
@@ -211,13 +211,13 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 88:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 10, pObject->Scale, pObject);
         }
         break;
     case 89:
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             float fRed = (rand() % 3) * 0.01f + 0.015f;
             Vector(fRed, 0.0f, 0.0f, Light);
@@ -228,7 +228,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     {
         Vector(1.0f, 0.4f, 0.4f, Light);
         vec3_t vAngle;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector((float)(rand() % 40 + 120), 0.f, (float)(rand() % 30), vAngle);
             VectorAdd(vAngle, pObject->Angle, vAngle);
@@ -495,7 +495,7 @@ bool SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackMonsterVisual(CHARACTER* c, OBJE
         Vector(0.9f, 0.2f, 0.1f, Light);
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 10 == 0) {
+            if (rand_fps_check(10)) {
                 CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
             }
         }
@@ -507,7 +507,7 @@ bool SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackMonsterVisual(CHARACTER* c, OBJE
         Vector(0.9f, 0.2f, 0.1f, Light);
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 10 == 0)
+            if (rand_fps_check(10))
             {
                 CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
             }
@@ -547,7 +547,7 @@ bool SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackMonsterVisual(CHARACTER* c, OBJE
         else
             if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
             {
-                if (rand() % 10 == 0) {
+                if (rand_fps_check(10)) {
                     CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
                 }
             }
@@ -794,7 +794,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderBalgasBarrackMonsterVisual(CHARACTER* c, OB
     case MODEL_MONSTER01 + 91:
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_BALRAM_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -826,7 +826,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderBalgasBarrackMonsterVisual(CHARACTER* c, OB
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_DEATHSPIRIT_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -870,7 +870,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderBalgasBarrackMonsterVisual(CHARACTER* c, OB
         BoneManager::GetBonePosition(o, "Monster94_zx01", Position);
         Vector(0.1f, 0.0f, 0.6f, Light);
         CreateSprite(BITMAP_SHINY + 1, Position, 0.8f, Light, o, Rot);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             Vector(0.7f, 0.7f, 1.0f, Light);
             CreateSprite(BITMAP_SHINY + 1, Position, 0.8f, Light, o, 360.f - Rot);
@@ -882,7 +882,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderBalgasBarrackMonsterVisual(CHARACTER* c, OB
     case MODEL_MONSTER01 + 94:
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_SORAM_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -913,7 +913,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderBalgasBarrackMonsterVisual(CHARACTER* c, OB
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_DARKELF_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -960,12 +960,12 @@ bool SEASON3A::CGM3rdChangeUp::RenderBalgasBarrackMonsterVisual(CHARACTER* c, OB
         Vector(0.f, 0.f, 0.f, vPos);
         Vector(0.6f, 0.6f, 0.9f, vLight);
         int iBoneThunder[] = { 6, 15, 27, 17, 29, 3, 34, 44, 45, 40 };
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             for (int i = 0; i < 10; ++i)
             {
                 b->TransformPosition(o->BoneTransform[iBoneThunder[i]], vRelativePos, vPos, true);
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     CreateEffect(MODEL_FENRIR_THUNDER, vPos, o->Angle, vLight, 1, o);
                 }

--- a/Source Main 5.2/source/GM3rdChangeUp.cpp
+++ b/Source Main 5.2/source/GM3rdChangeUp.cpp
@@ -142,14 +142,14 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     {
         Vector(1.f, 1.f, 1.f, Light);
         if (rand_fps_check(2)) {
-            if ((int)((pObject->Timer++) + 2) % 4 == 0)
+            if ((int)((pObject->Timer+=FPS_ANIMATION_FACTOR) + 2) % 4 == 0)
             {
                 CreateParticle(BITMAP_ADV_SMOKE + 1, pObject->Position, pObject->Angle, Light);
                 CreateParticle(BITMAP_ADV_SMOKE, pObject->Position, pObject->Angle, Light, 0);
             }
         }
         if (rand_fps_check(2)) {
-            if ((int)(pObject->Timer++) % 4 == 0)
+            if ((int)(pObject->Timer+=FPS_ANIMATION_FACTOR) % 4 == 0)
             {
                 CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 6);
                 CreateParticle(BITMAP_ADV_SMOKE, pObject->Position, pObject->Angle, Light, 1);
@@ -188,7 +188,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     case 85:
         if (rand_fps_check(2))
         {
-            if ((int)((pObject->Timer++) + 2) % 4 == 0)
+            if ((int)((pObject->Timer+=FPS_ANIMATION_FACTOR) + 2) % 4 == 0)
             {
                 if (rand_fps_check(2))
                 {
@@ -202,7 +202,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         Vector(1.f, 0.4f, 0.4f, Light);
         if (rand_fps_check(2))
         {
-            if ((int)(pObject->Timer++) % 4 == 0)
+            if ((int)(pObject->Timer+=FPS_ANIMATION_FACTOR) % 4 == 0)
             {
                 CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 14, pObject->Scale, 0);
                 CreateParticle(BITMAP_ADV_SMOKE, pObject->Position, pObject->Angle, Light, 2, pObject->Scale * 2);

--- a/Source Main 5.2/source/GM3rdChangeUp.cpp
+++ b/Source Main 5.2/source/GM3rdChangeUp.cpp
@@ -516,7 +516,7 @@ bool SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackMonsterVisual(CHARACTER* c, OBJE
     break;
     case MODEL_MONSTER01 + 94:
     {
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         vec3_t Light;
         vec3_t EndPos, EndRelative;
         Vector(1.f, 1.f, 1.f, Light);
@@ -598,7 +598,7 @@ void SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackBlurEffect(CHARACTER* c, OBJECT*
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -645,7 +645,7 @@ void SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackBlurEffect(CHARACTER* c, OBJECT*
         {
             vec3_t EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             VectorCopy(o->Angle, TempAngle);
@@ -686,7 +686,7 @@ void SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackBlurEffect(CHARACTER* c, OBJECT*
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 

--- a/Source Main 5.2/source/GM3rdChangeUp.cpp
+++ b/Source Main 5.2/source/GM3rdChangeUp.cpp
@@ -474,7 +474,7 @@ bool SEASON3A::CGM3rdChangeUp::AttackEffectBalgasBarrackMonster(CHARACTER* c, OB
     switch (o->Type)
     {
     case MODEL_MONSTER01 + 91:
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             CreateEffect(MODEL_ARROW_HOLY, o->Position, o->Angle, o->Light, 1, o, o->PKKey);
             return true;

--- a/Source Main 5.2/source/GMAida.cpp
+++ b/Source Main 5.2/source/GMAida.cpp
@@ -166,7 +166,7 @@ bool M33Aida::RenderAidaObjectVisual(OBJECT* pObject, BMD* pModel)
     break;
     case 56:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             CreateParticle(BITMAP_WATERFALL_1, pObject->Position, pObject->Angle, Light, 2, pObject->Scale);
         }
@@ -177,7 +177,7 @@ bool M33Aida::RenderAidaObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 58:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             CreateParticle(BITMAP_WATERFALL_2, pObject->Position, pObject->Angle, Light, 2, pObject->Scale);
         }
@@ -726,7 +726,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_WITCHQUEEN_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -810,7 +810,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_BLUEGOLEM_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -885,7 +885,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_DEATHRAIDER_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -919,7 +919,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
     {
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_FORESTORC_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -952,7 +952,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
     {
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_DEATHTREE_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -1026,7 +1026,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_HELL_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -1088,7 +1088,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
     {
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_FORESTORC_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -1131,7 +1131,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_DEATHRAIDER_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -1175,7 +1175,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_BLUEGOLEM_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)
@@ -1260,7 +1260,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_AIDA_WITCHQUEEN_MOVE1 + rand() % 2);
         }
         else if (pObject->CurrentAction == MONSTER01_ATTACK1)

--- a/Source Main 5.2/source/GMAida.cpp
+++ b/Source Main 5.2/source/GMAida.cpp
@@ -1465,7 +1465,7 @@ bool M33Aida::AttackEffectAidaMonster(CHARACTER* pCharacter, OBJECT* pObject, BM
     {
     case 304:
     {
-        if (pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
+        if ((int)pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             vec3_t Light;
             Vector(1.f, 1.f, 1.f, Light);
@@ -1475,7 +1475,7 @@ bool M33Aida::AttackEffectAidaMonster(CHARACTER* pCharacter, OBJECT* pObject, BM
     return true;
     case 308:
     {
-        if (pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
+        if ((int)pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             vec3_t Light;
             Vector(1.f, 1.f, 1.f, Light);
@@ -1487,7 +1487,7 @@ bool M33Aida::AttackEffectAidaMonster(CHARACTER* pCharacter, OBJECT* pObject, BM
     {
         for (int i = 0; i < 5; i++)
         {
-            if (pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK1)
+            if ((int)pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK1)
             {
                 vec3_t Light;
                 Vector(1.f, 1.f, 1.f, Light);
@@ -1498,7 +1498,7 @@ bool M33Aida::AttackEffectAidaMonster(CHARACTER* pCharacter, OBJECT* pObject, BM
     return true;
     case 552:
     {
-        if (pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
+        if ((int)pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             vec3_t Light;
             Vector(1.f, 1.f, 1.f, Light);

--- a/Source Main 5.2/source/GMAida.cpp
+++ b/Source Main 5.2/source/GMAida.cpp
@@ -541,7 +541,7 @@ void M33Aida::MoveAidaBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD* pM
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {
@@ -573,7 +573,7 @@ void M33Aida::MoveAidaBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD* pM
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {
@@ -609,7 +609,7 @@ void M33Aida::MoveAidaBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD* pM
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {
@@ -637,7 +637,7 @@ void M33Aida::MoveAidaBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD* pM
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {
@@ -673,7 +673,7 @@ void M33Aida::MoveAidaBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD* pM
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {

--- a/Source Main 5.2/source/GMBattleCastle.cpp
+++ b/Source Main 5.2/source/GMBattleCastle.cpp
@@ -180,7 +180,7 @@ namespace battleCastle
                         {
                             if (o->m_bCollisionCheck && o->ExtState == 0)
                             {
-                                o->Timer += 0.3f;
+                                o->Timer += 0.3f * FPS_ANIMATION_FACTOR;
                                 if (o->Timer >= 5)
                                 {
                                     o->ExtState = 99;
@@ -195,7 +195,7 @@ namespace battleCastle
                                 {
                                     if (o->ExtState == 0)
                                     {
-                                        o->Timer++;
+                                        o->Timer += FPS_ANIMATION_FACTOR;
                                         if (o->Timer >= 5)
                                         {
                                             o->ExtState = 99;

--- a/Source Main 5.2/source/GMBattleCastle.cpp
+++ b/Source Main 5.2/source/GMBattleCastle.cpp
@@ -714,25 +714,25 @@ namespace battleCastle
         }
 
         PlayBuffer(SOUND_BC_AMBIENT);
-        if (IsBattleCastleStart() && rand() % 10 == 0)
+        if (IsBattleCastleStart() && rand_fps_check(10))
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_BC_AMBIENT_BATTLE1);
             }
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_BC_AMBIENT_BATTLE2);
             }
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_BC_AMBIENT_BATTLE3);
             }
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_BC_AMBIENT_BATTLE4);
             }
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_BC_AMBIENT_BATTLE5);
             }
@@ -870,10 +870,10 @@ namespace battleCastle
                     Position[2] = 350.f;
 
                     BYTE subtype = 3;
-                    if (HeroY < 82 || HeroY>112 || rand() % 10 == 0)
+                    if (HeroY < 82 || HeroY>112 || rand_fps_check(10))
                     {
                         subtype = 4;
-                        if (rand() % 10 == 0)
+                        if (rand_fps_check(10))
                         {
                             subtype = 3;
                         }
@@ -1120,7 +1120,7 @@ namespace battleCastle
         switch (o->Type)
         {
         case 0:
-            if (IsBattleCastleStart() == false && rand() % 3 == 0)
+            if (IsBattleCastleStart() == false && rand_fps_check(3))
             {
                 Vector(1.f, 1.f, 1.f, Light);
                 CreateParticle(BITMAP_TRUE_FIRE, o->Position, o->Angle, Light, 0, o->Scale);
@@ -1132,7 +1132,7 @@ namespace battleCastle
             break;
 
         case 42:
-            if (IsBattleCastleStart() && rand() % 3 == 0)
+            if (IsBattleCastleStart() && rand_fps_check(3))
             {
                 Vector(1.f, 1.f, 1.f, Light);
                 CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 21, o->Scale);
@@ -1146,7 +1146,7 @@ namespace battleCastle
             }
             break;
         case 53:
-            if (IsBattleCastleStart() && rand() % 3 == 0)
+            if (IsBattleCastleStart() && rand_fps_check(3))
             {
                 Vector(1.f, 1.f, 1.f, Light);
                 CreateParticle(BITMAP_TRUE_FIRE, o->Position, o->Angle, Light, 0, o->Scale);
@@ -2073,7 +2073,7 @@ namespace battleCastle
             vec3_t Position;
             for (int i = 0; i < 5; i++)
             {
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     Position[0] = o->Position[0];
                     Position[1] = o->Position[1];

--- a/Source Main 5.2/source/GMBattleCastle.cpp
+++ b/Source Main 5.2/source/GMBattleCastle.cpp
@@ -1707,7 +1707,7 @@ namespace battleCastle
         switch (c->MonsterIndex)
         {
         case 104:
-            if (c->AttackTime == 5)
+            if ((int)c->AttackTime == 5)
             {
                 VectorCopy(o->Position, Position);
                 Position[2] += 500.f;

--- a/Source Main 5.2/source/GMBattleCastle.cpp
+++ b/Source Main 5.2/source/GMBattleCastle.cpp
@@ -544,9 +544,9 @@ namespace battleCastle
                 o->Live = false;
                 BoneManager::UnregisterBone(c);
 
-                for (int j = 0; j < MAX_BUTTERFLES; j++)
+                for (int j = 0; j < MAX_MOUNTS; j++)
                 {
-                    OBJECT* b = &Butterfles[j];
+                    OBJECT* b = &Mounts[j];
                     if (b->Live && b->Owner == o)
                         b->Live = false;
                 }

--- a/Source Main 5.2/source/GMCryingWolf2nd.cpp
+++ b/Source Main 5.2/source/GMCryingWolf2nd.cpp
@@ -59,14 +59,14 @@ bool M34CryingWolf2nd::RenderCryingWolf2ndObjectVisual(OBJECT* pObject, BMD* pMo
     switch (pObject->Type)
     {
     case 2:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, pObject->Position, pObject->Angle, Light, 21, pObject->Scale);
         }
         break;
     case 3:
-        if (rand() % 2 == 0) {
+        if (rand_fps_check(2)) {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, pObject->Position, pObject->Angle, Light, 5, pObject->Scale);
         }
@@ -74,14 +74,14 @@ bool M34CryingWolf2nd::RenderCryingWolf2ndObjectVisual(OBJECT* pObject, BMD* pMo
     case 5:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 2 == 0) {
+        if (rand_fps_check(2)) {
             if ((int)((pObject->Timer++) + 2) % 4 == 0)
             {
                 CreateParticle(BITMAP_ADV_SMOKE + 1, pObject->Position, pObject->Angle, Light);
                 CreateParticle(BITMAP_ADV_SMOKE, pObject->Position, pObject->Angle, Light, 0);
             }
         }
-        if (rand() % 2 == 0) {
+        if (rand_fps_check(2)) {
             if ((int)(pObject->Timer++) % 4 == 0)
             {
                 CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 6);
@@ -204,7 +204,7 @@ bool M34CryingWolf2nd::MoveCryingWolf2ndMonsterVisual(OBJECT* pObject, BMD* pMod
         //. Walking & Running Scene Processing
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 10 == 0) {
+            if (rand_fps_check(10)) {
                 CreateParticle(BITMAP_SMOKE + 1, pObject->Position, pObject->Angle, Light);
             }
         }

--- a/Source Main 5.2/source/GMCryingWolf2nd.cpp
+++ b/Source Main 5.2/source/GMCryingWolf2nd.cpp
@@ -280,7 +280,7 @@ void M34CryingWolf2nd::MoveCryingWolf2ndBlurEffect(CHARACTER* pCharacter, OBJECT
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {
@@ -315,7 +315,7 @@ void M34CryingWolf2nd::MoveCryingWolf2ndBlurEffect(CHARACTER* pCharacter, OBJECT
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {

--- a/Source Main 5.2/source/GMCryingWolf2nd.cpp
+++ b/Source Main 5.2/source/GMCryingWolf2nd.cpp
@@ -75,14 +75,14 @@ bool M34CryingWolf2nd::RenderCryingWolf2ndObjectVisual(OBJECT* pObject, BMD* pMo
     {
         Vector(1.f, 1.f, 1.f, Light);
         if (rand_fps_check(2)) {
-            if ((int)((pObject->Timer++) + 2) % 4 == 0)
+            if ((int)((pObject->Timer += FPS_ANIMATION_FACTOR) + 2) % 4 == 0)
             {
                 CreateParticle(BITMAP_ADV_SMOKE + 1, pObject->Position, pObject->Angle, Light);
                 CreateParticle(BITMAP_ADV_SMOKE, pObject->Position, pObject->Angle, Light, 0);
             }
         }
         if (rand_fps_check(2)) {
-            if ((int)(pObject->Timer++) % 4 == 0)
+            if ((int)(pObject->Timer += FPS_ANIMATION_FACTOR) % 4 == 0)
             {
                 CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 6);
                 CreateParticle(BITMAP_ADV_SMOKE, pObject->Position, pObject->Angle, Light, 1);

--- a/Source Main 5.2/source/GMCryingWolf2nd.cpp
+++ b/Source Main 5.2/source/GMCryingWolf2nd.cpp
@@ -345,7 +345,7 @@ bool M34CryingWolf2nd::AttackEffectCryingWolf2ndMonster(CHARACTER* pCharacter, O
     {
     case MODEL_MONSTER01 + 96:
     {
-        if (pCharacter->AttackTime == 14)
+        if ((int)pCharacter->AttackTime == 14)
         {
             CreateEffect(MODEL_ARROW_NATURE, pObject->Position, pObject->Angle, pObject->Light, 1, pObject, pObject->PKKey);
             return true;
@@ -354,7 +354,7 @@ bool M34CryingWolf2nd::AttackEffectCryingWolf2ndMonster(CHARACTER* pCharacter, O
     break;
     case MODEL_MONSTER01 + 91:
     {
-        if (pCharacter->AttackTime == 14)
+        if ((int)pCharacter->AttackTime == 14)
         {
             CreateEffect(MODEL_ARROW_HOLY, pObject->Position, pObject->Angle, pObject->Light, 1, pObject, pObject->PKKey);
             return true;

--- a/Source Main 5.2/source/GMCrywolf1st.cpp
+++ b/Source Main 5.2/source/GMCrywolf1st.cpp
@@ -996,7 +996,7 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     {
     case MODEL_MONSTER01 + 96:
     {
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             CreateEffect(MODEL_ARROW_NATURE, o->Position, o->Angle, o->Light, 1, o, o->PKKey);
             return true;
@@ -1005,7 +1005,7 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     break;
     case MODEL_MONSTER01 + 91:
     {
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             CreateEffect(MODEL_ARROW_HOLY, o->Position, o->Angle, o->Light, 1, o, o->PKKey);
             return true;
@@ -1015,11 +1015,11 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     case MODEL_MONSTER01 + 42:
     {
         vec3_t Angle;
-        if (c->AttackTime == 1)
+        if ((int)c->AttackTime == 1)
         {
             CreateInferno(o->Position);
         }
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             if (c->MonsterIndex == 59)
             {
@@ -1052,7 +1052,7 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
                 CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
             }
         }
-        if (c->AttackTime == 1)
+        if ((int)c->AttackTime == 1)
             PlayBuffer(SOUND_EVIL);
 
         for (int i = 0; i < 4; i++)
@@ -1069,7 +1069,7 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     break;
     case MODEL_MONSTER01 + 99:
     {
-        if (c->AttackTime == 15)
+        if ((int)c->AttackTime == 15)
         {
             CreateEffect(MODEL_ARROW_TANKER, o->Position, o->Angle, o->Light, 1, o, o->PKKey);
             return true;

--- a/Source Main 5.2/source/GMCrywolf1st.cpp
+++ b/Source Main 5.2/source/GMCrywolf1st.cpp
@@ -2076,9 +2076,9 @@ bool M34CryWolf1st::CreateMist(PARTICLE* pParticleObj)
             float Matrix[3][4];
             AngleMatrix(Hero->Object.Angle, Matrix);
             vec3_t Velocity, Direction;
-            Vector(0.f, -45.f * ScaledCharacterMoveSpeed(Hero), 0.f, Velocity);
+            Vector(0.f, -45.f * CharacterMoveSpeed(Hero), 0.f, Velocity);
             VectorRotate(Velocity, Matrix, Direction);
-            VectorAdd(TargetPosition, Direction, TargetPosition);
+            VectorAddScaled(TargetPosition, Direction, TargetPosition, FPS_ANIMATION_FACTOR);
         }
         if (Hero->Movement || (rand_fps_check(2)))
         {

--- a/Source Main 5.2/source/GMCrywolf1st.cpp
+++ b/Source Main 5.2/source/GMCrywolf1st.cpp
@@ -415,7 +415,7 @@ bool M34CryWolf1st::RenderCryWolf1stObjectVisual(OBJECT* o, BMD* b)
     }
     break;
     case 84:
-        if (rand() % 3 == 0 && m_OccupationState == CRYWOLF_OCCUPATION_STATE_OCCUPIED)
+        if (rand_fps_check(3) && m_OccupationState == CRYWOLF_OCCUPATION_STATE_OCCUPIED)
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 21, o->Scale);
@@ -460,7 +460,7 @@ bool M34CryWolf1st::RenderCryWolf1stObjectMesh(OBJECT* o, BMD* b, int ExtraMon)
 
             Vector(Color, Color, Color, Light);
 
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
                 CreateEffect(BITMAP_MAGIC, o->Position, o->Angle, Light, 3, o, 4.0f);
         }
     }
@@ -471,7 +471,7 @@ bool M34CryWolf1st::RenderCryWolf1stObjectMesh(OBJECT* o, BMD* b, int ExtraMon)
         return true;
     case 57:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, o->Position, o->Angle, Light, 5, o->Scale);
@@ -481,7 +481,7 @@ bool M34CryWolf1st::RenderCryWolf1stObjectMesh(OBJECT* o, BMD* b, int ExtraMon)
     return true;
     case 71:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, o->Position, o->Angle, Light, 5, o->Scale);
@@ -490,7 +490,7 @@ bool M34CryWolf1st::RenderCryWolf1stObjectMesh(OBJECT* o, BMD* b, int ExtraMon)
     return true;
     case 72:
     {
-        if (rand() % 10 == 0)
+        if (rand_fps_check(10))
         {
             vec3_t Position;
             VectorCopy(o->Position, Position);
@@ -509,7 +509,7 @@ bool M34CryWolf1st::RenderCryWolf1stObjectMesh(OBJECT* o, BMD* b, int ExtraMon)
     return true;
     case 74:
     {
-        if (rand() % 3 == 0 && m_OccupationState == CRYWOLF_OCCUPATION_STATE_OCCUPIED)
+        if (rand_fps_check(3) && m_OccupationState == CRYWOLF_OCCUPATION_STATE_OCCUPIED)
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 21, o->Scale);
@@ -518,7 +518,7 @@ bool M34CryWolf1st::RenderCryWolf1stObjectMesh(OBJECT* o, BMD* b, int ExtraMon)
     return true;
     case 77:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             //	Vector(0.02f,0.02f,0.03f,Light);
             Vector(0.02f, 0.03f, 0.02f, Light);
@@ -528,7 +528,7 @@ bool M34CryWolf1st::RenderCryWolf1stObjectMesh(OBJECT* o, BMD* b, int ExtraMon)
     return true;
     case 78:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.03f, 0.06f, 0.05f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 9, o->Scale, o);
@@ -748,7 +748,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         else
             if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
             {
-                if (rand() % 10 == 0) {
+                if (rand_fps_check(10)) {
                     CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
                 }
             }
@@ -787,7 +787,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         else
             if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
             {
-                if (rand() % 10 == 0) {
+                if (rand_fps_check(10)) {
                     CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
                 }
             }
@@ -819,7 +819,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         else
             if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
             {
-                if (rand() % 10 == 0) {
+                if (rand_fps_check(10)) {
                     CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
                 }
             }
@@ -831,7 +831,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         Vector(0.9f, 0.2f, 0.1f, Light);
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 10 == 0) {
+            if (rand_fps_check(10)) {
                 CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
             }
         }
@@ -867,7 +867,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         Vector(0.9f, 0.2f, 0.1f, Light);
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 10 == 0) {
+            if (rand_fps_check(10)) {
                 CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
             }
         }
@@ -907,7 +907,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                         //. Walking & Running Scene Processing
             if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
             {
-                if (rand() % 10 == 0) {
+                if (rand_fps_check(10)) {
                     CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
                 }
             }
@@ -958,7 +958,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     {
         if (m_CrywolfState == CRYWOLF_STATE_START)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 SetAction(o, MONSTER01_ATTACK1);
                 o->Timer = 1;
@@ -1608,7 +1608,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_BALGAS_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1655,7 +1655,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_DARKELF_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1723,7 +1723,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_DEATHSPIRIT_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1767,7 +1767,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         BoneManager::GetBonePosition(o, "Monster94_zx01", Position);
         Vector(0.1f, 0.0f, 0.6f, Light);
         CreateSprite(BITMAP_SHINY + 1, Position, 0.8f, Light, o, Rot);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             Vector(0.7f, 0.7f, 1.0f, Light);
             CreateSprite(BITMAP_SHINY + 1, Position, 0.8f, Light, o, 360.f - Rot);
@@ -1780,7 +1780,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_BALRAM_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1812,7 +1812,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_SORAM_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1854,14 +1854,14 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         //. Walking & Running Scene Processing
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 10 == 0) {
+            if (rand_fps_check(10)) {
                 CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
             }
         }
 
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_WWOLF_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1904,7 +1904,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         }
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_SCOUT2_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1959,7 +1959,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
 
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_SCOUT3_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1992,7 +1992,7 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_CRY1ST_SCOUT1_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -2029,7 +2029,7 @@ bool M34CryWolf1st::CreateMist(PARTICLE* pParticleObj)
     if (!IsCyrWolf1st())
         return false;
 
-    if (rand() % 30 == 0) {
+    if (rand_fps_check(30)) {
         vec3_t Light;
         Vector(0.07f, 0.07f, 0.07f, Light);
         int ff = 200.0f;
@@ -2080,7 +2080,7 @@ bool M34CryWolf1st::CreateMist(PARTICLE* pParticleObj)
             VectorRotate(Velocity, Matrix, Direction);
             VectorAdd(TargetPosition, Direction, TargetPosition);
         }
-        if (Hero->Movement || (rand() % 2 == 0))
+        if (Hero->Movement || (rand_fps_check(2)))
         {
             CreateParticle(BITMAP_CLOUD, TargetPosition, TargetAngle, Light, 8, 0.4f);
         }

--- a/Source Main 5.2/source/GMCrywolf1st.cpp
+++ b/Source Main 5.2/source/GMCrywolf1st.cpp
@@ -724,7 +724,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     {
     case MODEL_MONSTER01 + 98:
     {
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fAnimationFrame = o->AnimationFrame - fActionSpeed;
         b->Animation(BoneTransform, fAnimationFrame, o->PriorAnimationFrame, o->PriorAction, o->Angle, o->HeadAngle);
         vec3_t Light;
@@ -756,7 +756,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     break;
     case MODEL_MONSTER01 + 94:
     {
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         vec3_t Light;
         vec3_t EndPos, EndRelative;
         Vector(1.f, 1.f, 1.f, Light);
@@ -796,7 +796,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     case MODEL_MONSTER01 + 89:
     {
         MoveEye(o, b, 9, 10);
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fAnimationFrame = o->AnimationFrame - fActionSpeed;
         b->Animation(BoneTransform, fAnimationFrame, o->PriorAnimationFrame, o->PriorAction, o->Angle, o->HeadAngle);
         vec3_t Light;
@@ -884,7 +884,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             CreateSprite(BITMAP_LIGHT, Position, 3.5f, Light, o);
         }
 
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         vec3_t EndPos, EndRelative;
         Vector(1.f, 1.f, 1.f, Light);
 
@@ -1105,7 +1105,7 @@ void M34CryWolf1st::MoveCryWolf1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             //				vec3_t StartPos;//, StartRelative;
             vec3_t EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             VectorCopy(o->Angle, TempAngle);
@@ -1160,7 +1160,7 @@ void M34CryWolf1st::MoveCryWolf1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1197,7 +1197,7 @@ void M34CryWolf1st::MoveCryWolf1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -1248,7 +1248,7 @@ void M34CryWolf1st::MoveCryWolf1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -1292,7 +1292,7 @@ void M34CryWolf1st::MoveCryWolf1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -1340,7 +1340,7 @@ void M34CryWolf1st::MoveCryWolf1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {
@@ -1375,7 +1375,7 @@ void M34CryWolf1st::MoveCryWolf1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {
@@ -2076,7 +2076,7 @@ bool M34CryWolf1st::CreateMist(PARTICLE* pParticleObj)
             float Matrix[3][4];
             AngleMatrix(Hero->Object.Angle, Matrix);
             vec3_t Velocity, Direction;
-            Vector(0.f, -45.f * CharacterMoveSpeed(Hero), 0.f, Velocity);
+            Vector(0.f, -45.f * ScaledCharacterMoveSpeed(Hero), 0.f, Velocity);
             VectorRotate(Velocity, Matrix, Direction);
             VectorAdd(TargetPosition, Direction, TargetPosition);
         }

--- a/Source Main 5.2/source/GMDoppelGanger1.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger1.cpp
@@ -469,7 +469,7 @@ bool CGMDoppelGanger1::RenderObjectVisual(OBJECT* o, BMD* b)
         }
         return true;
     case 101:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             vec3_t Light, vPos;
             Vector(0.6f, 0.8f, 1.0f, Light);
@@ -493,7 +493,7 @@ bool CGMDoppelGanger1::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     {
     case MODEL_MONSTER01 + 189:
     case MODEL_MONSTER01 + 190:
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             b->TransformByObjectBone(vPos, o, 6);
             vPos[1] += 50.0f;
@@ -501,7 +501,7 @@ bool CGMDoppelGanger1::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(1.0f, 1.0f, 1.0f, vLight);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 61);
         }
-        if (c->Dead == 0 && rand() % 4 == 0)
+        if (c->Dead == 0 && rand_fps_check(4))
         {
             Vector(o->Position[0] + (float)(rand() % 64 - 32),
                 o->Position[1] + (float)(rand() % 64 - 32),
@@ -621,7 +621,7 @@ bool CGMDoppelGanger1::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_RAKLION_ICEWALKER_MOVE);
             }

--- a/Source Main 5.2/source/GMDoppelGanger1.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger1.cpp
@@ -159,7 +159,7 @@ CHARACTER* CGMDoppelGanger1::CreateMonster(int iType, int PosX, int PosY, int Ke
         pCharacter->Weapon[0].Type = MODEL_MACE + 10;
         pCharacter->Weapon[1].Type = MODEL_SHIELD + 7;
         pCharacter->Helper.Type = MODEL_HELPER + 4;
-        CreateBug(MODEL_DARK_HORSE, pCharacter->Object.Position, &pCharacter->Object, 1);
+        CreateMount(MODEL_DARK_HORSE, pCharacter->Object.Position, &pCharacter->Object, 1);
         break;
     case 539:
         pCharacter = CreateCharacter(Key, MODEL_PLAYER, PosX, PosY);
@@ -331,7 +331,7 @@ void CGMDoppelGanger1::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BM
         vec3_t StartPos, StartRelative;
         vec3_t EndPos, EndRelative;
 
-        float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+        float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fSpeedPerFrame = fActionSpeed / 10.f;
         float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
         for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GMDoppelGanger2.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger2.cpp
@@ -212,7 +212,7 @@ void CGMDoppelGanger2::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BM
         vec3_t StartPos, StartRelative;
         vec3_t EndPos, EndRelative;
 
-        float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+        float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fSpeedPerFrame = fActionSpeed / 10.f;
         float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
         for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GMDoppelGanger2.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger2.cpp
@@ -417,7 +417,7 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
     case 1:
     {
         o->HiddenMesh = -2;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.0f, 1.0f, 1.0f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 60, o->Scale, o);
@@ -428,7 +428,7 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
     {
         o->HiddenMesh = -2;
         vec3_t  Light;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.f, 0.f, 0.f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 16, o->Scale, o);
@@ -438,7 +438,7 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
     case 3:
     {
         o->HiddenMesh = -2;
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             float fRed = (rand() % 3) * 0.01f + 0.015f;
             Vector(fRed, 0.0f, 0.0f, Light);
@@ -451,7 +451,7 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
         o->HiddenMesh = -2;
         Vector(1.0f, 0.4f, 0.4f, Light);
         vec3_t vAngle;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector((float)(rand() % 40 + 120), 0.f, (float)(rand() % 30), vAngle);
             VectorAdd(vAngle, o->Angle, vAngle);
@@ -463,7 +463,7 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
     case 5:
     {
         o->HiddenMesh = -2;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.3f, 0.3f, 0.3f, o->Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 21, o->Scale);
@@ -515,7 +515,7 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
     }
     return true;
     case 48:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             vec3_t Light, vPos;
             Vector(0.6f, 0.8f, 1.0f, Light);
@@ -539,7 +539,7 @@ bool CGMDoppelGanger2::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     {
     case MODEL_MONSTER01 + 189:
     case MODEL_MONSTER01 + 190:
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             b->TransformByObjectBone(vPos, o, 6);
             vPos[1] += 50.0f;
@@ -547,7 +547,7 @@ bool CGMDoppelGanger2::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(1.0f, 1.0f, 1.0f, vLight);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 61);
         }
-        if (c->Dead == 0 && rand() % 4 == 0)
+        if (c->Dead == 0 && rand_fps_check(4))
         {
             Vector(o->Position[0] + (float)(rand() % 64 - 32),
                 o->Position[1] + (float)(rand() % 64 - 32),

--- a/Source Main 5.2/source/GMDoppelGanger3.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger3.cpp
@@ -227,7 +227,7 @@ void CGMDoppelGanger3::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BM
         vec3_t StartPos, StartRelative;
         vec3_t EndPos, EndRelative;
 
-        float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+        float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fSpeedPerFrame = fActionSpeed / 10.f;
         float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
         for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GMDoppelGanger3.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger3.cpp
@@ -67,7 +67,7 @@ bool CGMDoppelGanger3::MoveObject(OBJECT* o)
     {
     case 22:
         o->HiddenMesh = -2;
-        o->Timer += 0.1f;
+        o->Timer += 0.1f * FPS_ANIMATION_FACTOR;
         if (o->Timer > 10.f)
             o->Timer = 0.f;
         if (o->Timer > 5.f)

--- a/Source Main 5.2/source/GMDoppelGanger3.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger3.cpp
@@ -328,7 +328,7 @@ bool CGMDoppelGanger3::RenderObjectVisual(OBJECT* o, BMD* b)
     }
     return true;
     case 48:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             vec3_t Light, vPos;
             Vector(0.6f, 0.8f, 1.0f, Light);
@@ -351,7 +351,7 @@ bool CGMDoppelGanger3::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     {
     case MODEL_MONSTER01 + 189:
     case MODEL_MONSTER01 + 190:
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             b->TransformByObjectBone(vPos, o, 6);
             vPos[1] += 50.0f;
@@ -359,7 +359,7 @@ bool CGMDoppelGanger3::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(1.0f, 1.0f, 1.0f, vLight);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 61);
         }
-        if (c->Dead == 0 && rand() % 4 == 0)
+        if (c->Dead == 0 && rand_fps_check(4))
         {
             Vector(o->Position[0] + (float)(rand() % 64 - 32),
                 o->Position[1] + (float)(rand() % 64 - 32),

--- a/Source Main 5.2/source/GMDoppelGanger4.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger4.cpp
@@ -119,7 +119,7 @@ bool CGMDoppelGanger4::MoveObject(OBJECT* o)
         return true;
     case 97:
         o->HiddenMesh = -2;
-        o->Timer += 0.1f;
+        o->Timer += 0.1f * FPS_ANIMATION_FACTOR;
         if (o->Timer > 10.f)
             o->Timer = 0.f;
         if (o->Timer > 5.f)

--- a/Source Main 5.2/source/GMDoppelGanger4.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger4.cpp
@@ -259,7 +259,7 @@ void CGMDoppelGanger4::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BM
         vec3_t StartPos, StartRelative;
         vec3_t EndPos, EndRelative;
 
-        float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+        float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fSpeedPerFrame = fActionSpeed / 10.f;
         float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
         for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GMDoppelGanger4.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger4.cpp
@@ -384,7 +384,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
     }
     return true;
     case 48:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             vec3_t Light, vPos;
             Vector(0.6f, 0.8f, 1.0f, Light);
@@ -396,7 +396,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         }
         return true;
     case 59:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle,
@@ -404,7 +404,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         }
         return true;
     case 61:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, o->Position, o->Angle,
@@ -432,7 +432,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
     case 81:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_WATERFALL_1, o->Position, o->Angle, Light, 2, o->Scale);
         return true;
     case 82:
@@ -441,7 +441,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
     case 83:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
             CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 1, o->Scale);
         return true;
     case 85:
@@ -472,7 +472,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
     case 98:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             vec3_t vPos;
             Vector(0.0f, 0.0f, 0.0f, vPos);
@@ -501,7 +501,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         EndPos[1] += rand() % 50;
         StartPos[2] += 10.0f;
         EndPos[2] += 10.f;
-        if (rand() % 20 == 0)
+        if (rand_fps_check(20))
         {
             CreateJoint(BITMAP_JOINT_THUNDER, StartPos, EndPos, o->Angle, 8, NULL, 40.f);
         }
@@ -548,7 +548,7 @@ bool CGMDoppelGanger4::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     {
     case MODEL_MONSTER01 + 189:
     case MODEL_MONSTER01 + 190:
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             b->TransformByObjectBone(vPos, o, 6);
             vPos[1] += 50.0f;
@@ -556,7 +556,7 @@ bool CGMDoppelGanger4::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(1.0f, 1.0f, 1.0f, vLight);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 61);
         }
-        if (c->Dead == 0 && rand() % 4 == 0)
+        if (c->Dead == 0 && rand_fps_check(4))
         {
             Vector(o->Position[0] + (float)(rand() % 64 - 32),
                 o->Position[1] + (float)(rand() % 64 - 32),

--- a/Source Main 5.2/source/GMDuelArena.cpp
+++ b/Source Main 5.2/source/GMDuelArena.cpp
@@ -129,7 +129,7 @@ bool CGMDuelArena::RenderObjectVisual(OBJECT* o, BMD* b)
     case 35:
     {
         vec3_t vLight;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, vLight);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 14, o->Scale, o);

--- a/Source Main 5.2/source/GMEmpireGuardian1.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian1.cpp
@@ -488,7 +488,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 25; i++)
@@ -551,7 +551,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 25; i++)
@@ -586,7 +586,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 25; i++)
@@ -1015,7 +1015,7 @@ void GMEmpireGuardian1::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
     Vector(0.0f, 0.0f, 0.0f, StartRelative);
     Vector(0.0f, 0.0f, 0.0f, EndRelative);
 
-    float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+    float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
     float fSpeedPerFrame = fActionSpeed / 10.f;
     float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -1060,7 +1060,7 @@ void GMEmpireGuardian1::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
 
             float fDelay = 5.0f;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / fDelay;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < fDelay; i++)
@@ -1161,7 +1161,7 @@ void GMEmpireGuardian1::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1260,7 +1260,7 @@ void GMEmpireGuardian1::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1291,7 +1291,7 @@ void GMEmpireGuardian1::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 20.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 20; i++)

--- a/Source Main 5.2/source/GMEmpireGuardian1.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian1.cpp
@@ -2215,7 +2215,7 @@ bool GMEmpireGuardian1::CreateRain(PARTICLE* o)
             VectorRotate(Velocity, Matrix, o->Velocity);
         }
 
-        VectorAdd(o->Position, o->Velocity, o->Position);
+        VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
         float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (rand_fps_check(2))
         {

--- a/Source Main 5.2/source/GMEmpireGuardian1.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian1.cpp
@@ -325,7 +325,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(OBJECT* o, BMD* b)
     {
         if (o->CurrentAction == MONSTER01_DIE)
         {
-            if (o->LifeTime == 100)
+            if ((int)o->LifeTime == 100)
             {
                 o->LifeTime = 90;
 
@@ -340,7 +340,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(OBJECT* o, BMD* b)
     {
         if (o->CurrentAction == MONSTER01_DIE)
         {
-            if (o->LifeTime == 100)
+            if ((int)o->LifeTime == 100)
             {
                 o->LifeTime = 90;
 

--- a/Source Main 5.2/source/GMEmpireGuardian1.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian1.cpp
@@ -1695,7 +1695,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
     case 84:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 8 == 0)
+        if (rand_fps_check(8))
         {
             CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
         }
@@ -1722,7 +1722,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 86:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.05f, 0.02f, 0.01f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -1732,7 +1732,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 129:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.01f, 0.02f, 0.05f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -1742,7 +1742,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 130:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.01f, 0.05f, 0.02f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -1752,7 +1752,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 131:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 22, o->Scale);
@@ -1765,7 +1765,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 132:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 60, o->Scale, o);
@@ -2217,11 +2217,11 @@ bool GMEmpireGuardian1::CreateRain(PARTICLE* o)
 
         VectorAdd(o->Position, o->Velocity, o->Position);
         float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             o->Live = false;
             o->Position[2] = Height + 10.f;
-            if (rand() % 4 == 0)
+            if (rand_fps_check(4))
                 CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light);
             else
                 CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light);
@@ -2248,7 +2248,7 @@ void GMEmpireGuardian1::RenderFrontSideVisual()
     break;
     case WEATHER_STORM:
     {
-        if (rand() % 20 == 0)
+        if (rand_fps_check(20))
         {
             EnableAlphaBlend();
             glColor3f(0.7f, 0.7f, 0.9f);
@@ -2594,7 +2594,7 @@ bool GMEmpireGuardian1::PlayMonsterSound(OBJECT* o)
         {
         case MONSTER01_WALK:
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 PlayBuffer(SOUND_EMPIREGUARDIAN_JERINT_MONSTER_MOVE01);
             }

--- a/Source Main 5.2/source/GMEmpireGuardian2.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian2.cpp
@@ -270,7 +270,7 @@ bool GMEmpireGuardian2::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 10; i++)
@@ -304,7 +304,7 @@ bool GMEmpireGuardian2::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 10; i++)
@@ -343,7 +343,7 @@ bool GMEmpireGuardian2::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GMEmpireGuardian2.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian2.cpp
@@ -727,7 +727,7 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
     case 84:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 8 == 0)
+        if (rand_fps_check(8))
         {
             CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
         }
@@ -754,7 +754,7 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 86:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.05f, 0.02f, 0.01f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -764,7 +764,7 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 129:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.01f, 0.02f, 0.05f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -774,7 +774,7 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 130:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.01f, 0.05f, 0.02f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -784,7 +784,7 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 131:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 22, o->Scale);
@@ -797,7 +797,7 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 132:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 60, o->Scale, o);
@@ -1209,7 +1209,7 @@ bool GMEmpireGuardian2::PlayMonsterSound(OBJECT* o)
         {
         case MONSTER01_WALK:
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 PlayBuffer(SOUND_EMPIREGUARDIAN_JERINT_MONSTER_MOVE01);
             }
@@ -1253,7 +1253,7 @@ bool GMEmpireGuardian2::PlayMonsterSound(OBJECT* o)
         {
         case MONSTER01_WALK:
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 PlayBuffer(SOUND_EMPIREGUARDIAN_JERINT_MONSTER_MOVE01);
             }

--- a/Source Main 5.2/source/GMEmpireGuardian3.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian3.cpp
@@ -262,7 +262,7 @@ bool GMEmpireGuardian3::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 10; i++)
@@ -302,7 +302,7 @@ bool GMEmpireGuardian3::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t vPosBlur01, vPosBlurRelative01;
                 vec3_t vPosBlur02, vPosBlurRelative02;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 6.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 8; i++)
@@ -350,7 +350,7 @@ bool GMEmpireGuardian3::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t vPosBlur01, vPosBlurRelative01;
                 vec3_t vPosBlur02, vPosBlurRelative02;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 6.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 8; i++)
@@ -511,7 +511,7 @@ void GMEmpireGuardian3::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 Vector(0.9f, 0.5f, 0.4f, Light);
 
-                fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 fSpeedPerFrame = fActionSpeed / 5.f;
                 fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -533,7 +533,7 @@ void GMEmpireGuardian3::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 Vector(0.9f, 0.5f, 0.4f, Light);
 
-                fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);;
                 fSpeedPerFrame = fActionSpeed / 5.f;
                 fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -561,7 +561,7 @@ void GMEmpireGuardian3::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 Vector(0.9f, 0.5f, 0.4f, Light);
 
-                fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);;
                 fSpeedPerFrame = fActionSpeed / 5.f;
                 fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 3; i++)
@@ -592,7 +592,7 @@ void GMEmpireGuardian3::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 Vector(0.9f, 0.5f, 0.4f, Light);
 
-                fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);;
                 fSpeedPerFrame = fActionSpeed / 10.f;
                 fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 16; i++)
@@ -688,7 +688,7 @@ void GMEmpireGuardian3::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 5.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                 for (int i = 0; i < 5; i++)

--- a/Source Main 5.2/source/GMEmpireGuardian3.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian3.cpp
@@ -906,7 +906,7 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
     case 84:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 8 == 0)
+        if (rand_fps_check(8))
         {
             CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
         }
@@ -932,7 +932,7 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
     return true;
     case 86:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.05f, 0.02f, 0.01f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -941,7 +941,7 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
     return true;
     case 129:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.01f, 0.02f, 0.05f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -950,7 +950,7 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
     return true;
     case 130:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.01f, 0.05f, 0.02f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -959,7 +959,7 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
     return true;
     case 131:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 22, o->Scale);
@@ -971,7 +971,7 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
     return true;
     case 132:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 60, o->Scale, o);
@@ -1045,7 +1045,7 @@ bool GMEmpireGuardian3::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         CreateSprite(BITMAP_LIGHT_RED, Position, 1.2f, Light, o);
 
         Vector(0.9f, 0.9f, 0.9f, Light);
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             b->TransformByObjectBone(Position, o, 54);
             CreateParticle(BITMAP_SMOKELINE2, Position, o->Angle, Light, 3, 0.2f);

--- a/Source Main 5.2/source/GMEmpireGuardian4.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian4.cpp
@@ -929,7 +929,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
     case 84:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 8 == 0)
+        if (rand_fps_check(8))
         {
             CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
         }
@@ -955,7 +955,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 86:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.05f, 0.02f, 0.01f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -965,7 +965,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 129:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.01f, 0.02f, 0.05f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -975,7 +975,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 130:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.01f, 0.05f, 0.02f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 21, o->Scale, o);
@@ -985,7 +985,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 131:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 22, o->Scale);
@@ -998,7 +998,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 132:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 60, o->Scale, o);
@@ -1495,7 +1495,7 @@ bool GMEmpireGuardian4::PlayMonsterSound(OBJECT* o)
         {
         case MONSTER01_WALK:
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 PlayBuffer(SOUND_EMPIREGUARDIAN_JERINT_MONSTER_MOVE01);
             }

--- a/Source Main 5.2/source/GMEmpireGuardian4.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian4.cpp
@@ -473,10 +473,8 @@ bool GMEmpireGuardian4::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t vPosBlur01, vPosBlurRelative01;
                 vec3_t vPosBlur02, vPosBlurRelative02;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
-
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
-
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
                 int iSwordForceType = 0;
@@ -514,7 +512,7 @@ bool GMEmpireGuardian4::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
             if (8.0f <= o->AnimationFrame && o->AnimationFrame < 10.1f)
             {
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -556,7 +554,7 @@ bool GMEmpireGuardian4::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t vPosBlur01, vPosBlurRelative01;
                 vec3_t vPosBlur02, vPosBlurRelative02;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
@@ -596,7 +594,7 @@ bool GMEmpireGuardian4::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t vPosBlur03, vPosBlurRelative03;
                 vec3_t vPosBlur04, vPosBlurRelative04;
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / 10.f;
 
                 float fAnimationFrame = o->AnimationFrame - fActionSpeed;

--- a/Source Main 5.2/source/GMEmpireGuardian4.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian4.cpp
@@ -254,7 +254,7 @@ bool GMEmpireGuardian4::MoveMonsterVisual(OBJECT* o, BMD* b)
     {
         if (o->CurrentAction == MONSTER01_DIE)
         {
-            if (o->LifeTime == 100)
+            if ((int)o->LifeTime == 100)
             {
                 o->LifeTime = 90;
 

--- a/Source Main 5.2/source/GMHellas.cpp
+++ b/Source Main 5.2/source/GMHellas.cpp
@@ -1501,7 +1501,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 Vector(1.f, 0.1f, 0.1f, Light);
                 CreateParticle(BITMAP_HOLE, Position, o->Angle, Light, 0, 3.f);
             }
-            o->LifeTime++;
+            o->LifeTime += FPS_ANIMATION_FACTOR;
             if (o->LifeTime >= 5)
             {
                 o->LifeTime = 0;

--- a/Source Main 5.2/source/GMHellas.cpp
+++ b/Source Main 5.2/source/GMHellas.cpp
@@ -420,7 +420,7 @@ void CheckGrass(OBJECT* o)
 
         VectorScale(o->Direction, 0.6f, o->Direction);
         VectorScale(o->HeadAngle, 0.6f, o->HeadAngle);
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         VectorAdd(o->Angle, o->HeadAngle, o->Angle);
     }
 }
@@ -674,9 +674,9 @@ void MoveBigMon(OBJECT* o)
 
     if (o->LifeTime < 20)
     {
-        o->Alpha /= 1.2f;
-        o->Velocity += 0.5f;
-        o->Angle[0] += 2.f;
+        o->Alpha *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+        o->Velocity += 0.5f * FPS_ANIMATION_FACTOR;
+        o->Angle[0] += 2.f * FPS_ANIMATION_FACTOR;
     }
 
     if (o->LifeTime < 0) o->Live = false;

--- a/Source Main 5.2/source/GMHellas.cpp
+++ b/Source Main 5.2/source/GMHellas.cpp
@@ -327,13 +327,13 @@ bool MoveHellasObjectSetting(int& objCount, int object)
         }
     }
 
-    if ((rand() % 10) == 0 && object)
+    if (rand_fps_check(10) && object)
     {
         objCount = rand() % object;
         return true;
     }
 
-    if ((rand() % 5) == 0)
+    if (rand_fps_check(5))
     {
         vec3_t Position, Light;
 
@@ -345,7 +345,7 @@ bool MoveHellasObjectSetting(int& objCount, int object)
 
         CreateParticle(BITMAP_LIGHT, Position, Hero->Object.Angle, Light, 7, 1.f, &Hero->Object);
 
-        if ((rand() % 15) == 0)
+        if (rand_fps_check(15))
         {
             vec3_t Angle = { 0.f, 0.f, 0.f };
             Position[2] = Hero->Object.Position[2] + 800.f;
@@ -479,7 +479,7 @@ bool RenderHellasVisual(OBJECT* o, BMD* b)
         break;
     case 38:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             CreateParticle(BITMAP_WATERFALL_1, o->Position, o->Angle, Light, 0);
         }
@@ -493,7 +493,7 @@ bool RenderHellasVisual(OBJECT* o, BMD* b)
         break;
     case 40:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 0);
         }
@@ -667,7 +667,7 @@ void MoveBigMon(OBJECT* o)
 {
     o->Angle[2] += o->Gravity;
 
-    if (rand() % 5 == 0)
+    if (rand_fps_check(5))
     {
         o->Gravity *= -1;
     }
@@ -1434,7 +1434,7 @@ bool MoveHellasMonsterVisual(OBJECT* o, BMD* b)
         return true;
 
     case MODEL_MONSTER01 + 64:
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             Vector(2.f, 30.f, 0.f, p);
             b->TransformPosition(o->BoneTransform[6], p, Position, true);
@@ -1459,7 +1459,7 @@ bool MoveHellasMonsterVisual(OBJECT* o, BMD* b)
     case MODEL_MONSTER01 + 69:
         if (o->CurrentAction != MONSTER01_DIE)
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Vector(2.f, 30.f, 0.f, p);
                 b->TransformPosition(o->BoneTransform[31], p, Position, true);
@@ -1523,7 +1523,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 b->TransformPosition(o->BoneTransform[i + 74], p, Position, true);
                 CreateSprite(BITMAP_LIGHT, Position, 1.5f - (0.2f * i), Light, o, WorldTime);
                 CreateSprite(BITMAP_LIGHT, Position, 1.5f - (0.2f * i), Light, o, WorldTime);
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     CreateParticle(BITMAP_BUBBLE, Position, o->Angle, Light, 1);
                 }
@@ -1531,7 +1531,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 b->TransformPosition(o->BoneTransform[i + 62], p, Position, true);
                 CreateSprite(BITMAP_LIGHT, Position, 1.5f - (0.2f * i), Light, o, WorldTime);
                 CreateSprite(BITMAP_LIGHT, Position, 1.5f - (0.2f * i), Light, o, WorldTime);
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     CreateParticle(BITMAP_BUBBLE, Position, o->Angle, Light, 1);
                 }
@@ -1629,7 +1629,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     fRoar = 1.0f;
                     CreateSprite(BITMAP_FLARE_BLUE, Position, (1.2f + (sinf(WorldTime * 0.001f) * 0.3f)), Light, o, 0.f);
                 }
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 13, fRoar);
                 }
@@ -1849,7 +1849,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 b->TransformPosition(o->BoneTransform[0], p, Position, true);
                 CreateSprite(BITMAP_FLARE_BLUE, Position, 2.f + (sinf(WorldTime * 0.001f) * 0.3f), Light, o, 0.f);
 
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 13);
                 }
@@ -1914,7 +1914,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 b->TransformPosition(o->BoneTransform[63 + i], p, Position, true);
                 CreateSprite(BITMAP_LIGHT, Position, 0.5f + (sinf(WorldTime * 0.001f) * 0.2f), Light, o, 0.f);
 
-                if ((o->CurrentAction == MONSTER01_STOP1 || o->CurrentAction == MONSTER01_STOP2) && (rand() % 50) == 0)
+                if ((o->CurrentAction == MONSTER01_STOP1 || o->CurrentAction == MONSTER01_STOP2) && rand_fps_check(50))
                 {
                     Angle[0] = (float)(rand() % 360);
                     Angle[2] = (float)(rand() % 360);

--- a/Source Main 5.2/source/GMHellas.cpp
+++ b/Source Main 5.2/source/GMHellas.cpp
@@ -1494,13 +1494,14 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             VectorCopy(o->Position, Position);
             Position[2] += 20.f;
 
-            if (o->LifeTime == 0)
+            if ((int)o->LifeTime == 0)
             {
                 Vector(0.f, 0.f, 0.f, p);
                 b->TransformPosition(o->BoneTransform[8], p, Position, true);
                 Vector(1.f, 0.1f, 0.1f, Light);
                 CreateParticle(BITMAP_HOLE, Position, o->Angle, Light, 0, 3.f);
             }
+
             o->LifeTime += FPS_ANIMATION_FACTOR;
             if (o->LifeTime >= 5)
             {
@@ -1639,14 +1640,14 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 if (o->AnimationFrame < 2.0f)
                 {
-                    if (o->LifeTime != 100)
+                    if ((int)o->LifeTime != 100)
                     {
                         o->LifeTime = 100;
 
                         PlayBuffer(SOUND_KUNDUN_ROAR);
                     }
                 }
-                if (o->LifeTime == 100 && o->AnimationFrame > 4.0f)
+                if ((int)o->LifeTime == 100 && o->AnimationFrame > 4.0f)
                 {
                     o->LifeTime = 101;
                     if (gMapManager.InHellas())
@@ -1680,7 +1681,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 {
                     o->LifeTime = 100;
                 }
-                if (o->LifeTime == 100 && o->AnimationFrame > 3.0f)
+                if ((int)o->LifeTime == 100 && o->AnimationFrame > 3.0f)
                 {
                     o->LifeTime = 101;
                     vec3_t Position;
@@ -1696,7 +1697,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 {
                     o->LifeTime = 100;
                 }
-                if (o->LifeTime == 100 && o->AnimationFrame > 5.0f)
+                if ((int)o->LifeTime == 100 && o->AnimationFrame > 5.0f)
                 {
                     o->LifeTime = 101;
 
@@ -1706,7 +1707,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     Position[2] = 400;
                     CreateEffect(MODEL_CUNDUN_SKILL, Position, o->Angle, o->Light, 1);
                 }
-                if (o->LifeTime == 101 && o->AnimationFrame > 6.0f)
+                if ((int)o->LifeTime == 101 && o->AnimationFrame > 6.0f)
                 {
                     o->LifeTime = 102;
 
@@ -1727,7 +1728,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                         AddWaterWave((c->PositionX), (c->PositionY), 2, 2000);
                     }
                 }
-                if (o->LifeTime == 102 && o->AnimationFrame > 9.0f)
+                if ((int)o->LifeTime == 102 && o->AnimationFrame > 9.0f)
                 {
                     o->LifeTime = 103;
                     if (gMapManager.InHellas())
@@ -2011,7 +2012,7 @@ bool RenderHellasMonsterObjectMesh(OBJECT* o, BMD* b)
     }
     else if (o->Type == MODEL_MONSTER01 + 64)
     {
-        if (o->CurrentAction == MONSTER01_DIE && o->AnimationFrame > 14.8f && o->LifeTime == 90)
+        if (o->CurrentAction == MONSTER01_DIE && o->AnimationFrame > 14.8f && (int)o->LifeTime == 90)
         {
             if (o->LifeTime != 10)
             {

--- a/Source Main 5.2/source/GMHellas.cpp
+++ b/Source Main 5.2/source/GMHellas.cpp
@@ -1078,7 +1078,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
     case 260:
     case 268:
     case 276:
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             Vector(1.f, 1.f, 1.f, Light);
 
@@ -1122,7 +1122,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             break;
 
         case AT_SKILL_MONSTER_MAGIC_DEF:
-            if (c->AttackTime >= 13)
+            if ((int)c->AttackTime >= 13)
             {
                 g_CharacterRegisterBuff(o, eBuff_PhysDefense);
                 c->AttackTime = 15;
@@ -1131,7 +1131,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             break;
 
         case AT_SKILL_MONSTER_PHY_DEF:
-            if (c->AttackTime >= 13)
+            if ((int)c->AttackTime >= 13)
             {
                 g_CharacterRegisterBuff(o, eBuff_Defense);
                 c->AttackTime = 15;
@@ -1157,7 +1157,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
     case 262:
     case 270:
     case 278:
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             Vector(1.f, 1.f, 1.f, Light);
 
@@ -1197,7 +1197,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
         switch ((c->Skill))
         {
         case AT_SKILL_ENERGYBALL:
-            if (c->AttackTime == 14)
+            if ((int)c->AttackTime == 14)
             {
                 CreateEffect(MODEL_SKILL_FURY_STRIKE, o->Position, o->Angle, o->Light, 1, o, -1, 0, 1);
             }
@@ -1218,7 +1218,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
         switch ((c->Skill))
         {
         case AT_SKILL_POISON:
-            if (c->AttackTime == 14)
+            if ((int)c->AttackTime == 14)
             {
                 vec3_t Light, Position;
 
@@ -1236,7 +1236,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             break;
 
         case AT_SKILL_ENERGYBALL:
-            if (c->AttackTime == 14)
+            if ((int)c->AttackTime == 14)
             {
                 if (c->TargetCharacter >= 0 && c->TargetCharacter < MAX_CHARACTERS_CLIENT)
                 {
@@ -1298,7 +1298,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             break;
 
         case AT_SKILL_MONSTER_MAGIC_DEF:
-            if (c->AttackTime >= 13)
+            if ((int)c->AttackTime >= 13)
             {
                 g_CharacterRegisterBuff(o, eBuff_PhysDefense);
                 c->AttackTime = 15;
@@ -1307,7 +1307,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             break;
 
         case AT_SKILL_MONSTER_PHY_DEF:
-            if (c->AttackTime >= 13)
+            if ((int)c->AttackTime >= 13)
             {
                 g_CharacterRegisterBuff(o, eBuff_Defense);
                 c->AttackTime = 15;
@@ -1321,11 +1321,11 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
 
         if (o->CurrentAction == MONSTER01_ATTACK1)
         {
-            if (c->AttackTime == 7)
+            if ((int)c->AttackTime == 7)
             {
                 CreateEffect(MODEL_SKILL_FURY_STRIKE, o->Position, o->Angle, o->Light, 0, o, -1, 0, 0);
             }
-            else if (c->AttackTime >= 13)
+            else if ((int)c->AttackTime >= 13)
             {
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light, 0, o);
                 CreateEffect(BITMAP_FLAME, o->Position, o->Angle, o->Light, 1, o);
@@ -1354,7 +1354,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             break;
 
         case AT_SKILL_MONSTER_MAGIC_DEF:
-            if (c->AttackTime >= 13)
+            if ((int)c->AttackTime >= 13)
             {
                 g_CharacterRegisterBuff(o, eBuff_PhysDefense);
                 c->AttackTime = 15;
@@ -1364,7 +1364,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             break;
 
         case AT_SKILL_MONSTER_PHY_DEF:
-            if (c->AttackTime >= 13)
+            if ((int)c->AttackTime >= 13)
             {
                 g_CharacterRegisterBuff(o, eBuff_Defense);
                 c->AttackTime = 15;

--- a/Source Main 5.2/source/GMHuntingGround.cpp
+++ b/Source Main 5.2/source/GMHuntingGround.cpp
@@ -331,7 +331,7 @@ void M31HuntingGround::MoveHuntingGroundBlurEffect(CHARACTER* pCharacter, OBJECT
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++) {
@@ -967,7 +967,7 @@ bool M31HuntingGround::CreateMist(PARTICLE* pParticleObj)
             float Matrix[3][4];
             AngleMatrix(Hero->Object.Angle, Matrix);
             vec3_t Velocity, Direction;
-            Vector(0.f, -45.f * CharacterMoveSpeed(Hero), 0.f, Velocity);
+            Vector(0.f, -45.f * ScaledCharacterMoveSpeed(Hero), 0.f, Velocity);
             VectorRotate(Velocity, Matrix, Direction);
             VectorAdd(TargetPosition, Direction, TargetPosition);
         }

--- a/Source Main 5.2/source/GMHuntingGround.cpp
+++ b/Source Main 5.2/source/GMHuntingGround.cpp
@@ -124,13 +124,13 @@ bool M31HuntingGround::RenderHuntingGroundObjectVisual(OBJECT* pObject, BMD* pMo
     switch (pObject->Type)
     {
     case 3:
-        if (rand() % 3 == 0) {
+        if (rand_fps_check(3)) {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_WATERFALL_3, pObject->Position, pObject->Angle, Light, 3, pObject->Scale);
         }
         break;
     case 53:
-        if (rand() % 3 == 0) {
+        if (rand_fps_check(3)) {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, pObject->Position, pObject->Angle, Light, 22, pObject->Scale);
         }
@@ -373,7 +373,7 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0) {
+            if (rand_fps_check(15)) {
                 PlayBuffer(SOUND_BC_LIZARDWARRIOR_MOVE1 + rand() % 2);
             }
         }
@@ -425,7 +425,7 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
             BoneManager::GetBonePosition(pObject, "Monster82_Back", Position);
             CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 21, 0.8f);
 
-            if (rand() % 20 == 0) {
+            if (rand_fps_check(20)) {
                 PlayBuffer(SOUND_BC_FIREGOLEM_MOVE1 + rand() % 2);
             }
         }
@@ -553,8 +553,8 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
 
             vec3_t Angle;
             Vector(-55.f, sinf(WorldTime * 0.03f) * 45.f, pObject->Angle[2], Angle);
-            if (rand() % 2 == 0) {
-                if (rand() % 2 == 0)
+            if (rand_fps_check(2)) {
+                if (rand_fps_check(2))
                     BoneManager::GetBonePosition(pObject, "Monster84_PoisonRight", Position);
                 else
                     BoneManager::GetBonePosition(pObject, "Monster84_PoisonLeft", Position);
@@ -577,15 +577,15 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
             CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 11, (float)(rand() % 32 + 50) * 0.05f);
         }
 
-        if (rand() % 10 == 0) {
+        if (rand_fps_check(10)) {
             BoneManager::GetBonePosition(pObject, "Monster84_PoisonTop", Position);
             CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 23);
         }
-        if (rand() % 10 == 0) {
+        if (rand_fps_check(10)) {
             BoneManager::GetBonePosition(pObject, "Monster84_PoisonRight", Position);
             CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 23);
         }
-        if (rand() % 10 == 0) {
+        if (rand_fps_check(10)) {
             BoneManager::GetBonePosition(pObject, "Monster84_PoisonLeft", Position);
             CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 23);
         }
@@ -606,7 +606,7 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
         //. Walking & Running Scene Processing
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 10 == 0) {
+            if (rand_fps_check(10)) {
                 CreateParticle(BITMAP_SMOKE + 1, pObject->Position, pObject->Angle, Light);
                 PlayBuffer(SOUND_BC_AXEWARRIOR_MOVE1 + rand() % 2);
             }
@@ -921,7 +921,7 @@ bool M31HuntingGround::CreateMist(PARTICLE* pParticleObj)
     if (!IsInHuntingGroundSection2(Hero->Object.Position))
         return false;
 
-    if (rand() % 30 == 0) {
+    if (rand_fps_check(30)) {
         vec3_t Light;
         Vector(0.05f, 0.05f, 0.1f, Light);
 
@@ -971,7 +971,7 @@ bool M31HuntingGround::CreateMist(PARTICLE* pParticleObj)
             VectorRotate(Velocity, Matrix, Direction);
             VectorAdd(TargetPosition, Direction, TargetPosition);
         }
-        if (Hero->Movement || (rand() % 2 == 0)) {
+        if (Hero->Movement || (rand_fps_check(2))) {
             TargetPosition[2] = (rand() % 20) + RequestTerrainHeight(TargetPosition[0], TargetPosition[1]);
             CreateParticle(BITMAP_CLOUD, TargetPosition, TargetAngle, Light, 8, 0.4f);
         }

--- a/Source Main 5.2/source/GMHuntingGround.cpp
+++ b/Source Main 5.2/source/GMHuntingGround.cpp
@@ -967,9 +967,9 @@ bool M31HuntingGround::CreateMist(PARTICLE* pParticleObj)
             float Matrix[3][4];
             AngleMatrix(Hero->Object.Angle, Matrix);
             vec3_t Velocity, Direction;
-            Vector(0.f, -45.f * ScaledCharacterMoveSpeed(Hero), 0.f, Velocity);
+            Vector(0.f, -45.f * CharacterMoveSpeed(Hero), 0.f, Velocity);
             VectorRotate(Velocity, Matrix, Direction);
-            VectorAdd(TargetPosition, Direction, TargetPosition);
+            VectorAddScaled(TargetPosition, Direction, TargetPosition, FPS_ANIMATION_FACTOR);
         }
         if (Hero->Movement || (rand_fps_check(2))) {
             TargetPosition[2] = (rand() % 20) + RequestTerrainHeight(TargetPosition[0], TargetPosition[1]);

--- a/Source Main 5.2/source/GMKarutan1.cpp
+++ b/Source Main 5.2/source/GMKarutan1.cpp
@@ -468,7 +468,7 @@ bool CGMKarutan1::MoveMonsterVisual(OBJECT* o, BMD* b)
                 for (int j = 0; j < 6; ++j)
                     CreateEffect(MODEL_CONDRA_STONE + rand() % 6, vPos, o->Angle, vLight, 0);
             }
-            if (o->LifeTime == 100)
+            if ((int)o->LifeTime == 100)
             {
                 o->LifeTime = 90;
                 o->m_bRenderShadow = false;
@@ -541,7 +541,7 @@ bool CGMKarutan1::MoveMonsterVisual(OBJECT* o, BMD* b)
                 for (int j = 0; j < 4; ++j)
                     CreateEffect(MODEL_NARCONDRA_STONE + rand() % 4, vPos, o->Angle, vLight, 0);
             }
-            if (o->LifeTime == 100)
+            if ((int)o->LifeTime == 100)
             {
                 o->LifeTime = 90;
                 o->m_bRenderShadow = false;

--- a/Source Main 5.2/source/GMKarutan1.cpp
+++ b/Source Main 5.2/source/GMKarutan1.cpp
@@ -641,7 +641,7 @@ void CGMKarutan1::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD* pM
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; ++i)
@@ -673,7 +673,7 @@ void CGMKarutan1::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD* pM
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             int i;

--- a/Source Main 5.2/source/GMKarutan1.cpp
+++ b/Source Main 5.2/source/GMKarutan1.cpp
@@ -129,7 +129,7 @@ bool CGMKarutan1::RenderObjectVisual(OBJECT* o, BMD* b)
     }
     return true;
     case 114:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             vec3_t vLight;
             Vector(0.2f, 0.2f, 0.2f, vLight);
@@ -146,7 +146,7 @@ bool CGMKarutan1::RenderObjectVisual(OBJECT* o, BMD* b)
         }
         return true;
     case 116:
-        if (rand() % 8 == 0)
+        if (rand_fps_check(8))
         {
             vec3_t vLight;
             Vector(0.5f, 0.9f, 0.5f, vLight);
@@ -190,7 +190,7 @@ bool CGMKarutan1::RenderObjectMesh(OBJECT* o, BMD* b, bool ExtraMon)
     case 66:
         if (o->AnimationFrame >= 19)
         {
-            SetAction(o, rand() % 10 == 0 ? 1 : 0);
+            SetAction(o, rand_fps_check(10) ? 1 : 0);
         }
         o->m_bRenderAfterCharacter = true;
         return true;

--- a/Source Main 5.2/source/GMNewTown.cpp
+++ b/Source Main 5.2/source/GMNewTown.cpp
@@ -465,7 +465,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
                 pCharacter->Weapon[1].Level = 0;
                 pCharacter->Wing.Type = MODEL_WING + 5;
                 pCharacter->Helper.Type = MODEL_HELPER + 37;
-                CreateBug(MODEL_FENRIR_BLUE, pNewObject->Position, pNewObject);
+                CreateMount(MODEL_FENRIR_BLUE, pNewObject->Position, pNewObject);
                 break;
                 // 			case 137:
             case 138:
@@ -576,7 +576,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
                 pCharacter->Weapon[1].Level = 0;
                 pCharacter->Wing.Type = MODEL_HELPER + 30;
                 pCharacter->Helper.Type = MODEL_HELPER + 4;
-                CreateBug(MODEL_DARK_HORSE, pNewObject->Position, pNewObject);
+                CreateMount(MODEL_DARK_HORSE, pNewObject->Position, pNewObject);
                 CreatePetDarkSpirit_Now(pCharacter);
                 break;
             case 147:
@@ -1114,7 +1114,7 @@ void GMNewTown::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD* pMod
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GMNewTown.cpp
+++ b/Source Main 5.2/source/GMNewTown.cpp
@@ -295,7 +295,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     switch (pObject->Type)
     {
     case 0:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, pObject->Position, pObject->Angle, Light, 0, pObject->Scale);
@@ -303,7 +303,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 54:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             CreateParticle(BITMAP_WATERFALL_2, pObject->Position, pObject->Angle, Light, 4, pObject->Scale);
         }
@@ -333,7 +333,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         }
         break;
     case 61:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_BLUE, pObject->Position, pObject->Angle, Light, 0, pObject->Scale);
@@ -354,7 +354,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     case 110:
         Vector(1.0f, 1.0f, 1.0f, Light);
         Vector(0.f, 0.f, 70.f, p);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             p[0] = (float)cosf(WorldTime * 0.03f) * (30.f + rand() % 5);
             p[1] = (float)sinf(WorldTime * 0.03f) * (30.f + rand() % 5);
@@ -668,7 +668,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
             {
                 if (pObject->Type == 133)
                 {
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         pCharacter->Helper.Type = -1;
                         SetPlayerAttack(pCharacter);
@@ -687,7 +687,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
                 }
                 else if (pObject->Type == 134)
                 {
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         SetAction(pObject->Owner, PLAYER_ATTACK_SKILL_WHEEL);
                         pCharacter->Skill = AT_SKILL_WHEEL;
@@ -710,7 +710,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
                 }
                 else if (pObject->Type == 138)
                 {
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         SetPlayerAttack(pCharacter);
                     }
@@ -759,7 +759,7 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
                 }
                 else if ((pObject->Type >= 152 && pObject->Type <= 155))
                 {
-                    if (rand() % 2 == 0) SetAction(pObject->Owner, MONSTER01_ATTACK1);
+                    if (rand_fps_check(2)) SetAction(pObject->Owner, MONSTER01_ATTACK1);
                     else SetAction(pObject->Owner, MONSTER01_SHOCK);
                 }
                 else if ((pObject->Type >= 149 && pObject->Type <= 151))
@@ -1147,7 +1147,7 @@ bool GMNewTown::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BMD*
     switch (pObject->Type)
     {
     case MODEL_ELBELAND_RHEA:
-        if (pObject->CurrentAction == 0 && rand() % 5 == 0)
+        if (pObject->CurrentAction == 0 && rand_fps_check(5))
         {
             Vector((rand() % 90 + 10) * 0.01f, (rand() % 90 + 10) * 0.01f, (rand() % 90 + 10) * 0.01f, Light);
             fScale = (rand() % 5 + 5) * 0.1f;
@@ -1273,7 +1273,7 @@ bool GMNewTown::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 129:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_ELBELAND_RABBITUGLY_BREATH01);
             }
@@ -1291,7 +1291,7 @@ bool GMNewTown::PlayMonsterSound(OBJECT* pObject)
         if (pObject->CurrentAction == MONSTER01_STOP1 || pObject->CurrentAction == MONSTER01_STOP2
             || pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 30 == 0)
+            if (rand_fps_check(30))
             {
                 PlayBuffer(SOUND_ELBELAND_WOLFHUMAN_MOVE02);
             }
@@ -1308,7 +1308,7 @@ bool GMNewTown::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 131:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_ELBELAND_BUTTERFLYPOLLUTION_MOVE01);
             }
@@ -1321,7 +1321,7 @@ bool GMNewTown::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 132:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_ELBELAND_CURSERICH_MOVE01);
             }
@@ -1338,7 +1338,7 @@ bool GMNewTown::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 133:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 PlayBuffer(SOUND_ELBELAND_TOTEMGOLEM_MOVE01);
             else
                 PlayBuffer(SOUND_ELBELAND_TOTEMGOLEM_MOVE02);
@@ -1359,7 +1359,7 @@ bool GMNewTown::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 134:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_ELBELAND_BEASTWOO_MOVE01);
             }
@@ -1376,7 +1376,7 @@ bool GMNewTown::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 135:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_ELBELAND_BEASTWOOLEADER_MOVE01);
             }

--- a/Source Main 5.2/source/GMSantaTown.cpp
+++ b/Source Main 5.2/source/GMSantaTown.cpp
@@ -203,7 +203,7 @@ bool CGMSantaTown::CreateSnow(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     o->Scale = (float)(rand() % 10 + 5);
-    if (rand() % 10 == 0)
+    if (rand_fps_check(10))
     {
         o->Type = BITMAP_LEAF2;
         o->Scale = 12.f;

--- a/Source Main 5.2/source/GMSwampOfQuiet.cpp
+++ b/Source Main 5.2/source/GMSwampOfQuiet.cpp
@@ -439,7 +439,7 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
         if (pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             BMD* pModel = &Models[pObject->Type];
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float Start_Frame = 7.2f;
             float End_Frame = Start_Frame + fActionSpeed;
             if (pObject->AnimationFrame >= Start_Frame && pObject->AnimationFrame < End_Frame)
@@ -513,7 +513,7 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
         if (pObject->CurrentAction == MONSTER01_ATTACK1 || pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             BMD* pModel = &Models[pObject->Type];
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float Start_Frame = 5.5f;
             float End_Frame = Start_Frame + fActionSpeed;
             if (pObject->AnimationFrame >= Start_Frame && pObject->AnimationFrame < End_Frame)
@@ -595,7 +595,7 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
         if (pObject->CurrentAction == MONSTER01_ATTACK1 || pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             BMD* pModel = &Models[pObject->Type];
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float Start_Frame = 5.5f;
             float End_Frame = Start_Frame + fActionSpeed;
             if (pObject->AnimationFrame >= Start_Frame && pObject->AnimationFrame < End_Frame)
@@ -643,7 +643,7 @@ void GMSwampOfQuiet::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD*
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -683,7 +683,7 @@ void GMSwampOfQuiet::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD*
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -723,7 +723,7 @@ void GMSwampOfQuiet::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD*
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -781,7 +781,7 @@ void GMSwampOfQuiet::MoveBlurEffect(CHARACTER* pCharacter, OBJECT* pObject, BMD*
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[pObject->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GMSwampOfQuiet.cpp
+++ b/Source Main 5.2/source/GMSwampOfQuiet.cpp
@@ -136,7 +136,7 @@ bool GMSwampOfQuiet::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     {
     case 57:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, pObject->Position, pObject->Angle, Light, 5, pObject->Scale);
@@ -146,7 +146,7 @@ bool GMSwampOfQuiet::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     break;
     case 71:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, pObject->Position, pObject->Angle, Light, 5, pObject->Scale);
@@ -155,7 +155,7 @@ bool GMSwampOfQuiet::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     break;
     case 72:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             vec3_t Position;
             VectorCopy(pObject->Position, Position);
@@ -170,7 +170,7 @@ bool GMSwampOfQuiet::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 74:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, pObject->Position, pObject->Angle, Light, 21, pObject->Scale * 2.0f);
@@ -179,7 +179,7 @@ bool GMSwampOfQuiet::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     break;
     case 77:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.04f, 0.06f, 0.03f, Light);
             CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 20, pObject->Scale, pObject);
@@ -188,7 +188,7 @@ bool GMSwampOfQuiet::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
     break;
     case 78:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(0.03f, 0.03f, 0.05f, Light);
             CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 20, pObject->Scale, pObject);
@@ -567,7 +567,7 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
                     Vector(0.0f, 1.0f, 0.5f, vColor);
                     for (int i = 0; i < 2; ++i)
                     {
-                        if (i == 1 && rand() % 2 == 0) continue;
+                        if (i == 1 && rand_fps_check(2)) continue;
 
                         switch (rand() % 3)
                         {
@@ -1090,7 +1090,7 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
         CreateSprite(BITMAP_SHOCK_WAVE, vPos, 0.22f, vColor, pObject);
         Vector(0.9f, 1.0f, 0.9f, vColor);
         CreateSprite(BITMAP_SHINY + 1, vPos, 1.2f, vColor, pObject);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             CreateEffect(BITMAP_WATERFALL_4, vPos, pObject->Angle, vColor, 0, pObject, 68);
         }
@@ -1126,7 +1126,7 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
         {
             pObject->m_bRenderShadow = false;
 
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 Vector(0.4f, 0.9f, 0.6f, vColor);
                 pModel->TransformByObjectBone(vPos, pObject, 0);
@@ -1264,14 +1264,14 @@ bool GMSwampOfQuiet::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 137:
         if (pObject->CurrentAction == MONSTER01_ATTACK1 || pObject->CurrentAction == MONSTER01_ATTACK2)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_SAPI_UNUS_ATTACK01);
             }
         }
         else if (pObject->CurrentAction == MONSTER01_DIE)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_SAPI_DEATH01);
             }
@@ -1280,14 +1280,14 @@ bool GMSwampOfQuiet::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 138:
         if (pObject->CurrentAction == MONSTER01_ATTACK1 || pObject->CurrentAction == MONSTER01_ATTACK2)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_SAPI_TRES_ATTACK01);
             }
         }
         else if (pObject->CurrentAction == MONSTER01_DIE)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_SAPI_DEATH01);
             }
@@ -1326,7 +1326,7 @@ bool GMSwampOfQuiet::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 142:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_THUNDER_NAIPIN_BREATH01);
             }
@@ -1343,7 +1343,7 @@ bool GMSwampOfQuiet::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 143:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_GHOST_NAIPIN_BREATH01);
             }
@@ -1360,7 +1360,7 @@ bool GMSwampOfQuiet::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 144:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_BLAZE_NAIPIN_BREATH01);
             }
@@ -1382,14 +1382,14 @@ bool GMSwampOfQuiet::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 204:
         if (pObject->CurrentAction == MONSTER01_ATTACK1 || pObject->CurrentAction == MONSTER01_ATTACK2)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_SAPI_UNUS_ATTACK01);
             }
         }
         else if (pObject->CurrentAction == MONSTER01_DIE)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_SAPI_DEATH01);
             }
@@ -1398,7 +1398,7 @@ bool GMSwampOfQuiet::PlayMonsterSound(OBJECT* pObject)
     case MODEL_MONSTER01 + 202:
         if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_SWAMPOFQUIET_BLAZE_NAIPIN_BREATH01);
             }

--- a/Source Main 5.2/source/GMUnitedMarketPlace.cpp
+++ b/Source Main 5.2/source/GMUnitedMarketPlace.cpp
@@ -289,7 +289,7 @@ bool GMUnitedMarketPlace::RenderObjectVisual(OBJECT* o, BMD* b)
     case 56:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 8 == 0)
+        if (rand_fps_check(8))
         {
             CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
         }
@@ -544,7 +544,7 @@ bool GMUnitedMarketPlace::MoveRain(PARTICLE* o)
         {
             o->Live = false;
             o->Position[2] = Height + 10.f;
-            if (rand() % 4 == 0)
+            if (rand_fps_check(4))
                 CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light, 2);
             else
                 CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light, 2);
@@ -552,14 +552,14 @@ bool GMUnitedMarketPlace::MoveRain(PARTICLE* o)
     }
     else
     {
-        o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f;
-        o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f;
-        o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f;
+        o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         VectorAdd(o->Position, o->Velocity, o->Position);
 
-        o->TurningForce[0] += (float)(rand() % 8 - 4) * 0.02f;
-        o->TurningForce[1] += (float)(rand() % 16 - 8) * 0.02f;
-        o->TurningForce[2] += (float)(rand() % 8 - 4) * 0.02f;
+        o->TurningForce[0] += (float)(rand() % 8 - 4) * 0.02f * FPS_ANIMATION_FACTOR;
+        o->TurningForce[1] += (float)(rand() % 16 - 8) * 0.02f * FPS_ANIMATION_FACTOR;
+        o->TurningForce[2] += (float)(rand() % 8 - 4) * 0.02f * FPS_ANIMATION_FACTOR;
         VectorAdd(o->Angle, o->TurningForce, o->Angle);
 
         vec3_t Range;

--- a/Source Main 5.2/source/GMUnitedMarketPlace.cpp
+++ b/Source Main 5.2/source/GMUnitedMarketPlace.cpp
@@ -538,7 +538,7 @@ bool GMUnitedMarketPlace::MoveRain(PARTICLE* o)
 
     if (o->Type == BITMAP_RAIN)
     {
-        VectorAdd(o->Position, o->Velocity, o->Position);
+        VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
         float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
@@ -555,7 +555,7 @@ bool GMUnitedMarketPlace::MoveRain(PARTICLE* o)
         o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
-        VectorAdd(o->Position, o->Velocity, o->Position);
+        VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
         o->TurningForce[0] += (float)(rand() % 8 - 4) * 0.02f * FPS_ANIMATION_FACTOR;
         o->TurningForce[1] += (float)(rand() % 16 - 8) * 0.02f * FPS_ANIMATION_FACTOR;

--- a/Source Main 5.2/source/GM_Kanturu_2nd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_2nd.cpp
@@ -1401,7 +1401,7 @@ void CTrapCanon::Render_Object(OBJECT* o, BMD* b)
 
 void CTrapCanon::Render_Object_Visual(CHARACTER* c, OBJECT* o, BMD* b)
 {
-    if (c->AttackTime == 0)
+    if ((int)c->AttackTime == 0)
     {
         float fLumi;
         vec3_t vPos, vLight;
@@ -1421,7 +1421,7 @@ void CTrapCanon::Render_Object_Visual(CHARACTER* c, OBJECT* o, BMD* b)
 
 void CTrapCanon::Render_AttackEffect(CHARACTER* c, OBJECT* o, BMD* b)
 {
-    if (c->AttackTime == 1)
+    if ((int)c->AttackTime == 1)
     {
         CHARACTER* tc = &CharactersClient[c->TargetCharacter];
         OBJECT* to = &tc->Object;

--- a/Source Main 5.2/source/GM_Kanturu_2nd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_2nd.cpp
@@ -365,7 +365,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
         EndPos[1] += rand() % 50;
         StartPos[2] += 10.0f;
         EndPos[2] += 10.f;
-        if (rand() % 20 == 0)
+        if (rand_fps_check(20))
         {
             CreateJoint(BITMAP_JOINT_THUNDER, StartPos, EndPos, o->Angle, 18, NULL, 40.f);
         }
@@ -373,7 +373,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 10:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             vec3_t vPos;
             VectorCopy(o->Position, vPos);
@@ -424,7 +424,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 48:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             vec3_t  Light;
             Vector(0.2f, 0.2f, 0.2f, Light);
@@ -447,7 +447,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 50:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             float fBlue = (rand() % 3) * 0.01f + 0.02f;
             vec3_t  Light;
@@ -458,7 +458,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 51:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             float fRed = (rand() % 3) * 0.01f + 0.01f;
             vec3_t  Light;
@@ -469,7 +469,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 52:
     {
-        if (rand() % 6 == 0)
+        if (rand_fps_check(6))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 7, o->Scale);
@@ -478,7 +478,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 53:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.4f, 0.6f, 0.7f, Light);
             CreateParticle(BITMAP_TWINTAIL_WATER, o->Position, o->Angle, Light, 1);
@@ -487,7 +487,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 54:
     {
-        if (rand() % 20 == 0)
+        if (rand_fps_check(20))
         {
             CreateJoint(BITMAP_JOINT_THUNDER + 1, o->Position, o->Position, o->Angle, 8, NULL, 30.f + rand() % 10);
         }
@@ -495,7 +495,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 55:
     {
-        if (rand() % 5 == 0)
+        if (rand_fps_check(5))
         {
             Vector(0.8f, 0.8f, 1.0f, Light);
             CreateEffect(MODEL_FENRIR_THUNDER, o->Position, o->Angle, Light, 1, o);
@@ -504,7 +504,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 56:
     {
-        if (rand() % 10 == 0)
+        if (rand_fps_check(10))
         {
             CreateJoint(BITMAP_JOINT_THUNDER + 1, o->Position, o->Position, o->Angle, 9, NULL, 30.f + rand() % 10);
         }
@@ -512,7 +512,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 65:
     {
-        if (rand() % 10 == 0)
+        if (rand_fps_check(10))
         {
             CreateJoint(BITMAP_JOINT_THUNDER + 1, o->Position, o->Position, o->Angle, 10, NULL, 30.f + rand() % 10);
         }
@@ -763,7 +763,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
             {
                 PlayBuffer(SOUND_KANTURU_2ND_PERSO_MOVE1 + rand() % 2);
             }
@@ -805,12 +805,12 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
         BoneManager::GetBonePosition(o, "PRSona_A1", vPos);
         CreateSprite(BITMAP_LIGHT, vPos, 2.0f, vLight, o);
 
-        if (rand() % 5 == 0)
+        if (rand_fps_check(5))
         {
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 40);
         }
 
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.5f, 0.5f, 0.5f, vLight);
             BoneManager::GetBonePosition(o, "PRSona_Tail", vPos);
@@ -1009,7 +1009,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
 
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
             {
                 PlayBuffer(SOUND_KANTURU_2ND_DRED_MOVE1 + rand() % 2);
             }
@@ -1046,14 +1046,14 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
 
         if (o->CurrentAction != MONSTER01_STOP1 && o->CurrentAction != MONSTER01_DIE && gMapManager.WorldActive != WD_39KANTURU_3RD)
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 BoneManager::GetBonePosition(o, "Dreadfear_Wing32", vPos);
                 CreateParticle(BITMAP_CLUD64, vPos, o->Angle, vLight, 0);
                 BoneManager::GetBonePosition(o, "Dreadfear_Wing34", vPos);
                 CreateParticle(BITMAP_CLUD64, vPos, o->Angle, vLight, 0);
             }
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 BoneManager::GetBonePosition(o, "Dreadfear_Wing51", vPos);
                 CreateParticle(BITMAP_CLUD64, vPos, o->Angle, vLight, 0);
@@ -1098,7 +1098,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
             Vector(1.0f, 1.0f, 2.0f, vLight);
             if (iAnimationFrame < 40)
             {
-                if (rand() % 4 == 0)
+                if (rand_fps_check(4))
                 {
                     BoneManager::GetBonePosition(o, "KANTURU2ND_ENTER_NPC_1", vPos);
                     CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 18, 1.0f);
@@ -1118,7 +1118,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
             }
 
             Vector(1.0f, 1.0f, 2.f, vLight);
-            if (rand() % 4 == 0)
+            if (rand_fps_check(4))
             {
                 BoneManager::GetBonePosition(o, "KANTURU2ND_ENTER_NPC_8", vPos);
                 CreateParticle(BITMAP_CLUD64, vPos, o->Angle, vLight, 2, 2.f);
@@ -1282,13 +1282,13 @@ void M38Kanturu2nd::Move_Kanturu2nd_BlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(0.f, 0.f, 0.f, vRelative);
             if (gMapManager.WorldActive == WD_39KANTURU_3RD)
             {
-                if (rand() % 4 == 0)
+                if (rand_fps_check(4))
                 {
                     BoneManager::GetBonePosition(o, "Twintail_Hair24", vRelative, vPos);
                     CreateJoint(BITMAP_JOINT_ENERGY, vPos, to->Position, o->Angle, 0, to, 30.f);
                 }
 
-                if (rand() % 4 == 0)
+                if (rand_fps_check(4))
                 {
                     BoneManager::GetBonePosition(o, "Twintail_Hair32", vRelative, vPos);
                     CreateJoint(BITMAP_JOINT_ENERGY, vPos, to->Position, o->Angle, 0, to, 30.f);
@@ -1296,13 +1296,13 @@ void M38Kanturu2nd::Move_Kanturu2nd_BlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             }
             else
             {
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     BoneManager::GetBonePosition(o, "Twintail_Hair24", vRelative, vPos);
                     CreateJoint(BITMAP_JOINT_ENERGY, vPos, to->Position, o->Angle, 0, to, 30.f);
                 }
 
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     BoneManager::GetBonePosition(o, "Twintail_Hair32", vRelative, vPos);
                     CreateJoint(BITMAP_JOINT_ENERGY, vPos, to->Position, o->Angle, 0, to, 30.f);

--- a/Source Main 5.2/source/GM_Kanturu_2nd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_2nd.cpp
@@ -1256,7 +1256,7 @@ void M38Kanturu2nd::Move_Kanturu2nd_BlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1322,7 +1322,7 @@ void M38Kanturu2nd::Move_Kanturu2nd_BlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GM_Kanturu_3rd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_3rd.cpp
@@ -403,9 +403,9 @@ bool M39Kanturu3rd::RenderKanturu3rdObjectMesh(OBJECT* o, BMD* b, bool ExtraMon)
         {
             if (g_Direction.m_CKanturu.GetMayaExplotion())
             {
-                o->Light[0] /= 1.02f;
-                o->Light[1] /= 1.02f;
-                o->Light[2] /= 1.02f;
+                o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                 VectorCopy(o->Light, b->BodyLight);
 
@@ -441,9 +441,9 @@ bool M39Kanturu3rd::RenderKanturu3rdObjectMesh(OBJECT* o, BMD* b, bool ExtraMon)
 
             if (g_Direction.m_CKanturu.GetMayaExplotion())
             {
-                o->StartPosition[0] /= 1.02f;
-                o->StartPosition[1] /= 1.02f;
-                o->StartPosition[2] /= 1.02f;
+                o->StartPosition[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->StartPosition[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->StartPosition[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                 VectorCopy(o->StartPosition, b->BodyLight);
             }

--- a/Source Main 5.2/source/GM_Kanturu_3rd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_3rd.cpp
@@ -969,7 +969,7 @@ void M39Kanturu3rd::MoveKanturu3rdBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GM_Kanturu_3rd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_3rd.cpp
@@ -144,7 +144,7 @@ bool M39Kanturu3rd::MoveKanturu3rdObject(OBJECT* o)
     break;
     case 45:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             o->HiddenMesh = -2;
             Luminosity = (float)(rand() % 4 + 3) * 0.3f;
@@ -160,7 +160,7 @@ bool M39Kanturu3rd::MoveKanturu3rdObject(OBJECT* o)
     break;
     case 50:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Luminosity = (float)(rand() % 10) * 0.2f;
             Vector(Luminosity, Luminosity, Luminosity, Light);
@@ -288,7 +288,7 @@ bool M39Kanturu3rd::RenderKanturu3rdObjectVisual(OBJECT* o, BMD* b)
     break;
     case 32:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.4f, 0.6f, 0.7f, Light);
             CreateParticle(BITMAP_TWINTAIL_WATER, o->Position, o->Angle, Light, 1);
@@ -315,20 +315,20 @@ bool M39Kanturu3rd::RenderKanturu3rdObjectVisual(OBJECT* o, BMD* b)
             o->HiddenMesh = -2;
         else
         {
-            if (rand() % 5 == 0)
+            if (rand_fps_check(5))
                 CreateJoint(BITMAP_JOINT_THUNDER + 1, o->Position, o->Position, o->Angle, 11, NULL, o->Scale * 15.0f);
         }
     }
     break;
     case 47:
     {
-        if (rand() % 5 == 0)
+        if (rand_fps_check(5))
             CreateJoint(BITMAP_JOINT_THUNDER + 1, o->Position, o->Position, o->Angle, 11, NULL, o->Scale * 15.0f);
     }
     break;
     case 48:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, o->Light, 10, o->Scale, o);
         }
@@ -364,7 +364,7 @@ bool M39Kanturu3rd::RenderKanturu3rdObjectVisual(OBJECT* o, BMD* b)
     break;
     case 52:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.5f, 1.f, 0.7f, o->Light);
             CreateParticle(BITMAP_TRUE_BLUE, o->Position, o->Angle, o->Light, 1, o->Scale);
@@ -373,7 +373,7 @@ bool M39Kanturu3rd::RenderKanturu3rdObjectVisual(OBJECT* o, BMD* b)
     break;
     case 53:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.3f, 0.3f, 0.3f, o->Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 46, o->Scale);
@@ -382,7 +382,7 @@ bool M39Kanturu3rd::RenderKanturu3rdObjectVisual(OBJECT* o, BMD* b)
     break;
     case 54:
     {
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             o->HiddenMesh = -1;
             CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 19, NULL, o->Scale * 10.0f);
@@ -799,7 +799,7 @@ bool M39Kanturu3rd::MoveKanturu3rdMonsterVisual(OBJECT* o, BMD* b)
     {
         if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_3RD_NIGHTMARE_IDLE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -1083,7 +1083,7 @@ bool M39Kanturu3rd::RenderKanturu3rdMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         CreateSprite(BITMAP_FLARE_BLUE, Position, 0.3f, Light, o);
 
         BoneManager::GetBonePosition(o, "Windmill_Bone1", Position);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 16, 1.0f);
     }
     return true;
@@ -1224,7 +1224,7 @@ bool M39Kanturu3rd::RenderKanturu3rdMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         Position[1] = o->Position[1] + (float)(rand() % 250 - 125);
         Position[2] = o->Position[2] - (float)(rand() % 100) + 50.0f;
 
-        if (rand() % 10 == 0)
+        if (rand_fps_check(10))
         {
             Vector(0.5f, 1.0f, 0.8f, Light);
             CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 17, 0.6f);
@@ -1569,7 +1569,7 @@ void M39Kanturu3rd::MayaAction(OBJECT* o, BMD* b)
 
             if (iMayaDie_Counter == 0)
             {
-                if (rand() % 5 == 0)
+                if (rand_fps_check(5))
                 {
                     for (int j = 0; j < 3; j++)
                     {

--- a/Source Main 5.2/source/GM_Kanturu_3rd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_3rd.cpp
@@ -1369,7 +1369,7 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
         {
-            if (c->AttackTime == 14)
+            if ((int)c->AttackTime == 14)
             {
                 vec3_t vPos, vRelative, Light;
                 Vector(140.f, 0.f, -30.f, vRelative);
@@ -1399,16 +1399,16 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
         {
             Vector(1.0f, 1.0f, 1.0f, Light);
             CreateInferno(o->Position);
-            if (c->AttackTime == 10)
+            if ((int)c->AttackTime == 10)
                 CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
-            else if (c->AttackTime == 14)
+            else if ((int)c->AttackTime == 14)
                 CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
         }
     }
     return true;
     case 362:
     {
-        if (o->CurrentAction == MONSTER01_ATTACK1 && c->AttackTime == 14)
+        if (o->CurrentAction == MONSTER01_ATTACK1 && (int)c->AttackTime == 14)
         {
             CreateInferno(o->Position, 2);
             Vector(0.0f, 0.5f, 1.0f, Light);
@@ -1416,7 +1416,7 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
 
             PlayBuffer(SOUND_KANTURU_3RD_MAYAHAND_ATTACK1);
         }
-        else if (o->CurrentAction == MONSTER01_ATTACK2 && c->AttackTime == 14)
+        else if (o->CurrentAction == MONSTER01_ATTACK2 && (int)c->AttackTime == 14)
         {
             float Matrix[3][4];
             Vector(0.0f, 0.0f, 0.0f, Angle);
@@ -1434,7 +1434,7 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
     return true;
     case 363:
     {
-        if (o->CurrentAction == MONSTER01_ATTACK1 && c->AttackTime == 14)
+        if (o->CurrentAction == MONSTER01_ATTACK1 && (int)c->AttackTime == 14)
         {
             CreateInferno(o->Position, 3);
             Vector(1.0f, 0.5f, 0.0f, Light);
@@ -1442,7 +1442,7 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
 
             PlayBuffer(SOUND_KANTURU_3RD_MAYAHAND_ATTACK1);
         }
-        else if (o->CurrentAction == MONSTER01_ATTACK2 && c->AttackTime == 14)
+        else if (o->CurrentAction == MONSTER01_ATTACK2 && (int)c->AttackTime == 14)
         {
             float Matrix[3][4];
             Vector(0.0f, 0.0f, 0.0f, Angle);

--- a/Source Main 5.2/source/GM_PK_Field.cpp
+++ b/Source Main 5.2/source/GM_PK_Field.cpp
@@ -768,7 +768,7 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         }
         else					//o->CurrentAction == MONSTER01_DIE
         {
-            if (o->LifeTime == 100)
+            if ((int)o->LifeTime == 100)
             {
                 o->LifeTime = 90;
                 o->m_bRenderShadow = false;
@@ -930,7 +930,7 @@ bool CGM_PK_Field::RenderMonster(OBJECT* o, BMD* b, bool ExtraMon)
     {
         if (o->CurrentAction == MONSTER01_DIE)
         {
-            if (o->LifeTime == 100)
+            if ((int)o->LifeTime == 100)
             {
                 switch (o->Type)
                 {

--- a/Source Main 5.2/source/GM_PK_Field.cpp
+++ b/Source Main 5.2/source/GM_PK_Field.cpp
@@ -236,7 +236,7 @@ void CGM_PK_Field::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
 
             float fDelay = 5.0f;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / fDelay;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < fDelay; i++)

--- a/Source Main 5.2/source/GM_PK_Field.cpp
+++ b/Source Main 5.2/source/GM_PK_Field.cpp
@@ -380,7 +380,7 @@ bool CGM_PK_Field::RenderObjectVisual(OBJECT* o, BMD* b)
     case 1:
     {
         o->HiddenMesh = -2;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.0f, 1.0f, 1.0f, Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 60, o->Scale, o);
@@ -391,7 +391,7 @@ bool CGM_PK_Field::RenderObjectVisual(OBJECT* o, BMD* b)
     {
         o->HiddenMesh = -2;
         vec3_t  Light;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.f, 0.f, 0.f, Light);
             CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 16, o->Scale, o);
@@ -401,7 +401,7 @@ bool CGM_PK_Field::RenderObjectVisual(OBJECT* o, BMD* b)
     case 3:
     {
         o->HiddenMesh = -2;
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             float fRed = (rand() % 3) * 0.01f + 0.015f;
             Vector(fRed, 0.0f, 0.0f, Light);
@@ -414,7 +414,7 @@ bool CGM_PK_Field::RenderObjectVisual(OBJECT* o, BMD* b)
         o->HiddenMesh = -2;
         Vector(1.0f, 0.4f, 0.4f, Light);
         vec3_t vAngle;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector((float)(rand() % 40 + 120), 0.f, (float)(rand() % 30), vAngle);
             VectorAdd(vAngle, o->Angle, vAngle);
@@ -426,7 +426,7 @@ bool CGM_PK_Field::RenderObjectVisual(OBJECT* o, BMD* b)
     case 5:
     {
         o->HiddenMesh = -2;
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(0.3f, 0.3f, 0.3f, o->Light);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 21, o->Scale);
@@ -701,7 +701,7 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     case MODEL_MONSTER01 + 159:
     {
         vec3_t p, Position;
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             Vector(0.0f, 50.0f, 0.0f, p);
             b->TransformPosition(o->BoneTransform[6], p, Position, true);
@@ -854,7 +854,7 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         }
 
         vec3_t p, Position;
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             Vector(0.0f, 50.0f, 0.0f, p);
             b->TransformPosition(o->BoneTransform[7], p, Position, true);
@@ -1092,7 +1092,7 @@ bool CGM_PK_Field::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_PKFIELD_ZOMBIEWARRIOR_MOVE01);
             }
@@ -1118,7 +1118,7 @@ bool CGM_PK_Field::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_PKFIELD_RAISEDGLADIATOR_MOVE01);
             }
@@ -1144,7 +1144,7 @@ bool CGM_PK_Field::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_PKFIELD_ASHESBUTCHER_MOVE01);
             }
@@ -1171,7 +1171,7 @@ bool CGM_PK_Field::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_PKFIELD_BLOODASSASSIN_MOVE01);
             }
@@ -1202,7 +1202,7 @@ bool CGM_PK_Field::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_PKFIELD_BURNINGLAVAGOLEM_MOVE01);
             }

--- a/Source Main 5.2/source/GM_Raklion.cpp
+++ b/Source Main 5.2/source/GM_Raklion.cpp
@@ -1534,7 +1534,7 @@ bool CGM_Raklion::RenderMonster(OBJECT* o, BMD* b, bool ExtraMon)
         if (o->CurrentAction == MONSTER01_DIE)
         {
             float fBlendLight = 20.f - o->AnimationFrame;
-            fBlendLight /= 15;
+            fBlendLight *= pow(1.0f / (15), FPS_ANIMATION_FACTOR);
             vec3_t vOriginPos;
             VectorCopy(o->Position, vOriginPos);
 

--- a/Source Main 5.2/source/GM_Raklion.cpp
+++ b/Source Main 5.2/source/GM_Raklion.cpp
@@ -1769,7 +1769,7 @@ bool CGM_Raklion::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         {
             CreateInferno(o->Position, 5);
         }
-        else if (o->CurrentAction == MONSTER01_DIE && o->LifeTime == 100)
+        else if (o->CurrentAction == MONSTER01_DIE && (int)o->LifeTime == 100)
         {
             const int nBonesCount = 8;
             int iBones[nBonesCount] = { 4, 7, 10, 22, 39, 44, 12, 24 };
@@ -2026,7 +2026,7 @@ bool CGM_Raklion::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         {
             CreateInferno(o->Position, 5);
         }
-        else if (o->CurrentAction == MONSTER01_DIE && o->LifeTime == 100)
+        else if (o->CurrentAction == MONSTER01_DIE && (int)o->LifeTime == 100)
         {
             const int nBonesCount = 8;
             int iBones[nBonesCount] = { 4, 7, 10, 22, 39, 44, 12, 24 };

--- a/Source Main 5.2/source/GM_Raklion.cpp
+++ b/Source Main 5.2/source/GM_Raklion.cpp
@@ -351,7 +351,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
     break;
     case MODEL_MONSTER01 + 146:
     {
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         vec3_t Light;
         vec3_t EndPos, EndRelative;
         Vector(1.f, 1.f, 1.f, Light);
@@ -802,7 +802,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
     break;
     case MODEL_MONSTER01 + 205:
     {
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         vec3_t Light;
         vec3_t EndPos, EndRelative;
         Vector(1.f, 1.f, 1.f, Light);
@@ -991,7 +991,7 @@ void CGM_Raklion::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1049,7 +1049,7 @@ void CGM_Raklion::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1813,7 +1813,7 @@ bool CGM_Raklion::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         vec3_t StartPos, StartRelative;
         vec3_t EndPos, EndRelative;
 
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fSpeedPerFrame = fActionSpeed / 10.f;
         float fAnimationFrame = o->AnimationFrame - fActionSpeed;
         for (int i = 0; i < 10; i++)
@@ -1940,7 +1940,7 @@ bool CGM_Raklion::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         vec3_t StartPos, StartRelative;
         vec3_t EndPos, EndRelative;
 
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fSpeedPerFrame = fActionSpeed / 10.f;
         float fAnimationFrame = o->AnimationFrame - fActionSpeed;
         for (int i = 0; i < 10; i++)
@@ -2067,7 +2067,7 @@ bool CGM_Raklion::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         vec3_t StartPos, StartRelative;
         vec3_t EndPos, EndRelative;
 
-        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+        float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
         float fSpeedPerFrame = fActionSpeed / 10.f;
         float fAnimationFrame = o->AnimationFrame - fActionSpeed;
         for (int i = 0; i < 10; i++)

--- a/Source Main 5.2/source/GM_Raklion.cpp
+++ b/Source Main 5.2/source/GM_Raklion.cpp
@@ -403,7 +403,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
         else
         if(o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if(rand()%10==0) {
+            if(rand_fps_check(10)) {
                 CreateParticle ( BITMAP_SMOKE+1, o->Position, o->Angle, Light );
             }
         }
@@ -466,12 +466,12 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
                     for (int i = 0; i < b->NumBones; ++i)
                     {
                         b->TransformByObjectBone(vPos, o, i);
-                        if (rand() % 5 == 0)
+                        if (rand_fps_check(5))
                         {
                             Vector(0.0f, 1.f, 0.2f, vLight);
                             CreateParticle(BITMAP_WATERFALL_5, vPos, o->Angle, vLight, 8, 2.0f);
                         }
-                        if (rand() % 5 == 0)
+                        if (rand_fps_check(5))
                         {
                             Vector(0.1f, 1.f, 0.1f, vLight);
                             CreateParticle(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 8, 2.5f);
@@ -479,7 +479,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
                     }
                 }
 
-                if (rand() % 3 == 0)
+                if (rand_fps_check(3))
                 {
                     VectorCopy(o->Position, vPos);
                     vPos[0] += (float)(rand() % 200 - 100);
@@ -529,7 +529,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
                     vPos[2] = Hero->Object.Position[2] + 300.0f + (float)(rand() % 10) * 100.0f;
                     float fScale = 1.0f + (rand() % 10) / 5.0f;
                     int iIndex = MODEL_EFFECT_BROKEN_ICE1;
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         iIndex = MODEL_EFFECT_BROKEN_ICE3;
                     }
@@ -685,12 +685,12 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
                 for (int i = 0; i < b->NumBones; ++i)
                 {
                     b->TransformByObjectBone(vPos, o, i);
-                    if (rand() % 5 == 0)
+                    if (rand_fps_check(5))
                     {
                         Vector(0.0f, 1.f, 0.2f, vLight);
                         CreateParticle(BITMAP_WATERFALL_5, vPos, o->Angle, vLight, 8, 2.0f);
                     }
-                    if (rand() % 5 == 0)
+                    if (rand_fps_check(5))
                     {
                         Vector(0.1f, 1.f, 0.1f, vLight);
                         CreateParticle(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 8, 2.5f);
@@ -698,7 +698,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
                 }
             }
 
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 VectorCopy(o->Position, vPos);
                 vPos[0] += (float)(rand() % 400 - 200);
@@ -739,7 +739,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
             Vector(1.0f, 0.1f, 0.1f, vLight);
             for (int k = 0; k < 1; ++k)
             {
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     vec3_t vPos1, vPos2;
                     b->TransformByObjectBone(vPos1, o, 34);
@@ -788,7 +788,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
                 Vector(0.2f, 0.4f, 1.0f, vLight);
                 CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 11, 1.2f);
 
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     VectorCopy(o->Position, vPos);
                     vPos[0] += (float)(rand() % 200 - 100);
@@ -854,7 +854,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
         else
         if(o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
         {
-            if(rand()%10==0) {
+            if(rand_fps_check(10)) {
                 CreateParticle ( BITMAP_SMOKE+1, o->Position, o->Angle, Light );
             }
         }
@@ -917,12 +917,12 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
                     for (int i = 0; i < b->NumBones; ++i)
                     {
                         b->TransformByObjectBone(vPos, o, i);
-                        if (rand() % 5 == 0)
+                        if (rand_fps_check(5))
                         {
                             Vector(0.0f, 1.f, 0.2f, vLight);
                             CreateParticle(BITMAP_WATERFALL_5, vPos, o->Angle, vLight, 8, 2.0f);
                         }
-                        if (rand() % 5 == 0)
+                        if (rand_fps_check(5))
                         {
                             Vector(0.1f, 1.f, 0.1f, vLight);
                             CreateParticle(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 8, 2.5f);
@@ -930,7 +930,7 @@ bool CGM_Raklion::MoveMonsterVisual(OBJECT* o, BMD* b)
                     }
                 }
 
-                if (rand() % 3 == 0)
+                if (rand_fps_check(3))
                 {
                     VectorCopy(o->Position, vPos);
                     vPos[0] += (float)(rand() % 200 - 100);
@@ -1606,33 +1606,33 @@ bool CGM_Raklion::RenderMonster(OBJECT* o, BMD* b, bool ExtraMon)
                 {
                     b->TransformByObjectBone(vPos, o, 57);
                     CreateSprite(BITMAP_LIGHT, vPos, 3.f, vLight, o);
-                    if (rand() % 100 == 0)
+                    if (rand_fps_check(100))
                         CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 33, 1.f);
                 }
                 else if (o->Type == MODEL_MONSTER01 + 152)
                 {
                     b->TransformByObjectBone(vPos, o, 95);
                     CreateSprite(BITMAP_LIGHT, vPos, 3.f, vLight, o);
-                    if (rand() % 100 == 0)
+                    if (rand_fps_check(100))
                         CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 33, 1.f);
                     b->TransformByObjectBone(vPos, o, 115);
                     CreateSprite(BITMAP_LIGHT, vPos, 3.f, vLight, o);
-                    if (rand() % 100 == 0)
+                    if (rand_fps_check(100))
                         CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 33, 1.f);
                 }
                 else
                 {
                     b->TransformByObjectBone(vPos, o, 95);
                     CreateSprite(BITMAP_LIGHT, vPos, 3.f, vLight, o);
-                    if (rand() % 100 == 0)
+                    if (rand_fps_check(100))
                         CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 33, 1.f);
                     b->TransformByObjectBone(vPos, o, 115);
                     CreateSprite(BITMAP_LIGHT, vPos, 3.f, vLight, o);
-                    if (rand() % 100 == 0)
+                    if (rand_fps_check(100))
                         CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 33, 1.f);
                     b->TransformByObjectBone(vPos, o, 173);
                     CreateSprite(BITMAP_LIGHT, vPos, 3.f, vLight, o);
-                    if (rand() % 100 == 0)
+                    if (rand_fps_check(100))
                         CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 33, 1.f);
                 }
             }
@@ -2219,7 +2219,7 @@ bool CGM_Raklion::CreateSnow(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     o->Scale = (float)(rand() % 10 + 3);
-    if (rand() % 10 == 0)
+    if (rand_fps_check(10))
     {
         o->Scale = (float)(rand() % 3 + 10);
     }
@@ -2536,7 +2536,7 @@ bool CGM_Raklion::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_RAKLION_ICEWALKER_MOVE);
             }
@@ -2556,7 +2556,7 @@ bool CGM_Raklion::PlayMonsterSound(OBJECT* o)
         else
             if (o->CurrentAction == MONSTER01_WALK)
             {
-                if (rand() % 100 == 0)
+                if (rand_fps_check(100))
                 {
                     PlayBuffer(SOUND_RAKLION_GIANT_MAMUD_MOVE);
                 }
@@ -2570,7 +2570,7 @@ bool CGM_Raklion::PlayMonsterSound(OBJECT* o)
     case MODEL_MONSTER01 + 147:
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_RAKLION_ICEGIANT_MOVE);
             }
@@ -2587,7 +2587,7 @@ bool CGM_Raklion::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_RAKLION_COOLERTIN_MOVE);
             }
@@ -2637,7 +2637,7 @@ bool CGM_Raklion::PlayMonsterSound(OBJECT* o)
         }
         else if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_RAKLION_GIANT_MAMUD_MOVE);
             }
@@ -2650,7 +2650,7 @@ bool CGM_Raklion::PlayMonsterSound(OBJECT* o)
     case MODEL_MONSTER01 + 206:
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 PlayBuffer(SOUND_RAKLION_ICEGIANT_MOVE);
             }
@@ -2681,7 +2681,7 @@ bool CGM_Raklion::PlayMonsterSound(OBJECT* o)
         }
         else if (MONSTER01_WALK == o->CurrentAction)
         {
-            if (rand() % 20 == 0)
+            if (rand_fps_check(20))
             {
                 PlayBuffer(SOUND_RAKLION_COOLERTIN_MOVE);
             }
@@ -2793,7 +2793,7 @@ void CGM_Raklion::MoveEffect()
         }
         else
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 CreateMapEffect();
             }

--- a/Source Main 5.2/source/GM_kanturu_1st.cpp
+++ b/Source Main 5.2/source/GM_kanturu_1st.cpp
@@ -1619,7 +1619,7 @@ void M37Kanturu1st::MoveKanturu1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1655,7 +1655,7 @@ void M37Kanturu1st::MoveKanturu1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1691,7 +1691,7 @@ void M37Kanturu1st::MoveKanturu1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1723,7 +1723,7 @@ void M37Kanturu1st::MoveKanturu1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1760,7 +1760,7 @@ void M37Kanturu1st::MoveKanturu1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 18; i++)
@@ -1814,7 +1814,7 @@ void M37Kanturu1st::MoveKanturu1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1850,7 +1850,7 @@ void M37Kanturu1st::MoveKanturu1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -1886,7 +1886,7 @@ void M37Kanturu1st::MoveKanturu1stBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 18; i++)

--- a/Source Main 5.2/source/GM_kanturu_1st.cpp
+++ b/Source Main 5.2/source/GM_kanturu_1st.cpp
@@ -709,7 +709,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
             CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 4.0f);
         }
 
-        if (c->AttackTime == 10)
+        if ((int)c->AttackTime == 10)
         {
             vec3_t vPos, vRelative;
             Vector(0.f, 0.f, 0.f, vRelative);
@@ -724,7 +724,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
         {
-            if (c->AttackTime == 14)
+            if ((int)c->AttackTime == 14)
                 //				if(o->AnimationFrame >= StartAction && o->AnimationFrame < (StartAction + fActionSpeed))
             {
                 vec3_t vPos, vRelative, Light;
@@ -772,7 +772,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
             BoneManager::GetBonePosition(o, "KENTAUROS_BIP_21", vRelative, vPos);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, index, Width);
         }
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             vec3_t vPos, vRelative;
 
@@ -829,7 +829,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
             BoneManager::GetBonePosition(o, "KENTAUROS_BIP_21", vRelative, vPos);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, index, Width);
         }
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             vec3_t vPos, vRelative;
 

--- a/Source Main 5.2/source/GM_kanturu_1st.cpp
+++ b/Source Main 5.2/source/GM_kanturu_1st.cpp
@@ -149,7 +149,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
     }
     break;
     case 59:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_SMOKE, pObject->Position, pObject->Angle,
@@ -157,7 +157,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
         }
         break;
     case 61:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             Vector(1.f, 1.f, 1.f, Light);
             CreateParticle(BITMAP_TRUE_FIRE, pObject->Position, pObject->Angle,
@@ -187,7 +187,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 81:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_WATERFALL_1, pObject->Position,
                 pObject->Angle, Light, 2, pObject->Scale);
         break;
@@ -198,7 +198,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 83:
         Vector(1.f, 1.f, 1.f, Light);
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
             CreateParticle(BITMAP_WATERFALL_2, pObject->Position,
                 pObject->Angle, Light, 2, pObject->Scale);
         break;
@@ -237,7 +237,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
         pModel->StreamMesh = -1;
         break;
     case 98:
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             vec3_t vPos;
             Vector(0.0f, 0.0f, 0.0f, vPos);
@@ -267,7 +267,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
         EndPos[1] += rand() % 50;
         StartPos[2] += 10.0f;
         EndPos[2] += 10.f;
-        if (rand() % 20 == 0)
+        if (rand_fps_check(20))
             CreateJoint(BITMAP_JOINT_THUNDER, StartPos, EndPos,
                 pObject->Angle, 8, NULL, 40.f);
     }
@@ -601,7 +601,7 @@ bool M37Kanturu1st::SetCurrentActionKanturu1stMonster(CHARACTER* c, OBJECT* o)
     case 351:
     case 352:
     {
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             SetAction(o, MONSTER01_ATTACK1);
         else
             SetAction(o, MONSTER01_ATTACK2);
@@ -644,7 +644,7 @@ bool M37Kanturu1st::SetCurrentActionKanturu1stMonster(CHARACTER* c, OBJECT* o)
     break;
     case 555:
     {
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             SetAction(o, MONSTER01_ATTACK1);
         else
             SetAction(o, MONSTER01_ATTACK2);
@@ -1093,7 +1093,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_BER_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1135,7 +1135,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_GIGAN_MOVE1);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1184,7 +1184,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_GENO_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1226,7 +1226,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
 
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_SWOLF_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1265,7 +1265,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
 
             if (o->CurrentAction == MONSTER01_WALK)
             {
-                if (rand() % 15 == 0)
+                if (rand_fps_check(15))
                     PlayBuffer(SOUND_KANTURU_1ST_IR_MOVE1 + rand() % 2);
             }
             else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1298,7 +1298,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_SATI_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1346,7 +1346,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         }
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 10 == 0)
+            if (rand_fps_check(10))
             {
                 if (gMapManager.WorldActive != WD_39KANTURU_3RD)
                     CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, o->Light);
@@ -1376,7 +1376,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_KENTA_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1416,7 +1416,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         else
             if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
             {
-                if (rand() % 10 == 0) {
+                if (rand_fps_check(10)) {
                     CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, o->Light);
                 }
             }
@@ -1426,7 +1426,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_BER_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1465,7 +1465,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_KENTA_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1506,7 +1506,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         {
             if (o->CurrentAction == MONSTER01_WALK || o->CurrentAction == MONSTER01_RUN)
             {
-                if (rand() % 10 == 0) {
+                if (rand_fps_check(10)) {
                     CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, o->Light);
                 }
             }
@@ -1517,7 +1517,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_GIGAN_MOVE1);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
@@ -1563,7 +1563,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (rand() % 15 == 0)
+            if (rand_fps_check(15))
                 PlayBuffer(SOUND_KANTURU_1ST_GENO_MOVE1 + rand() % 2);
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)

--- a/Source Main 5.2/source/GM_kanturu_1st.cpp
+++ b/Source Main 5.2/source/GM_kanturu_1st.cpp
@@ -107,7 +107,7 @@ bool M37Kanturu1st::MoveKanturu1stObject(OBJECT* pObject)
         break;
     case 97:
         pObject->HiddenMesh = -2;
-        pObject->Timer += 0.1f;
+        pObject->Timer += 0.1f * FPS_ANIMATION_FACTOR;
         if (pObject->Timer > 10.f)
             pObject->Timer = 0.f;
         if (pObject->Timer > 5.f)

--- a/Source Main 5.2/source/GOBoid.cpp
+++ b/Source Main 5.2/source/GOBoid.cpp
@@ -733,7 +733,10 @@ void RenderDarkHorseSkill(OBJECT* o, BMD* b)
     if (o == NULL)	return;
     if (b == NULL)	return;
 
+    // The weapon level is misused here to count how many frames have been rendered
+    // for this effect...
     o->WeaponLevel++;
+
     if (o->LastHorseWaveEffect < WorldTime - HorseEffectInterval)
     {
         CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, o->Light);
@@ -742,25 +745,25 @@ void RenderDarkHorseSkill(OBJECT* o, BMD* b)
 
     if (o->AnimationFrame >= 8.f && o->AnimationFrame <= 9.5f)
     {
-        if ((o->WeaponLevel % 2) == 1)
+        if (rand_fps_check(2))
         {
             float  Matrix[3][4];
             vec3_t Angle, p, Position;
-            Vector(0.f, 150.f * (o->WeaponLevel / 2), 0.f, p);
+            Vector(0.f, 150.f * (o->WeaponLevel / 2) * FPS_ANIMATION_FACTOR, 0.f, p);
             Vector(0.f, 0.f, (float)(rand() % 360), Angle);
             for (int i = 0; i < 6; ++i)
             {
                 Angle[2] += 60.f;
                 AngleMatrix(Angle, Matrix);
                 VectorRotate(p, Matrix, Position);
-                VectorAddScaled(o->Position, Position, Position, FPS_ANIMATION_FACTOR);
+                VectorAdd(o->Position, Position, Position);
 
                 CreateEffect(MODEL_GROUND_STONE + rand() % 2, Position, o->Angle, o->Light);
             }
         }
         EarthQuake = (rand() % 3 - 3) * 0.7f;
     }
-    else if (o->WeaponLevel == 19)
+    else if (o->WeaponLevel == (BYTE)(19.f / FPS_ANIMATION_FACTOR))
     {
         CreateEffect(MODEL_SKILL_FURY_STRIKE, o->Position, o->Angle, o->Light, 0, o, -1, 0, 2);
         o->WeaponLevel = -3;
@@ -784,7 +787,7 @@ void RenderSkillEarthQuake(CHARACTER* c, OBJECT* o, BMD* b, int iMaxSkill)
         o->WeaponLevel == iMaxSkill - 1 ||
         o->WeaponLevel == iMaxSkill - 0)
     {
-        Vector(0.f, 40.f * (o->WeaponLevel / 2), 0.f, p);
+        Vector(0.f, 40.f * (o->WeaponLevel / 2) * FPS_ANIMATION_FACTOR, 0.f, p);
         Vector(0.f, 0.f, (float)(rand() % 360), Angle);
         for (int i = 0; i < 6; ++i)
         {

--- a/Source Main 5.2/source/GOBoid.cpp
+++ b/Source Main 5.2/source/GOBoid.cpp
@@ -1008,9 +1008,9 @@ void MoveHeavenBug(OBJECT* o, int index)
 {
     const float iFrame = WorldTime / 40.0f;
 
-    o->Position[0] += o->Velocity * (float)sinf(o->Angle[2]);
-    o->Position[1] -= o->Velocity * (float)cosf(o->Angle[2]);
-    o->Angle[2] += 0.01f * cosf((float)(34571 + iFrame + index * 41273) * 0.0003f) * sinf((float)(17732 + iFrame + index * 5161) * 0.0003f);
+    o->Position[0] += o->Velocity * (float)sinf(o->Angle[2]) * FPS_ANIMATION_FACTOR;
+    o->Position[1] -= o->Velocity * (float)cosf(o->Angle[2]) * FPS_ANIMATION_FACTOR;
+    o->Angle[2] += 0.01f * cosf((float)(34571 + iFrame + index * 41273) * 0.0003f) * sinf((float)(17732 + iFrame + index * 5161) * 0.0003f) * FPS_ANIMATION_FACTOR;
 
     float dx = o->Position[0] - Hero->Object.Position[0];
     float dy = o->Position[1] - Hero->Object.Position[1];
@@ -1095,8 +1095,8 @@ void MoveEagle(OBJECT* o)
             o->AI = BOID_FLY;
             o->HeadAngle[2] = 0;
 
-            o->HeadAngle[0] = cosf(fSeedAngle) * fFlyRange;
-            o->HeadAngle[1] = sinf(fSeedAngle) * fFlyRange;
+            o->HeadAngle[0] = cosf(fSeedAngle) * fFlyRange * FPS_ANIMATION_FACTOR;
+            o->HeadAngle[1] = sinf(fSeedAngle) * fFlyRange * FPS_ANIMATION_FACTOR;
             fAngle = CreateAngle(o->Position[0], o->Position[1], o->Position[0] + o->HeadAngle[0], o->Position[1] + o->HeadAngle[1]);
         }
     }
@@ -1115,10 +1115,10 @@ void MoveTornado(OBJECT* o)
     {
         o->HeadAngle[0] = (rand() % 314) / 100.0f;
     }
-    o->Position[0] += sinf(o->HeadAngle[0]) * 2.0f;
-    o->Position[1] += cosf(o->HeadAngle[0]) * 2.0f;
+    o->Position[0] += sinf(o->HeadAngle[0]) * 2.0f * FPS_ANIMATION_FACTOR;
+    o->Position[1] += cosf(o->HeadAngle[0]) * 2.0f * FPS_ANIMATION_FACTOR;
     o->Angle[2] = 0;
-    if (o->BlendMeshLight < 1.0f) o->BlendMeshLight += 0.1f;
+    if (o->BlendMeshLight < 1.0f) o->BlendMeshLight += 0.1f * FPS_ANIMATION_FACTOR;
 }
 
 void MoveBoidGroup(OBJECT* o, int index)
@@ -1126,7 +1126,10 @@ void MoveBoidGroup(OBJECT* o, int index)
     if (o->AI != BOID_GROUND)
     {
         if (o->Type != MODEL_BUTTERFLY01 || rand() % 4 == 0)
+        {
             MoveBoid(o, index, Boids, MAX_BOIDS);
+        }
+
         AngleMatrix(o->Angle, o->Matrix);
         vec3_t p, Direction;
         if (gMapManager.WorldActive == WD_7ATLANSE || gMapManager.WorldActive == WD_67DOPPLEGANGER3)
@@ -1135,20 +1138,20 @@ void MoveBoidGroup(OBJECT* o, int index)
             {
                 if (index < 35)
                 {
-                    Vector(o->Velocity * (float)(rand() % 16 + 8), 0.f, o->Direction[2], Direction);
+                    Vector(FPS_ANIMATION_FACTOR * o->Velocity * (float)(rand() % 16 + 8), 0.f, o->Direction[2], Direction);
                 }
                 else
                 {
-                    Vector(o->Velocity * (float)(rand() % 16 + 16), 0.f, o->Direction[2], Direction);
+                    Vector(FPS_ANIMATION_FACTOR * o->Velocity * (float)(rand() % 16 + 16), 0.f, o->Direction[2], Direction);
                 }
                 o->Gravity = 15;
             }
             else
             {
-                Vector(o->Velocity * (float)(rand() % 32 + 32), 0.f, o->Direction[2], Direction);
+                Vector(FPS_ANIMATION_FACTOR * o->Velocity * (float)(rand() % 32 + 32), 0.f, o->Direction[2], Direction);
                 o->Gravity = 5;
             }
-            o->Timer += 0.1f;
+            o->Timer += 0.1f * FPS_ANIMATION_FACTOR;
             if (o->Timer >= 10)
             {
                 o->Timer = 0.f;
@@ -1205,9 +1208,10 @@ void MoveBoids()
         vec3_t Position, Angle, Light;
         if (rand() % 40 == 0)
         {
-            Vector(Hero->Object.Position[0] + (float)(rand() % 600 - 200),
-                Hero->Object.Position[1] + (float)(rand() % 400 + 200),
-                Hero->Object.Position[2] + 300.f, Position);
+            Vector(Hero->Object.Position[0] + (float)(rand() % 600 - 200) * FPS_ANIMATION_FACTOR,
+                Hero->Object.Position[1] + (float)(rand() % 400 + 200) * FPS_ANIMATION_FACTOR,
+                Hero->Object.Position[2] + 300.f * FPS_ANIMATION_FACTOR,
+                Position);
             Vector(0.f, 0.f, 0.f, Angle);
             Vector(1.f, 1.f, 1.f, Light);
             CreateEffect(MODEL_FIRE, Position, Angle, Light, 3);
@@ -1300,7 +1304,8 @@ void MoveBoids()
                     }
                     Vector(Hero->Object.Position[0] + (float)(rand() % 600 - 100),
                         Hero->Object.Position[1] + (float)(rand() % 400 + 200),
-                        Hero->Object.Position[2] + 300.f, o->Position);
+                        Hero->Object.Position[2] + 300.f,
+                        o->Position);
                 }
             }
             else if (gMapManager.WorldActive == WD_0LORENCIA
@@ -1402,13 +1407,13 @@ void MoveBoids()
                 b->PlayAnimation(&o->AnimationFrame, &o->PriorAnimationFrame, &o->PriorAction, PlaySpeed, o->Position, o->Angle);
                 AngleMatrix(o->Angle, o->Matrix);
                 vec3_t Position, Direction;
-                Vector(o->Scale * 40.f, 0.f, 0.f, Position);
+                Vector(o->Scale * 40.f * FPS_ANIMATION_FACTOR, 0.f, 0.f, Position);
                 VectorRotate(Position, o->Matrix, Direction);
                 VectorAdd(o->Position, Direction, o->Position);
                 o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]) + 300.f;
                 o->Position[2] += -absf(sinf(o->Timer)) * 100.f + 100.f;
-                o->Timer += o->Scale * 0.05f;
-                o->LifeTime--;
+                o->Timer += o->Scale * 0.05f * FPS_ANIMATION_FACTOR;
+                o->LifeTime -= FPS_ANIMATION_FACTOR;
                 if (o->LifeTime <= 0)
                     o->Live = false;
                 if (rand() % 128 == 0)
@@ -1470,9 +1475,16 @@ void MoveBoids()
                     o->SubType++;
                 }
 
-                if (o->Type == MODEL_EAGLE || o->Type == MODEL_MAP_TORNADO);
-                else if (o->SubType >= 2) o->Live = false;
-                o->LifeTime--;
+                if (o->Type == MODEL_EAGLE || o->Type == MODEL_MAP_TORNADO)
+                {
+                    // do nothing?
+                }
+                else if (o->SubType >= 2)
+                {
+                    o->Live = false;
+                }
+
+                o->LifeTime -= FPS_ANIMATION_FACTOR;
 
                 float dx = o->Position[0] - Hero->Object.Position[0];
                 float dy = o->Position[1] - Hero->Object.Position[1];
@@ -1791,7 +1803,7 @@ void MoveFishs()
             if (o->Type == MODEL_FISH01 + 7 || o->Type == MODEL_FISH01 + 8)
             {
                 o->BlendMeshLight = sinf(o->Timer) * 0.4f + 0.5f;
-                o->Timer += 0.1f;
+                o->Timer += 0.1f * FPS_ANIMATION_FACTOR;
             }
 
             if ((o->Type >= MODEL_FISH01 && o->Type <= MODEL_FISH01 + 10) ||
@@ -1806,7 +1818,7 @@ void MoveFishs()
                 MoveBoid(o, i, Fishs, MAX_FISHS);
                 AngleMatrix(o->Angle, o->Matrix);
                 vec3_t Position, Direction;
-                Vector(o->Velocity * (float)(rand() % 4 + 6), 0.f, 0.f, Position);
+                Vector(o->Velocity * (float)(rand() % 4 + 6) * FPS_ANIMATION_FACTOR, 0.f, 0.f, Position);
                 VectorRotate(Position, o->Matrix, Direction);
                 VectorAdd(o->Position, Direction, o->Position);
                 if (gMapManager.WorldActive != 7 || gMapManager.InHellas() == false || gMapManager.WorldActive != WD_67DOPPLEGANGER3)
@@ -1871,7 +1883,7 @@ void MoveFishs()
                 SetAction(o, 0);
             }
 
-            o->LifeTime--;
+            o->LifeTime -= FPS_ANIMATION_FACTOR;
             if (o->LifeTime <= 0)
             {
                 if (o->Type == MODEL_BUG01)

--- a/Source Main 5.2/source/GOBoid.cpp
+++ b/Source Main 5.2/source/GOBoid.cpp
@@ -304,7 +304,7 @@ bool MoveMount(OBJECT* o, bool bForceRender)
                         }
                     }
                 }
-                else if (rand() % 3 == 0 && !gMapManager.InHellas())
+                else if (rand_fps_check(3) && !gMapManager.InHellas())
                 {
                     if (o->Owner && !g_isCharacterBuff(o->Owner, eBuff_Cloaking))
                     {
@@ -387,7 +387,7 @@ bool MoveMount(OBJECT* o, bool bForceRender)
                         }
                     }
                 }
-                else if (rand() % 2 == 0 && !gMapManager.InHellas())
+                else if (rand_fps_check(2) && !gMapManager.InHellas())
                 {
                     if (o->Owner && !g_isCharacterBuff(o->Owner, eBuff_Cloaking))
                     {
@@ -432,7 +432,7 @@ bool MoveMount(OBJECT* o, bool bForceRender)
             {
                 if (o->Owner && !g_isCharacterBuff(o->Owner, eBuff_Cloaking))
                 {
-                    if (rand() % 3 == 0)
+                    if (rand_fps_check(3))
                     {
                         vec3_t p = { 50.f, -4.f, 0.f };
                         b->TransformPosition(BoneTransform[27], p, Position);
@@ -539,7 +539,7 @@ bool MoveMount(OBJECT* o, bool bForceRender)
                     SetAction(o, 2);
                 }
 
-                if (rand() % 2 == 0 && gMapManager.WorldActive != WD_10HEAVEN)
+                if (rand_fps_check(2) && gMapManager.WorldActive != WD_10HEAVEN)
                 {
                     if (!g_Direction.m_CKanturu.IsMayaScene())
 
@@ -599,7 +599,7 @@ bool MoveMount(OBJECT* o, bool bForceRender)
         case MODEL_BUTTERFLY01:
             FlyRange = 100.f;
             Vector(0.4f, 0.6f, 1.f, Light);
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 1);
             break;
         case MODEL_HELPER:
@@ -638,7 +638,7 @@ bool MoveMount(OBJECT* o, bool bForceRender)
             VectorRotate(o->Direction, o->Matrix, Direction);
             VectorAdd(o->Position, Direction, o->Position);
             o->Position[2] += (float)(rand() % 16 - 8);
-            if (rand() % 32 == 0)
+            if (rand_fps_check(32))
             {
                 float Speed = 0;
                 if (Distance >= FlyRange * FlyRange)
@@ -923,28 +923,28 @@ int CreateAtlanseFish(OBJECT* o)
 void MoveBat(OBJECT* o)
 {
     o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
-    o->Position[2] += -absf(sinf(o->Timer)) * 150.f + 350.f;
+    o->Position[2] += ( - absf(sinf(o->Timer)) * 150.f + 350.f) * FPS_ANIMATION_FACTOR;
     o->Timer += 0.2f;
 }
 
 void MoveButterFly(OBJECT* o)
 {
-    if (rand() % 32 == 0)
+    if (rand_fps_check(32))
     {
         o->Angle[2] = (float)(rand() % 360);
         o->Direction[2] = (float)(rand() % 15 - 7) * 1.f;
     }
-    o->Direction[2] += (float)(rand() % 15 - 7) * 0.2f;
+    o->Direction[2] += (float)(rand() % 15 - 7) * 0.2f * FPS_ANIMATION_FACTOR;
     float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
     if (o->Position[2] < Height + 50.f)
     {
-        o->Direction[2] *= 0.8f;
-        o->Direction[2] += 1.f;
+        o->Direction[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+        o->Direction[2] += 1.f * FPS_ANIMATION_FACTOR;
     }
     if (o->Position[2] > Height + 300.f)
     {
-        o->Direction[2] *= 0.8f;
-        o->Direction[2] -= 1.f;
+        o->Direction[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+        o->Direction[2] -= 1.f * FPS_ANIMATION_FACTOR;
     }
     o->Position[2] += (float)(rand() % 15 - 7) * 0.3f;
 }
@@ -966,13 +966,13 @@ void MoveBird(OBJECT* o)
             }
         }
         o->Velocity = 1.f;
-        o->Position[2] += (float)(rand() % 16 - 8);
+        o->Position[2] += (float)(rand() % 16 - 8) * FPS_ANIMATION_FACTOR;
         if (o->Position[2] < 200.f) o->Direction[2] = 10.f;
         else if (o->Position[2] > 600.f) o->Direction[2] = -10.f;
     }
     if (o->AI == BOID_DOWN)
     {
-        //o->Velocity *= 0.95f;
+        //o->Velocity *= pow(0.95f, FPS_ANIMATION_FACTOR);
         o->Direction[2] = -20.f;
         float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
@@ -985,7 +985,7 @@ void MoveBird(OBJECT* o)
     }
     if (o->AI == BOID_GROUND)
     {
-        if (Hero->Object.CurrentAction >= PLAYER_WALK_MALE || rand() % 256 == 0)
+        if (Hero->Object.CurrentAction >= PLAYER_WALK_MALE || rand_fps_check(256))
         {
             o->AI = BOID_UP;
             o->Velocity = 1.1f;
@@ -995,8 +995,8 @@ void MoveBird(OBJECT* o)
     }
     if (o->AI == BOID_UP)
     {
-        o->Position[2] += (float)(rand() % 16 - 8);
-        o->Velocity -= 0.005f;
+        o->Position[2] += (float)(rand() % 16 - 8) * FPS_ANIMATION_FACTOR;
+        o->Velocity -= 0.005f * FPS_ANIMATION_FACTOR;
         if (o->Velocity <= 1.f)
         {
             o->AI = BOID_FLY;
@@ -1017,7 +1017,7 @@ void MoveHeavenBug(OBJECT* o, int index)
     float Range = sqrtf(dx * dx + dy * dy);
     if (Range >= 1500.f)
         o->Live = false;
-    if (rand() % 5120 == 0)
+    if (rand_fps_check(5120))
         o->Live = false;
 
     if (gMapManager.InBloodCastle())
@@ -1031,7 +1031,7 @@ void MoveHeavenBug(OBJECT* o, int index)
 
 void MoveEagle(OBJECT* o)
 {
-    if (o->SubType == 0 && rand() % 120 == 0)
+    if (o->SubType == 0 && rand_fps_check(120))
     {
         o->SubType = 1;
         o->AnimationFrame = 0;
@@ -1050,7 +1050,7 @@ void MoveEagle(OBJECT* o)
     }
 
     float fSeedAngle = WorldTime * 0.001f;
-    float fFlyRange = o->Gravity;
+    float fFlyRange = o->Gravity * FPS_ANIMATION_FACTOR;
     float fAngle = 0;
     if (o->AI == BOID_FLY)
     {
@@ -1111,7 +1111,7 @@ void MoveEagle(OBJECT* o)
 void MoveTornado(OBJECT* o)
 {
     o->Scale = 1.0f;
-    if (rand() % 500 == 0)
+    if (rand_fps_check(500))
     {
         o->HeadAngle[0] = (rand() % 314) / 100.0f;
     }
@@ -1125,7 +1125,7 @@ void MoveBoidGroup(OBJECT* o, int index)
 {
     if (o->AI != BOID_GROUND)
     {
-        if (o->Type != MODEL_BUTTERFLY01 || rand() % 4 == 0)
+        if (o->Type != MODEL_BUTTERFLY01 || rand_fps_check(4))
         {
             MoveBoid(o, index, Boids, MAX_BOIDS);
         }
@@ -1159,7 +1159,7 @@ void MoveBoidGroup(OBJECT* o, int index)
         }
         else
         {
-            Vector(o->Velocity * 25.f, 0.f, o->Direction[2], Direction);
+            Vector(FPS_ANIMATION_FACTOR * o->Velocity * 25.f, 0.f, o->Direction[2], Direction);
         }
         VectorRotate(Direction, o->Matrix, p);
         VectorAdd(o->Position, p, o->Position);
@@ -1186,7 +1186,7 @@ void MoveBoidGroup(OBJECT* o, int index)
             );
         else
         {
-            if (rand() % 512 == 0)
+            if (rand_fps_check(512))
                 o->Live = false;
         }
 #ifndef PJH_NEW_SERVER_SELECT_MAP
@@ -1206,7 +1206,7 @@ void MoveBoids()
     {
         OBJECT* o = &Hero->Object;
         vec3_t Position, Angle, Light;
-        if (rand() % 40 == 0)
+        if (rand_fps_check(40))
         {
             Vector(Hero->Object.Position[0] + (float)(rand() % 600 - 200) * FPS_ANIMATION_FACTOR,
                 Hero->Object.Position[1] + (float)(rand() % 400 + 200) * FPS_ANIMATION_FACTOR,
@@ -1281,7 +1281,7 @@ void MoveBoids()
         {
             if (EnableEvent != 0)
             {
-                if (rand() % 300 == 0)
+                if (rand_fps_check(300))
                 {
                     o->Live = true;
                     OpenMonsterModel(31);
@@ -1316,7 +1316,7 @@ void MoveBoids()
                 || ((gMapManager.WorldActive == WD_7ATLANSE || gMapManager.WorldActive == WD_67DOPPLEGANGER3) && (TerrainWall[Index] == 0 || TerrainWall[Index] == TW_CHARACTER))
                 || gMapManager.InBloodCastle()
                 || gMapManager.InHellas()
-                || (gMapManager.WorldActive == WD_51HOME_6TH_CHAR && i < 1 && rand() % 500 == 0 && Hero->SafeZone != true)
+                || (gMapManager.WorldActive == WD_51HOME_6TH_CHAR && i < 1 && rand_fps_check(500) && Hero->SafeZone != true)
                 )
             {
                 int iCreateBoid = 0;
@@ -1416,7 +1416,7 @@ void MoveBoids()
                 o->LifeTime -= FPS_ANIMATION_FACTOR;
                 if (o->LifeTime <= 0)
                     o->Live = false;
-                if (rand() % 128 == 0)
+                if (rand_fps_check(128))
                     PlayBuffer(SOUND_MONSTER + 124);
             }
             else
@@ -1493,21 +1493,21 @@ void MoveBoids()
                 {
                     if (o->Type == MODEL_BIRD01)
                     {
-                        if (rand() % 512 == 0)
+                        if (rand_fps_check(512))
                             PlayBuffer(SOUND_BIRD01, o);
-                        if (rand() % 512 == 0)
+                        if (rand_fps_check(512))
                             PlayBuffer(SOUND_BIRD02, o);
                     }
                     else if (o->Type == MODEL_BAT01)
                     {
-                        if (rand() % 256 == 0)
+                        if (rand_fps_check(256))
                             PlayBuffer(SOUND_BAT01, o);
                     }
                     else if (o->Type == MODEL_CROW)
                     {
                         if (TerrainWall[Index] == TW_SAFEZONE)
                         {
-                            if (rand() % 128 == 0)
+                            if (rand_fps_check(128))
                                 PlayBuffer(SOUND_CROW, o);
                         }
                     }
@@ -1756,7 +1756,7 @@ void MoveFishs()
                     {
                         o->Type = MODEL_FISH01 + 1 + 2 + rand() % 4;
                         o->Velocity = 1.f / o->Scale;
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                             o->Gravity = 2;
                         else
                             o->Gravity = 3;
@@ -1770,7 +1770,7 @@ void MoveFishs()
                             o->BlendMeshLight = 1.f;
                         }
                         o->Velocity = 0.5f / o->Scale;
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                             o->Gravity = 1;
                         else
                             o->Gravity = 2;
@@ -1875,7 +1875,7 @@ void MoveFishs()
                     o->Live = false;
 
                 if (Range < 600.f)
-                    if (o->Type == MODEL_RAT01 && rand() % 256 == 0)
+                    if (o->Type == MODEL_RAT01 && rand_fps_check(256))
                         PlayBuffer(SOUND_RAT01, o);
             }
             else
@@ -1891,7 +1891,7 @@ void MoveFishs()
                 }
                 else
                 {
-                    if (rand() % 64 == 0)
+                    if (rand_fps_check(64))
                         o->LifeTime = rand() % 128;
                 }
             }

--- a/Source Main 5.2/source/GOBoid.cpp
+++ b/Source Main 5.2/source/GOBoid.cpp
@@ -29,11 +29,11 @@ static  const   BYTE    BOID_DOWN = 1;
 static  const   BYTE    BOID_GROUND = 2;
 static  const   BYTE    BOID_UP = 3;
 
-void DeleteBug(OBJECT* Owner)
+void DeleteMount(OBJECT* Owner)
 {
-    for (int i = 0; i < MAX_BUTTERFLES; i++)
+    for (int i = 0; i < MAX_MOUNTS; i++)
     {
-        OBJECT* o = &Butterfles[i];
+        OBJECT* o = &Mounts[i];
         if (o->Live)
         {
             if (o->Owner == Owner)
@@ -42,7 +42,7 @@ void DeleteBug(OBJECT* Owner)
     }
 }
 
-bool IsBug(ITEM* pItem)
+bool IsMount(ITEM* pItem)
 {
     if (pItem == NULL)
     {
@@ -64,9 +64,12 @@ bool IsBug(ITEM* pItem)
     return false;
 }
 
-bool CreateBugSub(int Type, vec3_t Position, OBJECT* Owner, OBJECT* o, int SubType, int LinkBone)
+bool CreateMountSub(int Type, vec3_t Position, OBJECT* Owner, OBJECT* o, int SubType, int LinkBone)
 {
-    if (gMapManager.InChaosCastle() == true) return false;
+    if (gMapManager.InChaosCastle() == true)
+    {
+        return false;
+    }
 
     if (!o->Live)
     {
@@ -122,26 +125,32 @@ bool CreateBugSub(int Type, vec3_t Position, OBJECT* Owner, OBJECT* o, int SubTy
             o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]) + (float)(rand() % 100);
             break;
         }
+
         return FALSE;
     }
+
     return TRUE;
 }
 
-void CreateBug(int Type, vec3_t Position, OBJECT* Owner, int SubType, int LinkBone)
+void CreateMount(int Type, vec3_t Position, OBJECT* Owner, int SubType, int LinkBone)
 {
     if (gMapManager.InChaosCastle() == true) return;
 
     if (Owner->Type != MODEL_PLAYER && Type != MODEL_HELPER)
         return;
 
-    for (int i = 0; i < MAX_BUTTERFLES; i++)
+    for (int i = 0; i < MAX_MOUNTS; i++)
     {
-        OBJECT* o = &Butterfles[i];
-        if (CreateBugSub(Type, Position, Owner, o, SubType, LinkBone) == FALSE) return;
+        OBJECT* o = &Mounts[i];
+        if (CreateMountSub(Type, Position, Owner, o, SubType, LinkBone) == FALSE)
+        {
+            // False means, it has been successful ...
+            return;
+        }
     }
 }
 
-bool MoveBug(OBJECT* o, bool bForceRender)
+bool MoveMount(OBJECT* o, bool bForceRender)
 {
     if (o->Live)
     {
@@ -321,10 +330,11 @@ bool MoveBug(OBJECT* o, bool bForceRender)
 
             b->BoneHead = 7;
 
+            // Take riders position and angle:
             VectorCopy(o->Owner->HeadAngle, o->HeadAngle);
             VectorCopy(o->Owner->Position, o->Position);
-
             VectorCopy(o->Owner->Angle, o->Angle);
+
             if (o->Owner->CurrentAction == PLAYER_ATTACK_DARKHORSE)
             {
                 SetAction(o, 3);
@@ -381,15 +391,15 @@ bool MoveBug(OBJECT* o, bool bForceRender)
                 {
                     if (o->Owner && !g_isCharacterBuff(o->Owner, eBuff_Cloaking))
                     {
+                        // Smoke at the back feet of the horse.
                         Vector(o->Position[0] + (float)(rand() % 64 - 32),
                             o->Position[1] + (float)(rand() % 64 - 32),
                             o->Position[2] + (float)(rand() % 32 - 16), Position);
 
                         if (gMapManager.WorldActive == WD_2DEVIAS)
                             CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light);
-                        else if (gMapManager.WorldActive != WD_10HEAVEN)
-                            if (!g_Direction.m_CKanturu.IsMayaScene())
-                                CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, Light);
+                        else if (gMapManager.WorldActive != WD_10HEAVEN && !g_Direction.m_CKanturu.IsMayaScene())
+                            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, Light);
                     }
                 }
 
@@ -417,7 +427,8 @@ bool MoveBug(OBJECT* o, bool bForceRender)
                 o->Velocity = 0.3f;
             }
 
-            if (o->CurrentAction != 1)
+            // Breathing smoke/bubbles:
+            //if (o->CurrentAction != 1)
             {
                 if (o->Owner && !g_isCharacterBuff(o->Owner, eBuff_Cloaking))
                 {
@@ -609,6 +620,7 @@ bool MoveBug(OBJECT* o, bool bForceRender)
             break;
         }
         b->CurrentAction = o->CurrentAction;
+
         b->PlayAnimation(&o->AnimationFrame, &o->PriorAnimationFrame, &o->PriorAction, o->Velocity, o->Position, o->Angle);
 
         if (o->Type == MODEL_HELPER || o->Type == MODEL_HELPER + 1)
@@ -646,16 +658,16 @@ bool MoveBug(OBJECT* o, bool bForceRender)
     }
     return TRUE;
 }
-void MoveBugs()
+void MoveMounts()
 {
-    for (int i = 0; i < MAX_BUTTERFLES; i++)
+    for (int i = 0; i < MAX_MOUNTS; i++)
     {
-        OBJECT* o = &Butterfles[i];
-        if (MoveBug(o) == FALSE) return;
+        OBJECT* o = &Mounts[i];
+        if (MoveMount(o) == FALSE) return;
     }
 }
 
-bool RenderBug(OBJECT* o, bool bForceRender)
+bool RenderMount(OBJECT* o, bool bForceRender)
 {
     if (o->Live)
     {
@@ -701,12 +713,12 @@ bool RenderBug(OBJECT* o, bool bForceRender)
     return TRUE;
 }
 
-void RenderBugs()
+void RenderMount()
 {
-    for (int i = 0; i < MAX_BUTTERFLES; i++)
+    for (int i = 0; i < MAX_MOUNTS; i++)
     {
-        OBJECT* o = &Butterfles[i];
-        if (RenderBug(o) == FALSE)
+        OBJECT* o = &Mounts[i];
+        if (RenderMount(o) == FALSE)
         {
             return;
         }

--- a/Source Main 5.2/source/GOBoid.cpp
+++ b/Source Main 5.2/source/GOBoid.cpp
@@ -21,6 +21,7 @@
 #include "DSPlaySound.h"
 #include "MapManager.h"
 #include "CameraMove.h"
+#include "NewUISystem.h"
 
 int EnableEvent = 0;
 
@@ -1123,6 +1124,11 @@ void MoveTornado(OBJECT* o)
 
 void MoveBoidGroup(OBJECT* o, int index)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     if (o->AI != BOID_GROUND)
     {
         if (o->Type != MODEL_BUTTERFLY01 || rand_fps_check(4))
@@ -1202,6 +1208,11 @@ void MoveBoidGroup(OBJECT* o, int index)
 
 void MoveBoids()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     if (EnableEvent != 0)
     {
         OBJECT* o = &Hero->Object;
@@ -1520,6 +1531,11 @@ void MoveBoids()
 
 void RenderBoids(bool bAfterCharacter)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_BOIDS; i++)
     {
         OBJECT* o = &Boids[i];
@@ -1629,6 +1645,11 @@ void RenderBoids(bool bAfterCharacter)
 
 void RenderFishs()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_FISHS; i++)
     {
         OBJECT* o = &Fishs[i];
@@ -1665,6 +1686,11 @@ void RenderFishs()
 
 void MoveFishs()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_FISHS; i++)
     {
         if (gMapManager.WorldActive != WD_7ATLANSE && gMapManager.WorldActive != WD_8TARKAN

--- a/Source Main 5.2/source/GOBoid.cpp
+++ b/Source Main 5.2/source/GOBoid.cpp
@@ -636,7 +636,7 @@ bool MoveMount(OBJECT* o, bool bForceRender)
             AngleMatrix(o->Angle, o->Matrix);
             vec3_t Direction;
             VectorRotate(o->Direction, o->Matrix, Direction);
-            VectorAdd(o->Position, Direction, o->Position);
+            VectorAddScaled(o->Position, Direction, o->Position, FPS_ANIMATION_FACTOR);
             o->Position[2] += (float)(rand() % 16 - 8);
             if (rand_fps_check(32))
             {
@@ -752,7 +752,7 @@ void RenderDarkHorseSkill(OBJECT* o, BMD* b)
                 Angle[2] += 60.f;
                 AngleMatrix(Angle, Matrix);
                 VectorRotate(p, Matrix, Position);
-                VectorAdd(o->Position, Position, Position);
+                VectorAddScaled(o->Position, Position, Position, FPS_ANIMATION_FACTOR);
 
                 CreateEffect(MODEL_GROUND_STONE + rand() % 2, Position, o->Angle, o->Light);
             }
@@ -924,7 +924,7 @@ void MoveBat(OBJECT* o)
 {
     o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
     o->Position[2] += ( - absf(sinf(o->Timer)) * 150.f + 350.f) * FPS_ANIMATION_FACTOR;
-    o->Timer += 0.2f;
+    o->Timer += 0.2f * FPS_ANIMATION_FACTOR;
 }
 
 void MoveButterFly(OBJECT* o)
@@ -1138,17 +1138,17 @@ void MoveBoidGroup(OBJECT* o, int index)
             {
                 if (index < 35)
                 {
-                    Vector(FPS_ANIMATION_FACTOR * o->Velocity * (float)(rand() % 16 + 8), 0.f, o->Direction[2], Direction);
+                    Vector(o->Velocity * (float)(rand() % 16 + 8), 0.f, o->Direction[2], Direction);
                 }
                 else
                 {
-                    Vector(FPS_ANIMATION_FACTOR * o->Velocity * (float)(rand() % 16 + 16), 0.f, o->Direction[2], Direction);
+                    Vector(o->Velocity * (float)(rand() % 16 + 16), 0.f, o->Direction[2], Direction);
                 }
                 o->Gravity = 15;
             }
             else
             {
-                Vector(FPS_ANIMATION_FACTOR * o->Velocity * (float)(rand() % 32 + 32), 0.f, o->Direction[2], Direction);
+                Vector(o->Velocity * (float)(rand() % 32 + 32), 0.f, o->Direction[2], Direction);
                 o->Gravity = 5;
             }
             o->Timer += 0.1f * FPS_ANIMATION_FACTOR;
@@ -1159,10 +1159,10 @@ void MoveBoidGroup(OBJECT* o, int index)
         }
         else
         {
-            Vector(FPS_ANIMATION_FACTOR * o->Velocity * 25.f, 0.f, o->Direction[2], Direction);
+            Vector(o->Velocity * 25.f, 0.f, o->Direction[2], Direction);
         }
         VectorRotate(Direction, o->Matrix, p);
-        VectorAdd(o->Position, p, o->Position);
+        VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
         o->Direction[0] = o->Position[0] + 3.f * p[0];
         o->Direction[1] = o->Position[1] + 3.f * p[1];
 
@@ -1407,9 +1407,9 @@ void MoveBoids()
                 b->PlayAnimation(&o->AnimationFrame, &o->PriorAnimationFrame, &o->PriorAction, PlaySpeed, o->Position, o->Angle);
                 AngleMatrix(o->Angle, o->Matrix);
                 vec3_t Position, Direction;
-                Vector(o->Scale * 40.f * FPS_ANIMATION_FACTOR, 0.f, 0.f, Position);
+                Vector(o->Scale * 40.f, 0.f, 0.f, Position);
                 VectorRotate(Position, o->Matrix, Direction);
-                VectorAdd(o->Position, Direction, o->Position);
+                VectorAddScaled(o->Position, Direction, o->Position, FPS_ANIMATION_FACTOR);
                 o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]) + 300.f;
                 o->Position[2] += -absf(sinf(o->Timer)) * 100.f + 100.f;
                 o->Timer += o->Scale * 0.05f * FPS_ANIMATION_FACTOR;
@@ -1818,9 +1818,9 @@ void MoveFishs()
                 MoveBoid(o, i, Fishs, MAX_FISHS);
                 AngleMatrix(o->Angle, o->Matrix);
                 vec3_t Position, Direction;
-                Vector(o->Velocity * (float)(rand() % 4 + 6) * FPS_ANIMATION_FACTOR, 0.f, 0.f, Position);
+                Vector(o->Velocity * (float)(rand() % 4 + 6), 0.f, 0.f, Position);
                 VectorRotate(Position, o->Matrix, Direction);
-                VectorAdd(o->Position, Direction, o->Position);
+                VectorAddScaled(o->Position, Direction, o->Position, FPS_ANIMATION_FACTOR);
                 if (gMapManager.WorldActive != 7 || gMapManager.InHellas() == false || gMapManager.WorldActive != WD_67DOPPLEGANGER3)
                 {
                     o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);

--- a/Source Main 5.2/source/GOBoid.h
+++ b/Source Main 5.2/source/GOBoid.h
@@ -6,17 +6,17 @@
 
 #include "zzzObject.h"
 
-bool CreateBugSub(int Type, vec3_t Position, OBJECT* Owner, OBJECT* o, int SubType = 0, int LinkBone = 0);
-void CreateBug(int Type, vec3_t Position, OBJECT* Owner, int SubType = 0, int LinkBone = 0);
-bool MoveBug(OBJECT* o, bool bForceRender = false);
-void MoveBugs(void);
-bool RenderBug(OBJECT* o, bool bForceRender = false);
-void RenderBugs(void);
+bool CreateMountSub(int Type, vec3_t Position, OBJECT* Owner, OBJECT* o, int SubType = 0, int LinkBone = 0);
+void CreateMount(int Type, vec3_t Position, OBJECT* Owner, int SubType = 0, int LinkBone = 0);
+bool MoveMount(OBJECT* o, bool bForceRender = false);
+void MoveMounts(void);
+bool RenderMount(OBJECT* o, bool bForceRender = false);
+void RenderMount(void);
 void RenderDarkHorseSkill(OBJECT* o, BMD* b);
 void RenderSkillEarthQuake(CHARACTER* c, OBJECT* o, BMD* b, int iMaxSkill = 30);
-void DeleteBug(OBJECT* Owner);
+void DeleteMount(OBJECT* Owner);
 // 아이템이 펫 아이템인가?
-bool IsBug(ITEM* pItem);
+bool IsMount(ITEM* pItem);
 
 void MoveBoids(void);
 void RenderBoids(bool bAfterCharacter = false);

--- a/Source Main 5.2/source/MapManager.cpp
+++ b/Source Main 5.2/source/MapManager.cpp
@@ -1239,15 +1239,15 @@ void CMapManager::LoadWorld(int Map)
     char WorldName[32];
     int  iMapWorld = this->WorldActive + 1;
 
-    if (InBloodCastle() == true)
+    if (InBloodCastle(Map) == true)
     {
         iMapWorld = WD_11BLOODCASTLE1 + 1;
     }
-    else if (gMapManager.InHellas() == true)
+    else if (gMapManager.InHellas(Map) == true)
     {
         iMapWorld = WD_24HELLAS + 1;
     }
-    else if (InChaosCastle() == true)
+    else if (InChaosCastle(Map) == true)
     {
         iMapWorld = WD_18CHAOS_CASTLE + 1;
     }

--- a/Source Main 5.2/source/Math/ZzzMathLib.h
+++ b/Source Main 5.2/source/Math/ZzzMathLib.h
@@ -26,6 +26,7 @@ extern "C" {
 #define Vector(a,b,c,d) {(d)[0]=a;(d)[1]=b;(d)[2]=c;}
 #define VectorAvg(a) ( ( (a)[0] + (a)[1] + (a)[2] ) / 3 )
 #define VectorSubtract(a,b,c) {(c)[0]=(a)[0]-(b)[0];(c)[1]=(a)[1]-(b)[1];(c)[2]=(a)[2]-(b)[2];}
+#define VectorSubtractScaled(a,b,c,d) {(c)[0]=(a)[0]-(b)[0]*(d);(c)[1]=(a)[1]-(b)[1]*(d);(c)[2]=(a)[2]-(b)[2]*(d);}
 #define VectorAdd(a,b,c) {(c)[0]=(a)[0]+(b)[0];(c)[1]=(a)[1]+(b)[1];(c)[2]=(a)[2]+(b)[2];}
 #define VectorAddScaled(a,b,c,d) {(c)[0]=(a)[0]+(b)[0]*(d);(c)[1]=(a)[1]+(b)[1]*(d);(c)[2]=(a)[2]+(b)[2]*(d);}
 #define VectorCopy(a,b) {(b)[0]=(a)[0];(b)[1]=(a)[1];(b)[2]=(a)[2];}

--- a/Source Main 5.2/source/Math/ZzzMathLib.h
+++ b/Source Main 5.2/source/Math/ZzzMathLib.h
@@ -27,6 +27,7 @@ extern "C" {
 #define VectorAvg(a) ( ( (a)[0] + (a)[1] + (a)[2] ) / 3 )
 #define VectorSubtract(a,b,c) {(c)[0]=(a)[0]-(b)[0];(c)[1]=(a)[1]-(b)[1];(c)[2]=(a)[2]-(b)[2];}
 #define VectorAdd(a,b,c) {(c)[0]=(a)[0]+(b)[0];(c)[1]=(a)[1]+(b)[1];(c)[2]=(a)[2]+(b)[2];}
+#define VectorAddScaled(a,b,c,d) {(c)[0]=(a)[0]+(b)[0]*(d);(c)[1]=(a)[1]+(b)[1]*(d);(c)[2]=(a)[2]+(b)[2]*(d);}
 #define VectorCopy(a,b) {(b)[0]=(a)[0];(b)[1]=(a)[1];(b)[2]=(a)[2];}
 #define QuaternionCopy(a,b) {(b)[0]=(a)[0];(b)[1]=(a)[1];(b)[2]=(a)[2];(b)[3]=(a)[3];}
 #define VectorScale(a,b,c) {(c)[0]=(b)*(a)[0];(c)[1]=(b)*(a)[1];(c)[2]=(b)*(a)[2];}

--- a/Source Main 5.2/source/MonkSystem.cpp
+++ b/Source Main 5.2/source/MonkSystem.cpp
@@ -270,8 +270,9 @@ void CMonkSystem::MoveBlurEffect(CHARACTER* _pCha, OBJECT* _pObj, BMD* pModel)
     vec3_t Light;
     vec3_t StartPos, StartLocal, EndPos, EndLocal;
     float fDelay = 10.0f;
-    float fSpeedPerFrame = b->Actions[_pObj->CurrentAction].PlaySpeed / fDelay;
-    float fAnimationFrame = _pObj->AnimationFrame - b->Actions[_pObj->CurrentAction].PlaySpeed;
+    float fPlaySpeed = b->Actions[_pObj->CurrentAction].PlaySpeed * FPS_ANIMATION_FACTOR;
+    float fSpeedPerFrame = fPlaySpeed / fDelay;
+    float fAnimationFrame = _pObj->AnimationFrame - fPlaySpeed;
 
     if (fAnimationFrame > 5.5f)
         return;

--- a/Source Main 5.2/source/MsgWin.cpp
+++ b/Source Main 5.2/source/MsgWin.cpp
@@ -1,4 +1,4 @@
-//*****************************************************************************
+ï»¿//*****************************************************************************
 // File: MsgWin.cpp
 //*****************************************************************************
 
@@ -93,7 +93,7 @@ void CMsgWin::SetCtrlPosition()
         m_sprInput.SetPosition(nBaseXPos + 32, nBtnYPos + 4);
         m_aBtn[MW_OK].SetPosition(nBaseXPos + 209, nBtnYPos);
         m_aBtn[MW_CANCEL].SetPosition(nBaseXPos + 264, nBtnYPos);
-        // ÀÔ·Â ÅØ½ºÆ® À§Ä¡ ÁöÁ¤.
+        // ï¿½Ô·ï¿½ ï¿½Ø½ï¿½Æ® ï¿½ï¿½Ä¡ ï¿½ï¿½ï¿½ï¿½.
         if (m_nMsgCode == MESSAGE_DELETE_CHARACTER_RESIDENT)
             if (g_iChatInputType == 1)
                 g_pSinglePasswdInputBox->SetPosition(
@@ -408,7 +408,7 @@ void CMsgWin::PopUp(int nMsgCode, char* pszMsg)
         break;
     case MESSAGE_DELETE_CHARACTER_SUCCESS:
         CharactersClient[SelectedHero].Object.Live = false;
-        DeleteBug(&CharactersClient[SelectedHero].Object);
+        DeleteMount(&CharactersClient[SelectedHero].Object);
         SelectedHero = -1;
         rUIMng.m_CharSelMainWin.UpdateDisplay();
         rUIMng.m_CharInfoBalloonMng.UpdateDisplay();

--- a/Source Main 5.2/source/NewUIMyInventory.cpp
+++ b/Source Main 5.2/source/NewUIMyInventory.cpp
@@ -936,20 +936,20 @@ void CNewUIMyInventory::CreateEquippingEffect(ITEM* pItem)
         switch (pItem->Type)
         {
         case ITEM_HELPER:
-            CreateBug(MODEL_HELPER, pHeroObject->Position, pHeroObject);
+            CreateMount(MODEL_HELPER, pHeroObject->Position, pHeroObject);
             break;
         case ITEM_HELPER + 2:
-            CreateBug(MODEL_UNICON, pHeroObject->Position, pHeroObject);
+            CreateMount(MODEL_UNICON, pHeroObject->Position, pHeroObject);
             if (!Hero->SafeZone)
                 CreateEffect(BITMAP_MAGIC + 1, pHeroObject->Position, pHeroObject->Angle, pHeroObject->Light, 1, pHeroObject);
             break;
         case ITEM_HELPER + 3:
-            CreateBug(MODEL_PEGASUS, pHeroObject->Position, pHeroObject);
+            CreateMount(MODEL_PEGASUS, pHeroObject->Position, pHeroObject);
             if (!Hero->SafeZone)
                 CreateEffect(BITMAP_MAGIC + 1, pHeroObject->Position, pHeroObject->Angle, pHeroObject->Light, 1, pHeroObject);
             break;
         case ITEM_HELPER + 4:
-            CreateBug(MODEL_DARK_HORSE, pHeroObject->Position, pHeroObject);
+            CreateMount(MODEL_DARK_HORSE, pHeroObject->Position, pHeroObject);
             if (!Hero->SafeZone)
                 CreateEffect(BITMAP_MAGIC + 1, pHeroObject->Position, pHeroObject->Angle, pHeroObject->Light, 1, pHeroObject);
             break;
@@ -957,19 +957,19 @@ void CNewUIMyInventory::CreateEquippingEffect(ITEM* pItem)
             Hero->Helper.Option1 = pItem->Option1;
             if (pItem->Option1 == 0x01)
             {
-                CreateBug(MODEL_FENRIR_BLACK, pHeroObject->Position, pHeroObject);
+                CreateMount(MODEL_FENRIR_BLACK, pHeroObject->Position, pHeroObject);
             }
             else if (pItem->Option1 == 0x02)
             {
-                CreateBug(MODEL_FENRIR_BLUE, pHeroObject->Position, pHeroObject);
+                CreateMount(MODEL_FENRIR_BLUE, pHeroObject->Position, pHeroObject);
             }
             else if (pItem->Option1 == 0x04)
             {
-                CreateBug(MODEL_FENRIR_GOLD, pHeroObject->Position, pHeroObject);
+                CreateMount(MODEL_FENRIR_GOLD, pHeroObject->Position, pHeroObject);
             }
             else
             {
-                CreateBug(MODEL_FENRIR_RED, pHeroObject->Position, pHeroObject);
+                CreateMount(MODEL_FENRIR_RED, pHeroObject->Position, pHeroObject);
             }
 
             if (!Hero->SafeZone)
@@ -1035,9 +1035,9 @@ void CNewUIMyInventory::DeleteEquippingEffectBug(ITEM* pItem)
         return;
     }
 
-    if (IsBug(pItem) == true)
+    if (IsMount(pItem) == true)
     {
-        DeleteBug(&Hero->Object);
+        DeleteMount(&Hero->Object);
     }
 }
 

--- a/Source Main 5.2/source/NewUIOptionWindow.cpp
+++ b/Source Main 5.2/source/NewUIOptionWindow.cpp
@@ -25,6 +25,7 @@ SEASON3B::CNewUIOptionWindow::CNewUIOptionWindow()
     m_bSlideHelp = true;
     m_iVolumeLevel = 0;
     m_iRenderLevel = 4;
+    m_bRenderAllEffects = true;
 }
 
 SEASON3B::CNewUIOptionWindow::~CNewUIOptionWindow()

--- a/Source Main 5.2/source/NewUIOptionWindow.cpp
+++ b/Source Main 5.2/source/NewUIOptionWindow.cpp
@@ -50,7 +50,7 @@ void SEASON3B::CNewUIOptionWindow::SetButtonInfo()
 {
     m_BtnClose.ChangeTextBackColor(RGBA(255, 255, 255, 0));
     m_BtnClose.ChangeButtonImgState(true, IMAGE_OPTION_BTN_CLOSE, true);
-    m_BtnClose.ChangeButtonInfo(m_Pos.x + 68, m_Pos.y + 209, 54, 30);
+    m_BtnClose.ChangeButtonInfo(m_Pos.x + 68, m_Pos.y + 229, 54, 30);
     m_BtnClose.ChangeImgColor(BUTTON_STATE_UP, RGBA(255, 255, 255, 255));
     m_BtnClose.ChangeImgColor(BUTTON_STATE_DOWN, RGBA(255, 255, 255, 255));
 }
@@ -91,6 +91,11 @@ bool SEASON3B::CNewUIOptionWindow::UpdateMouseEvent()
     if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(m_Pos.x + 150, m_Pos.y + 127, 15, 15))
     {
         m_bSlideHelp = !m_bSlideHelp;
+    }
+
+    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(m_Pos.x + 150, m_Pos.y + 210, 15, 15))
+    {
+        m_bRenderAllEffects = !m_bRenderAllEffects;
     }
 
     if (CheckMouseIn(m_Pos.x + 33 - 8, m_Pos.y + 104, 124 + 8, 16))
@@ -143,7 +148,7 @@ bool SEASON3B::CNewUIOptionWindow::UpdateMouseEvent()
         }
     }
 
-    if (CheckMouseIn(m_Pos.x, m_Pos.y, 190, 249) == true)
+    if (CheckMouseIn(m_Pos.x, m_Pos.y, 190, 269) == true)
     {
         return false;
     }
@@ -239,10 +244,10 @@ void SEASON3B::CNewUIOptionWindow::RenderFrame()
     float x, y;
     x = m_Pos.x;
     y = m_Pos.y;
-    RenderImage(IMAGE_OPTION_FRAME_BACK, x, y, 190.f, 249.f);
+    RenderImage(IMAGE_OPTION_FRAME_BACK, x, y, 190.f, 269.f);
     RenderImage(IMAGE_OPTION_FRAME_UP, x, y, 190.f, 64.f);
     y += 64.f;
-    for (int i = 0; i < 14; ++i)
+    for (int i = 0; i < 16; ++i)
     {
         RenderImage(IMAGE_OPTION_FRAME_LEFT, x, y, 21.f, 10.f);
         RenderImage(IMAGE_OPTION_FRAME_RIGHT, x + 190 - 21, y, 21.f, 10.f);
@@ -257,6 +262,9 @@ void SEASON3B::CNewUIOptionWindow::RenderFrame()
     y += 40.f;
     RenderImage(IMAGE_OPTION_LINE, x + 18, y, 154.f, 2.f);
     y += 22.f;
+    RenderImage(IMAGE_OPTION_LINE, x + 18, y, 154.f, 2.f);
+
+    y += 60.f;
     RenderImage(IMAGE_OPTION_LINE, x + 18, y, 154.f, 2.f);
 }
 
@@ -275,6 +283,9 @@ void SEASON3B::CNewUIOptionWindow::RenderContents()
     y += 22.f;
     RenderImage(IMAGE_OPTION_POINT, x, y, 10.f, 10.f);
 
+    y += 60.f;
+    RenderImage(IMAGE_OPTION_POINT, x, y, 10.f, 10.f);
+
     g_pRenderText->SetFont(g_hFont);
     g_pRenderText->SetTextColor(255, 255, 255, 255);
     g_pRenderText->SetBgColor(0);
@@ -283,6 +294,7 @@ void SEASON3B::CNewUIOptionWindow::RenderContents()
     g_pRenderText->RenderText(m_Pos.x + 40, m_Pos.y + 92, GlobalText[389]);
     g_pRenderText->RenderText(m_Pos.x + 40, m_Pos.y + 132, GlobalText[919]);
     g_pRenderText->RenderText(m_Pos.x + 40, m_Pos.y + 154, GlobalText[1840]);
+    g_pRenderText->RenderText(m_Pos.x + 40, m_Pos.y + 154+60, "Render Full Effects");
 }
 
 void SEASON3B::CNewUIOptionWindow::RenderButtons()
@@ -326,6 +338,15 @@ void SEASON3B::CNewUIOptionWindow::RenderButtons()
     if (m_iRenderLevel >= 0)
     {
         RenderImage(IMAGE_OPTION_EFFECT_COLOR, m_Pos.x + 25, m_Pos.y + 168, 141.f * 0.2f * (m_iRenderLevel + 1), 29.f);
+    }
+
+    if (m_bRenderAllEffects)
+    {
+        RenderImage(IMAGE_OPTION_BTN_CHECK, m_Pos.x + 150, m_Pos.y + 210, 15, 15, 0, 0);
+    }
+    else
+    {
+        RenderImage(IMAGE_OPTION_BTN_CHECK, m_Pos.x + 150, m_Pos.y + 210, 15, 15, 0, 15.f);
     }
 }
 
@@ -377,4 +398,14 @@ void SEASON3B::CNewUIOptionWindow::SetRenderLevel(int iRender)
 int SEASON3B::CNewUIOptionWindow::GetRenderLevel()
 {
     return m_iRenderLevel;
+}
+
+void SEASON3B::CNewUIOptionWindow::SetRenderAllEffects(bool bRenderAllEffects)
+{
+    m_bRenderAllEffects = bRenderAllEffects;
+}
+
+bool SEASON3B::CNewUIOptionWindow::GetRenderAllEffects()
+{
+    return m_bRenderAllEffects;
 }

--- a/Source Main 5.2/source/NewUIOptionWindow.h
+++ b/Source Main 5.2/source/NewUIOptionWindow.h
@@ -65,6 +65,8 @@ namespace SEASON3B
         int GetVolumeLevel();
         void SetRenderLevel(int iRender);
         int GetRenderLevel();
+        void SetRenderAllEffects(bool bRenderAllEffects);
+        bool GetRenderAllEffects();
 
     private:
         void LoadImages();
@@ -87,6 +89,7 @@ namespace SEASON3B
         bool m_bSlideHelp;		// 슬라이드 도움말
         int m_iVolumeLevel;		// 볼륨조절
         int m_iRenderLevel;		// 효과제한
+        bool m_bRenderAllEffects;
     };
 }
 

--- a/Source Main 5.2/source/PhysicsManager.cpp
+++ b/Source Main 5.2/source/PhysicsManager.cpp
@@ -73,35 +73,35 @@ void CPhysicsVertex::UpdateForce(unsigned int iKey, DWORD dwType, float fWind)
     switch (PCT_MASK_ELASTIC & dwType)	// m_dwType
     {
     case PCT_RUBBER:
-        m_vForce[2] += fRand * (fWind + 0.1f) * 1.f;
+        m_vForce[2] += fRand * (fWind + 0.1f) * 1.f * FPS_ANIMATION_FACTOR;
         break;
     case PCT_RUBBER2:
-        m_vForce[2] += fRand * (fWind);
+        m_vForce[2] += fRand * (fWind) * FPS_ANIMATION_FACTOR;
         break;
     }
 
     switch (PCT_MASK_ELASTIC_EXT & dwType)
     {
     case PCT_ELASTIC_HALLOWEEN:
-        m_vForce[0] += -(fRand * fWind * 0.5f);
-        m_vForce[2] += fRand * (fWind + 0.1f) * 0.5f * (float)sinf(WorldTime * 0.003f) * 5.0f;
-        m_vForce[2] -= s_Gravity * fGravityRate * s_fMass * 50.0f;
+        m_vForce[0] += -(fRand * fWind * 0.5f * FPS_ANIMATION_FACTOR);
+        m_vForce[2] += fRand * (fWind + 0.1f) * 0.5f * (float)sinf(WorldTime * 0.003f) * 5.0f * FPS_ANIMATION_FACTOR;
+        m_vForce[2] -= s_Gravity * fGravityRate * s_fMass * 50.0f * FPS_ANIMATION_FACTOR;
         break;
     case PCT_ELASTIC_RAGE_L:
-        m_vForce[0] += -(fRand * fWind * 0.8f);
+        m_vForce[0] += -(fRand * fWind * 0.8f * FPS_ANIMATION_FACTOR);
         break;
     case PCT_ELASTIC_RAGE_R:
-        m_vForce[0] -= -(fRand * fWind * 0.8f);
+        m_vForce[0] -= -(fRand * fWind * 0.8f * FPS_ANIMATION_FACTOR);
         break;
     }
 
     switch (PCT_MASK_WEIGHT & dwType)	// m_dwType
     {
     case PCT_HEAVY:
-        m_vForce[2] -= s_Gravity * fGravityRate * s_fMass * 180.0f;
+        m_vForce[2] -= s_Gravity * fGravityRate * s_fMass * 180.0f * FPS_ANIMATION_FACTOR;
         break;
     default:
-        m_vForce[2] -= s_Gravity * fGravityRate * s_fMass * 100.0f;
+        m_vForce[2] -= s_Gravity * fGravityRate * s_fMass * 100.0f * FPS_ANIMATION_FACTOR;
         break;
     }
 }

--- a/Source Main 5.2/source/SummonSystem.cpp
+++ b/Source Main 5.2/source/SummonSystem.cpp
@@ -131,9 +131,9 @@ void CSummonSystem::CreateSummonObject(int iSkill, CHARACTER* pCharacter, OBJECT
     {
         vec3_t vPos;
         VectorCopy(pObject->Position, vPos);
-        if (rand() % 2 == 0) vPos[0] += rand() % 300 + 150;
+        if (rand_fps_check(2)) vPos[0] += rand() % 300 + 150;
         else vPos[0] -= rand() % 250 + 150;
-        if (rand() % 2 == 0) vPos[1] += rand() % 300 + 150;
+        if (rand_fps_check(2)) vPos[1] += rand() % 300 + 150;
         else vPos[1] -= rand() % 250 + 150;
 
         vec3_t vTargetPos;

--- a/Source Main 5.2/source/Time/CTimCheck.cpp
+++ b/Source Main 5.2/source/Time/CTimCheck.cpp
@@ -34,15 +34,15 @@ bool CTimeCheck::GetTimeCheck(int index, int DelayTime)
 {
     int I = CheckIndex(index);
 
-    int PresentTime = timeGetTime();
+    const auto presentTime = WorldTime;
 
     if (stl_Time[I].bTimeCheck)
     {
-        stl_Time[I].iBackupTime = PresentTime;
+        stl_Time[I].iBackupTime = presentTime;
         stl_Time[I].bTimeCheck = false;
     }
 
-    if (stl_Time[I].iBackupTime + DelayTime <= PresentTime)
+    if (stl_Time[I].iBackupTime + DelayTime <= presentTime)
     {
         stl_Time[I].bTimeCheck = true;
         return true;

--- a/Source Main 5.2/source/Time/CTimCheck.h
+++ b/Source Main 5.2/source/Time/CTimCheck.h
@@ -5,8 +5,8 @@
 
 struct TimeCheck
 {
+    double		iBackupTime;	// 시간 관련 백업
     int		iIndex;			// 시간 관련 번호
-    int		iBackupTime;	// 시간 관련 백업
     bool	bTimeCheck;		// 시간 관련 체크
 };
 

--- a/Source Main 5.2/source/UIWindows.cpp
+++ b/Source Main 5.2/source/UIWindows.cpp
@@ -1764,7 +1764,7 @@ void CUIPhotoViewer::RenderPhotoCharacter()
     gMapManager.WorldActive = WD_0LORENCIA;
     MoveCharacter(c, o);
     MoveCharacterVisual(c, o);
-    MoveBug(&m_PhotoHelper, TRUE);
+    MoveMount(&m_PhotoHelper, TRUE);
     gMapManager.WorldActive = WorldBackup;
 
     glMatrixMode(GL_PROJECTION);
@@ -1818,7 +1818,7 @@ void CUIPhotoViewer::RenderPhotoCharacter()
         m_PhotoHelper.Position[2] += 10;
     else if (c->Helper.Type == MODEL_HELPER + 3)
         m_PhotoHelper.Position[2] += 25;
-    RenderBug(&m_PhotoHelper, TRUE);
+    RenderMount(&m_PhotoHelper, TRUE);
     if (c->Helper.Type == MODEL_HELPER + 2)
         m_PhotoHelper.Position[2] -= 10;
     else if (c->Helper.Type == MODEL_HELPER + 3)
@@ -2258,26 +2258,26 @@ void CUIPhotoViewer::CopyPlayer()
         m_PhotoHelper.Live = false;
         switch (m_PhotoChar.Helper.Type - MODEL_HELPER)
         {
-        case 0:CreateBugSub(MODEL_HELPER, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper); break;
-        case 2:CreateBugSub(MODEL_UNICON, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper); break;
-        case 3:CreateBugSub(MODEL_PEGASUS, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper); break;
-        case 4:CreateBugSub(MODEL_DARK_HORSE, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper); break;
+        case 0:CreateMountSub(MODEL_HELPER, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper); break;
+        case 2:CreateMountSub(MODEL_UNICON, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper); break;
+        case 3:CreateMountSub(MODEL_PEGASUS, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper); break;
+        case 4:CreateMountSub(MODEL_DARK_HORSE, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper); break;
         case 37:	//^ 펜릴 편지 관련
             if (m_PhotoChar.Helper.Option1 == 0x01)
             {
-                CreateBugSub(MODEL_FENRIR_BLACK, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper);
+                CreateMountSub(MODEL_FENRIR_BLACK, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper);
             }
             else if (m_PhotoChar.Helper.Option1 == 0x02)
             {
-                CreateBugSub(MODEL_FENRIR_BLUE, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper);
+                CreateMountSub(MODEL_FENRIR_BLUE, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper);
             }
             else if (m_PhotoChar.Helper.Option1 == 0x04)
             {
-                CreateBugSub(MODEL_FENRIR_GOLD, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper);
+                CreateMountSub(MODEL_FENRIR_GOLD, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper);
             }
             else
             {
-                CreateBugSub(MODEL_FENRIR_RED, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper);
+                CreateMountSub(MODEL_FENRIR_RED, m_PhotoChar.Object.Position, &m_PhotoChar.Object, &m_PhotoHelper);
             }
             break;
         }

--- a/Source Main 5.2/source/UIWindows.cpp
+++ b/Source Main 5.2/source/UIWindows.cpp
@@ -2460,7 +2460,7 @@ void CUIPhotoViewer::Render()
 
     if (o->AnimationFrame < m_iCurrentFrame)
     {
-        if (m_bActionRepeatCheck == FALSE && rand() % 4 == 0)
+        if (m_bActionRepeatCheck == FALSE && rand_fps_check(4))
         {
             m_bActionRepeatCheck = TRUE;
             SetPhotoPose(m_iSettingAnimation);

--- a/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
+++ b/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
@@ -66,10 +66,6 @@ void CmuConsoleDebug::UpdateMainScene()
 
 bool CmuConsoleDebug::CheckCommand(const std::string& strCommand)
 {
-#ifdef CSK_LH_DEBUG_CONSOLE
-    if (!m_bInit)
-        return false;
-
     if (strCommand._Starts_with("$fps"))
     {
         auto fps_str = strCommand.substr(5);
@@ -77,6 +73,10 @@ bool CmuConsoleDebug::CheckCommand(const std::string& strCommand)
         SetTargetFps(target_fps);
         return true;
     }
+
+#ifdef CSK_LH_DEBUG_CONSOLE
+    if (!m_bInit)
+        return false;
 
     if (strCommand.compare("$open") == NULL)
     {

--- a/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
+++ b/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
@@ -11,6 +11,7 @@
 #include "./Utilities/Log/ErrorReport.h"
 #include "GlobalBitmap.h"
 #include "ZzzTexture.h"
+#include "ZzzScene.h"
 #ifdef CSK_DEBUG_MAP_PATHFINDING
 #include "ZzzPath.h"
 #endif // CSK_DEBUG_MAP_PATHFINDING
@@ -62,11 +63,20 @@ void CmuConsoleDebug::UpdateMainScene()
 #endif
 }
 
+
 bool CmuConsoleDebug::CheckCommand(const std::string& strCommand)
 {
 #ifdef CSK_LH_DEBUG_CONSOLE
     if (!m_bInit)
         return false;
+
+    if (strCommand._Starts_with("$fps"))
+    {
+        auto fps_str = strCommand.substr(5);
+        auto target_fps = std::stof(fps_str);
+        SetTargetFps(target_fps);
+        return true;
+    }
 
     if (strCommand.compare("$open") == NULL)
     {

--- a/Source Main 5.2/source/WSclient.cpp
+++ b/Source Main 5.2/source/WSclient.cpp
@@ -2832,7 +2832,7 @@ void ProcessDamageCastle(LPPRECEIVE_ATTACK Data)
         else
         {
             if (c->MonsterIndex == 275);
-            else if (rand() % 2 == 0)
+            else if (rand_fps_check(2))
                 SetPlayerShock(c, Damage);
         }
 
@@ -2933,7 +2933,7 @@ void ReceiveAttackDamage(const BYTE* ReceiveBuffer)
             if (c->MonsterIndex == 275)
             {
             }
-            else if (rand() % 2 == 0)
+            else if (rand_fps_check(2))
             {
                 SetPlayerShock(c, Damage);
             }
@@ -5164,7 +5164,7 @@ void ReceiveMagicPosition(const BYTE* ReceiveBuffer, int Size)
         int TargetKey = ((int)(Data2->KeyH) << 8) + Data2->KeyL;
         CHARACTER* tc = &CharactersClient[FindCharacterIndex(TargetKey)];
         OBJECT* to = &tc->Object;
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             SetPlayerShock(tc, tc->Hit);
         if (tc->Hit > 0)
         {

--- a/Source Main 5.2/source/WSclient.cpp
+++ b/Source Main 5.2/source/WSclient.cpp
@@ -1228,7 +1228,7 @@ BOOL ReceiveInventory(const BYTE* ReceiveBuffer, BOOL bEncrypted)
 
     auto Data = (LPPHEADER_DEFAULT_SUBCODE_WORD)ReceiveBuffer; //LPPHEADER_DEFAULT_SUBCODE_WORD 6byte
     int Offset = sizeof(PHEADER_DEFAULT_SUBCODE_WORD);
-    DeleteBug(&Hero->Object);
+    DeleteMount(&Hero->Object);
     giPetManager::DeletePet(Hero);
 
     ThePetProcess().DeletePet(Hero);
@@ -1714,7 +1714,7 @@ BOOL ReceiveTeleport(const BYTE* ReceiveBuffer, BOOL bEncrypted)
                 g_pNewUISystem->Hide(SEASON3B::INTERFACE_FRIEND);
 
                 SetCharacterClass(Hero);
-                DeleteBug(&Hero->Object);
+                DeleteMount(&Hero->Object);
             }
             if (gMapManager.InChaosCastle() == false)
             {
@@ -1973,7 +1973,7 @@ void ReceiveChangePlayer(const BYTE* ReceiveBuffer)
         if (Type == 0x1FFF)
         {
             c->Helper.Type = -1;
-            DeleteBug(o);
+            DeleteMount(o);
             ThePetProcess().DeletePet(c, c->Helper.Type, true);
         }
         else
@@ -1983,27 +1983,27 @@ void ReceiveChangePlayer(const BYTE* ReceiveBuffer)
             c->Helper.Level = 0;
             switch (Type)
             {
-            case ITEM_HELPER:CreateBug(MODEL_HELPER, o->Position, o); break;
-            case ITEM_HELPER + 2:CreateBug(MODEL_UNICON, o->Position, o); break;
-            case ITEM_HELPER + 3:CreateBug(MODEL_PEGASUS, o->Position, o); break;
-            case ITEM_HELPER + 4:CreateBug(MODEL_DARK_HORSE, o->Position, o); break;
+            case ITEM_HELPER:CreateMount(MODEL_HELPER, o->Position, o); break;
+            case ITEM_HELPER + 2:CreateMount(MODEL_UNICON, o->Position, o); break;
+            case ITEM_HELPER + 3:CreateMount(MODEL_PEGASUS, o->Position, o); break;
+            case ITEM_HELPER + 4:CreateMount(MODEL_DARK_HORSE, o->Position, o); break;
             case ITEM_HELPER + 37:
                 c->Helper.Option1 = Option;
                 if (Option == 0x01)
                 {
-                    CreateBug(MODEL_FENRIR_BLACK, o->Position, o);
+                    CreateMount(MODEL_FENRIR_BLACK, o->Position, o);
                 }
                 else if (Option == 0x02)
                 {
-                    CreateBug(MODEL_FENRIR_BLUE, o->Position, o);
+                    CreateMount(MODEL_FENRIR_BLUE, o->Position, o);
                 }
                 else if (Option == 0x04)
                 {
-                    CreateBug(MODEL_FENRIR_GOLD, o->Position, o);
+                    CreateMount(MODEL_FENRIR_GOLD, o->Position, o);
                 }
                 else
                 {
-                    CreateBug(MODEL_FENRIR_RED, o->Position, o);
+                    CreateMount(MODEL_FENRIR_RED, o->Position, o);
                 }
                 break;
             case ITEM_HELPER + 64:

--- a/Source Main 5.2/source/WSclient.cpp
+++ b/Source Main 5.2/source/WSclient.cpp
@@ -4644,6 +4644,9 @@ BOOL ReceiveMagicContinue(const BYTE* ReceiveBuffer, int Size, BOOL bEncrypted)
 
     sc->Skill = MagicNumber;
 
+    if (MagicNumber == AT_SKILL_PLASMA_STORM_FENRIR)
+        sc->m_iFenrirSkillTarget = FindCharacterIndex(Key);
+
     so->Angle[2] = (Data->Angle / 255.f) * 360.f;
 
     if (so->Type == MODEL_PLAYER)

--- a/Source Main 5.2/source/Winmain.cpp
+++ b/Source Main 5.2/source/Winmain.cpp
@@ -78,7 +78,7 @@ CMovieScene* g_pMovieScene = NULL;
 CUIManager* g_pUIManager = NULL;
 CUIMapName* g_pUIMapName = NULL;		// rozy
 
-int Time_Effect = 0;
+float Time_Effect = 0;
 bool ashies = false;
 int weather = rand() % 3;
 

--- a/Source Main 5.2/source/Winmain.h
+++ b/Source Main 5.2/source/Winmain.h
@@ -57,7 +57,7 @@
 
 extern bool ashies;
 extern int weather;
-extern int Time_Effect;
+extern float Time_Effect;
 extern HWND      g_hWnd;
 extern HINSTANCE g_hInst;
 extern HDC       g_hDC;

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -769,14 +769,6 @@ bool PathFinding2(int sx, int sy, int tx, int ty, PATH_t* a, float fDistance, in
 
 CTimer* g_WorldTime = new CTimer();
 
-/**
- * \brief It's the FPS for which the game was initially developed.
- * All speeds of animations, positional movements, etc. are based on it.
- * Increasing this value means increasing the speed on which the game is running.
- * It's not recommended to change this value.
- */
-constexpr double REFERENCE_FPS = 25.0;
-
 double   FPS;
 
 /**

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -778,17 +778,16 @@ double   WorldTime = 0.0;
 void CalcFPS()
 {
     static int timeinit = 0;
-    static double start, start2, last;
-    static int frame = 0, frame2 = 0;
+    static double start, last;
+    static int frame = 0;
     if (!timeinit)
     {
         g_WorldTime->ResetTimer();
         start = g_WorldTime->GetTimeElapsed();
         timeinit = 1;
     }
-    frame++;
-    frame2++;
 
+    frame++;
     WorldTime = g_WorldTime->GetTimeElapsed();
 
     const double differenceMs = WorldTime - last;
@@ -802,18 +801,14 @@ void CalcFPS()
     }
 
     FPS_ANIMATION_FACTOR = DEFAULT_ANIMATION_FPS / FPS;
-    
-    //double dif = differenceMs / CLOCKS_PER_SEC;
 
-    // Calculate average fps every 2 seconds or 10 frames
+    // Calculate average fps every 2 seconds or 25 frames
     const double diffSinceStart = WorldTime - start;
-    if (diffSinceStart > 2000.0 && frame > 10)
+    if (diffSinceStart > 2000.0 || frame > 25)
     {
-        start = start2;
-        frame = frame2;
-        start2 = g_WorldTime->GetTimeElapsed();
-        frame2 = 0;
-        FPS_AVG = frame / diffSinceStart;
+        FPS_AVG = (1000 * frame) / diffSinceStart;
+        start = WorldTime;
+        frame = 0;
     }
 
     DeltaT = (float)differenceMs / CLOCKS_PER_SEC;

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -791,7 +791,7 @@ std::uniform_real_distribution<> distrib(0.0, 1.0);
 
 bool rand_fps_check(int reference_frames)
 {
-    return rand() % reference_frames == 0;
+    // return rand() % reference_frames == 0;
     const auto animation_factor = min(1.0, static_cast<double>(FPS_ANIMATION_FACTOR));
     const auto rand_value = distrib(gen);// *1.5;
     const auto chance = reference_frames == 1

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -137,13 +137,14 @@ int CalcAngle(float PositionX, float PositionY, float TargetX, float TargetY)
 
 float MoveHumming(vec3_t Position, vec3_t Angle, vec3_t TargetPosition, float Turn)
 {
+    float scaledTurn = Turn * FPS_ANIMATION_FACTOR;
     float targetAngle = CreateAngle2D(Position, TargetPosition);
-    Angle[2] = TurnAngle2(Angle[2], targetAngle, Turn);
+    Angle[2] = TurnAngle2(Angle[2], targetAngle, scaledTurn);
     vec3_t Range;
     VectorSubtract(Position, TargetPosition, Range);
     float distance = sqrtf(Range[0] * Range[0] + Range[1] * Range[1]);
     targetAngle = 360.f - CreateAngle(Position[2], distance, TargetPosition[2], 0.f);
-    Angle[0] = TurnAngle2(Angle[0], targetAngle, Turn);
+    Angle[0] = TurnAngle2(Angle[0], targetAngle, scaledTurn);
     return VectorLength(Range);
 }
 

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -12,6 +12,9 @@
 #include "ZzzCharacter.h"
 #include "ZzzLodTerrain.h"
 #include "ZzzAI.h"
+
+#include <random>
+
 #include "ZzzTexture.h"
 #include "ZzzOpenglUtil.h"
 #include "ZzzInterface.h"
@@ -782,9 +785,20 @@ float   FPS_ANIMATION_FACTOR;
 double   FPS_AVG;
 double   WorldTime = 0.0;
 
+std::random_device rd;  // a seed source for the random number engine
+std::mt19937 gen(rd()); // mersenne_twister_engine seeded with rd()
+std::uniform_real_distribution<> distrib(0.0, 1.0);
+
 bool rand_fps_check(int reference_frames)
 {
     return rand() % reference_frames == 0;
+    const auto animation_factor = min(1.0, static_cast<double>(FPS_ANIMATION_FACTOR));
+    const auto rand_value = distrib(gen);// *1.5;
+    const auto chance = reference_frames == 1
+        ? animation_factor
+        : (1.0 / reference_frames) * animation_factor;
+
+    return rand_value <= chance;
 }
 
 void CalcFPS()

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -220,6 +220,9 @@ void MoveBoid(OBJECT* o, int i, OBJECT* Boids, int MAX)
                     xdist += t->Direction[0] - o->Position[0];
                     ydist += t->Direction[1] - o->Position[1];
                 }
+
+                xdist *= FPS_ANIMATION_FACTOR;
+                ydist *= FPS_ANIMATION_FACTOR;
                 float pdist = sqrtf(xdist * xdist + ydist * ydist);
                 TargetX += xdist / pdist;
                 TargetY += ydist / pdist;

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -491,7 +491,7 @@ void MoveHead(CHARACTER* c)
     {
         if (o->CurrentAction == MONSTER01_STOP1)
         {
-            if (rand() % 32 == 0)
+            if (rand_fps_check(32))
             {
                 o->HeadTargetAngle[0] = (float)(rand() % 128 - 64);
                 o->HeadTargetAngle[1] = (float)(rand() % 48 - 16);
@@ -781,6 +781,11 @@ double   FPS;
 float   FPS_ANIMATION_FACTOR;
 double   FPS_AVG;
 double   WorldTime = 0.0;
+
+bool rand_fps_check(int reference_frames)
+{
+    return rand() % reference_frames == 0;
+}
 
 void CalcFPS()
 {

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -812,7 +812,7 @@ void CalcFPS()
         FPS = 1000 / differenceMs;
     }
 
-    FPS_ANIMATION_FACTOR = static_cast<float>(REFERENCE_FPS / FPS);
+    FPS_ANIMATION_FACTOR = minf(static_cast<float>(REFERENCE_FPS / FPS), 2.5f); // no less than 10 fps
 
     // Calculate average fps every 2 seconds or 25 frames
     const double diffSinceStart = WorldTime - start;

--- a/Source Main 5.2/source/ZzzAI.h
+++ b/Source Main 5.2/source/ZzzAI.h
@@ -1,6 +1,6 @@
 int CalcAngle(float PositionX, float PositionY, float TargetX, float TargetY);
 float CreateAngle(float x1, float y1, float x2, float y2);
-inline float CreateAngle2D(const vec3_t from, const vec2_t to);
+float CreateAngle2D(const vec3_t from, const vec2_t to);
 int TurnAngle(int iTheta, int iHeading, int maxTURN);
 float TurnAngle2(float angle, float a, float d);
 float FarAngle(float angle1, float angle2, bool abs = true);

--- a/Source Main 5.2/source/ZzzAI.h
+++ b/Source Main 5.2/source/ZzzAI.h
@@ -1,3 +1,13 @@
+#pragma once
+
+/**
+ * \brief It's the FPS for which the game was initially developed.
+ * All speeds of animations, positional movements, etc. are based on it.
+ * Increasing this value means increasing the speed on which the game is running.
+ * It's not recommended to change this value.
+ */
+constexpr double REFERENCE_FPS = 25.0;
+
 int CalcAngle(float PositionX, float PositionY, float TargetX, float TargetY);
 float CreateAngle(float x1, float y1, float x2, float y2);
 float CreateAngle2D(const vec3_t from, const vec2_t to);

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -463,7 +463,7 @@ bool BMD::PlayAnimation(float* AnimationFrame, float* PriorAnimationFrame, unsig
         }
     }
     CurrentAnimation = *AnimationFrame;
-    CurrentAnimationFrame = (int)CurrentAnimation;
+    CurrentAnimationFrame = (int)maxf(0, CurrentAnimation);
 
     return Loop;
 }

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -45,7 +45,7 @@ extern int  MouseY;
 extern bool MouseLButton;
 
 extern double FPS;
-extern double FPS_ANIMATION_FACTOR;
+extern float FPS_ANIMATION_FACTOR;
 
 bool  StopMotion = false;
 float ParentMatrix[3][4];

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -44,6 +44,9 @@ extern int  MouseX;
 extern int  MouseY;
 extern bool MouseLButton;
 
+extern double FPS;
+extern double FPS_ANIMATION_FACTOR;
+
 bool  StopMotion = false;
 float ParentMatrix[3][4];
 
@@ -399,7 +402,7 @@ bool BMD::PlayAnimation(float* AnimationFrame, float* PriorAnimationFrame, unsig
 {
     bool Loop = true;
 
-    if (AnimationFrame == NULL || PriorAnimationFrame == NULL || PriorAction == NULL || (NumActions > 0 && CurrentAction >= NumActions))
+    if (AnimationFrame == nullptr || PriorAnimationFrame == nullptr || PriorAction == nullptr || (NumActions > 0 && CurrentAction >= NumActions))
     {
         return Loop;
     }
@@ -409,12 +412,12 @@ bool BMD::PlayAnimation(float* AnimationFrame, float* PriorAnimationFrame, unsig
         return Loop;
     }
 
-    int Temp = (int)*AnimationFrame;
-    *AnimationFrame += Speed;
-    if (Temp != (int)*AnimationFrame)
+    const int priorAnimationFrame = (int)*AnimationFrame;
+    *AnimationFrame += Speed * FPS_ANIMATION_FACTOR;
+    if (priorAnimationFrame != (int)*AnimationFrame)
     {
         *PriorAction = CurrentAction;
-        *PriorAnimationFrame = (float)Temp;
+        *PriorAnimationFrame = (float)priorAnimationFrame;
     }
     if (*AnimationFrame <= 0.f)
     {
@@ -904,7 +907,7 @@ void BMD::EndRender()
     glPopMatrix();
 }
 
-extern float WorldTime;
+extern double WorldTime;
 extern int WaterTextureNumber;
 
 void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float BlendMeshLight, float BlendMeshTexCoordU, float BlendMeshTexCoordV, int MeshTexture)
@@ -914,7 +917,7 @@ void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float Bl
     Mesh_t* m = &Meshs[i];
     if (m->NumTriangles == 0) return;
 
-    float Wave = (int)WorldTime % 10000 * 0.0001f;
+    float Wave = (long)WorldTime % 10000 * 0.0001f;
 
     int Texture = IndexTexture[m->Texture];
     if (Texture == BITMAP_HIDE)

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -19,6 +19,7 @@
 #include "UIMng.h"
 #include "CameraMove.h"
 #include "PhysicsManager.h"
+#include "NewUISystem.h"
 
 //BMD Models[MAX_MODELS];
 BMD* Models;
@@ -2267,6 +2268,11 @@ void BMD::AddMeshShadowTriangles(const int blendMesh, const int hiddenMesh, cons
 
 void BMD::RenderBodyShadow(const int blendMesh, const int hiddenMesh, const int startMeshNumber, const int endMeshNumber, void* pClothes, const int clothesCount)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     if (NumMeshs == 0 && clothesCount == 0)
     {
         return;

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -1687,11 +1687,11 @@ void BMD::RenderMeshEffect(int i, int iType, int iSubType, vec3_t Angle, VOID* o
             case MODEL_STONE_COFFIN:
                 if (iSubType == 0)
                 {
-                    if ((rand() % 2) == 0)
+                    if (rand_fps_check(2))
                     {
                         CreateEffect(MODEL_STONE_COFFIN + 1, VertexTransform[i][vi], angle, Light);
                     }
-                    if ((rand() % 10) == 0)
+                    if (rand_fps_check(10))
                     {
                         CreateEffect(MODEL_STONE_COFFIN, VertexTransform[i][vi], angle, Light);
                     }
@@ -1713,11 +1713,11 @@ void BMD::RenderMeshEffect(int i, int iType, int iSubType, vec3_t Angle, VOID* o
                 if (iSubType == 1)
                 {
                     Vector(0.2f, 0.2f, 0.2f, Light);
-                    if ((rand() % 5) == 0)
+                    if (rand_fps_check(5))
                     {
                         CreateEffect(MODEL_GATE + 1, VertexTransform[i][vi], angle, Light, 2);
                     }
-                    if ((rand() % 10) == 0)
+                    if (rand_fps_check(10))
                     {
                         CreateEffect(MODEL_GATE, VertexTransform[i][vi], angle, Light, 2);
                     }
@@ -1725,32 +1725,32 @@ void BMD::RenderMeshEffect(int i, int iType, int iSubType, vec3_t Angle, VOID* o
                 else if (iSubType == 0)
                 {
                     Vector(0.2f, 0.2f, 0.2f, Light);
-                    if ((rand() % 12) == 0)
+                    if (rand_fps_check(12))
                     {
                         CreateEffect(MODEL_GATE + 1, VertexTransform[i][vi], angle, Light);
                     }
-                    if ((rand() % 50) == 0)
+                    if (rand_fps_check(50))
                     {
                         CreateEffect(MODEL_GATE, VertexTransform[i][vi], angle, Light);
                     }
                 }
                 break;
             case MODEL_BIG_STONE_PART1:
-                if ((rand() % 3) == 0)
+                if (rand_fps_check(3))
                 {
                     CreateEffect(MODEL_BIG_STONE_PART1 + rand() % 2, VertexTransform[i][vi], angle, Light, 1);
                 }
                 break;
 
             case MODEL_BIG_STONE_PART2:
-                if ((rand() % 3) == 0)
+                if (rand_fps_check(3))
                 {
                     CreateEffect(MODEL_BIG_STONE_PART1 + rand() % 2, VertexTransform[i][vi], angle, Light);
                 }
                 break;
 
             case MODEL_WALL_PART1:
-                if ((rand() % 3) == 0)
+                if (rand_fps_check(3))
                 {
                     CreateEffect(MODEL_WALL_PART1 + rand() % 2, VertexTransform[i][vi], angle, Light);
                 }
@@ -1758,21 +1758,21 @@ void BMD::RenderMeshEffect(int i, int iType, int iSubType, vec3_t Angle, VOID* o
 
             case MODEL_GATE_PART1:
                 Vector(0.2f, 0.2f, 0.2f, Light);
-                if ((rand() % 12) == 0)
+                if (rand_fps_check(12))
                 {
                     CreateEffect(MODEL_GATE_PART1 + 1, VertexTransform[i][vi], angle, Light);
                 }
-                if ((rand() % 40) == 0)
+                if (rand_fps_check(40))
                 {
                     CreateEffect(MODEL_GATE_PART1, VertexTransform[i][vi], angle, Light);
                 }
-                if ((rand() % 40) == 0)
+                if (rand_fps_check(40))
                 {
                     CreateEffect(MODEL_GATE_PART1 + 2, VertexTransform[i][vi], angle, Light);
                 }
                 break;
             case MODEL_GOLEM_STONE:
-                if ((rand() % 45) == 0 && iEffectCount < 20)
+                if (rand_fps_check(45) && iEffectCount < 20)
                 {
                     if (iSubType == 0) {	//. ºÒ°ñ·½
                         CreateEffect(MODEL_GOLEM_STONE, VertexTransform[i][vi], angle, Light);
@@ -1785,7 +1785,7 @@ void BMD::RenderMeshEffect(int i, int iType, int iSubType, vec3_t Angle, VOID* o
                 }
                 break;
             case MODEL_SKIN_SHELL:
-                if ((rand() % 8) == 0)
+                if (rand_fps_check(8))
                 {
                     CreateEffect(MODEL_SKIN_SHELL, VertexTransform[i][vi], angle, Light, iSubType);
                 }
@@ -1812,7 +1812,7 @@ void BMD::RenderMeshEffect(int i, int iType, int iSubType, vec3_t Angle, VOID* o
                 break;
             case BITMAP_BUBBLE:
                 Vector(1.f, 1.f, 1.f, Light);
-                if ((rand() % 30) == 0)
+                if (rand_fps_check(30))
                 {
                     CreateParticle(BITMAP_BUBBLE, VertexTransform[i][vi], angle, Light, 2);
                 }

--- a/Source Main 5.2/source/ZzzCharacter.cpp
+++ b/Source Main 5.2/source/ZzzCharacter.cpp
@@ -1501,7 +1501,7 @@ void AttackEffect(CHARACTER* c)
         {
             if ((rand() % 2) == 0)
             {
-                if (c->AttackTime == 1)
+                if ((int)c->AttackTime == 1)
                 {
                     CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light, 1);
                 }
@@ -1520,7 +1520,7 @@ void AttackEffect(CHARACTER* c)
     case 69:
         break;
     case 70:
-        if (c->AttackTime == 5)
+        if ((int)c->AttackTime == 5)
         {
             if (c->TargetCharacter != -1)
             {
@@ -1538,7 +1538,7 @@ void AttackEffect(CHARACTER* c)
     case 74:
         if (c->Object.CurrentAction == MONSTER01_ATTACK1 || c->Object.CurrentAction == MONSTER01_ATTACK2)
         {
-            if (c->AttackTime == 5)
+            if ((int)c->AttackTime == 5)
             {
                 CreateInferno(o->Position);
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light);
@@ -1548,7 +1548,7 @@ void AttackEffect(CHARACTER* c)
     case 72:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if (c->AttackTime == 14)
+            if ((int)c->AttackTime == 14)
             {
                 vec3_t Angle = { 0.0f, 0.0f, 0.0f };
                 int iCount = 36;
@@ -1571,7 +1571,7 @@ void AttackEffect(CHARACTER* c)
     case 75:
         if (c->Object.CurrentAction == MONSTER01_ATTACK1)
         {
-            if (c->AttackTime == 11)
+            if ((int)c->AttackTime == 11)
             {
                 CreateInferno(o->Position);
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light);
@@ -1592,7 +1592,7 @@ void AttackEffect(CHARACTER* c)
         }
         else
         {
-            if (c->AttackTime == 13)
+            if ((int)c->AttackTime == 13)
             {
                 Vector(1.f, 0.5f, 0.f, Light);
                 Vector(-50.f, 100.f, 0.f, p);
@@ -1603,7 +1603,7 @@ void AttackEffect(CHARACTER* c)
                 CreateEffect(MODEL_PIERCING + 1, Position, Angle, Light, 1, o);
                 PlayBuffer(SOUND_METEORITE01);
             }
-            else if (c->AttackTime == 9)
+            else if ((int)c->AttackTime == 9)
             {
                 Vector(1.f, 0.5f, 0.f, Light);
                 Vector(0.f, 0.f, 0.f, p);
@@ -1617,7 +1617,7 @@ void AttackEffect(CHARACTER* c)
     case 77:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if (c->AttackTime == 2 || c->AttackTime == 6)
+            if ((int)c->AttackTime == 2 || c->AttackTime == 6)
             {
                 vec3_t Angle = { 0.0f, 0.0f, 0.0f };
                 int iCount = 40;
@@ -1639,7 +1639,7 @@ void AttackEffect(CHARACTER* c)
     case 61:
         if (c->MonsterIndex == 63)
         {
-            if (c->AttackTime == 1)
+            if ((int)c->AttackTime == 1)
             {
                 CreateInferno(o->Position);
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light);
@@ -1651,7 +1651,7 @@ void AttackEffect(CHARACTER* c)
                     Vector(o->Position[0] + rand() % 800 - 400, o->Position[1] + rand() % 800 - 400, o->Position[2], Position);
                     CreateEffect(MODEL_SKILL_BLAST, Position, o->Angle, o->Light);
                 }
-                if (c->AttackTime == 14)
+                if ((int)c->AttackTime == 14)
                 {
                     for (int i = 0; i < 18; i++)
                     {
@@ -1664,7 +1664,7 @@ void AttackEffect(CHARACTER* c)
         }
         else
         {
-            if (c->AttackTime == 1)
+            if ((int)c->AttackTime == 1)
             {
                 //CreateInferno(o->Position);
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light);
@@ -1674,7 +1674,7 @@ void AttackEffect(CHARACTER* c)
     case 66:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if (c->AttackTime == 1)
+            if ((int)c->AttackTime == 1)
             {
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light, 1);
             }
@@ -1683,7 +1683,7 @@ void AttackEffect(CHARACTER* c)
     case 54:
     case 57:
     case 151:
-        if (c->AttackTime == 1)
+        if ((int)c->AttackTime == 1)
         {
             Vector(60.f, -110.f, 0.f, p);
             b->TransformPosition(o->BoneTransform[c->Weapon[0].LinkBone], p, Position, true);
@@ -1702,11 +1702,11 @@ void AttackEffect(CHARACTER* c)
     case 53:
     case 58:
     case 59:
-        if (c->AttackTime == 1)
+        if ((int)c->AttackTime == 1)
         {
             CreateInferno(o->Position);
         }
-        if (c->AttackTime == 14)
+        if ((int)c->AttackTime == 14)
         {
             if (c->MonsterIndex == 59)
             {
@@ -1723,14 +1723,14 @@ void AttackEffect(CHARACTER* c)
         }
         break;
     case 49:
-        if (c->AttackTime % 5 == 1)
+        if ((int)c->AttackTime % 5 == 1)
         {
             b->TransformPosition(o->BoneTransform[63], p, Position, true);
             CreateEffect(BITMAP_BOSS_LASER + 1, Position, o->Angle, o->Light);
         }
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if (c->AttackTime == 1)
+            if ((int)c->AttackTime == 1)
             {
                 VectorCopy(o->Angle, Angle); Angle[2] += 20.f;
                 VectorCopy(o->Position, p); p[2] += 50.f;
@@ -1748,7 +1748,7 @@ void AttackEffect(CHARACTER* c)
     case 42:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if (c->AttackTime == 1)
+            if ((int)c->AttackTime == 1)
             {
                 Vector(0.f, 0.f, 0.f, p);
                 b->TransformPosition(o->BoneTransform[11], p, Position, true);
@@ -1768,7 +1768,7 @@ void AttackEffect(CHARACTER* c)
     case 35:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if (c->AttackTime == 1)
+            if ((int)c->AttackTime == 1)
             {
                 for (int i = 0; i < 18; i++)
                 {
@@ -1783,7 +1783,7 @@ void AttackEffect(CHARACTER* c)
     case 67:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if (c->AttackTime == 1)
+            if ((int)c->AttackTime == 1)
             {
                 CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, o->Light);
                 CreateEffect(MODEL_CIRCLE_LIGHT, o->Position, o->Angle, o->Light);
@@ -1833,14 +1833,14 @@ void AttackEffect(CHARACTER* c)
             case 427:
                 if (c->Weapon[0].Type == MODEL_BOW + 19)
                 {
-                    if (c->AttackTime == 8)
+                    if ((int)c->AttackTime == 8)
                     {
                         CreateArrows(c, o, o, 0, 0, 0);
                     }
                 }
                 else if (c->Object.CurrentAction == MONSTER01_ATTACK1)
                 {
-                    if (c->AttackTime == 15)
+                    if ((int)c->AttackTime == 15)
                     {
                         CalcAddPosition(o, -20.f, -90.f, 100.f, Position);
                         CreateEffect(BITMAP_BOSS_LASER, Position, o->Angle, Light, 0, o);
@@ -1848,7 +1848,7 @@ void AttackEffect(CHARACTER* c)
                 }
                 else if (c->Object.CurrentAction == MONSTER01_ATTACK2)
                 {
-                    if (c->AttackTime == 8)
+                    if ((int)c->AttackTime == 8)
                     {
                         if (rand() % 2 == 0)
                         {
@@ -1889,7 +1889,7 @@ void AttackEffect(CHARACTER* c)
             case 122:	//. 자이언트오거5
             case 128:	//. 자이언트오거6
             case 141:
-                if (c->AttackTime == 13)
+                if ((int)c->AttackTime == 13)
                 {
                     Vector(1.0f, 1.0f, 1.0f, Light);
                     Vector(60.f, 30.f, 0.f, p);
@@ -1918,7 +1918,7 @@ void AttackEffect(CHARACTER* c)
             case 75:
                 if (c->Object.CurrentAction == MONSTER01_ATTACK2)
                 {
-                    if (c->AttackTime == 13)
+                    if ((int)c->AttackTime == 13)
                     {
                         Vector(1.f, 0.5f, 0.f, Light);
                         Vector(-50.f, 100.f, 0.f, p);
@@ -1931,7 +1931,7 @@ void AttackEffect(CHARACTER* c)
                 }
                 break;
             case 69:
-                if (c->AttackTime == 1)
+                if ((int)c->AttackTime == 1)
                 {
                     for (int i = 0; i < 4; ++i)
                     {
@@ -1951,7 +1951,7 @@ void AttackEffect(CHARACTER* c)
                     CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
                 }
 
-                if (c->AttackTime == 1)
+                if ((int)c->AttackTime == 1)
                     PlayBuffer(SOUND_EVIL);
 
                 for (int i = 0; i < 4; i++)
@@ -1965,7 +1965,7 @@ void AttackEffect(CHARACTER* c)
                 }
                 break;
             case 46:
-                if (c->AttackTime == 1)
+                if ((int)c->AttackTime == 1)
                     PlayBuffer(SOUND_EVIL);
 
                 for (int i = 0; i < 4; i++)
@@ -1979,7 +1979,7 @@ void AttackEffect(CHARACTER* c)
                 }
                 break;
             case 37:
-                if (c->AttackTime == 1)
+                if ((int)c->AttackTime == 1)
                     PlayBuffer(SOUND_EVIL);
 
                 for (int i = 0; i < 4; i++)
@@ -1994,9 +1994,9 @@ void AttackEffect(CHARACTER* c)
                 break;
             case 66:
             {
-                if (c->AttackTime == 1)
+                if ((int)c->AttackTime == 1)
                     PlayBuffer(SOUND_THUNDER01);
-                float fAngle = (float)(45.f - (c->AttackTime * 3 + (int)WorldTime / 10) % 90) + 180.f;
+                float fAngle = (float)((int)(45.f - (c->AttackTime * 3 + (int)WorldTime / 10)) % 90) + 180.f;
 
                 for (int i = 0; i < 4; i++)
                 {
@@ -2025,9 +2025,9 @@ void AttackEffect(CHARACTER* c)
             case 130:
             case 143:
             {
-                if (c->AttackTime == 1)
+                if ((int)c->AttackTime == 1)
                     PlayBuffer(SOUND_THUNDER01);
-                float fAngle = (float)(45.f - (c->AttackTime * 3 + (int)WorldTime / 10) % 90) + 180.f;
+                float fAngle = (float)(45.f - (int)(c->AttackTime * 3 + (int)WorldTime / 10) % 90) + 180.f;
                 for (int i = 0; i < 4; i++)
                 {
                     b->TransformPosition(o->BoneTransform[c->Weapon[i % 2].LinkBone], p, Position, true);
@@ -2052,7 +2052,7 @@ void AttackEffect(CHARACTER* c)
                 }
                 break;
             case 37://데빌
-                if (c->AttackTime == 1)
+                if ((int)c->AttackTime == 1)
                     PlayBuffer(SOUND_EVIL);
 
                 for (int i = 0; i < 4; i++)
@@ -2366,7 +2366,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
                 CreateJoint(MODEL_SPEARSKILL, TempPos, TempPos, o->Angle, 2, o, 40.0f);
             }
         }
-        if (c->AttackTime <= 8)
+        if ((int)c->AttackTime <= 8)
         {	// 기 모일 곳 위치
             vec3_t Position2 = { 0.0f, 0.0f, 0.0f };
             b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], Position2, o->m_vPosSword, true);
@@ -2406,7 +2406,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
                 }
             }
         }
-        if (c->AttackTime >= 12)
+        if ((int)c->AttackTime >= 12)
         {
             c->AttackTime = g_iLimitAttackTime;
         }
@@ -2417,11 +2417,11 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
         BMD* b = &Models[o->Type];
 
         vec3_t p;
-        if (c->AttackTime == 10)
+        if ((int)c->AttackTime == 10)
         {
             PlayBuffer(SOUND_RIDINGSPEAR);
         }
-        else if (c->AttackTime == 4)
+        else if ((int)c->AttackTime == 4)
         {	// 준비동작
             vec3_t Light = { 1.0f, 1.0f, .5f };
             vec3_t Position2 = { 0.0f, 0.0f, 0.0f };
@@ -2451,7 +2451,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
                 Position[2] += 110.0f;
                 //vec3_t Light = { .6f, .6f, .2f};
                 vec3_t Light = { .3f, .3f, .3f };
-                if (c->AttackTime == 11)
+                if ((int)c->AttackTime == 11)
                 {
                     /*Light[0] = 1.0f;
                     Light[1] = 0.5f;
@@ -2479,7 +2479,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
             }
         }
 
-        if (c->AttackTime == 3)  //  氣 모으기.
+        if ((int)c->AttackTime == 3)  //  氣 모으기.
         {
             CreateEffect(BITMAP_GATHERING, o->Position, o->Angle, o->Light, 0, o);
             PlayBuffer(SOUND_PIERCING, o);
@@ -2497,7 +2497,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
         {
             SetAction(o, PLAYER_ATTACK_SKILL_WHEEL);
 
-            if (c->AttackTime >= 1 && c->AttackTime <= 2)
+            if ((int)c->AttackTime >= 1 && c->AttackTime <= 2)
             {
                 vec3_t Angle;
                 Vector(1.f, 0.f, 0.f, Angle);
@@ -2569,7 +2569,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
     case AT_SKILL_LIFE_UP + 3:
     case AT_SKILL_LIFE_UP + 4:
     case    AT_SKILL_VITALITY:
-        if (c->AttackTime > 9 && o->Type == MODEL_PLAYER && o->CurrentAction == PLAYER_SKILL_VITALITY)
+        if ((int)c->AttackTime > 9 && o->Type == MODEL_PLAYER && o->CurrentAction == PLAYER_SKILL_VITALITY)
         {
             c->AttackTime = 15;
         }
@@ -2624,7 +2624,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
         }
         break;
     case    AT_SKILL_PARTY_TELEPORT:
-        if (c->AttackTime > 5 && o->Type == MODEL_PLAYER && (o->CurrentAction == PLAYER_ATTACK_TELEPORT || o->CurrentAction == PLAYER_ATTACK_RIDE_TELEPORT
+        if ((int)c->AttackTime > 5 && o->Type == MODEL_PLAYER && (o->CurrentAction == PLAYER_ATTACK_TELEPORT || o->CurrentAction == PLAYER_ATTACK_RIDE_TELEPORT
             || o->CurrentAction == PLAYER_FENRIR_ATTACK_DARKLORD_TELEPORT))
         {
             c->AttackTime = 15;
@@ -2771,7 +2771,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
             int RightType = CharacterMachine->Equipment[EQUIPMENT_WEAPON_RIGHT].Type;
             int LeftType = CharacterMachine->Equipment[EQUIPMENT_WEAPON_LEFT].Type;
 
-            if (c->AttackTime >= 1 && LeftType == ITEM_BOW + 21 && o->Type == MODEL_PLAYER)
+            if ((int)c->AttackTime >= 1 && LeftType == ITEM_BOW + 21 && o->Type == MODEL_PLAYER)
             {
                 for (int i = 0; i < 20; i++)
                 {
@@ -2859,7 +2859,7 @@ void  PushingCharacter(CHARACTER* c, OBJECT* o)
     if (c->StormTime > 0)
     {
         o->Angle[2] += c->StormTime * 10;
-        c->StormTime--;
+        c->StormTime -= FPS_ANIMATION_FACTOR;
     }
     if (c->JumpTime > 0)
     {
@@ -2870,9 +2870,9 @@ void  PushingCharacter(CHARACTER* c, OBJECT* o)
         }
         if (gMapManager.InChaosCastle() == true)
         {
-            o->Position[0] += (((float)c->TargetX) * TERRAIN_SCALE - o->Position[0]) * Speed;
-            o->Position[1] += (((float)c->TargetY) * TERRAIN_SCALE - o->Position[1]) * Speed;
-            c->JumpTime++;
+            o->Position[0] += (((float)c->TargetX) * TERRAIN_SCALE - o->Position[0]) * Speed * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (((float)c->TargetY) * TERRAIN_SCALE - o->Position[1]) * Speed * FPS_ANIMATION_FACTOR;
+            c->JumpTime += FPS_ANIMATION_FACTOR;
             if (c->JumpTime > 15)
             {
                 SetPlayerStop(c);
@@ -2888,11 +2888,12 @@ void  PushingCharacter(CHARACTER* c, OBJECT* o)
         }
         else
         {
-            o->Position[0] += (((float)c->TargetX + 0.5f) * TERRAIN_SCALE - o->Position[0]) * Speed;
-            o->Position[1] += (((float)c->TargetY + 0.5f) * TERRAIN_SCALE - o->Position[1]) * Speed;
+            o->Position[0] += (((float)c->TargetX + 0.5f) * TERRAIN_SCALE - o->Position[0]) * Speed + FPS_ANIMATION_FACTOR;
+            o->Position[1] += (((float)c->TargetY + 0.5f) * TERRAIN_SCALE - o->Position[1]) * Speed + FPS_ANIMATION_FACTOR;
             if (o->Type != MODEL_BALL)
                 o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
-            if (c->JumpTime++ > 15)
+            c->JumpTime += FPS_ANIMATION_FACTOR;
+            if (c->JumpTime > 15)
             {
                 if (o->Type == MODEL_MONSTER01 + 52)
                     SetPlayerStop(c);
@@ -3840,14 +3841,14 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
         CreateParticle(BITMAP_LIGHT, Position, o->Angle, Light);
     }
 
-    if (c->AttackTime > 0)
+    if ((int)c->AttackTime > 0)
     {
         AttackStage(c, o);
         AttackEffect(c);
-        c->AttackTime++;
+        c->AttackTime += FPS_ANIMATION_FACTOR;
     }
 
-    if (c->AttackTime >= g_iLimitAttackTime)
+    if ((int)c->AttackTime >= g_iLimitAttackTime)
     {
         c->AttackTime = 0;
         o->PKKey = getTargetCharacterKey(c, SelectedCharacter);
@@ -5100,7 +5101,7 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
 
     if (c->m_iDeleteTime > 0)
     {
-        c->m_iDeleteTime--;
+        c->m_iDeleteTime -= FPS_ANIMATION_FACTOR;
     }
     if (c->m_iDeleteTime != -128 && c->m_iDeleteTime <= 0)
     {
@@ -10571,7 +10572,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
 
                     c->ExtendStateTime = 0;
                 }
-                c->ExtendStateTime++;
+                c->ExtendStateTime += min(1, FPS_ANIMATION_FACTOR);
             }
             if (fullset)
             {

--- a/Source Main 5.2/source/ZzzCharacter.cpp
+++ b/Source Main 5.2/source/ZzzCharacter.cpp
@@ -356,7 +356,7 @@ void SetPlayerStop(CHARACTER* c)
             SetAction(&c->Object, MONSTER01_STOP1);
     }
 
-    if (rand() % 16 == 0)
+    if (rand_fps_check(16))
     {
         if (o->Type != MODEL_PLAYER || (o->SubType >= MODEL_SKELETON1 && o->SubType <= MODEL_SKELETON3))
         {
@@ -372,7 +372,7 @@ void SetPlayerStop(CHARACTER* c)
         }
         else if (c->Helper.Type == MODEL_HELPER + 37)
         {
-            if ((rand() % 3) == 0)
+            if (rand_fps_check(3))
             {
                 PlayBuffer(SOUND_FENRIR_IDLE_1 + rand() % 2, o);
             }
@@ -718,7 +718,7 @@ void SetPlayerWalk(CHARACTER* c)
     {
         PlayBuffer(SOUND_FENRIR_RUN_1 + rand() % 2, o);
     }
-    else if ((c == Hero && rand() % 64 == 0) || (c != Hero && rand() % 16 == 0))
+    else if ((c == Hero && rand_fps_check(64)) || (c != Hero && rand_fps_check(16)))
     {
         if (o->Type != MODEL_PLAYER || (o->SubType >= MODEL_SKELETON1 && o->SubType <= MODEL_SKELETON3))
         {
@@ -1226,7 +1226,7 @@ void SetPlayerShock(CHARACTER* c, int Hit)
             if (c->Helper.Type == MODEL_HELPER + 37)
             {
                 SetAction_Fenrir_Damage(c, &c->Object);
-                if ((rand() % 3) == 0)
+                if (rand_fps_check(3))
                     PlayBuffer(SOUND_FENRIR_DAMAGE_1 + rand() % 2, o);
             }
             else
@@ -1279,7 +1279,7 @@ void SetPlayerShock(CHARACTER* c, int Hit)
             vec3_t Position;
             for (int i = 0; i < 5; i++)
             {
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     Position[0] = o->Position[0] + (rand() % 128 - 64);
                     Position[1] = o->Position[1];
@@ -1499,7 +1499,7 @@ void AttackEffect(CHARACTER* c)
     case 143:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if ((rand() % 2) == 0)
+            if (rand_fps_check(2))
             {
                 if ((int)c->AttackTime == 1)
                 {
@@ -1850,7 +1850,7 @@ void AttackEffect(CHARACTER* c)
                 {
                     if ((int)c->AttackTime == 8)
                     {
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                         {
                             CreateEffect(MODEL_SKILL_BLAST, to->Position, o->Angle, o->Light, 0, o);
                             CreateEffect(MODEL_SKILL_BLAST, to->Position, o->Angle, o->Light, 0, o);
@@ -3097,7 +3097,7 @@ void HeroAttributeCalc(CHARACTER* c)
 
 void OnlyNpcChatProcess(CHARACTER* c, OBJECT* o)
 {
-    if (o->Kind == KIND_NPC && (rand() % 2) == 0)
+    if (o->Kind == KIND_NPC && rand_fps_check(2))
     {
         switch (o->Type)
         {
@@ -3467,7 +3467,7 @@ void AnimationCharacter(CHARACTER* c, OBJECT* o, BMD* b)
     case MODEL_DEVIAS_TRADER:
         if (b->CurrentAnimationFrame == b->Actions[o->CurrentAction].NumAnimationKeys - 1)
         {
-            if (rand() % 32 == 0)
+            if (rand_fps_check(32))
                 SetAction(o, 1);
             else
                 SetAction(o, 0);
@@ -3476,7 +3476,7 @@ void AnimationCharacter(CHARACTER* c, OBJECT* o, BMD* b)
     case MODEL_MONSTER01 + 128:
         if (o->CurrentAction <= 1 && b->CurrentAnimationFrame == b->Actions[o->CurrentAction].NumAnimationKeys - 1)
         {
-            if (rand() % 10 == 0)
+            if (rand_fps_check(10))
                 SetAction(o, 1);
             else
                 SetAction(o, 0);
@@ -4612,7 +4612,7 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
                 {
                     for (int i = 0; i < 5; i++)
                     {
-                        if ((rand() % 2) == 0)
+                        if (rand_fps_check(2))
                         {
                             Position[0] = to->Position[0];
                             Position[1] = to->Position[1];
@@ -5396,7 +5396,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
         {
             if (o->Type != MODEL_PLAYER)
                 MoveHead(c);
-            if (c != Hero && c->Dead == 0 && rand() % 32 == 0)
+            if (c != Hero && c->Dead == 0 && rand_fps_check(32))
             {
                 o->HeadTargetAngle[0] = (float)(rand() % 128 - 64);
                 o->HeadTargetAngle[1] = (float)(rand() % 32 - 16);
@@ -5420,9 +5420,9 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                 Vector(o->Position[0] + (float)(rand() % 64 - 32),
                     o->Position[1] + (float)(rand() % 64 - 32),
                     o->Position[2] + (float)(rand() % 32 - 16), Position);
-                if (rand() % 10 == 0)
+                if (rand_fps_check(10))
                     CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light, 1);
-                if (rand() % 10 == 0)
+                if (rand_fps_check(10))
                     CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
             }
         }
@@ -5444,7 +5444,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
         }
         if (c->Freeze > 0.f)
         {
-            if (c->FreezeType == BITMAP_ICE && rand() % 4 == 0)
+            if (c->FreezeType == BITMAP_ICE && rand_fps_check(4))
             {
                 Vector(o->Position[0] + (float)(rand() % 100 - 50), o->Position[1] + (float)(rand() % 100 - 50), o->Position[2] + (float)(rand() % 180), Position);
                 //CreateParticle(BITMAP_SHINY,Position,o->Angle,o->Light);
@@ -5483,12 +5483,12 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
             Vector(-15.f, 0.f, 0.f, p);
             if (gMapManager.InDevilSquare() == true)
             {
-                if (rand() % 4 == 0)
+                if (rand_fps_check(4))
                 {
                     b->TransformPosition(o->BoneTransform[26], p, Position, true);
                     CreateParticle(BITMAP_RAIN_CIRCLE + 1, Position, o->Angle, Light);
                 }
-                if (rand() % 4 == 0)
+                if (rand_fps_check(4))
                 {
                     b->TransformPosition(o->BoneTransform[35], p, Position, true);
                     CreateParticle(BITMAP_RAIN_CIRCLE + 1, Position, o->Angle, Light);
@@ -5748,7 +5748,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
         case MODEL_MONSTER01 + 29:
             o->BlendMesh = 3;
             o->BlendMeshTexCoordV = -(float)((int)(WorldTime) % 1000) * 0.001f;
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Vector(0.f, 0.f, 0.f, p);
                 b->TransformPosition(o->BoneTransform[2], p, Position, true);
@@ -5820,11 +5820,11 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
             o->BlendMeshTexCoordV = -(float)((int)(WorldTime) % 2000) * 0.0005f;
             break;
         case MODEL_MIX_NPC:
-            if (rand() % 64 == 0)
+            if (rand_fps_check(64))
                 PlayBuffer(SOUND_NPC + 1);
             break;
         case MODEL_ELF_WIZARD:
-            if (rand() % 256 == 0)
+            if (rand_fps_check(256))
                 PlayBuffer(SOUND_NPC);
             break;
         case MODEL_SMITH:
@@ -5896,7 +5896,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                 Vector(Luminosity * 1.f, Luminosity * 0.4f, Luminosity * 0.2f, Light);
                 CreateSprite(BITMAP_LIGHT, Position, 1.f, Light, o);
             }
-            if (c->Dead == 0 && rand() % 4 == 0)
+            if (c->Dead == 0 && rand_fps_check(4))
             {
                 Vector(o->Position[0] + (float)(rand() % 64 - 32),
                     o->Position[1] + (float)(rand() % 64 - 32),
@@ -5908,7 +5908,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
             }
             break;
         case MODEL_MONSTER01 + 33:
-            if (c->Dead == 0 && c->Level == 1 && rand() % 4 == 0)
+            if (c->Dead == 0 && c->Level == 1 && rand_fps_check(4))
             {
                 Vector(o->Position[0] + (float)(rand() % 64 - 32),
                     o->Position[1] + (float)(rand() % 64 - 32),
@@ -5921,7 +5921,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
             break;
         case MODEL_MONSTER01 + 12:
         case MODEL_MONSTER01 + 13:
-            if (rand() % 4 == 0)
+            if (rand_fps_check(4))
             {
                 Vector(0.f, 0.f, 0.f, p);
                 b->TransformPosition(o->BoneTransform[22], p, Position, true);
@@ -5938,7 +5938,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                     (o->AnimationFrame >= 5.f && o->AnimationFrame <= 6.f))) Smoke = true;
             if (Smoke)
             {
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     Vector(0.f, -4.f, 0.f, p);
                     b->TransformPosition(o->BoneTransform[24], p, Position, true);
@@ -6731,7 +6731,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
             Vector(i * 30.f - 180.f, -40.f, 0.f, p);
             b->TransformPosition(BoneTransform[0], p, Position, true);
 
-            if ((rand() % 3) == 0)
+            if (rand_fps_check(3))
             {
                 CreateSprite(BITMAP_SHINY + 1, Position, 0.6f, Light2, o, (float)(rand() % 360));
             }
@@ -6951,7 +6951,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
             CreateSprite(BITMAP_LIGHT, Position, 1.1f, Light, o);
         }
 
-        if (o->CurrentAction == PLAYER_RUN_TWO_HAND_SWORD_TWO && gMapManager.WorldActive != WD_10HEAVEN && rand() % 2 == 0)
+        if (o->CurrentAction == PLAYER_RUN_TWO_HAND_SWORD_TWO && gMapManager.WorldActive != WD_10HEAVEN && rand_fps_check(2))
         {
             if (!g_Direction.m_CKanturu.IsMayaScene())
             {
@@ -7154,7 +7154,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
             Vector(0.4f, 0.4f, 0.4f, Light2);
             b->TransformPosition(BoneTransform[i + 2], p, Position, true);
 
-            if ((rand() % 3) == 0)
+            if (rand_fps_check(3))
             {
                 CreateSprite(BITMAP_SHINY + 1, Position, 0.6f, Light2, o, (float)(rand() % 360));
             }
@@ -7185,7 +7185,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
                     Vector(0.f,i*30.f-10.f,0.f,p);
                     b->TransformPosition(BoneTransform[0],p,Position,true);
 
-                    if ( (rand()%3)==0 )
+                    if ( rand_fps_check(3) )
                     {
                         CreateSprite(BITMAP_SHINY+1,Position,0.6f,Light2, o, ( float)( rand()%360));
                     }
@@ -7308,7 +7308,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         vec3_t Light2;
         Vector(0.4f, 0.4f, 0.4f, Light2);
         b->TransformPosition(BoneTransform[0], p, Position, true);
-        if ((rand() % 3) == 0)
+        if (rand_fps_check(3))
         {
             CreateSprite(BITMAP_SHINY + 1, Position, 0.6f, Light2, o, (float)(rand() % 360));
         }
@@ -7354,7 +7354,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
     break;
     case MODEL_SWORD + 21:
     case MODEL_SWORD + 31:
-        if (o->CurrentAction == PLAYER_RUN_TWO_HAND_SWORD_TWO && gMapManager.WorldActive != WD_10HEAVEN && rand() % 2 == 0)
+        if (o->CurrentAction == PLAYER_RUN_TWO_HAND_SWORD_TWO && gMapManager.WorldActive != WD_10HEAVEN && rand_fps_check(2))
         {
             if (!g_Direction.m_CKanturu.IsMayaScene())
             {
@@ -7536,7 +7536,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         vDPos[1] = Position[1] + ((float)(rand() % 20 - 10) * 3.f);
         vDPos[2] = Position[2] + ((float)(rand() % 20 - 10) * 3.f);
 
-        if (rand() % 10 == 0)
+        if (rand_fps_check(10))
         {
             CreateEffect(MODEL_STAR_SHINE, vDPos, o->Angle, Light, 0, Object, -1, 0, 0, 0, 0.22f);
         }
@@ -8717,14 +8717,14 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
         float Luminosity = absf(sinf(WorldTime * 0.002f)) * 0.4f;
         Vector(0.5f + Luminosity, 0.0f + Luminosity, 0.0f + Luminosity, Light);
 
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             VectorCopy(o->Position, b->BodyOrigin);
             b->Animation(BoneTransform, o->AnimationFrame, o->PriorAnimationFrame, o->PriorAction, o->Angle, o->HeadAngle);
             b->TransformPosition(BoneTransform[43], vRelativePos, vtaWorldPos, false);
             vtaWorldPos[2] += 20.f;
 
-            CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 3 == 0 ? vLight : vLight1, 1, 0.3f);
+            CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand_fps_check(3) ? vLight : vLight1, 1, 0.3f);
         }
 
         VectorCopy(o->Position, b->BodyOrigin);
@@ -8732,8 +8732,8 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
         b->TransformPosition(BoneTransform[43], vRelativePos, vtaWorldPos, false);
         vtaWorldPos[2] += 20.f;
 
-        CreateParticle(BITMAP_SPARK + 1, vtaWorldPos, o->Angle, rand() % 3 == 0 ? vLight2 : vLight1, 25, Scale + 0.2f);
-        CreateParticle(BITMAP_SPARK + 1, vtaWorldPos, o->Angle, rand() % 2 == 0 ? vLight2 : vLight1, 25, Scale + 0.3f);
+        CreateParticle(BITMAP_SPARK + 1, vtaWorldPos, o->Angle, rand_fps_check(3) ? vLight2 : vLight1, 25, Scale + 0.2f);
+        CreateParticle(BITMAP_SPARK + 1, vtaWorldPos, o->Angle, rand_fps_check(2) ? vLight2 : vLight1, 25, Scale + 0.3f);
 
         Vector(0.7f, 0.5f, 0.2f, vLight);
         CreateSprite(BITMAP_LIGHT, vtaWorldPos, 2.f, vLight, o, 0.f);
@@ -8753,10 +8753,10 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
 
             CreateSprite(BITMAP_LIGHT, vtaWorldPos, 1.5f, vLight, o, 0.f);
 
-            if (rand() % 3 == 0) {
+            if (rand_fps_check(3)) {
                 auto randpos = (float)(rand() % 30 + 5);
 
-                if (rand() % 2 == 0) {
+                if (rand_fps_check(2)) {
                     vtaWorldPos[0] += randpos;
                 }
                 else {
@@ -10009,7 +10009,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
 
                         CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 23, 1.0f);
 #ifdef ASG_ADD_ETERNALWING_STICK_EFFECT
-                        if (rand() % 20 == 0)
+                        if (rand_fps_check(20))
                             CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 20, 1.0f);
                         Vector(1.0f, 0.0f, 0.0f, Light);
                         RenderBrightEffect(b, BITMAP_LIGHT, 2, 3.0f, Light, o);
@@ -10136,7 +10136,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
 
                 if (o->AnimationFrame < 2.f)
                 {
-                    if (PartyNumber > 0 /*&& rand()%2==0*/)
+                    if (PartyNumber > 0 /*&& rand_fps_check(2)*/)
                     {
                         if (g_pPartyManager->IsPartyMemberChar(c) == false)
                             break;
@@ -10606,7 +10606,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                             Vector(0.6f, 0.3f, 0.4f, o->Light);
                         if (EquipmentLevelSet == 10)
                         {
-                            if ((rand() % 4) == 0)
+                            if (rand_fps_check(4))
                             {
                                 Vector(0.0f, -18.0f, 50.0f, p);
                                 b->TransformPosition(o->BoneTransform[0], p, Position, true);
@@ -10621,7 +10621,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 11)
                         {
-                            if ((rand() % 3) == 0)
+                            if (rand_fps_check(3))
                             {
                                 Vector(0.0f, -18.0f, 50.0f, p);
                                 b->TransformPosition(o->BoneTransform[0], p, Position, true);
@@ -10636,7 +10636,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 12)
                         {
-                            if ((rand() % 2) == 0)
+                            if (rand_fps_check(2))
                             {
                                 Vector(0.0f, -18.0f, 50.0f, p);
                                 b->TransformPosition(o->BoneTransform[0], p, Position, true);
@@ -10690,7 +10690,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                 }
                 if (EquipmentLevelSet > 9)
                 {
-                    if ((rand() % 20) == 0)//(o->CurrentAction<PLAYER_WALK_MALE || o->CurrentAction>PLAYER_RUN_RIDE_WEAPON) && (rand()%6)==0)
+                    if (rand_fps_check(20))//(o->CurrentAction<PLAYER_WALK_MALE || o->CurrentAction>PLAYER_RUN_RIDE_WEAPON) && rand_fps_check(6))
                     {
                         VectorCopy(o->Light, Light);
                         Vector(1.f, 1.f, 1.f, o->Light);
@@ -10701,7 +10701,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 11)
                         {
-                            if ((rand() % 8) == 0)
+                            if (rand_fps_check(8))
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 0, o);
                             }
@@ -10712,25 +10712,25 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 12)
                         {
-                            if ((rand() % 6) == 0)
+                            if (rand_fps_check(6))
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 0);
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 1);
                             }
-                            else if ((rand() % 3) == 0)
+                            else if (rand_fps_check(3))
                             {
                                 CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
                             }
                         }
                         else if (EquipmentLevelSet == 13)
                         {
-                            if ((rand() % 6) == 0)
+                            if (rand_fps_check(6))
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 0);
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 1);
                             }
 
-                            if ((rand() % 4) == 0)
+                            if (rand_fps_check(4))
                             {
                                 CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
                                 CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 7, o, 20, 40, 1);
@@ -10738,13 +10738,13 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 14)
                         {
-                            if ((rand() % 6) == 0)
+                            if (rand_fps_check(6))
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 0);
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 1);
                             }
 
-                            if ((rand() % 4) == 0)
+                            if (rand_fps_check(4))
                             {
                                 CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
                                 CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 7, o, 20, 40, 1);
@@ -10752,13 +10752,13 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         }
                         else if (EquipmentLevelSet == 15)
                         {
-                            if ((rand() % 6) == 0)
+                            if (rand_fps_check(6))
                             {
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 0);
                                 CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 18, o, 20, -1, 1);
                             }
 
-                            if ((rand() % 4) == 0)
+                            if (rand_fps_check(4))
                             {
                                 CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
                                 CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 7, o, 20, 40, 1);
@@ -10855,7 +10855,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
         CreateSprite(BITMAP_LIGHTNING + 1, Position, Scale, Light, o, (WorldTime / 50.0f));
         CreateSprite(BITMAP_LIGHTNING + 1, Position, Scale, Light, o, ((-WorldTime) / 50.0f));
 
-        if (rand() % 30 == 0)
+        if (rand_fps_check(30))
         {
             p[0] = Position[0] + rand() % 100 - 50;
             p[1] = Position[1] + rand() % 100 - 50;
@@ -10886,7 +10886,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
         CreateSprite(BITMAP_LIGHT, vPos, fScale, Light, o);
         CreateSprite(BITMAP_KANTURU_2ND_EFFECT1, vPos, fScale, Light, o);
 
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             Vector(-20.0f, 10.0f, 0.0f, vRelative);
             b->TransformPosition(
@@ -10931,7 +10931,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         CreateSprite(BITMAP_SHINY + 1, Position, 2.5f, Light, o, 0.f, 1);
                     else
                         CreateSprite(BITMAP_MAGIC + 1, Position, 0.8f, Light, o, 0.f);
-                    if (rand() % 4 == 0 && o->CurrentAction >= MONSTER01_ATTACK1 && o->CurrentAction <= MONSTER01_ATTACK2)
+                    if (rand_fps_check(4) && o->CurrentAction >= MONSTER01_ATTACK1 && o->CurrentAction <= MONSTER01_ATTACK2)
                     {
                         CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                     }
@@ -14447,9 +14447,9 @@ BOOL PlayMonsterSoundGlobal(OBJECT* pObject)
     case MODEL_MONSTER01 + 155:
         if (pObject->CurrentAction == MONSTER01_STOP1)
         {
-            // 			if (rand() % 10 == 0)
+            // 			if (rand_fps_check(10))
             {
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                     PlayBuffer(SOUND_XMAS_SANTA_IDLE_1);
                 else
                     PlayBuffer(SOUND_XMAS_SANTA_IDLE_2);
@@ -14457,9 +14457,9 @@ BOOL PlayMonsterSoundGlobal(OBJECT* pObject)
         }
         else if (pObject->CurrentAction == MONSTER01_WALK)
         {
-            //if (rand() % 10 == 0)
+            //if (rand_fps_check(10))
             {
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                     PlayBuffer(SOUND_XMAS_SANTA_WALK_1);
                 else
                     PlayBuffer(SOUND_XMAS_SANTA_WALK_2);
@@ -14471,7 +14471,7 @@ BOOL PlayMonsterSoundGlobal(OBJECT* pObject)
         }
         else if (pObject->CurrentAction == MONSTER01_SHOCK)
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 PlayBuffer(SOUND_XMAS_SANTA_DAMAGE_1);
             else
                 PlayBuffer(SOUND_XMAS_SANTA_DAMAGE_2);
@@ -14516,7 +14516,7 @@ BOOL PlayMonsterSoundGlobal(OBJECT* pObject)
     case MODEL_DOPPELGANGER_NPC_LUGARD:
         if (pObject->CurrentAction == MONSTER01_STOP1)
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 PlayBuffer(SOUND_DOPPELGANGER_LUGARD_BREATH);
         }
         return TRUE;

--- a/Source Main 5.2/source/ZzzCharacter.cpp
+++ b/Source Main 5.2/source/ZzzCharacter.cpp
@@ -10601,54 +10601,44 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         if (c->BodyPart[BODYPART_BOOTS].Type == MODEL_BOOTS + 31) Vector(0.0f, 0.32f, 0.24f, o->Light);
                         if (c->BodyPart[BODYPART_BOOTS].Type == MODEL_BOOTS + 32) Vector(0.5f, 0.24f, 0.8f, o->Light);
                         if (c->BodyPart[BODYPART_BOOTS].Type == MODEL_BOOTS + 33) Vector(0.6f, 0.4f, 0.0f, o->Light);
-                        if (c->BodyPart[BODYPART_BOOTS].Type == MODEL_BOOTS + 43)
-                            Vector(0.6f, 0.3f, 0.4f, o->Light);
-                        if (EquipmentLevelSet == 10)
+                        if (c->BodyPart[BODYPART_BOOTS].Type == MODEL_BOOTS + 43) Vector(0.6f, 0.3f, 0.4f, o->Light);
+                        if (EquipmentLevelSet == 10 && rand_fps_check(4))
                         {
-                            if (rand_fps_check(4))
-                            {
-                                Vector(0.0f, -18.0f, 50.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                                Vector(0.0f, 0.0f, 70.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                                Vector(0.0f, 18.0f, 50.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                            }
+                            Vector(0.0f, -18.0f, 50.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
+                            Vector(0.0f, 0.0f, 70.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
+                            Vector(0.0f, 18.0f, 50.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
                         }
-                        else if (EquipmentLevelSet == 11)
+                        else if (EquipmentLevelSet == 11 && rand_fps_check(3))
                         {
-                            if (rand_fps_check(3))
-                            {
-                                Vector(0.0f, -18.0f, 50.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                                Vector(0.0f, 0.0f, 70.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                                Vector(0.0f, 18.0f, 50.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                            }
+                            Vector(0.0f, -18.0f, 50.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
+                            Vector(0.0f, 0.0f, 70.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
+                            Vector(0.0f, 18.0f, 50.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
                         }
-                        else if (EquipmentLevelSet == 12)
+                        else if (EquipmentLevelSet == 12 && rand_fps_check(2))
                         {
-                            if (rand_fps_check(2))
-                            {
-                                Vector(0.0f, -18.0f, 50.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                                Vector(0.0f, 0.0f, 70.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                                Vector(0.0f, 18.0f, 50.0f, p);
-                                b->TransformPosition(o->BoneTransform[0], p, Position, true);
-                                CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
-                            }
+                            Vector(0.0f, -18.0f, 50.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
+                            Vector(0.0f, 0.0f, 70.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
+                            Vector(0.0f, 18.0f, 50.0f, p);
+                            b->TransformPosition(o->BoneTransform[0], p, Position, true);
+                            CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
                         }
-                        else if (EquipmentLevelSet == 13)
+                        else if (EquipmentLevelSet == 13 && rand_fps_check(1))
                         {
                             Vector(0.0f, -20.0f, 50.0f, p);
                             b->TransformPosition(o->BoneTransform[0], p, Position, true);
@@ -10660,7 +10650,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                             b->TransformPosition(o->BoneTransform[0], p, Position, true);
                             CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
                         }
-                        else if (EquipmentLevelSet == 14)
+                        else if (EquipmentLevelSet == 14 && rand_fps_check(1))
                         {
                             Vector(0.0f, -20.0f, 50.0f, p);
                             b->TransformPosition(o->BoneTransform[0], p, Position, true);
@@ -10672,7 +10662,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                             b->TransformPosition(o->BoneTransform[0], p, Position, true);
                             CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
                         }
-                        else if (EquipmentLevelSet == 15)
+                        else if (EquipmentLevelSet == 15 && rand_fps_check(1))
                         {
                             Vector(0.0f, -20.0f, 50.0f, p);
                             b->TransformPosition(o->BoneTransform[0], p, Position, true);
@@ -10684,6 +10674,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                             b->TransformPosition(o->BoneTransform[0], p, Position, true);
                             CreateParticle(BITMAP_WATERFALL_2, Position, o->Angle, o->Light, 3);
                         }
+
                         VectorCopy(Light, o->Light);
                     }
                 }
@@ -10767,7 +10758,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         VectorCopy(Light, o->Light);
                     }
 
-                    if (EquipmentLevelSet == 15 && g_pOption->GetRenderLevel() >= 4)
+                    if (EquipmentLevelSet == 15 && g_pOption->GetRenderLevel() >= 4 && rand_fps_check(1))
                     {
                         //left
                         vec3_t vColor;

--- a/Source Main 5.2/source/ZzzCharacter.cpp
+++ b/Source Main 5.2/source/ZzzCharacter.cpp
@@ -10572,7 +10572,8 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                 }
                 c->ExtendStateTime += min(1, FPS_ANIMATION_FACTOR);
             }
-            if (fullset)
+
+            if (fullset && g_pOption->GetRenderLevel() >= 2)
             {
                 PartObjectColor(c->BodyPart[5].Type, o->Alpha, 0.5f, Light);
 
@@ -10686,6 +10687,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         VectorCopy(Light, o->Light);
                     }
                 }
+
                 if (EquipmentLevelSet > 9)
                 {
                     if (rand_fps_check(20))//(o->CurrentAction<PLAYER_WALK_MALE || o->CurrentAction>PLAYER_RUN_RIDE_WEAPON) && rand_fps_check(6))
@@ -10765,7 +10767,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         VectorCopy(Light, o->Light);
                     }
 
-                    if (EquipmentLevelSet == 15)
+                    if (EquipmentLevelSet == 15 && g_pOption->GetRenderLevel() >= 4)
                     {
                         //left
                         vec3_t vColor;

--- a/Source Main 5.2/source/ZzzCharacter.cpp
+++ b/Source Main 5.2/source/ZzzCharacter.cpp
@@ -417,7 +417,8 @@ void SetPlayerWalk(CHARACTER* c)
                 || c->Object.SubType == MODEL_CURSEDTEMPLE_ALLIED_PLAYER
                 || c->Object.SubType == MODEL_CURSEDTEMPLE_ILLUSION_PLAYER)
             {
-                c->Run++;
+                // RUN are the number of frames which are required until running gets active
+                c->Run += FPS_ANIMATION_FACTOR;
             }
         }
     OBJECT* o = &c->Object;
@@ -3711,11 +3712,11 @@ void CreateWeaponBlur(CHARACTER* c, OBJECT* o, BMD* b)
             }
             else
             {
-                float inter = 10.f;
-                float animationFrame = o->AnimationFrame - b->Actions[b->CurrentAction].PlaySpeed;
-                float priorAnimationFrame = o->PriorAnimationFrame;
-                float animationSpeed = b->Actions[b->CurrentAction].PlaySpeed / inter;
-
+                constexpr float inter = 10.f;
+                const float playSpeed = b->Actions[b->CurrentAction].PlaySpeed * FPS_ANIMATION_FACTOR;
+                float animationFrame = o->AnimationFrame - playSpeed;
+                const float priorAnimationFrame = o->PriorAnimationFrame;
+                const float animationSpeed = playSpeed / inter;
                 for (int i = 0; i < (int)(inter); ++i)
                 {
                     b->Animation(BoneTransform, animationFrame, priorAnimationFrame, o->PriorAction, o->Angle, o->HeadAngle);
@@ -6104,13 +6105,18 @@ float CharacterMoveSpeed(CHARACTER* c)
     return Speed;
 }
 
+float ScaledCharacterMoveSpeed(CHARACTER* c)
+{
+    return CharacterMoveSpeed(c) * FPS_ANIMATION_FACTOR;
+}
+
 void MoveCharacterPosition(CHARACTER* c)
 {
     OBJECT* o = &c->Object;
     float Matrix[3][4];
     AngleMatrix(o->Angle, Matrix);
     vec3_t v, Velocity;
-    Vector(0.f, -CharacterMoveSpeed(c), 0.f, v);
+    Vector(0.f, -ScaledCharacterMoveSpeed(c), 0.f, v);
     VectorRotate(v, Matrix, Velocity);
     VectorAdd(o->Position, Velocity, o->Position);
 
@@ -11097,9 +11103,9 @@ void ClearCharacters(int Key)
 
             BoneManager::UnregisterBone(c);
 
-            for (int j = 0; j < MAX_BUTTERFLES; j++)
+            for (int j = 0; j < MAX_MOUNTS; j++)
             {
-                OBJECT* b = &Butterfles[j];
+                OBJECT* b = &Mounts[j];
                 if (b->Live && b->Owner == o)
                     b->Live = false;
             }
@@ -11123,9 +11129,9 @@ void DeleteCharacter(int Key)
 
             BoneManager::UnregisterBone(c);
 
-            for (int j = 0; j < MAX_BUTTERFLES; j++)
+            for (int j = 0; j < MAX_MOUNTS; j++)
             {
-                OBJECT* b = &Butterfles[j];
+                OBJECT* b = &Mounts[j];
                 if (b->Live && b->Owner == o)
                     b->Live = false;
             }
@@ -11143,9 +11149,9 @@ void DeleteCharacter(CHARACTER* c, OBJECT* o)
 
     BoneManager::UnregisterBone(c);
 
-    for (int j = 0; j < MAX_BUTTERFLES; j++)
+    for (int j = 0; j < MAX_MOUNTS; j++)
     {
-        OBJECT* b = &Butterfles[j];
+        OBJECT* b = &Mounts[j];
         if (b->Live && b->Owner == o)
             b->Live = false;
     }
@@ -12159,7 +12165,7 @@ void ChangeCharacterExt(int Key, BYTE* Equipment, CHARACTER* pCharacter, OBJECT*
 
     if (pHelper == NULL)
     {
-        DeleteBug(o);
+        DeleteMount(o);
         ThePetProcess().DeletePet(c, c->Helper.Type, true);
     }
     else
@@ -12174,9 +12180,9 @@ void ChangeCharacterExt(int Key, BYTE* Equipment, CHARACTER* pCharacter, OBJECT*
         {
             c->Helper.Type = MODEL_HELPER + 3;
             if (pHelper == NULL)
-                CreateBug(MODEL_PEGASUS, o->Position, o);
+                CreateMount(MODEL_PEGASUS, o->Position, o);
             else
-                CreateBugSub(MODEL_PEGASUS, o->Position, o, pHelper);
+                CreateMountSub(MODEL_PEGASUS, o->Position, o, pHelper);
         }
         else
         {
@@ -12221,9 +12227,9 @@ void ChangeCharacterExt(int Key, BYTE* Equipment, CHARACTER* pCharacter, OBJECT*
             if (bCreateHelper == TRUE)
             {
                 if (pHelper == NULL)
-                    CreateBug(HelperType, o->Position, o);
+                    CreateMount(HelperType, o->Position, o);
                 else
-                    CreateBugSub(HelperType, o->Position, o, pHelper);
+                    CreateMountSub(HelperType, o->Position, o, pHelper);
             }
         }
     }
@@ -12233,9 +12239,9 @@ void ChangeCharacterExt(int Key, BYTE* Equipment, CHARACTER* pCharacter, OBJECT*
     {
         c->Helper.Type = MODEL_HELPER + 4;
         if (pHelper == NULL)
-            CreateBug(MODEL_DARK_HORSE, o->Position, o);
+            CreateMount(MODEL_DARK_HORSE, o->Position, o);
         else
-            CreateBugSub(MODEL_DARK_HORSE, o->Position, o, pHelper);
+            CreateMountSub(MODEL_DARK_HORSE, o->Position, o, pHelper);
     }
 
     Type = Equipment[11] & 0x04;
@@ -12255,30 +12261,30 @@ void ChangeCharacterExt(int Key, BYTE* Equipment, CHARACTER* pCharacter, OBJECT*
         if (Type == 0x01)
         {
             if (pHelper == NULL)
-                CreateBug(MODEL_FENRIR_BLACK, o->Position, o);
+                CreateMount(MODEL_FENRIR_BLACK, o->Position, o);
             else
-                CreateBugSub(MODEL_FENRIR_BLACK, o->Position, o, pHelper);
+                CreateMountSub(MODEL_FENRIR_BLACK, o->Position, o, pHelper);
         }
         else if (Type == 0x02)
         {
             if (pHelper == NULL)
-                CreateBug(MODEL_FENRIR_BLUE, o->Position, o);
+                CreateMount(MODEL_FENRIR_BLUE, o->Position, o);
             else
-                CreateBugSub(MODEL_FENRIR_BLUE, o->Position, o, pHelper);
+                CreateMountSub(MODEL_FENRIR_BLUE, o->Position, o, pHelper);
         }
         else if (Type == 0x04)
         {
             if (pHelper == NULL)
-                CreateBug(MODEL_FENRIR_GOLD, o->Position, o);
+                CreateMount(MODEL_FENRIR_GOLD, o->Position, o);
             else
-                CreateBugSub(MODEL_FENRIR_GOLD, o->Position, o, pHelper);
+                CreateMountSub(MODEL_FENRIR_GOLD, o->Position, o, pHelper);
         }
         else
         {
             if (pHelper == NULL)
-                CreateBug(MODEL_FENRIR_RED, o->Position, o);
+                CreateMount(MODEL_FENRIR_RED, o->Position, o);
             else
-                CreateBugSub(MODEL_FENRIR_RED, o->Position, o, pHelper);
+                CreateMountSub(MODEL_FENRIR_RED, o->Position, o, pHelper);
         }
     }
 

--- a/Source Main 5.2/source/ZzzCharacter.h
+++ b/Source Main 5.2/source/ZzzCharacter.h
@@ -68,7 +68,7 @@ void SetCharacterClass(CHARACTER* c);
 void SetCharacterScale(CHARACTER* c);
 void SetChangeClass(CHARACTER* c);
 int LevelConvert(BYTE Level);
-float ScaledCharacterMoveSpeed(CHARACTER* c);
+float CharacterMoveSpeed(CHARACTER* c);
 
 bool CheckMonsterSkill(CHARACTER* c, OBJECT* o);
 bool CheckMonsterInRange(CHARACTER* c, float Range);

--- a/Source Main 5.2/source/ZzzCharacter.h
+++ b/Source Main 5.2/source/ZzzCharacter.h
@@ -68,7 +68,8 @@ void SetCharacterClass(CHARACTER* c);
 void SetCharacterScale(CHARACTER* c);
 void SetChangeClass(CHARACTER* c);
 int LevelConvert(BYTE Level);
-float CharacterMoveSpeed(CHARACTER* c);
+float ScaledCharacterMoveSpeed(CHARACTER* c);
+
 bool CheckMonsterSkill(CHARACTER* c, OBJECT* o);
 bool CheckMonsterInRange(CHARACTER* c, float Range);
 bool CharacterAnimation(CHARACTER* c, OBJECT* o);

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -3330,7 +3330,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     if (o->SubType == 2)
                     {
                         CreateJoint(BITMAP_JOINT_THUNDER + 1, o->Position, o->Position, o->Angle, 4, o, 60.f + rand() % 10);
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                             CreateJoint(BITMAP_JOINT_THUNDER + 1, o->Position, o->Position, o->Angle, 4, o, 60.f + rand() % 10);
                     }
                 }
@@ -3666,7 +3666,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     float angle = 45.f + (-90.f * o->SubType);
 
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         if (o->SubType)
                         {
@@ -4053,12 +4053,12 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
             {
                 if (o->Type == MODEL_NEWYEARSDAY_EVENT_HOTPEPPER_GREEN)
                 {
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                         o->Type = MODEL_NEWYEARSDAY_EVENT_HOTPEPPER_RED;
                 }
                 else if (o->Type == MODEL_NEWYEARSDAY_EVENT_HOTPEPPER_RED)
                 {
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                         o->Type = MODEL_NEWYEARSDAY_EVENT_HOTPEPPER_GREEN;
                 }
 
@@ -4194,7 +4194,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
                     default:
                         o->m_vDeadPosition[0] = Hero->Object.Position[0] + (rand() % 16 - 8) * TERRAIN_SCALE;
-                        if (rand() % 5 == 0)
+                        if (rand_fps_check(5))
                             o->m_vDeadPosition[1] = 114 * TERRAIN_SCALE;
                         else
                             o->m_vDeadPosition[1] = (rand() % 33 + 98) * TERRAIN_SCALE;
@@ -4506,7 +4506,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     else if (irandom >= 6 && irandom <= 7)
                     {
                         o->Scale -= (0.2f) * FPS_ANIMATION_FACTOR;
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                             p_b->TransformPosition(BoneTransform[50], vPos, o->Position, false);
                         else
                             p_b->TransformPosition(BoneTransform[51], vPos, o->Position, false);
@@ -6608,13 +6608,13 @@ void CreateBomb3(vec3_t vPos, int iSubType, float fScale)
     {
         if (iSubType == 2)
         {
-            if (rand() % 10 == 0) break;
+            if (rand_fps_check(10)) break;
             Vector(vPos[0] + rand() % 150 - 75, vPos[1] + rand() % 150 - 75, vPos[2] + rand() % 130 + 30, vBombPos);
         }
         else if (iSubType == 1)
         {
             if (i == 1) break;
-            else if (rand() % 5 == 0) break;
+            else if (rand_fps_check(5)) break;
             Vector(vPos[0] + rand() % 80 - 40, vPos[1] + rand() % 80 - 40, vPos[2] + rand() % 120 + 30, vBombPos);
         }
         else if (iSubType == 3)
@@ -6769,7 +6769,7 @@ void CheckClientArrow(OBJECT* o)
     }
     else
     {
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             if (o->Owner == &Hero->Object)
             {
                 float range = 100.f;
@@ -6981,9 +6981,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         OBJECT* pOwner = o->Owner;
         if (o->SubType == 1)
         {
-            o->Light[0] *= 0.95f;
-            o->Light[1] *= 0.95f;
-            o->Light[2] *= 0.95f;
+            o->Light[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.95f, FPS_ANIMATION_FACTOR);
         }
         VectorTransform(tmp, pOwner->BoneTransform[29], o->Position);
         VectorScale(o->Position, pOwner->Scale, o->Position);
@@ -6998,16 +6998,16 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            o->Light[0] *= 0.95f;
-            o->Light[1] *= 0.95f;
-            o->Light[2] *= 0.95f;
+            o->Light[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.95f, FPS_ANIMATION_FACTOR);
             VectorCopy(o->Owner->Position, o->Position);
         }
         else if (o->SubType == 1)
         {
-            o->Light[0] *= 0.98f;
-            o->Light[1] *= 0.98f;
-            o->Light[2] *= 0.98f;
+            o->Light[0] *= pow(0.98f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.98f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.98f, FPS_ANIMATION_FACTOR);
             if (o->LifeTime == 40)
                 CreateEffect(MODEL_INFINITY_ARROW3, o->Position, o->Angle, o->Light, 2, o);
             else
@@ -7017,16 +7017,16 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 2)
         {
-            o->Light[0] *= 0.98f;
-            o->Light[1] *= 0.98f;
-            o->Light[2] *= 0.98f;
+            o->Light[0] *= pow(0.98f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.98f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.98f, FPS_ANIMATION_FACTOR);
             VectorCopy(o->Owner->Position, o->Position);
         }
         else if (o->SubType == 3)
         {
-            o->Light[0] *= 0.98f;
-            o->Light[1] *= 0.98f;
-            o->Light[2] *= 0.98f;
+            o->Light[0] *= pow(0.98f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.98f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.98f, FPS_ANIMATION_FACTOR);
             VectorCopy(o->Owner->Position, o->Position);
         }
     }
@@ -7035,10 +7035,10 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         vec3_t tmp = { 0.f, 0.f, 0.f };
         OBJECT* pOwner = o->Owner;
-        o->Scale *= 1.2f;
-        o->Light[0] *= 0.9f;
-        o->Light[1] *= 0.9f;
-        o->Light[2] *= 0.9f;
+        o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
+        o->Light[0] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+        o->Light[1] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+        o->Light[2] *= pow(0.9f, FPS_ANIMATION_FACTOR);
 
         VectorTransform(tmp, pOwner->BoneTransform[29], o->Position);
         VectorScale(o->Position, pOwner->Scale, o->Position);
@@ -7132,12 +7132,12 @@ void MoveEffect(OBJECT* o, int iIndex)
 
     case MODEL_IRON_RIDER_ARROW:
     {
-        o->Scale *= 1.05f;
+        o->Scale *= pow(1.05f, FPS_ANIMATION_FACTOR);
         if (o->LifeTime < 5)
         {
-            o->Light[0] *= 0.7f;
-            o->Light[1] *= 0.7f;
-            o->Light[2] *= 0.7f;
+            o->Light[0] *= pow(0.7f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.7f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.7f, FPS_ANIMATION_FACTOR);
         }
         vec3_t vPos;
         VectorScale(o->Direction, o->Velocity, vPos);
@@ -7261,7 +7261,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         if (o->LifeTime <= 24)
         {
-            o->Scale *= 1.05f;
+            o->Scale *= pow(1.05f, FPS_ANIMATION_FACTOR);
             vec3_t vLight = { 0.3f, 0.5f, 1.f };
             vec3_t vPos;
             VectorScale(o->Direction, o->Velocity, vPos);
@@ -7347,7 +7347,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else
             o->Angle[2] -= (rand() % 10) * FPS_ANIMATION_FACTOR;
 
-        if (rand() % 32 == 0)
+        if (rand_fps_check(32))
         {
             o->Direction[2] = (float)(rand() % 15 - 7) * 1.f;
         }
@@ -7355,12 +7355,12 @@ void MoveEffect(OBJECT* o, int iIndex)
         float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height + 50.f)
         {
-            o->Direction[2] *= 0.8f;
+            o->Direction[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
             o->Direction[2] += (1.f) * FPS_ANIMATION_FACTOR;
         }
         if (o->Position[2] > Height + 150.f)
         {
-            o->Direction[2] *= 0.8f;
+            o->Direction[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
             o->Direction[2] -= (1.f) * FPS_ANIMATION_FACTOR;
         }
         o->Position[2] += ((float)(rand() % 15 - 7) * 0.3f) * FPS_ANIMATION_FACTOR;
@@ -7378,7 +7378,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else if (o->SubType == 3)
         {
             Vector(Luminosity * 0.7f, Luminosity * 0.9f, Luminosity * 0.5f, Light);
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 vec3_t Position;
                 Vector((float)(rand() % 16 - 8), (float)(rand() % 16 - 8), (float)(rand() % 16 - 8), Position);
@@ -7545,7 +7545,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->Type == MODEL_HALLOWEEN_CANDY_HOBAK)
             {
-                if (rand() % 3 == 0)
+                if (rand_fps_check(3))
                 {
                     CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 5, 0.4f + rand() % 10 * 0.01f);
                 }
@@ -7627,7 +7627,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             //CreateParticle(BITMAP_SMOKE, o->Position, o->Angle,o->Light, 23, 1.0f);
             //CreateParticle(BITMAP_SMOKE, o->Position, o->Angle,o->Light, 8, 1.0f);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 11, 1.0f);
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, o->Light, 3, 3.f);
             }
@@ -7838,7 +7838,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else
             {
-                if (Hero->SafeZone/* || rand()%100 == 0*/ || sinf(WorldTime * 0.0004f + o->Skill * 0.024f) < 0.3f)
+                if (Hero->SafeZone/* || rand_fps_check(100)*/ || sinf(WorldTime * 0.0004f + o->Skill * 0.024f) < 0.3f)
                     o->Kind = 1;
                 if (o->Alpha < 1.0f) o->Alpha += 0.03f;
             }
@@ -7852,7 +7852,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1)
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 OBJECT* pObject = o->Owner;
                 if (pObject->Live == false)
@@ -7889,7 +7889,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else
             {
-                if (Hero->SafeZone/* || rand()%100 == 0*/ || sinf(WorldTime * 0.0004f + o->Skill * 0.024f) < 0.3f)
+                if (Hero->SafeZone/* || rand_fps_check(100)*/ || sinf(WorldTime * 0.0004f + o->Skill * 0.024f) < 0.3f)
                     o->Kind = 1;
                 if (o->Alpha < 1.0f) o->Alpha += 0.03f;
             }
@@ -7900,7 +7900,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             vec3_t vLight;
             Vector(o->Alpha, o->Alpha, o->Alpha, vLight);
             CreateParticle(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 CreateParticle(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
 
             //DeleteJoint(MODEL_SPEARSKILL, o, 15);
@@ -8066,7 +8066,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->AnimationFrame >= 11.0f)
         {
             CreateBomb3(o->Position, o->SubType);
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 PlayBuffer(SOUND_SUMMON_EXPLOSION);
         }
 
@@ -8235,9 +8235,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime <= 10)
             {
                 o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
-                o->Light[0] *= o->Alpha;
-                o->Light[1] *= o->Alpha;
-                o->Light[2] *= o->Alpha;
+                o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 12)
@@ -8255,14 +8255,14 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Scale > 5.0f)
             {
                 //o->Scale = 5.0f;
-                o->Light[0] *= 0.5f;
-                o->Light[1] *= 0.5f;
-                o->Light[2] *= 0.5f;
+                o->Light[0] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(0.5f, FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 13)
         {
-            o->Scale *= 1.1f;
+            o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.95f, o->Light);
             if (o->Scale > 8)
             {
@@ -8275,7 +8275,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 14)
         {
-            o->Scale *= 1.1f;
+            o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.95f, o->Light);
             if (o->Scale > 8)
             {
@@ -8413,7 +8413,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     pModel->TransformPosition(o->Owner->BoneTransform[iBone], vRelativePos, vWorldPos, false);
                     VectorScale(vWorldPos, pModel->BodyScale, vWorldPos);
                     VectorAdd(vWorldPos, o->Owner->Position, vWorldPos);
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         vWorldPos[2] -= 20.f;
                         CreateParticle(o->Type, vWorldPos, o->Angle, o->Light, 0, o->Scale);
@@ -8462,7 +8462,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[0] = o->Position[0] + (float)(rand() % 500 - 250);
             Position[1] = o->Position[1] + (float)(rand() % 500 - 250);
             Position[2] = o->Position[2] - (float)(rand() % 100) + 150.0f;
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 if (o->SubType == 3)
                     CreateParticle(o->Type, Position, o->Angle, o->Light, 1, o->Scale);
@@ -8486,7 +8486,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     pModel->TransformPosition(o->Owner->BoneTransform[iBone], vRelativePos, vWorldPos, false);
                     VectorScale(vWorldPos, pModel->BodyScale, vWorldPos);
                     VectorAdd(vWorldPos, o->Owner->Position, vWorldPos);
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         vWorldPos[2] -= 20.f;
                         CreateParticle(o->Type, vWorldPos, o->Angle, o->Light, 0, o->Scale);
@@ -8542,7 +8542,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->LifeTime = 100;
 
-            if (rand() % 60 == 0)
+            if (rand_fps_check(60))
                 CreateParticle(o->Type, o->Position, o->Angle, o->Light, o->SubType, 0.5f, o->Owner);
         }
         break;
@@ -8637,14 +8637,14 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (o->LifeTime > 10)
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 CreateEffect(BITMAP_MAGIC + 1, vPosition, o->Angle, vLight, 11, o);
         }
 
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
             CreateParticle(BITMAP_SMOKE, vPosition, o->Angle, vLight, 54, 2.8f);
 
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
         {
             CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, vLight, 13);
         }
@@ -8652,11 +8652,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->LifeTime > 5)
         {
             Vector(0.15f, 0.15f, 0.4f, vLight);
-            if (rand() % 5 == 0)
+            if (rand_fps_check(5))
                 CreateEffect(BITMAP_CHROME_ENERGY2, vPosition, o->Angle, vLight, 0);
         }
 
-        if (o->Owner != NULL && rand() % 5 == 0 && o->Owner->BoneTransform != NULL)
+        if (o->Owner != NULL && rand_fps_check(5) && o->Owner->BoneTransform != NULL)
         {
             BMD* pTargetModel = &Models[o->Owner->Type];
             int iNumBones = pTargetModel->NumBones;
@@ -8725,44 +8725,55 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             for (int j = 0; j < 6; j++)
             {
+                //if (!rand_fps_check(1)) continue;
                 Vector((float)(rand() % 50 - 25), (float)(rand() % 50 - 25), 0.f, Position);
                 VectorAdd(Position, o->Position, Position);
                 CreateParticle(BITMAP_FLAME, Position, o->Angle, Light);
             }
-            if ((int)WorldTime % 16)
+            if (rand_fps_check(8))
+            {
                 CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+            }
 
             Vector(Luminosity * 1.f, Luminosity * 0.4f, Luminosity * 0.f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
-            if (o->Owner == &Hero->Object)
-                if ((int)o->LifeTime % 20 == 0)
-                    AttackCharacterRange(o->Skill, o->Position, 150.f, o->Weapon, o->PKKey);
+            if (o->Owner == &Hero->Object && (int)o->LifeTime % 20 == 0)
+            {
+                o->LifeTime = ((int)o->LifeTime / 20) * 19.9f;
+                AttackCharacterRange(o->Skill, o->Position, 150.f, o->Weapon, o->PKKey);
+            }
         }
         else if (o->SubType == 1 || o->SubType == 2)
         {
             for (int j = 0; j < 18; j++)
             {
-                Vector(0.f, 250.f, 0.f, p);
-                Vector(0.f, 0.f, j * 20.f, Angle);
-                AngleMatrix(Angle, Matrix);
-                VectorRotate(p, Matrix, Position);
-                VectorAdd(Position, o->Position, Position);
-                Position[0] += rand() % 64 - 32;
-                Position[1] += rand() % 64 - 32;
-                if (o->SubType == 1)
-                    CreateParticle(BITMAP_FLAME, Position, o->Angle, Light, 0, 1.2f);
-                else if (o->SubType == 2)
-                    CreateParticle(BITMAP_FIRE + 3, Position, o->Angle, Light, 13, 2.5f);
+                if (rand_fps_check(1))
+                {
+                    Vector(0.f, 250.f, 0.f, p);
+                    Vector(0.f, 0.f, j * 20.f, Angle);
+                    AngleMatrix(Angle, Matrix);
+                    VectorRotate(p, Matrix, Position);
+                    VectorAdd(Position, o->Position, Position);
+                    Position[0] += rand() % 64 - 32;
+                    Position[1] += rand() % 64 - 32;
+                    if (o->SubType == 1)
+                        CreateParticle(BITMAP_FLAME, Position, o->Angle, Light, 0, 1.2f);
+                    else if (o->SubType == 2)
+                        CreateParticle(BITMAP_FIRE + 3, Position, o->Angle, Light, 13, 2.5f);
+                }
             }
         }
         else if (o->SubType == 3)
         {
             for (int j = 0; j < 3; j++)
             {
-                CreateParticle(BITMAP_FLAME, o->Position, o->Angle, Light, 6);
-                Vector((float)(rand() % 10 - 5), (float)(rand() % 10 - 5), 40.f, Position);
-                VectorAdd(Position, o->Position, Position);
-                CreateParticle(BITMAP_TRUE_FIRE, Position, o->Angle, Light, 0, 2.8f);
+                if (rand_fps_check(1))
+                {
+                    CreateParticle(BITMAP_FLAME, o->Position, o->Angle, Light, 6);
+                    Vector((float)(rand() % 10 - 5), (float)(rand() % 10 - 5), 40.f, Position);
+                    VectorAdd(Position, o->Position, Position);
+                    CreateParticle(BITMAP_TRUE_FIRE, Position, o->Angle, Light, 0, 2.8f);
+                }
             }
             Vector((float)(rand() % 10 - 5), (float)(rand() % 10 - 5), -40.f, Position);
             VectorAdd(Position, o->Position, Position);
@@ -8778,14 +8789,17 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Scale += (20.f) * FPS_ANIMATION_FACTOR;
             for (int j = 0; j < 18; j++)
             {
-                Vector(0.f, 150.f - o->Scale, 0.f, p);
-                Vector(0.f, 0.f, j * 20.f, Angle);
-                AngleMatrix(Angle, Matrix);
-                VectorRotate(p, Matrix, Position);
-                VectorAdd(Position, o->Position, Position);
-                Position[0] += rand() % 64 - 32;
-                Position[1] += rand() % 64 - 32;
-                CreateParticle(BITMAP_FLAME, Position, o->Angle, Light, 0, 1.2f);
+                if (rand_fps_check(1))
+                {
+                    Vector(0.f, 150.f - o->Scale, 0.f, p);
+                    Vector(0.f, 0.f, j * 20.f, Angle);
+                    AngleMatrix(Angle, Matrix);
+                    VectorRotate(p, Matrix, Position);
+                    VectorAdd(Position, o->Position, Position);
+                    Position[0] += rand() % 64 - 32;
+                    Position[1] += rand() % 64 - 32;
+                    CreateParticle(BITMAP_FLAME, Position, o->Angle, Light, 0, 1.2f);
+                }
             }
             CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 12);
         }
@@ -8826,7 +8840,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     CreateParticle(BITMAP_FLAME, Position, o->Angle, o->Light, 11, 1.4f);
                 }
 
-                if (rand() % 8 == 0)
+                if (rand_fps_check(8))
                 {
                     CreateEffect(MODEL_ICE_SMALL, Position, o->Angle, o->Light, 0);
                 }
@@ -8836,14 +8850,17 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             for (int j = 0; j < 9; j++)
             {
-                Vector(0.f, 250.f, 0.f, p);
-                Vector(0.f, 0.f, j * 40.f, Angle);
-                AngleMatrix(Angle, Matrix);
-                VectorRotate(p, Matrix, Position);
-                VectorAdd(Position, o->Position, Position);
-                Position[0] += rand() % 64 - 32;
-                Position[1] += rand() % 64 - 32;
-                CreateParticle(BITMAP_FIRE + 3, Position, o->Angle, Light, 13, 2.5f);
+                if (rand_fps_check(1))
+                {
+                    Vector(0.f, 250.f, 0.f, p);
+                    Vector(0.f, 0.f, j * 40.f, Angle);
+                    AngleMatrix(Angle, Matrix);
+                    VectorRotate(p, Matrix, Position);
+                    VectorAdd(Position, o->Position, Position);
+                    Position[0] += rand() % 64 - 32;
+                    Position[1] += rand() % 64 - 32;
+                    CreateParticle(BITMAP_FIRE + 3, Position, o->Angle, Light, 13, 2.5f);
+                }
             }
         }
         break;
@@ -8871,11 +8888,14 @@ void MoveEffect(OBJECT* o, int iIndex)
         float Scale = 6.f;
         for (int j = 0; j < 18; j++)
         {
-            Position[2] += Scale * 4.f;
-            if (j == 0)
-                CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 1, Scale * 2.f);
-            else
-                CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 1, Scale);
+            if (rand_fps_check(1))
+            {
+                Position[2] += Scale * 4.f;
+                if (j == 0)
+                    CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 1, Scale * 2.f);
+                else
+                    CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 1, Scale);
+            }
         }
         break;
     }
@@ -9191,7 +9211,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(0.4f, 0.4f, 0.8f, vLight);
                 //CreateParticle( BITMAP_LIGHT, vTargetPos, pTargetObj->Angle, vLight, 14, 3.5f);
 
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     VectorCopy(pSourceObj->Position, vSourcePos);
                     vSourcePos[2] += 80.0f;
@@ -9360,7 +9380,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                     else if (o->SubType == 4)
                     {
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                         {
                             vWorldPos[2] -= 20.f;
                             CreateParticle(BITMAP_TWINTAIL_WATER, vWorldPos, o->Angle, o->Light, 2);
@@ -9482,7 +9502,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             for (int i = 0; i < 2; i++)
                 CreateParticle(BITMAP_SMOKE, vPosition, o->Angle, vLight, 58);
 
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Vector(1.0f, 0.0f, 0.0f, vLight);
                 CreateParticle(BITMAP_SMOKE, vPosition, o->Angle, vLight, 54, 2.8f);
@@ -9505,13 +9525,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                     pTargetModel->TransformPosition(o->Owner->BoneTransform[i], vRelativePos, vPos, true);
 
                     Vector(0.8f, 0.0f, 0.0f, vLight);
-                    if (rand() % 60 == 0)
+                    if (rand_fps_check(60))
                     {
                         fRandom = 5.0f + ((float)(rand() % 20 - 10) * 0.1f);
                         CreateParticle(BITMAP_LIGHT, vPos, vAngle, vLight, 5, fRandom);
                     }
                     Vector(1.0f, 0.8f, 0.4f, vLight);
-                    if (rand() % 5 == 0)
+                    if (rand_fps_check(5))
                     {
                         fRandom = (float)(rand() % 70 + 22) * 0.01f * 1.0f;
                         CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, vAngle, vLight, 0, fRandom);
@@ -9522,7 +9542,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 //for(i=0; i<2; i++)
                 CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 58);
 
-                if (rand() % 4 == 0)
+                if (rand_fps_check(4))
                 {
                     Vector(1.0f, 0.0f, 0.0f, vLight);
                     CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
@@ -9640,7 +9660,10 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(o->Position[0], o->Position[1], o->Position[2] + 80.f, Position);
             for (int j = 0; j < 6; j++)
             {
-                CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+                if (rand_fps_check(1))
+                {
+                    CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+                }
             }
             CreateParticle(BITMAP_SHINY + 4, Position, o->Angle, Light);
             CreateParticle(BITMAP_EXPLOTION, Position, o->Angle, Light);
@@ -9691,9 +9714,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Scale += (0.04f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 10)
             {
-                o->Light[0] *= 0.8f;
-                o->Light[1] *= 0.8f;
-                o->Light[2] *= 0.8f;
+                o->Light[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 3)
@@ -9785,7 +9808,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Live = false;
                 EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
                 for (int j = 0; j < 5; j++)
-                    CreateEffect(MODEL_METEO1 + rand() % 2, o->Position, o->Angle, o->Light, 0);
+                {
+                    if (rand_fps_check(1))
+                    {
+                        CreateEffect(MODEL_METEO1 + rand() % 2, o->Position, o->Angle, o->Light, 0);
+                    }
+                }
             }
         }
         VectorAdd(o->Position, o->Direction, o->Position);
@@ -9869,13 +9897,16 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             for (int j = 0; j < 4; j++)
             {
-                Vector((float)(rand() % 60 + 60 - 90), 0.f, (float)(rand() % 30 + 90), Angle);
-                VectorAdd(Angle, o->Angle, Angle);
-                VectorCopy(o->Position, Position);
-                Position[0] += rand() % 20 - 10;
-                Position[1] += rand() % 20 - 10;
-                CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
-                if (j == 0) CreateParticle(BITMAP_SPARK, Position, Angle, Light);
+                if (rand_fps_check(1))
+                {
+                    Vector((float)(rand() % 60 + 60 - 90), 0.f, (float)(rand() % 30 + 90), Angle);
+                    VectorAdd(Angle, o->Angle, Angle);
+                    VectorCopy(o->Position, Position);
+                    Position[0] += rand() % 20 - 10;
+                    Position[1] += rand() % 20 - 10;
+                    CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
+                    if (rand_fps_check(4)) CreateParticle(BITMAP_SPARK, Position, Angle, Light);
+                }
             }
         }
         VectorCopy(o->Position, Position);
@@ -9929,7 +9960,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         EarthQuake = (float)(rand() % 4 - 2) * 0.1f;
 
-        if (rand() % 2 == 0) {
+        if (rand_fps_check(2)) {
             Vector(0.f, (float)(rand() % 150) + 300.f, 0.f, p);
             Vector(0.f, 0.f, (float)(rand() % 360), Angle);
             AngleMatrix(Angle, Matrix);
@@ -9943,7 +9974,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         pModel->Animation(BoneTransform, o->AnimationFrame, o->PriorAnimationFrame, o->PriorAction, o->Angle, o->HeadAngle, false, false);
         Vector(1.f, 1.f, 1.f, Light);
         for (int i = 0; i < pModel->NumBones; i++) {
-            if (!pModel->Bones[i].Dummy && rand() % 12 == 0)
+            if (!pModel->Bones[i].Dummy && rand_fps_check(12))
             {
                 Vector(0.f, 0.f, 0.f, p);
                 pModel->TransformPosition(BoneTransform[i], p, Position, true);
@@ -10003,13 +10034,16 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 for (int j = 0; j < 8; j++)
                 {
-                    Vector((float)(rand() % 60 - 60.f), 0.f, (float)(rand() % 30 + 90), Angle);
-                    VectorAdd(Angle, o->Angle, Angle);
-                    VectorCopy(o->StartPosition, Position);
-                    Position[0] += rand() % 20 - 10;
-                    Position[1] += rand() % 20 - 10;
-                    CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
-                    if (j == 0) CreateParticle(BITMAP_SPARK, Position, Angle, Light);
+                    if (rand_fps_check(1))
+                    {
+                        Vector((float)(rand() % 60 - 60.f), 0.f, (float)(rand() % 30 + 90), Angle);
+                        VectorAdd(Angle, o->Angle, Angle);
+                        VectorCopy(o->StartPosition, Position);
+                        Position[0] += rand() % 20 - 10;
+                        Position[1] += rand() % 20 - 10;
+                        CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
+                        if (rand_fps_check(8)) CreateParticle(BITMAP_SPARK, Position, Angle, Light);
+                    }
                 }
             }
             Vector(0.f, 0.f, 0.f, Angle);
@@ -10121,7 +10155,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 count = 12.5;
                 addAngle = 18.f;
-                if (o->LifeTime == 15) o->Gravity *= -1;
+                if (o->LifeTime == 15) o->Gravity *= pow(-1, FPS_ANIMATION_FACTOR);
             }
 
             if (o->Kind == 0)
@@ -10209,7 +10243,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             o->BlendMeshLight = (o->LifeTime * 0.1f);
 
-            if (o->LifeTime >= 5 && rand() % 10 == 0)
+            if (o->LifeTime >= 5 && rand_fps_check(10))
             {
                 vec3_t p, Position;
                 vec3_t Angle;
@@ -10261,7 +10295,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             o->BlendMeshLight = (o->LifeTime * 0.1f);
 
-            if (o->LifeTime >= 5 && rand() % 15 == 0)
+            if (o->LifeTime >= 5 && rand_fps_check(15))
             {
                 vec3_t p, Position;
                 vec3_t Angle;
@@ -10307,7 +10341,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
         }
 
-        if (o->LifeTime >= 13 && rand() % 5 == 0)
+        if (o->LifeTime >= 13 && rand_fps_check(5))
         {
             vec3_t Position;
 
@@ -10345,7 +10379,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         vec3_t  Loc;
         int STwo = 2;
-        if (rand() % STwo == 0)
+        if (rand_fps_check(STwo))
         {
             //               Vector(0.f,0.f,(float)(rand()%360),o->Angle);
 
@@ -10499,18 +10533,18 @@ void MoveEffect(OBJECT* o, int iIndex)
             //VectorAdd(o->Position,o->Direction,o->Position);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
             Vector(90.f, 0.f, o->Angle[2], Angle);
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Vector(o->Position[0] - 200.f, o->Position[1], o->Position[2] + 700.f, Position);
                 CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 10.f);
             }
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Vector(o->Position[0] + 200.f, o->Position[1], o->Position[2] + 700.f, Position);
                 CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 10.f);
             }
             o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
-            if (rand() % 4 == 0)
+            if (rand_fps_check(4))
                 CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
             Vector(-Luminosity * 0.4f, -Luminosity * 0.3f, -Luminosity * 0.2f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 5, PrimaryTerrainLight);
@@ -10568,7 +10602,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 28);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 29);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 30);
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
             break;
         case 8:
@@ -10586,9 +10620,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->LifeTime >= 30)
         {
-            o->Light[0] *= 1.03f;
-            o->Light[1] *= 1.03f;
-            o->Light[2] *= 1.03f;
+            o->Light[0] *= pow(1.03f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.03f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.03f, FPS_ANIMATION_FACTOR);
         }
         else
         {
@@ -10689,7 +10723,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         for (int i = 0; i < 5; i++)
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 vec3_t Pos1, Pos2;
 
@@ -10780,7 +10814,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else
             o->Angle[0] -= (o->Scale * 32.f) * FPS_ANIMATION_FACTOR;
 
-        if (rand() % 10 == 0)
+        if (rand_fps_check(10))
             CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 15);
     }
     break;
@@ -10908,7 +10942,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.01f;
             EarthQuake = (float)(rand() % 6 - 6) * 0.1f;
 
-            if (rand() % value == 0)
+            if (rand_fps_check(value))
             {
                 vec3_t p, Position;
                 vec3_t Angle;
@@ -10934,7 +10968,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             o->BlendMeshLight = min(0.5f, o->BlendMeshLight);
             o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.01f;
-            if (o->LifeTime > 30 && rand() % value == 0)
+            if (o->LifeTime > 30 && rand_fps_check(value))
             {
                 vec3_t p, Position;
                 vec3_t Angle;
@@ -10967,7 +11001,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             o->BlendMeshLight = min(0.5f, o->BlendMeshLight);
             o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.01f;
-            if (rand() % value == 0 && o->LifeTime > 5)
+            if (rand_fps_check(value) && o->LifeTime > 5)
             {
                 vec3_t p, Position;
                 vec3_t Angle;
@@ -11000,7 +11034,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime < 10)
             {
-                o->Alpha *= 0.8f;
+                o->Alpha *= pow(0.8f, FPS_ANIMATION_FACTOR);
             }
             break;
         }
@@ -11018,8 +11052,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Position[2] + o->Direction[2] <= Height)
             {
                 o->Position[2] = Height;
-                o->HeadAngle[0] *= 0.6f;
-                o->HeadAngle[1] *= 0.6f;
+                o->HeadAngle[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                o->HeadAngle[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
                 o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                 if (o->HeadAngle[2] < 0.5f)
                     o->HeadAngle[2] = 0;
@@ -11027,7 +11061,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Alpha -= (0.1f) * FPS_ANIMATION_FACTOR;
             }
 
-            // 			if (rand()%3==0)
+            // 			if (rand_fps_check(3))
             // 			{
             // 				CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, o->Light, 0, 1, o);
             // 			}
@@ -11086,7 +11120,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             else
                 o->Angle[0] -= (o->Scale * 32.f) * FPS_ANIMATION_FACTOR;
 
-            if ((o->SubType == 0 || o->SubType == 12 || o->SubType == 13) && rand() % 10 == 0)
+            if ((o->SubType == 0 || o->SubType == 12 || o->SubType == 13) && rand_fps_check(10))
             {
                 if (o->Type == MODEL_ICE_SMALL || o->Type == MODEL_METEO1 || o->Type == MODEL_METEO2)
                     CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light);
@@ -11134,8 +11168,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Position[2] + o->Direction[2] <= Height)
             {
                 o->Position[2] = Height;
-                o->HeadAngle[0] *= 0.6f;
-                o->HeadAngle[1] *= 0.6f;
+                o->HeadAngle[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                o->HeadAngle[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
                 o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                 if (o->HeadAngle[2] < 0.5f)
                     o->HeadAngle[2] = 0;
@@ -11143,7 +11177,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Alpha -= (0.1f) * FPS_ANIMATION_FACTOR;
             }
 
-            if (rand() % 30 == 0)
+            if (rand_fps_check(30))
                 CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light);
         }
         else if (o->SubType == 1)
@@ -11226,8 +11260,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Position[2] + o->Direction[2] <= Height)
             {
                 o->Position[2] = Height;
-                o->HeadAngle[0] *= 0.6f;
-                o->HeadAngle[1] *= 0.6f;
+                o->HeadAngle[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                o->HeadAngle[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
                 o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                 if (o->HeadAngle[2] < 0.5f)
                     o->HeadAngle[2] = 0;
@@ -11258,8 +11292,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->HeadAngle[2] += ((float)(rand() % 32 - 16) * 0.8f) * FPS_ANIMATION_FACTOR;
             o->Angle[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
             o->Angle[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
-            o->HeadAngle[0] *= 0.6f;
-            o->HeadAngle[2] *= 0.8f;
+            o->HeadAngle[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+            o->HeadAngle[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
 
             if (o->LifeTime < 10)
             {
@@ -11390,7 +11424,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 if (o->SubType != 2 && o->LifeTime > 200 + 50 + 135)
                 {
                     vec3_t Angle = { 0.0f, 0.0f, 0.0f };
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         //Angle[2] = ( float)i * 10.0f;
                         Angle[0] = 0;//( float)( rand() % 360);
@@ -11399,11 +11433,11 @@ void MoveEffect(OBJECT* o, int iIndex)
                         vec3_t Position;
                         VectorCopy(o->Position, Position);
                         //Position[2] += 100.f;
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                             CreateJoint(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 8, NULL, 50.f, 0, 0);
                     }
 
-                    if (rand() % 3 == 0)
+                    if (rand_fps_check(3))
                     {
                         vec3_t Light;
                         Vector(0.5f, 0.5f, 0.5f, Light);
@@ -11539,8 +11573,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Position[2] + o->Direction[2] <= Height)
         {
             o->Position[2] = Height;
-            o->HeadAngle[0] *= 0.8f;
-            o->HeadAngle[1] *= 0.8f;
+            o->HeadAngle[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->HeadAngle[1] *= pow(0.8f, FPS_ANIMATION_FACTOR);
             o->HeadAngle[2] += (0.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
@@ -11573,16 +11607,16 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (o->LifeTime < 10)
         {
-            o->Light[0] *= 0.8f;
-            o->Light[1] *= 0.8f;
-            o->Light[2] *= 0.8f;
+            o->Light[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
         }
 
         if (o->Position[2] + o->Direction[2] <= Height)
         {
             o->Position[2] = Height;
-            o->HeadAngle[0] *= 0.8f;
-            o->HeadAngle[1] *= 0.8f;
+            o->HeadAngle[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->HeadAngle[1] *= pow(0.8f, FPS_ANIMATION_FACTOR);
             o->HeadAngle[2] += (1.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
@@ -11638,8 +11672,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Position[2] + o->Direction[2] <= Height)
         {
             o->Position[2] = Height;
-            o->HeadAngle[0] *= 0.5f;
-            o->HeadAngle[1] *= 0.5f;
+            o->HeadAngle[0] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+            o->HeadAngle[1] *= pow(0.5f, FPS_ANIMATION_FACTOR);
             o->HeadAngle[2] += (0.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
@@ -11735,7 +11769,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         break;
 
     case MODEL_PIERCING + 1:
-        if ((rand() % 2) == 0)
+        if (rand_fps_check(2))
         {
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 0);
         }
@@ -12168,11 +12202,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
         case 4:
         {
-            o->Light[0] *= 0.97f;
-            o->Light[1] *= 0.97f;
-            o->Light[2] *= 0.97f;
+            o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
-            o->Alpha *= 0.97f;
+            o->Alpha *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
             VectorAdd(o->EyeRight, o->Angle, o->Angle);
         }
@@ -12200,7 +12234,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->AnimationFrame >= 5.f)
             {
                 o->Velocity = 0.f;
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     vec3_t Position;
                     Vector(o->Position[0] + (float)(rand() % 64 - 32),
@@ -12427,8 +12461,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 o->Gravity = 10.f;
                 o->Position[2] += (10.f) * FPS_ANIMATION_FACTOR;
-                o->Direction[1] *= 0.5f;
-                o->Scale *= 1.1f;
+                o->Direction[1] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
             }
 
             int PositionX = (int)(o->Position[0] / TERRAIN_SCALE);
@@ -12552,7 +12586,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             int iSubType = rand() % 30;
             Vector((rand() % 3) * .3f + .4f, (rand() % 4) * .1f, .0f, Light);
             //for ( int j = 0; j < 200; ++j)
-            for (int j = 0; j < 80; ++j)
+            for (int j = 0; j < 80 * FPS_ANIMATION_FACTOR; ++j)
             {
                 CreateParticle(BITMAP_FIRECRACKER, o->Position, o->Angle, Light, iSubType);
             }
@@ -12575,7 +12609,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     break;
     case BITMAP_FIRECRACKER0002:
     {
-        if (rand() % 5 == 0)
+        if (rand_fps_check(5))
         {
             vec3_t vLight;
             Vector(0.3f + (rand() % 700) * 0.001f, 0.3f + (rand() % 700) * 0.001f, 0.3f + (rand() % 700) * 0.001f, vLight);
@@ -12606,7 +12640,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Light[0] /= 1.05f;
             o->Light[1] /= 1.05f;
             o->Light[2] /= 1.05f;
-            o->Scale *= 1.02f;
+            o->Scale *= pow(1.02f, FPS_ANIMATION_FACTOR);
         }
         CreateSprite(BITMAP_FIRECRACKER0001 + iFrame, o->Position, o->Scale, o->Light, o, o->Angle[2]);
     }
@@ -12675,7 +12709,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Position[2] += 50.f;
                     CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
 
-                    if ((rand() % 5) == 0)
+                    if (rand_fps_check(5))
                         CreateEffect(MODEL_ICE_SMALL, Position, o->Angle, o->Light);
                 }
             }
@@ -12733,7 +12767,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else
             o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
 
-        if ((rand() % 10) == 0)
+        if (rand_fps_check(10))
         {
             CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, Light);
         }
@@ -12763,7 +12797,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
 
         o->Alpha = o->LifeTime / 10.f;
-        if ((rand() % 10) == 0)
+        if (rand_fps_check(10))
         {
             CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, Light);
         }
@@ -12792,7 +12826,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->StartPosition[0] -= (10.f) * FPS_ANIMATION_FACTOR;
 
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 0, 1.5f);
-            if ((rand() % 2) == 0)
+            if (rand_fps_check(2))
             {
                 CreateParticle(BITMAP_ENERGY, o->Position, o->Angle, Light, 1, 0.5f);
             }
@@ -12815,7 +12849,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Position[2] += 50.f;
                 CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
 
-                if ((rand() % 5) == 0)
+                if (rand_fps_check(5))
                 {
                     CreateEffect(MODEL_ICE_SMALL, Position, o->Angle, o->Light);
                 }
@@ -12844,7 +12878,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] > Height)
             {
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
                 }
@@ -13115,7 +13149,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                                 arrEachBonePos[iBone02],
                                 vLightBlur, iTypeBlur, false, iBlurIdentity, 20);
 
-                            if (rand() % 10 == 0)
+                            if (rand_fps_check(10))
                             {
                                 vec3_t	vAngle, vRandomDir, vRandomDirPosition, vResultRandomPosition;
                                 vec34_t	matRandomRotation;
@@ -13154,7 +13188,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 float Distance;
                 for (int i = 1; i < o->Gravity; ++i)
                 {
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         if (o->Angle[0] < -90)
                             o->Angle[0] += (20.f) * FPS_ANIMATION_FACTOR;
@@ -13206,7 +13240,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 float Distance;
                 for (int i = 1; i < o->Gravity; ++i)
                 {
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         if (o->Angle[0] < -90)
                             o->Angle[0] += (20.f) * FPS_ANIMATION_FACTOR;
@@ -13498,9 +13532,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 //o->Scale = 6.0f;
 
-                o->Light[0] *= 0.5f;
-                o->Light[1] *= 0.5f;
-                o->Light[2] *= 0.5f;
+                o->Light[0] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(0.5f, FPS_ANIMATION_FACTOR);
             }
         }
         break;
@@ -13528,7 +13562,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     CreateJoint(BITMAP_FLARE_BLUE, Position, Position, o->Angle, 14, o, 40.f);
                     CreateJoint(BITMAP_FLARE_BLUE, Position, Position, o->Angle, 15, o, 40.f);
 
-                    if ((rand() % 2) == 0 && o->LifeTime > 5 && o->LifeTime < 15)
+                    if (rand_fps_check(2) && o->LifeTime > 5 && o->LifeTime < 15)
                     {
                         Vector(o->Position[0] - 200.f, o->Position[1], o->Position[2] + 700.f, Position);
                         CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 20.f);
@@ -13557,7 +13591,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[0] = o->Position[0];
             Position[1] = o->Position[1];
             Position[2] = 350;
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Angle[2] = (float)(rand() % 24 * 30);
                 CreateJoint(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 14, NULL, 100.f, 0, 0);
@@ -13948,7 +13982,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->HiddenMesh = -1;
                 Vector(1.f, 1.f, 1.f, Light);
 
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light, 1, 2.f);
                 }
@@ -14081,12 +14115,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(0.f, 0.f, 0.f, o->Angle);
                 o->HiddenMesh = 0;
 
-                if (rand() % 10 == 0)
+                if (rand_fps_check(10))
                     CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 24, 1.25f * o->Scale);
             }
             else
             {
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                     CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 24, 0.2f);
             }
             break;
@@ -14120,17 +14154,17 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->Alpha = o->LifeTime / 10.f;
         if (o->Type == MODEL_GOLEM_STONE)
         {
-            if (rand() % 4 == 0) {
+            if (rand_fps_check(4)) {
                 CreateParticle(BITMAP_TRUE_FIRE, o->Position, o->Angle, Light, 5, 2.8f);
                 CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 21, 1.8f);
             }
-            if ((rand() % 10) == 0) {
+            if (rand_fps_check(10)) {
                 CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
             }
         }
         else if (o->Type == MODEL_BIG_STONE_PART1 && o->SubType == 2)
         {
-            if ((rand() % 10) == 0) {
+            if (rand_fps_check(10)) {
                 Vector(0.2f, 0.5f, 0.35f, Light);
                 o->Position[2] = Height;
                 CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 11, 2.f);
@@ -14162,7 +14196,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else
             o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
 
-        if ((rand() % 10) == 0)
+        if (rand_fps_check(10))
         {
             CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, Light);
         }
@@ -14300,8 +14334,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Position[2] + o->Direction[2] <= fHeight)
             {
                 o->Position[2] = fHeight;
-                o->HeadAngle[0] *= 0.6f;
-                o->HeadAngle[1] *= 0.6f;
+                o->HeadAngle[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                o->HeadAngle[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
                 o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                 if (o->HeadAngle[2] < 0.5f)
                     o->HeadAngle[2] = 0;
@@ -14441,9 +14475,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_CHROME_ENERGY2:
         if (o->LifeTime < 10)
         {
-            o->Light[0] *= 0.8f;
-            o->Light[1] *= 0.8f;
-            o->Light[2] *= 0.8f;
+            o->Light[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
         }
         break;
 
@@ -14813,9 +14847,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime <= 10)
             {
                 o->BlendMeshLight -= (0.05f) * FPS_ANIMATION_FACTOR;
-                o->Light[0] *= o->BlendMeshLight;
-                o->Light[1] *= o->BlendMeshLight;
-                o->Light[2] *= o->BlendMeshLight;
+                o->Light[0] *= pow(o->BlendMeshLight, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(o->BlendMeshLight, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(o->BlendMeshLight, FPS_ANIMATION_FACTOR);
             }
         }
     }
@@ -14832,9 +14866,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime <= 10)
             {
                 o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
-                o->Light[0] *= o->Alpha;
-                o->Light[1] *= o->Alpha;
-                o->Light[2] *= o->Alpha;
+                o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
             }
         }
     }
@@ -14864,9 +14898,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime <= 10)
             {
                 o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
-                o->Light[0] *= o->Alpha;
-                o->Light[1] *= o->Alpha;
-                o->Light[2] *= o->Alpha;
+                o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
             }
         }
     }
@@ -15002,7 +15036,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         o->Owner->PriorAnimationFrame, o->Owner->PriorAction, o->Owner->Angle, o->Owner->HeadAngle);
                     characterBMD->TransformPosition(o->Owner->BoneTransform[20], vRelativePos, vtaWorldPos, false);
 
-                    if (rand() % 2 == 0) {
+                    if (rand_fps_check(2)) {
                         vtaWorldPos[0] += rand() % 40 + 10;
                     }
                     else {
@@ -15016,7 +15050,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     for (int k = 0; k < 70; ++k)
                     {
-                        if (rand() % 3 == 0) {
+                        if (rand_fps_check(3)) {
                             CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 7 == 3 ? vLight2 : vLight1, 0, 0.4f);
                         }
                         CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_FLOWER, vtaWorldPos, o->Angle, rand() % 4 == 3 ? vLight2 : vLight1, 0, 0.4f);
@@ -15108,10 +15142,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                         vPos[2] += rand() % 300 - 150;
                         float fScale = 1.6f + rand() % 10 * 0.1f;
                         Vector(0.5f, 0.5f, 1.0f, vLight);
-                        int index = (rand() % 2 == 0) ? BITMAP_WATERFALL_5 : BITMAP_WATERFALL_3;
+                        int index = (rand_fps_check(2)) ? BITMAP_WATERFALL_5 : BITMAP_WATERFALL_3;
                         CreateParticle(index, vPos, o->Angle, vLight, 8, fScale);
                         Vector(1.0f, 1.0f, 1.0f, vLight);
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                         {
                             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 55, 1.f);
                         }
@@ -15193,7 +15227,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             //if (o->LifeTime < 10)
             {
-                o->Alpha *= 0.9f;
+                o->Alpha *= pow(0.9f, FPS_ANIMATION_FACTOR);
             }
         }
         break;
@@ -15371,11 +15405,11 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->LifeTime >= 15)
             {
-                o->Scale *= 1.05f;
+                o->Scale *= pow(1.05f, FPS_ANIMATION_FACTOR);
             }
             else
             {
-                o->Scale *= 0.95f;
+                o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
             }
 
             CreateSprite(BITMAP_LIGHT, o->Position, o->Scale, o->Light, o->Owner);
@@ -15383,7 +15417,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->LifeTime <= 10)
             {
-                o->Alpha *= 0.95f;
+                o->Alpha *= pow(0.95f, FPS_ANIMATION_FACTOR);
             }
         }
 #ifdef PJH_ADD_PANDA_CHANGERING
@@ -15396,7 +15430,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->LifeTime > 15)
             {
-                o->Scale *= 0.9f;
+                o->Scale *= pow(0.9f, FPS_ANIMATION_FACTOR);
             }
             else
                 if (o->LifeTime == 15)
@@ -15405,7 +15439,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
                 else
                 {
-                    o->Scale *= 0.65f;
+                    o->Scale *= pow(0.65f, FPS_ANIMATION_FACTOR);
                 }
 
             if (o->PKKey == 0)
@@ -15426,7 +15460,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->LifeTime <= 10)
             {
-                o->Alpha *= 0.95f;
+                o->Alpha *= pow(0.95f, FPS_ANIMATION_FACTOR);
             }
         }
 #endif //PJH_ADD_PANDA_CHANGERING
@@ -15461,11 +15495,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime <= 10)
             {
-                o->Scale *= 0.9f;
-                o->Alpha *= 0.9f;
-                o->Light[0] *= 0.9f;
-                o->Light[1] *= 0.9f;
-                o->Light[2] *= 0.9f;
+                o->Scale *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                o->Alpha *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                o->Light[0] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(0.9f, FPS_ANIMATION_FACTOR);
             }
             else if (o->LifeTime <= 20)
             {
@@ -15473,11 +15507,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else if (o->LifeTime <= 30)
             {
-                o->Scale *= 1.1f;
-                o->Alpha *= 1.1f;
-                o->Light[0] *= 1.1f;
-                o->Light[1] *= 1.1f;
-                o->Light[2] *= 1.1f;
+                o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                o->Alpha *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
             }
 
             CreateSprite(BITMAP_SHINY, o->Position, o->Scale, o->Light, o, o->Angle[0]);
@@ -15489,47 +15523,47 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
         case 2:
         {
-            o->Light[0] *= 0.97f;
-            o->Light[1] *= 0.97f;
-            o->Light[2] *= 0.97f;
+            o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
-            o->Scale *= 0.97f;
-            o->Alpha *= 0.97f;
+            o->Scale *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Alpha *= pow(0.97f, FPS_ANIMATION_FACTOR);
             VectorAdd(o->EyeRight, o->Angle, o->Angle);
         }
         break;
         case 0:
         {
-            o->Light[0] *= 0.97f;
-            o->Light[1] *= 0.97f;
-            o->Light[2] *= 0.97f;
+            o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
-            o->Alpha *= 0.97f;
+            o->Alpha *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
             VectorAdd(o->EyeRight, o->Angle, o->Angle);
         }
         break;
         case 3:
         {
-            o->Light[0] *= 0.97f;
-            o->Light[1] *= 0.97f;
-            o->Light[2] *= 0.97f;
+            o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
-            o->Alpha *= 0.97f;
+            o->Alpha *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
-            o->Scale *= 0.97f;
+            o->Scale *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
             VectorAdd(o->EyeRight, o->Angle, o->Angle);
         }break;
         case 1:
         {
-            o->Light[0] *= 0.97f;
-            o->Light[1] *= 0.97f;
-            o->Light[2] *= 0.97f;
+            o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
-            o->Alpha *= 0.97f;
+            o->Alpha *= pow(0.97f, FPS_ANIMATION_FACTOR);
 
-            o->Scale *= 0.99f;
+            o->Scale *= pow(0.99f, FPS_ANIMATION_FACTOR);
 
             VectorAdd(o->EyeRight, o->Angle, o->Angle);
         }break;
@@ -15620,8 +15654,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Position[2] + o->Direction[2] <= Height)
         {
             o->Position[2] = Height;
-            o->HeadAngle[0] *= 0.8f;
-            o->HeadAngle[1] *= 0.8f;
+            o->HeadAngle[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->HeadAngle[1] *= pow(0.8f, FPS_ANIMATION_FACTOR);
             o->HeadAngle[2] += (0.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
@@ -15679,9 +15713,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Alpha <= 0.0f)
             o->Live = false;
 
-        o->Light[0] *= 0.93f;
-        o->Light[1] *= 0.93f;
-        o->Light[2] *= 0.93f;
+        o->Light[0] *= pow(0.93f, FPS_ANIMATION_FACTOR);
+        o->Light[1] *= pow(0.93f, FPS_ANIMATION_FACTOR);
+        o->Light[2] *= pow(0.93f, FPS_ANIMATION_FACTOR);
     }
     break;
     case MODEL_PROJECTILE:
@@ -15746,15 +15780,15 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Position[2] + o->Direction[2] <= Height)
         {
             o->Position[2] = Height;
-            o->HeadAngle[0] *= 0.8f;
-            o->HeadAngle[1] *= 0.8f;
+            o->HeadAngle[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->HeadAngle[1] *= pow(0.8f, FPS_ANIMATION_FACTOR);
             o->HeadAngle[2] += (0.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
 
             o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
 
-            if (rand() % 4 == 0)
+            if (rand_fps_check(4))
             {
                 Vector(0.f, (float)(rand() % 80) + 50.f, 0.f, p);
                 Vector(0.f, 0.f, (float)(rand() % 360), Angle);
@@ -15779,7 +15813,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
         }
 
-        if (rand() % 3 == 0)
+        if (rand_fps_check(3))
         {
             CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, o->Light, 6);
         }
@@ -16027,7 +16061,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                                     arrEachBonePos[iBone02],
                                     vLightBlur, iTypeBlur, false, iBlurIdentity, 25);
 
-                                if (rand() % 2 == 0)
+                                if (rand_fps_check(2))
                                 {
                                     vec3_t	vAngle, vRandomDir, vRandomDirPosition, vResultRandomPosition;
                                     vec34_t	matRandomRotation;
@@ -16228,7 +16262,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                         for (int j = 0; j < 11; ++j)
                         {
-                            if (rand() % 20 == 0)
+                            if (rand_fps_check(20))
                             {
                                 CreateEffect(BITMAP_FIRE_CURSEDLICH, arrEachBonePos[j], vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale);
                             }
@@ -16261,7 +16295,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         v3PosModify[0] = arrEachBonePos[i][0] + (float)((rand() % 80) - 40);
                         v3PosModify[1] = arrEachBonePos[i][1] + (float)((rand() % 80) - 40);
                         v3PosModify[2] = arrEachBonePos[i][2] + (float)((rand() % 80) - 40);
-                        if (rand() % 10 == 0)
+                        if (rand_fps_check(10))
                         {
                             CreateEffect(BITMAP_FIRE_CURSEDLICH, v3PosModify, vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale * 1.5f);
                         }
@@ -16563,7 +16597,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     for (int j = 0; j < 11; ++j)
                     {
                         Vector(1.0f, 1.0f, 1.0f, v3LightModify);
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                         {
                             CreateParticle(BITMAP_POUNDING_BALL, arrEachBonePos[j], o->Angle, v3LightModify, 3, 1.3f);
                         }
@@ -16577,7 +16611,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     for (int j = 0; j < 11; ++j)
                     {
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                         {
                             CreateParticle(BITMAP_FIRE_HIK1_MONO, arrEachBonePos[j], o->Angle, v3LightModify, 10, o->Scale);
                         }
@@ -16590,7 +16624,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     for (int j = 0; j < 11; ++j)
                     {
-                        if (rand() % 20 == 0)
+                        if (rand_fps_check(20))
                         {
                             CreateEffect(BITMAP_FIRE_CURSEDLICH, arrEachBonePos[j], vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale);
                         }
@@ -16662,7 +16696,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(0.3f, 0.4f, 1.0f, v3LightModify);
                     for (int j = 0; j < 11; ++j)
                     {
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                         {
                             CreateParticle(BITMAP_FIRE_HIK1_MONO, arrEachBonePos[j], o->Angle, v3LightModify, 10, o->Scale);
                         }
@@ -16784,10 +16818,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                         vPos[2] += rand() % 400 - 200;
                         float fScale = (o->Scale * 1.6f) + rand() % 10 * 0.1f;
                         Vector(0.3f, 0.3f, 1.0f, vLight);
-                        int index = (rand() % 2 == 0) ? BITMAP_WATERFALL_5 : BITMAP_WATERFALL_3;
+                        int index = (rand_fps_check(2)) ? BITMAP_WATERFALL_5 : BITMAP_WATERFALL_3;
                         CreateParticle(index, vPos, o->Angle, vLight, 8, fScale);
                         Vector(1.0f, 1.0f, 1.0f, vLight);
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                         {
                             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 55, o->Scale * 0.9f);
                         }
@@ -16878,7 +16912,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Light[0] /= 1.4f;
             o->Light[1] /= 1.4f;
             o->Light[2] /= 1.4f;
-            o->Scale *= 1.1f;
+            o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
         }
         CreateSprite(BITMAP_SHOCK_WAVE, o->Position, o->Scale, o->Light, o->Owner);
         CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, o->Light, 16, 2.5f);
@@ -16903,10 +16937,10 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->Distance += (2.1f) * FPS_ANIMATION_FACTOR;
         o->Angle[0] += (0.7f) * FPS_ANIMATION_FACTOR;
 
-        o->Light[0] *= 0.95f;
-        o->Light[1] *= 0.95f;
-        o->Light[2] *= 0.95f;
-        //o->Alpha *= 0.92f;
+        o->Light[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+        o->Light[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+        o->Light[2] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+        //o->Alpha *= pow(0.92f, FPS_ANIMATION_FACTOR);
 
         vec3_t vPos;
         for (int i = 0; i < 3; i++)
@@ -17153,8 +17187,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 1 || o->SubType == 2)
         {
             o->Alpha = 1.0f;
-            o->Scale *= 1.24f;
-            o->Position[2] *= 1.19f;
+            o->Scale *= pow(1.24f, FPS_ANIMATION_FACTOR);
+            o->Position[2] *= pow(1.19f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.45f, o->Light);
             if (o->Light[0] < 0.001f)
             {
@@ -17163,7 +17197,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 3)
         {
-            o->Scale *= 1.15f;
+            o->Scale *= pow(1.15f, FPS_ANIMATION_FACTOR);
             VectorScale(o->StartPosition, 0.99f, o->StartPosition);
             VectorSubtract(o->Position, o->StartPosition, o->Position);
             VectorScale(o->Light, 0.7f, o->Light);
@@ -17175,7 +17209,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 4)
         {
-            o->Scale *= 1.15f;
+            o->Scale *= pow(1.15f, FPS_ANIMATION_FACTOR);
             VectorScale(o->StartPosition, 1.04f, o->StartPosition);
             VectorSubtract(o->Position, o->StartPosition, o->Position);
             VectorScale(o->Light, 1.5f, o->Light);
@@ -17187,7 +17221,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 5)
         {
-            o->Scale *= 1.15f;
+            o->Scale *= pow(1.15f, FPS_ANIMATION_FACTOR);
             VectorScale(o->StartPosition, 1.04f, o->StartPosition);
             VectorSubtract(o->Position, o->StartPosition, o->Position);
             VectorScale(o->Light, 0.5f, o->Light);
@@ -17235,7 +17269,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     break;
     case MODEL_SHOCKWAVE_SPIN01:
     {
-        o->Scale *= 1.01f;
+        o->Scale *= pow(1.01f, FPS_ANIMATION_FACTOR);
         o->Angle[1] -= (10.0f) * FPS_ANIMATION_FACTOR;
         if (o->SubType == 1)
         {
@@ -17249,7 +17283,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 1)
         {
-            o->Scale *= 1.08f;
+            o->Scale *= pow(1.08f, FPS_ANIMATION_FACTOR);
             if (o->Scale > 5)
             {
                 o->Scale = 5.0f;
@@ -17259,7 +17293,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else
         {
-            o->Scale *= 1.08f;
+            o->Scale *= pow(1.08f, FPS_ANIMATION_FACTOR);
             if (o->Scale > 3)
             {
                 o->Scale = 3.0f;
@@ -17280,7 +17314,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 o->Scale = 3;
             }
-            o->Alpha *= 0.92f;
+            o->Alpha *= pow(0.92f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.9f, o->Light);
             if (o->LifeTime == 40 || o->LifeTime == 30)
             {
@@ -17331,7 +17365,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 o->Scale = 3;
             }
-            o->Alpha *= 0.92f;
+            o->Alpha *= pow(0.92f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.85f, o->Light);
 
             if (o->LifeTime == 60 || o->LifeTime == 50)
@@ -17349,7 +17383,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 o->Scale = 3;
             }
-            o->Alpha *= 0.92f;
+            o->Alpha *= pow(0.92f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.85f, o->Light);
         }
     }
@@ -17418,7 +17452,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 {
                     VectorCopy(o->Position, Position);
                     Vector(1.0f, 0.12f, 0.0f, Light);
-                    b->TransformByObjectBone(Position, o->Owner, (rand() % 2 == 0) ? 26 : 35);
+                    b->TransformByObjectBone(Position, o->Owner, (rand_fps_check(2)) ? 26 : 35);
                     CreateParticle(BITMAP_SMOKELINE1, Position, o->Angle, Light, 5, 0.005f, o->Owner);
                 }
             }
@@ -17434,7 +17468,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             break;
         }
         o->Angle[2] = (int)WorldTime * 0.4f;
-        o->Scale *= 1.015f;
+        o->Scale *= pow(1.015f, FPS_ANIMATION_FACTOR);
 
         if (o->Scale > 1.5f)
         {
@@ -17536,17 +17570,17 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 1)
         {
-            o->Scale *= 1.2f;
+            o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.9f, o->Light);
         }
         else if (o->SubType == 2)
         {
-            o->Scale *= 1.2f;
+            o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.7f, o->Light);
         }
         else
         {
-            o->Scale *= 1.2f;
+            o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.8f, o->Light);
         }
     }
@@ -17758,7 +17792,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             CreateEffect(BITMAP_LIGHT_RED, o->Position, o->Angle, vLight, 1, o, -1, 0, 0, 0, 15.0f);
             o->LifeTime = 80;
         }
-        o->Alpha *= 0.96f;
+        o->Alpha *= pow(0.96f, FPS_ANIMATION_FACTOR);
     }
     break;
     case MODEL_TARGETMON_EFFECT:
@@ -17888,8 +17922,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Position[2] + o->Direction[2] <= Height)
         {
             o->Position[2] = Height;
-            o->HeadAngle[0] *= 0.6f;
-            o->HeadAngle[1] *= 0.6f;
+            o->HeadAngle[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+            o->HeadAngle[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
             o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 0.5f)
                 o->HeadAngle[2] = 0;
@@ -17991,19 +18025,18 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         switch (o->Type)
         {
-        case BITMAP_LIGHT:
-        {
-            if (o->SubType == 0 && 0 != ((int)o->LifeTime % 2))
-                MoveEffect(o, iIndex);
-        }
-        break;
-        case MODEL_FIRE:
-            if (o->SubType == 3)
-            {
-                if (0 != ((int)o->LifeTime % 2))
+            case BITMAP_LIGHT:
+                if (o->SubType == 0 && rand_fps_check(2))
+                {
                     MoveEffect(o, iIndex);
-            }
-            break;
+                }
+                break;
+            case MODEL_FIRE:
+                if (o->SubType == 3 && rand_fps_check(2))
+                {
+                    MoveEffect(o, iIndex);
+                }
+                break;
         }
     }
 }
@@ -18339,7 +18372,7 @@ void RenderEffects(bool bRenderBlendMesh)
                             CreateSprite(BITMAP_SHINY + 6, vPos, o->Scale * 0.3f, vLight, NULL);
                         }
 
-                        if (rand() % 5 == 0)
+                        if (rand_fps_check(5))
                         {
                             int nBones = Models[o->Type].NumBones;
                             pModel->TransformByObjectBone(vPos, o, rand() % nBones);
@@ -18375,6 +18408,8 @@ void RenderEffects(bool bRenderBlendMesh)
                     VectorCopy(o->Position, Position);
                     for (int j = 0; j < 20; j++)
                     {
+                        if (!rand_fps_check(1)) continue;
+
                         if (o->SubType == 1)
                         {
                             o->Angle[2] -= (0.1f) * FPS_ANIMATION_FACTOR;
@@ -18688,9 +18723,9 @@ void RenderEffects(bool bRenderBlendMesh)
                     }
                     else
                     {
-                        o->Light[0] *= fLight;
-                        o->Light[1] *= fLight;
-                        o->Light[2] *= fLight;
+                        o->Light[0] *= pow(fLight, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(fLight, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(fLight, FPS_ANIMATION_FACTOR);
                     }
                     BMD* pModel = &Models[o->Owner->Type];
                     vec3_t vPos;

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -3658,7 +3658,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
             case MODEL_DARKLORD_SKILL:
             {
-                o->LifeTime = 10;
+                o->LifeTime = 10 * FPS_ANIMATION_FACTOR;
                 o->Scale = 0.2f;
                 o->Velocity = 0.1f;
 
@@ -3681,7 +3681,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 }
                 else if (o->SubType == 2)
                 {
-                    o->LifeTime = 12;
+                    o->LifeTime = 12 * FPS_ANIMATION_FACTOR;
                     o->Velocity = 0.4f;
                 }
             }
@@ -8357,7 +8357,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             else if (o->AlphaTarget < 1.0f)
                 o->AlphaTarget += (0.02f) * FPS_ANIMATION_FACTOR;
 
-            if (1 == o->LifeTime)
+            if (1 <= o->LifeTime)
                 o->LifeTime = 50;
         }
         break;
@@ -9040,7 +9040,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, pTargetObj->Angle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
             }
 
-            if (o->LifeTime == 15)
+            if ((int)o->LifeTime == 15)
             {
                 int iNumBones = pTargetModel->NumBones;
                 float fRandom;

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -7008,10 +7008,10 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Light[0] *= pow(0.98f, FPS_ANIMATION_FACTOR);
             o->Light[1] *= pow(0.98f, FPS_ANIMATION_FACTOR);
             o->Light[2] *= pow(0.98f, FPS_ANIMATION_FACTOR);
-            if (o->LifeTime == 40)
+            if ((int)o->LifeTime == 40)
                 CreateEffect(MODEL_INFINITY_ARROW3, o->Position, o->Angle, o->Light, 2, o);
             else
-                if (o->LifeTime == 20)
+                if ((int)o->LifeTime == 20)
                     CreateEffect(MODEL_INFINITY_ARROW3, o->Position, o->Angle, o->Light, 3, o);
             VectorCopy(o->Owner->Position, o->Position);
         }
@@ -7064,7 +7064,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorScale(o->Direction, ftmp, o->Light);
         }
 
-        if (o->LifeTime == 23)
+        if ((int)o->LifeTime == 23)
         {
             if (o->SubType == 1)
             {
@@ -7250,7 +7250,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     break;
     case MODEL_KENTAUROS_ARROW:
     {
-        if (o->LifeTime == 24)
+        if ((int)o->LifeTime == 24)
         {
             vec3_t vDir;
             vec34_t vMat;
@@ -8300,7 +8300,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 #ifdef ENABLE_POTION_EFFECT
         if (o->SubType == 15)
         {
-            if (o->LifeTime == 1)
+            if ((int)o->LifeTime == 1)
             {
                 if ((o->State & STATE_HP_RECOVERY) == STATE_HP_RECOVERY)
                     o->State ^= STATE_HP_RECOVERY;
@@ -9196,7 +9196,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
         }
 
-        if (o->LifeTime == 64)
+        if ((int)o->LifeTime == 64)
         {
             VectorCopy(pSourceObj->Position, pSourceModel->BodyOrigin);
             pSourceModel->TransformPosition(pSourceObj->BoneTransform[18], vRelativePos, vSourcePos, true);
@@ -9923,7 +9923,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         break;
     case MODEL_SKILL_FISSURE:
     {
-        if (o->LifeTime == 8)
+        if ((int)o->LifeTime == 8)
         {
             for (int i = 0; i < 16; ++i)
             {
@@ -9942,7 +9942,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 CreateJoint(BITMAP_FLARE, Position, Position, Angle, 24, NULL, 90);
             }
         }
-        else if (o->LifeTime == 2)
+        else if ((int)o->LifeTime == 2)
         {
             Vector(0.f, 0.f, rand() % 360, Angle);
             CreateEffect(MODEL_FISSURE, o->Position, Angle, o->Light, 0, o);
@@ -10155,7 +10155,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 count = 12.5;
                 addAngle = 18.f;
-                if (o->LifeTime == 15)
+                if ((int)o->LifeTime == 15)
                     o->Gravity *= pow(-1, FPS_ANIMATION_FACTOR);
             }
 
@@ -10431,16 +10431,16 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            if (o->LifeTime == 100)
+            if ((int)o->LifeTime == 100)
             {
                 CreateEffect(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 1, o);
             }
             else
-                if (o->LifeTime == 70)
+                if ((int)o->LifeTime == 70)
                 {
                     CreateEffect(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 2, o);
                 }
-            if (o->LifeTime == 40)
+            if ((int)o->LifeTime == 40)
             {
                 CreateEffect(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 3, o);
             }
@@ -10889,7 +10889,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Position[2] += 100.f;
                     CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 6, o, 60.f, 0, 0);
 
-                    if (o->LifeTime == (44 - o->Owner->m_bySkillCount + 1))
+                    if ((int)o->LifeTime == (44 - o->Owner->m_bySkillCount + 1))
                     {
                         Angle[2] = i * 10.f;
                         CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 7, o, 60.f, 0, 0);
@@ -11822,7 +11822,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->Angle[1] += (60.f) * FPS_ANIMATION_FACTOR;
 
-            if (o->LifeTime == 13)
+            if ((int)o->LifeTime == 13)
                 CreateEffect(MODEL_PIERCING, o->Position, o->Angle, o->Light, 3, o);
             CheckClientArrow(o);
 
@@ -11838,11 +11838,11 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->SubType != 0)
             {
-                if (o->LifeTime == 13)
+                if ((int)o->LifeTime == 13)
                 {
                     CreateEffect(MODEL_PIERCING, o->Position, o->Angle, o->Light, 0, o);
                 }
-                else if (o->LifeTime == 30)
+                else if ((int)o->LifeTime == 30)
                 {
                     o->AttackPoint[0] = 0;
                     o->Kind = 1;
@@ -12123,7 +12123,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             CreateParticle(BITMAP_BUBBLE, Position, o->Angle, o->Light, 1);
         }
         MoveJump(o);
-        if (o->LifeTime == 1)
+        if ((int)o->LifeTime == 1)
         {
             CreateBomb(o->Position, true);
             if (o->Owner == &Hero->Object && o->SubType != 99)
@@ -12161,7 +12161,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         CreateSprite(BITMAP_LIGHT, vPos, 3.0f, Light, o);
         CreateSprite(BITMAP_LIGHT, vPos, 2.0f, Light, o);
 
-        if (o->LifeTime == 30 || o->LifeTime == 28 || o->LifeTime == 26 || o->LifeTime == 24)
+        if ((int)o->LifeTime == 30 || (int)o->LifeTime == 28 || (int)o->LifeTime == 26 || (int)o->LifeTime == 24)
         {
             int iNumCreateFeather = rand() % 3;
             Vector(0.6f, 0.7f, 0.9f, Light);
@@ -12173,7 +12173,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
         }
 
-        if (o->LifeTime == 30)
+        if ((int)o->LifeTime == 30)
         {
             pModel->TransformByObjectBone(vPos, o, 1);
             Vector(0.4f, 0.4f, 0.9f, Light);
@@ -12478,7 +12478,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             int WallIndex = TERRAIN_INDEX_REPEAT(PositionX, PositionY);
             int Wall = TerrainWall[WallIndex] & TW_NOGROUND;
 
-            if (o->LifeTime == 1 || Wall == TW_NOGROUND)
+            if ((int)o->LifeTime == 1 || Wall == TW_NOGROUND)
             {
                 o->Position[2] = Height;
 
@@ -12606,8 +12606,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         break;
     case BITMAP_FIRECRACKER0001:
     {
-        if (o->LifeTime == 1 || o->LifeTime == 9 || o->LifeTime == 17
-            || o->LifeTime == 24 || o->LifeTime == 31)
+        if ((int)o->LifeTime == 1 || (int)o->LifeTime == 9 || (int)o->LifeTime == 17
+            || (int)o->LifeTime == 24 || (int)o->LifeTime == 31)
         {
             Vector(o->Position[0] + (rand() % 200 - 100), o->Position[1] + (rand() % 200 - 100),
                 o->Position[2], Position);
@@ -12654,7 +12654,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     }
     break;
     case BITMAP_SWORD_FORCE:
-        if (o->LifeTime == 30)
+        if ((int)o->LifeTime == 30)
         {
             VectorCopy(o->Position, Position);
             Position[2] += 100.f;
@@ -12745,7 +12745,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorAdd(o->Position, Position, o->StartPosition);
         CreateParticle(BITMAP_FIRE + 2, o->StartPosition, o->Angle, Light, 10, o->Scale);
 
-        if (o->LifeTime == 1)
+        if ((int)o->LifeTime == 1)
         {
             CreateBomb2(o->Position, false);
         }
@@ -12871,7 +12871,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->BlendMeshLight *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
-            if (o->LifeTime == 18 && o->PKKey == 1)
+            if ((int)o->LifeTime == 18 && o->PKKey == 1)
                 PlayBuffer(SOUND_SUDDEN_ICE2);
         }
         else if (o->SubType == 2)
@@ -12909,7 +12909,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
 
-            if (o->LifeTime == 1)
+            if ((int)o->LifeTime == 1)
             {
                 CreateBomb(o->Position, true);
             }
@@ -13218,7 +13218,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     CreateEffect(MODEL_TAIL, o->Position, o->Angle, o->Light, 0, o);
                 }
-                if (Distance < 40 && o->LifeTime == 5)
+                if (Distance < 40 && (int)o->LifeTime == 5)
                 {
                     VectorCopy(o->Position, Position);
                     Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
@@ -13269,7 +13269,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     CreateEffect(MODEL_PIER_PART, o->Position, o->Angle, o->Light, 1, o);
                 }
-                if (Distance < 40 && o->LifeTime == 5)
+                if (Distance < 40 && (int)o->LifeTime == 5)
                 {
                     VectorCopy(o->Position, Position);
                     Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
@@ -13665,7 +13665,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_CUNDUN_SKILL:
         if (o->SubType == 0)
         {
-            if (o->LifeTime == 30)
+            if ((int)o->LifeTime == 30)
             {
                 for (int i = 0; i < 10; ++i)
                 {
@@ -13680,7 +13680,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             vec3_t Angle;
             Angle[0] = 0;
             Angle[1] = 0;
-            if (o->LifeTime == 30)
+            if ((int)o->LifeTime == 30)
             {
                 for (int i = 0; i < 20; ++i)
                 {
@@ -14939,7 +14939,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             CheckTargetRange(o);
 
-            if (o->LifeTime == 1)
+            if ((int)o->LifeTime == 1)
             {
                 for (int i = 0; i < 3; i++)
                 {
@@ -15034,7 +15034,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 7 == 3 ? vLight2 : vLight1, 0, 0.5f);
                 }
 
-                if (o->LifeTime == 30 || o->LifeTime == 15 || o->LifeTime == 4)
+                if ((int)o->LifeTime == 30 || (int)o->LifeTime == 15 || (int)o->LifeTime == 4)
                 {
                     vec3_t vAngle;
 
@@ -15345,7 +15345,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             vec3_t vLight, vPos;
 
             Vector(0.4f, 0.3f, 0.9f, vLight);
-            if (o->LifeTime == 45 || o->LifeTime == 35 || o->LifeTime == 25)
+            if ((int)o->LifeTime == 45 || (int)o->LifeTime == 35 || (int)o->LifeTime == 25)
             {
                 CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 14, o, -1, 0, 0, 0, 5.0f);
                 CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 14, o, -1, 0, 0, 0, 5.0f);
@@ -15367,7 +15367,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
 
             Vector(0.2f, 0.2f, 0.9f, vLight);
-            if (o->LifeTime == 45)
+            if ((int)o->LifeTime == 45)
             {
                 pModel->TransformByObjectBone(vPos, o->Owner, 28);
                 CreateEffect(MODEL_ARROWSRE06, vPos, o->Angle, vLight, 1, o->Owner, 28);
@@ -15442,7 +15442,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Scale *= pow(0.9f, FPS_ANIMATION_FACTOR);
             }
             else
-                if (o->LifeTime == 15)
+                if ((int)o->LifeTime == 15)
                 {
                     o->Scale = 2.f;
                 }
@@ -16325,7 +16325,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             case MODEL_SWORDLEFT01_EMPIREGUARDIAN_BOSS_GAION_:
             case MODEL_SWORDRIGHT01_EMPIREGUARDIAN_BOSS_GAION_:
             {
-                if (o->LifeTime == 5)
+                if ((int)o->LifeTime == 5)
                 {
                     CreateEffect(o->Type, o->Position, o->Angle, o->Light, 11, o->Owner, -1, 0, 0, 0, o->Scale);
                 }
@@ -16334,7 +16334,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             case MODEL_SWORDRIGHT02_EMPIREGUARDIAN_BOSS_GAION_:
             case MODEL_SWORDLEFT02_EMPIREGUARDIAN_BOSS_GAION_:
             {
-                if (o->LifeTime == 3)
+                if ((int)o->LifeTime == 3)
                 {
                     CreateEffect(o->Type, o->Position, o->Angle, o->Light, 11, o->Owner, -1, 0, 0, 0, o->Scale);
                 }
@@ -16342,7 +16342,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             break;
             case MODEL_EMPIREGUARDIANBOSS_FRAMESTRIKE:
             {
-                if (o->LifeTime == 10)
+                if ((int)o->LifeTime == 10)
                 {
                     CreateEffect(MODEL_SWORDMAIN01_EMPIREGUARDIAN_BOSS_GAION_,
                         o->Position, o->Angle, o->Light, 11, o->Owner, -1, 0, 0, 0, o->Scale);
@@ -16351,7 +16351,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             break;
             case MODEL_SWORDMAIN01_EMPIREGUARDIAN_BOSS_GAION_:
             {
-                if (o->LifeTime == 1)
+                if ((int)o->LifeTime == 1)
                 {
                     CreateEffect(MODEL_EMPIREGUARDIANBOSS_FRAMESTRIKE,
                         o->Position, o->Angle, o->Light, 1,
@@ -16365,7 +16365,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             case MODEL_SWORDRIGHT01_EMPIREGUARDIAN_BOSS_GAION_:
             case MODEL_SWORDLEFT01_EMPIREGUARDIAN_BOSS_GAION_:
             {
-                if (o->LifeTime == o->ExtState - 1)
+                if ((int)o->LifeTime == o->ExtState - 1)
                 {
                     //PlayBuffer( SOUND_ASSASSIN );
                     PlayBuffer(SOUND_BLOODATTACK);
@@ -16375,7 +16375,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             case MODEL_SWORDRIGHT02_EMPIREGUARDIAN_BOSS_GAION_:
             case MODEL_SWORDLEFT02_EMPIREGUARDIAN_BOSS_GAION_:
             {
-                if (o->LifeTime == o->ExtState - 1)
+                if ((int)o->LifeTime == o->ExtState - 1)
                 {
                     PlayBuffer(SOUND_ATTACK01 + 4);
                     //PlayBuffer( SOUND_ASSASSIN );
@@ -16384,7 +16384,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             break;
             case MODEL_EMPIREGUARDIANBOSS_FRAMESTRIKE:
             {
-                if (o->LifeTime == o->ExtState - 5)
+                if ((int)o->LifeTime == o->ExtState - 5)
                 {
                     PlayBuffer(SOUND_SKILL_FLAME_STRIKE);
                 }
@@ -16436,7 +16436,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             case MODEL_SWORDLEFT02_EMPIREGUARDIAN_BOSS_GAION_:
             {
                 // - SWORD POSTEFFECT
-                if (o->LifeTime == 0)
+                if ((int)o->LifeTime == 0)
                 {
                     OBJECT* oHighHier = o->Owner;
 
@@ -16456,7 +16456,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             break;
             case MODEL_SWORDMAIN01_EMPIREGUARDIAN_BOSS_GAION_:
             {
-                if (o->LifeTime == 40)
+                if ((int)o->LifeTime == 40)
                 {
                     vec34_t Matrix;
                     vec3_t vAngle, vDirection, vPosition, vLight;
@@ -16531,7 +16531,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             break;
             }
 
-            if (o->LifeTime == 15)
+            if ((int)o->LifeTime == 15)
             {
                 CreateEffect(o->Type, o->Position, o->Angle, o->Light, 12, o->Owner, -1, 0, 0, 0, o->Scale);
             }
@@ -16542,17 +16542,17 @@ void MoveEffect(OBJECT* o, int iIndex)
                 EarthQuake = (float)(rand() % 2 - 2) * 0.5f;
             }
 
-            if (o->LifeTime == o->ExtState)
+            if ((int)o->LifeTime == o->ExtState)
             {
                 PlayBuffer(SOUND_ASSASSIN);
             }
 
-            if (o->LifeTime == o->ExtState / 2 + 2)
+            if ((int)o->LifeTime == o->ExtState / 2 + 2)
             {
                 PlayBuffer(SOUND_SKILL_GIGANTIC_STORM);
             }
 
-            if (o->LifeTime == (o->ExtState / 2) + 5)
+            if ((int)o->LifeTime == (o->ExtState / 2) + 5)
             {
                 PlayBuffer(SOUND_FURY_STRIKE2);
             }
@@ -16773,7 +16773,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     EarthQuake = 0.f;
                 }
 
-                if (o->LifeTime == 23)
+                if ((int)o->LifeTime == 23)
                 {
                     Vector(0.3f, 0.3f, 1.0f, vLight);
                     //CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o);
@@ -16837,7 +16837,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                 }
 
-                if (o->LifeTime == 23)
+                if ((int)o->LifeTime == 23)
                 {
                     vec3_t vLight;
                     Vector(0.5f, 0.5f, 1.f, vLight);
@@ -16874,7 +16874,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            if (o->LifeTime == 20)
+            if ((int)o->LifeTime == 20)
                 break;
 
             o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
@@ -16890,7 +16890,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            if (o->LifeTime == 28 || o->LifeTime == 18 || o->LifeTime == 8)
+            if ((int)o->LifeTime == 28 || (int)o->LifeTime == 18 || (int)o->LifeTime == 8)
             {
                 vec3_t vLight;
                 Vector(1.0f, 0.2f, 0.5f, vLight);
@@ -17041,7 +17041,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             float Scale = 1.5f + (rand() % 10 * 0.02f);
             CreateParticle(BITMAP_SBUMB, vPosition, o->Angle, vLight, 0, Scale * o->Scale, o->Owner);
         }
-        if (o->LifeTime == 15 || o->LifeTime == 9 || o->LifeTime == 6)
+        if ((int)o->LifeTime == 15 || (int)o->LifeTime == 9 || (int)o->LifeTime == 6)
         {
             StopBuffer(SOUND_RAGESKILL_THRUST_ATTACK, true);
             PlayBuffer(SOUND_RAGESKILL_THRUST_ATTACK);
@@ -17325,7 +17325,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             o->Alpha *= pow(0.92f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.9f, o->Light);
-            if (o->LifeTime == 40 || o->LifeTime == 30)
+            if ((int)o->LifeTime == 40 || (int)o->LifeTime == 30)
             {
                 vec3_t vLight;
                 if (o->SubType == 0)
@@ -17377,7 +17377,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Alpha *= pow(0.92f, FPS_ANIMATION_FACTOR);
             VectorScale(o->Light, 0.85f, o->Light);
 
-            if (o->LifeTime == 60 || o->LifeTime == 50)
+            if ((int)o->LifeTime == 60 || (int)o->LifeTime == 50)
             {
                 vec3_t vLight;
                 Vector(1.0f, 0.5f, 0.0f, vLight);
@@ -17495,7 +17495,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if ((int)o->LifeTime % 3 != 0)
             CreateParticle(BITMAP_SWORD_EFFECT_MONO, o->Position, o->Angle, o->Light, 0, o->Scale, o);
 
-        if (o->LifeTime == 14)
+        if ((int)o->LifeTime == 14)
         {
             Vector(0.4f, 0.4f, 1.0f, vLight);
             if (o->SubType == 0)
@@ -17674,7 +17674,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 o->LifeTime = 150;
             }
-            if (o->LifeTime == 150)
+            if ((int)o->LifeTime == 150)
             {
                 PlayBuffer(SOUND_RAGESKILL_DRAGONKICK_ATTACK);
             }
@@ -17870,7 +17870,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 break;
             }
 
-            if (o->LifeTime == 10)
+            if ((int)o->LifeTime == 10)
             {
                 for (int i = 0; i < 4; ++i)
                 {
@@ -17905,7 +17905,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 break;
             }
 
-            if (o->LifeTime == 2)
+            if ((int)o->LifeTime == 2)
             {
                 CreateEffect(MODEL_VOLCANO_OF_MONK, o->Position, o->Angle, o->Light, 1, o, -1, 0, 0, 0, 1.0f);
                 o->LifeTime = 0;

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -9596,6 +9596,11 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (g_isCharacterBuff(o->Owner, eBuff_Cloaking)) break;
 
+            if (!rand_fps_check(1))
+            {
+                break;
+            }
+
             Vector(1.f, 0.5f, 0.1f, Light);
             Vector(0.f, 0.f, 0.f, Angle);
 

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -2754,8 +2754,8 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->LifeTime = 40;
                     o->Scale = (float)(rand() % 8 + 10) * 0.1f;
-                    o->Position[0] += 130.f + rand() % 32;
-                    o->Position[2] += 400.f;
+                    o->Position[0] += (130.f + rand() % 32) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += 400.f * FPS_ANIMATION_FACTOR;
                     Vector(0.f, 0.f, -50.f, o->Direction);
                     Vector(0.f, 20.f, 0.f, o->Angle);
                 }
@@ -15250,11 +15250,11 @@ void MoveEffect(OBJECT* o, int iIndex)
                 vec3_t StartPos, StartRelative;
                 vec3_t EndPos, EndRelative;
 
-                float fOwnerActionSpeed = pOwnerModel->Actions[pOwnerModel->CurrentAction].PlaySpeed;
+                float fOwnerActionSpeed = pOwnerModel->Actions[pOwnerModel->CurrentAction].PlaySpeed * FPS_ANIMATION_FACTOR;
                 float fOwnerSpeedPerFrame = fOwnerActionSpeed / 10.f;
                 float fOwnerAnimationFrame = pOwner->AnimationFrame - fOwnerActionSpeed;
 
-                float fActionSpeed = pObject->Velocity;
+                float fActionSpeed = pObject->Velocity * FPS_ANIMATION_FACTOR;
                 float fSpeedPerFrame = fActionSpeed / 10.f;
                 float fAnimationFrame = pObject->AnimationFrame - fActionSpeed;
 
@@ -17569,7 +17569,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Owner->AnimationFrame > 4 && o->Owner->AnimationFrame < 5)
             {
                 float fDelay = o->Velocity * 10.0f;
-                float fActionSpeed = pModel->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = pModel->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
                 float fSpeedPerFrame = fActionSpeed / fDelay;
                 float fAnimationFrame = o->Owner->AnimationFrame - fActionSpeed;
                 o->AlphaTarget = fSpeedPerFrame * (o->Velocity / pModel->Actions[o->CurrentAction].PlaySpeed);
@@ -17658,7 +17658,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             vec3_t _StartPos, _EndPos;
 
             float fDelay = o->Velocity * 10.0f;
-            float fActionSpeed = pModel->Actions[o->Owner->CurrentAction].PlaySpeed;
+            float fActionSpeed = pModel->Actions[o->Owner->CurrentAction].PlaySpeed * FPS_ANIMATION_FACTOR;
             float fSpeedPerFrame = fActionSpeed / fDelay;
             float fAnimationFrame = o->Owner->AnimationFrame - fActionSpeed;
 

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -8730,7 +8730,6 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             for (int j = 0; j < 6; j++)
             {
-                //if (!rand_fps_check(1)) continue;
                 Vector((float)(rand() % 50 - 25), (float)(rand() % 50 - 25), 0.f, Position);
                 VectorAdd(Position, o->Position, Position);
                 CreateParticle(BITMAP_FLAME, Position, o->Angle, Light);
@@ -18422,8 +18421,6 @@ void RenderEffects(bool bRenderBlendMesh)
                     VectorCopy(o->Position, Position);
                     for (int j = 0; j < 20; j++)
                     {
-                        if (!rand_fps_check(1)) continue;
-
                         if (o->SubType == 1)
                         {
                             o->Angle[2] -= (0.1f) * FPS_ANIMATION_FACTOR;

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -9880,10 +9880,12 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             Vector(0.f, -150.f, 0.f, p);
         }
+
         AngleMatrix(o->Angle, Matrix);
         VectorRotate(p, Matrix, Position);
-        VectorAdd(Position, o->Owner->Position, o->Position);
-        o->Angle[2] -= 18;//
+        VectorAdd(o->Owner->Position, Position, o->Position);
+        o->Angle[2] -= 18 * FPS_ANIMATION_FACTOR;
+
         CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
         Vector(Luminosity * 0.3f, Luminosity * 0.3f, Luminosity * 0.3f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
@@ -18084,7 +18086,7 @@ void RenderWheelWeapon(OBJECT* o)
     VectorCopy(o->Angle, TempAngle);
 
     o->Direction[2] -= (30) * FPS_ANIMATION_FACTOR;
-    o->Angle[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
+    o->Angle[2] += o->Direction[2];
     o->Angle[1] = 90;
     o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
 

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -308,6 +308,11 @@ void DeleteEffect(int efftype)
 
 bool DeleteParticle(int iType)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return false;
+    }
+
     for (int i = 0; i < MAX_PARTICLES; ++i)
     {
         PARTICLE* o = &Particles[i];
@@ -19146,6 +19151,11 @@ void RenderAfterEffects(bool bRenderBlendMesh)
 
 void RenderEffectShadows()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     int iEffectSize = MAX_EFFECTS + g_SkillEffects.GetSize();
     for (int i = 0; i < iEffectSize; ++i)
     {

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -1208,8 +1208,8 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 Vector(0.f, -60.f, 0.f, p1);
                 VectorRotate(p1, Matrix, p2);
-                VectorAdd(o->Position, p2, o->Position)
-                    o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR)
+                o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
                 break;
             case BITMAP_FLAME:
                 if (o->SubType == 0)
@@ -1448,7 +1448,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     Vector(0.f, -100.f, 0.f, p1);
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(p1, Matrix, p2);
-                    VectorAdd(o->Position, p2, o->Position);
+                    VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
 
                     o->Position[2] += (150.f) * FPS_ANIMATION_FACTOR;
                     break;
@@ -1462,7 +1462,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     Vector(-10.f, 10.f, 0.f, p1);
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(p1, Matrix, p2);
-                    VectorAdd(o->Position, p2, o->Position);
+                    VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
                     break;
                 }
                 break;
@@ -1702,7 +1702,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 Vector(-10.f, -60.f, 135.f, p1);
                 VectorRotate(p1, Matrix, p2);
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
 
                 o->Scale = 0.8f;
                 o->Direction[1] = -70.f;
@@ -1817,7 +1817,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 Vector(-10.f, -60.f, 135.f, p1);
                 VectorRotate(p1, Matrix, p2);
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
                 if (Type == MODEL_ARROW_WING)
                 {
                     o->Scale = 1.8f;
@@ -1974,7 +1974,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 Vector(-10.f, -60.f, 135.f, p1);
                 VectorRotate(p1, Matrix, p2);
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
 
                 o->BlendMesh = 0;
                 o->Scale = 1.f;
@@ -2042,9 +2042,9 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
                 o->LifeTime = 20;//18;
                 o->SubType = rand() % 100;
-                o->Angle[2] += (330.f) * FPS_ANIMATION_FACTOR;
-                o->HeadAngle[0] += (80.f) * FPS_ANIMATION_FACTOR;
-                o->HeadAngle[2] += (180.f) * FPS_ANIMATION_FACTOR;
+                o->Angle[2] += 330.f;
+                o->HeadAngle[0] += 80.f;
+                o->HeadAngle[2] += 180.f;
                 o->Gravity = 50.f;
 
                 o->Weapon = CharacterMachine->PacketSerial++;
@@ -2429,7 +2429,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 Vector(0.f, -40.f, 150.f, p1);
                 VectorRotate(p1, Matrix, p2);
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
                 o->Direction[1] = -40.f;
                 o->Direction[2] = 10.f;
                 o->LifeTime = 20;
@@ -2458,7 +2458,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     AngleMatrix(o->Angle, Matrix);
                     Vector(0.f, -60.f, 150.f, p1);
                     VectorRotate(p1, Matrix, p2);
-                    VectorAdd(o->Position, p2, o->Position);
+                    VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
                     o->Direction[1] = -40.f;
                     o->Direction[2] = 10.f;
                     o->LifeTime = 20;
@@ -2928,7 +2928,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 if (o->Type == MODEL_BIG_STONE1 || o->Type == MODEL_BIG_STONE2)
                 {
                     Vector((float)(rand() % 128 - 64), (float)(rand() % 128 - 64), (float)(rand() % 180), p1);
-                    VectorAdd(o->Position, p1, o->Position);
+                    VectorAddScaled(o->Position, p1, o->Position, FPS_ANIMATION_FACTOR);
                 }
 
                 if (Type == MODEL_ICE_SMALL)
@@ -3084,7 +3084,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 Vector((float)(rand() % 64 - 32), -(float)(rand() % 32 + 50), (float)(rand() % 128 + 200), p1);
                 AngleMatrix(o->Angle, Matrix);
                 VectorRotate(p1, Matrix, p2);
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
                 break;
             case MODEL_WARCRAFT:
                 o->LifeTime = 50;
@@ -3218,7 +3218,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 Vector(0.f, -20.f, 50.f, p1);
                 VectorRotate(p1, Matrix, p2);
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
 
                 vec3_t  Angle, Pos, p3;
                 Vector(-20.f, -20.f, 60.f, p1);
@@ -3658,7 +3658,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
             case MODEL_DARKLORD_SKILL:
             {
-                o->LifeTime = 10 * FPS_ANIMATION_FACTOR;
+                o->LifeTime = 10;
                 o->Scale = 0.2f;
                 o->Velocity = 0.1f;
 
@@ -3681,7 +3681,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 }
                 else if (o->SubType == 2)
                 {
-                    o->LifeTime = 12 * FPS_ANIMATION_FACTOR;
+                    o->LifeTime = 12;
                     o->Velocity = 0.4f;
                 }
             }
@@ -4726,7 +4726,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 Vector(-10.f, -80.f, 200.f, p1);
                 VectorRotate(p1, Matrix, p2);
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
 
                 o->Angle[0] = -30.f;
                 CreateJoint(BITMAP_FLASH, o->Position, o->Position, o->Angle, 4, o, 40.f, 50);
@@ -6137,7 +6137,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     vec3_t Transpos;
                     VectorScale(vDir, 5.0f, vDir);
                     VectorCopy(vDir, Transpos);
-                    VectorAdd(o->Position, Transpos, o->Position);
+                    VectorAddScaled(o->Position, Transpos, o->Position, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 4)
                 {
@@ -6157,7 +6157,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     VectorNormalize(vDir);
                     VectorScale(vDir, 150.0f, vDir);
                     VectorCopy(vDir, Transpos);
-                    VectorAdd(o->Position, Transpos, o->Position);
+                    VectorAddScaled(o->Position, Transpos, o->Position, FPS_ANIMATION_FACTOR);
                 }
                 else
                 {
@@ -6467,11 +6467,11 @@ void MoveParticle(OBJECT* o, int Turn)
         VectorCopy(o->Angle, Angle);
         AngleMatrix(Angle, Matrix);
         VectorRotate(o->Direction, Matrix, Position);
-        VectorAdd(o->Position, Position, o->Position);
+        VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
     }
     else
     {
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
     }
 }
 
@@ -6483,7 +6483,7 @@ void MoveParticle(OBJECT* o, vec3_t angle)
     VectorCopy(angle, Angle);
     AngleMatrix(Angle, Matrix);
     VectorRotate(o->Direction, Matrix, Position);
-    VectorAdd(o->Position, Position, o->Position);
+    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 }
 
 bool MoveJump(OBJECT* o)
@@ -6713,7 +6713,7 @@ void CheckClientArrow(OBJECT* o)
         {
             o->Velocity = 0.f;
             Vector(0.f, 0.f, 0.f, o->Direction);
-            o->LifeTime /= 2.f;
+            o->LifeTime *= pow(1.0f / (2.f), FPS_ANIMATION_FACTOR);
             return;
         }
     }
@@ -6968,7 +6968,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             OBJECT* pOwner = o->Owner;
             VectorTransform(tmp, pOwner->BoneTransform[47], o->Position);
             VectorScale(o->Position, pOwner->Scale, o->Position);
-            VectorAdd(o->Position, pOwner->Position, o->Position);
+            VectorAddScaled(o->Position, pOwner->Position, o->Position, FPS_ANIMATION_FACTOR);
             VectorCopy(pOwner->Angle, o->Angle);
             o->Angle[0] += 85.f; o->Angle[1] += -17.f; o->Angle[2] += (20.f) * FPS_ANIMATION_FACTOR;
         }
@@ -6987,7 +6987,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         VectorTransform(tmp, pOwner->BoneTransform[29], o->Position);
         VectorScale(o->Position, pOwner->Scale, o->Position);
-        VectorAdd(o->Position, pOwner->Position, o->Position);
+        VectorAddScaled(o->Position, pOwner->Position, o->Position, FPS_ANIMATION_FACTOR);
         VectorCopy(pOwner->Angle, o->Angle);
     }
     break;
@@ -7042,7 +7042,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         VectorTransform(tmp, pOwner->BoneTransform[29], o->Position);
         VectorScale(o->Position, pOwner->Scale, o->Position);
-        VectorAdd(o->Position, pOwner->Position, o->Position);
+        VectorAddScaled(o->Position, pOwner->Position, o->Position, FPS_ANIMATION_FACTOR);
         VectorCopy(pOwner->Angle, o->Angle);
     }
     break;
@@ -7541,7 +7541,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->LifeTime -= 2 * FPS_ANIMATION_FACTOR;
             }
 
-            VectorAdd(o->Position, o->Direction, o->Position);
+            VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
 
             if (o->Type == MODEL_HALLOWEEN_CANDY_HOBAK)
             {
@@ -7572,7 +7572,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->LifeTime -= 2 * FPS_ANIMATION_FACTOR;
         }
 
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         break;
 
     case MODEL_XMAS_EVENT_ICEHEART:
@@ -7607,7 +7607,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->LifeTime -= (2) * FPS_ANIMATION_FACTOR;
         }
 
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         break;
     case MODEL_MOONHARVEST_MOON:
         if (o->SubType == 0)
@@ -7622,7 +7622,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1)
         {
-            VectorAdd(o->Position, o->Direction, o->Position);
+            VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
             CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, o->Position, o->Angle, o->Light, 0, 1.0f);
             //CreateParticle(BITMAP_SMOKE, o->Position, o->Angle,o->Light, 23, 1.0f);
             //CreateParticle(BITMAP_SMOKE, o->Position, o->Angle,o->Light, 8, 1.0f);
@@ -8049,7 +8049,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(0, o->Distance / -45.0f, 0, vMoveDir);
                 }
                 VectorRotate(vMoveDir, Matrix, Position);
-                VectorAdd(o->Position, Position, o->Position);
+                VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
             }
             if (o->AnimationFrame <= 4.0f)
             {
@@ -8329,9 +8329,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         else if (o->SubType == 9)
         {
             o->Scale += (0.3f) * FPS_ANIMATION_FACTOR;
-            o->Light[0] /= 1.1f;
-            o->Light[1] /= 1.1f;
-            o->Light[2] /= 1.1f;
+            o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
         }
         break;
     case BITMAP_OUR_INFLUENCE_GROUND:
@@ -8867,9 +8867,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_CLOUD:
         if (o->SubType == 0)
         {
-            o->Light[0] /= 1.05f;
-            o->Light[1] /= 1.05f;
-            o->Light[2] /= 1.05f;
+            o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
             o->Scale += (0.03f) * FPS_ANIMATION_FACTOR;
         }
         break;
@@ -8987,9 +8987,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
             }
 
-            o->Light[0] /= 1.08f;
-            o->Light[1] /= 1.08f;
-            o->Light[2] /= 1.08f;
+            o->Light[0] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
         }
     }
     break;
@@ -9571,7 +9571,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_LIGHT:
         if (o->SubType == 0)
         {
-            VectorAdd(o->Position, o->Direction, o->Position);
+            VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
             //o->Direction[2] -= .35f;
             o->Direction[2] -= .01f * FPS_ANIMATION_FACTOR;
             //VectorScale( o->Light, 0.9f, o->Light);
@@ -9765,8 +9765,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->BlendMeshLight = o->LifeTime / 80.f;
             o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
-            o->Light[0] /= 1.04f;
-            o->Light[2] /= 1.04f;
+            o->Light[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
             o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 10)
@@ -9816,7 +9816,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
             }
         }
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         o->Angle[0] += (10.f / o->Scale) * FPS_ANIMATION_FACTOR;
         CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
         //CreateParticle(BITMAP_ENERGY,o->Position,o->Angle,Light);
@@ -9995,7 +9995,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         Vector(0.f, 0.f, 0.f, Angle);
         Vector(0.f, 0.f, 0.f, p);
 
-        if (o->LifeTime == 11)
+        if ((int)o->LifeTime == 11)
         {
             vec3_t  light;
             Vector(1.f, 1.f, 1.f, light);
@@ -10051,7 +10051,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Kind == 0)
                 CreateEffect(MODEL_WAVE, o->StartPosition, Angle, o->Light);
 
-            o->StartPosition[2] -= (27) * FPS_ANIMATION_FACTOR;
+            o->StartPosition[2] -= 27; //* FPS_ANIMATION_FACTOR;
 
             if (o->Owner != NULL)
             {
@@ -10094,7 +10094,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
             }
         }
-        else if (o->LifeTime == 10)
+        else if ((int)o->LifeTime == 10)
         {
             for (int j = 0; j < 5; ++j)
             {
@@ -10155,12 +10155,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 count = 12.5;
                 addAngle = 18.f;
-                if (o->LifeTime == 15) o->Gravity *= pow(-1, FPS_ANIMATION_FACTOR);
+                if (o->LifeTime == 15)
+                    o->Gravity *= pow(-1, FPS_ANIMATION_FACTOR);
             }
 
             if (o->Kind == 0)
             {
-                if (o->LifeTime == 13)
+                if ((int)o->LifeTime == 13)
                 {
                     vec3_t  pos;
                     Vector(0.f, 0.f, 0.f, Angle);
@@ -10208,8 +10209,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorRotate(o->Direction, Matrix, Position);
             VectorAdd(Position, o->StartPosition, o->Position);
 
-            o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
-            o->Position[2] += (200) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += o->Gravity;
+            o->Position[2] += 200;
         }
     }
     break;
@@ -10258,7 +10259,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
         }
 
-        o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.01f;
+        o->BlendMeshTexCoordU = -(float)(int)o->LifeTime * 0.01f;
 
         if (o->Owner != NULL)
             if (o->Owner->Type == MODEL_MONSTER01 + 95)
@@ -10310,16 +10311,19 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
         }
 
-        o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.01f;
+        o->BlendMeshTexCoordU = -(float)(int)o->LifeTime * 0.01f;
 
         if (o->Owner != NULL)
+        {
             if (o->Owner->Type == MODEL_MONSTER01 + 95)
             {
                 Vector(Luminosity * 0.0f, Luminosity * 0.0f, Luminosity * 1.0f, Light);
             }
             else
-
+            {
                 Vector(Luminosity * 1.0f, Luminosity * 0.0f, Luminosity * 0.0f, Light);
+            }
+        }
         AddTerrainLight(o->Position[0], o->Position[1], Light, 1, PrimaryTerrainLight);
         break;
     case MODEL_SKILL_FURY_STRIKE + 7:
@@ -10350,16 +10354,20 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[2] = o->Position[2] + 10;
         }
 
-        o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.01f;
+        o->BlendMeshTexCoordU = -(float)(int)o->LifeTime * 0.01f;
 
         if (o->Owner != NULL)
+        {
             if (o->Owner->Type == MODEL_MONSTER01 + 95)
             {
                 Vector(Luminosity * 0.0f, Luminosity * 0.0f, Luminosity * 1.0f, Light);
             }
             else
-
+            {
                 Vector(Luminosity * 1.0f, Luminosity * 0.0f, Luminosity * 0.0f, Light);
+            }
+        }
+
         AddTerrainLight(o->Position[0], o->Position[1], Light, 1, PrimaryTerrainLight);
         break;
 
@@ -10556,7 +10564,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 {
                     o->Velocity = 0.f;
                     Vector(0.f, 0.f, 0.f, o->Direction);
-                    o->LifeTime /= 5.f;
+                    o->LifeTime *= pow(1.0f / (5.f), FPS_ANIMATION_FACTOR);
                     break;
                 }
             }
@@ -10626,9 +10634,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else
         {
-            o->Light[0] /= 1.08f;
-            o->Light[1] /= 1.08f;
-            o->Light[2] /= 1.08f;
+            o->Light[0] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
         }
         o->Angle[2] += (1.0f) * FPS_ANIMATION_FACTOR;
     }
@@ -10641,9 +10649,9 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->LifeTime <= 5)
             {
-                o->Light[0] /= 1.01f;
-                o->Light[1] /= 1.01f;
-                o->Light[2] /= 1.01f;
+                o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 1)
@@ -10685,9 +10693,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             CreateEffect(MODEL_STONE1 + rand() % 2, Pos2, o->Angle, Light, 2);
 
             o->Angle[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
-            o->Light[0] /= 1.02f;
-            o->Light[1] /= 1.02f;
-            o->Light[2] /= 1.02f;
+            o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
             o->Alpha += (0.01f) * FPS_ANIMATION_FACTOR;
 
@@ -10700,9 +10708,9 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->LifeTime <= 5)
             {
-                o->Light[0] /= 1.01f;
-                o->Light[1] /= 1.01f;
-                o->Light[2] /= 1.01f;
+                o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
             }
 
             CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
@@ -10713,9 +10721,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->LifeTime <= 30)
         {
-            o->Light[0] /= 1.1f;
-            o->Light[1] /= 1.1f;
-            o->Light[2] /= 1.1f;
+            o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
         }
         o->Angle[1] += (30.0f) * FPS_ANIMATION_FACTOR;
 
@@ -10743,9 +10751,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->LifeTime <= 20)
         {
-            o->Light[0] /= 1.2f;
-            o->Light[1] /= 1.2f;
-            o->Light[2] /= 1.2f;
+            o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
         }
         o->Scale += (sinf(WorldTime * 0.005f) * 2.0f) * FPS_ANIMATION_FACTOR;
         o->Angle[1] += (10.0f) * FPS_ANIMATION_FACTOR;
@@ -10799,7 +10807,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_MAYASTONE4:
     case MODEL_MAYASTONE5:
     {
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         VectorScale(o->Direction, 0.9f, o->Direction);
         o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
         o->Gravity -= (3.f) * FPS_ANIMATION_FACTOR;
@@ -10831,9 +10839,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            o->Light[0] /= 1.17f;
-            o->Light[1] /= 1.17f;
-            o->Light[2] /= 1.17f;
+            o->Light[0] *= pow(1.0f / (1.17f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.17f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.17f), FPS_ANIMATION_FACTOR);
 
             vec3_t vPos;
             VectorCopy(o->Position, vPos);
@@ -10852,9 +10860,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1)
         {
-            o->Light[0] /= 1.17f;
-            o->Light[1] /= 1.17f;
-            o->Light[2] /= 1.17f;
+            o->Light[0] *= pow(1.0f / (1.17f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.17f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.17f), FPS_ANIMATION_FACTOR);
 
             vec3_t vPos;
             VectorCopy(o->Position, vPos);
@@ -11084,7 +11092,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_EFFECT_SAPITRES_ATTACK_2:
         if (o->SubType == 0 || o->SubType == 10 || o->SubType == 12)
         {
-            VectorAdd(o->Position, o->Direction, o->Position);
+            VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         }
         else if (o->Type == MODEL_EFFECT_SAPITRES_ATTACK_2 && o->SubType == 14)
         {
@@ -11102,7 +11110,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             AngleMatrix(o->Angle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
-            VectorAdd(o->Position, Position, o->Position);
+            VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
         }
         VectorScale(o->Direction, 0.9f, o->Direction);
         o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
@@ -11297,8 +11305,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->LifeTime < 10)
             {
-                o->Alpha /= 1.1f;
-                o->BlendMeshLight /= 1.2f;
+                o->Alpha *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->BlendMeshLight *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
 
                 if (o->Angle[0] <= 80)
                 {
@@ -11517,7 +11525,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->LifeTime -= (2) * FPS_ANIMATION_FACTOR;
             }
 
-            VectorAdd(o->Position, o->Direction, o->Position);
+            VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         }
     }
     break;
@@ -12637,9 +12645,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             iFrame = 6;
             o->Position[2] -= (1.0f) * FPS_ANIMATION_FACTOR;
-            o->Light[0] /= 1.05f;
-            o->Light[1] /= 1.05f;
-            o->Light[2] /= 1.05f;
+            o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
             o->Scale *= pow(1.02f, FPS_ANIMATION_FACTOR);
         }
         CreateSprite(BITMAP_FIRECRACKER0001 + iFrame, o->Position, o->Scale, o->Light, o, o->Angle[2]);
@@ -12746,7 +12754,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
     case MODEL_GATE:
     case MODEL_GATE + 1:
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         VectorScale(o->Direction, 0.9f, o->Direction);
         o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
@@ -12775,7 +12783,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
     case MODEL_STONE_COFFIN:
     case MODEL_STONE_COFFIN + 1:
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         VectorScale(o->Direction, 0.9f, o->Direction);
         o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
@@ -12861,7 +12869,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1)
         {
-            o->BlendMeshLight /= 1.1f;
+            o->BlendMeshLight *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
             if (o->LifeTime == 18 && o->PKKey == 1)
                 PlayBuffer(SOUND_SUDDEN_ICE2);
@@ -12926,7 +12934,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
                 o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
             }
-            o->BlendMeshLight /= 1.4f;
+            o->BlendMeshLight *= pow(1.0f / (1.4f), FPS_ANIMATION_FACTOR);
         }
         break;
     case MODEL_WAVES:
@@ -12937,28 +12945,28 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
                 o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
             }
-            o->BlendMeshLight /= 1.4f;
+            o->BlendMeshLight *= pow(1.0f / (1.4f), FPS_ANIMATION_FACTOR);
         }
         else if (o->SubType == 1)
         {
             o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Gravity += (0.07f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 2.f) o->Scale = 2.f;
-            o->BlendMeshLight /= 1.5f;
+            o->BlendMeshLight *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
         }
         else if (o->SubType == 2)
         {
             o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Gravity += (0.01f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 1.5f) o->Scale = 1.5f;
-            o->BlendMeshLight /= 1.5f;
+            o->BlendMeshLight *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
         }
         else if (o->SubType == 3)
         {
             o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Gravity += (0.005f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 1.5f) o->Scale = 1.5f;
-            o->BlendMeshLight /= 1.3f;
+            o->BlendMeshLight *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
             o->Angle[1] += (45.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 4)
@@ -12966,7 +12974,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Gravity += (0.002f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 2.5f) o->Scale = 2.5f;
-            o->BlendMeshLight /= 1.2f;
+            o->BlendMeshLight *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
             o->Angle[1] += (45.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 5)
@@ -12974,7 +12982,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Gravity += (0.015f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 2.5f) o->Scale = 2.5f;
-            o->BlendMeshLight /= 1.3f;
+            o->BlendMeshLight *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
             o->Angle[1] += (45.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 6)
@@ -12982,7 +12990,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Gravity += (0.015f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 2.5f) o->Scale = 2.5f;
-            o->BlendMeshLight /= 1.3f;
+            o->BlendMeshLight *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
             o->Angle[1] += (45.f) * FPS_ANIMATION_FACTOR;
         }
         break;
@@ -12994,7 +13002,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         if (o->SubType == 0)
         {
-            o->BlendMeshLight /= 1.5f;
+            o->BlendMeshLight *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
             o->Scale += (0.2f) * FPS_ANIMATION_FACTOR;
         }
 
@@ -13008,7 +13016,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             AngleMatrix(o->Angle, Matrix);
             VectorRotate(p, Matrix, Position);
             Position[2] += 100.f;
-            VectorAdd(o->Position, Position, o->Position);
+            VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
         }
         break;
     case MODEL_PIERCING2:
@@ -13021,7 +13029,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (o->SubType == 1) {
             if (o->LifeTime > 1) {
-                o->BlendMeshLight /= 1.6f;
+                o->BlendMeshLight *= pow(1.0f / (1.6f), FPS_ANIMATION_FACTOR);
                 CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
             }
         }
@@ -13031,13 +13039,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 //			o->Direction[1] -= 10.f;
                 if (o->LifeTime > 1)
                 {
-                    o->BlendMeshLight /= 1.6f;
+                    o->BlendMeshLight *= pow(1.0f / (1.6f), FPS_ANIMATION_FACTOR);
                     CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
                 }
             }
             else {
                 if (o->LifeTime > 5) {
-                    o->BlendMeshLight /= 1.6f;
+                    o->BlendMeshLight *= pow(1.0f / (1.6f), FPS_ANIMATION_FACTOR);
                     CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
                 }
             }
@@ -13206,7 +13214,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(o->Direction, Matrix, Position);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
                     CreateEffect(MODEL_TAIL, o->Position, o->Angle, o->Light, 0, o);
                 }
@@ -13224,7 +13232,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime < 5)
             {
-                o->Alpha /= 1.3f;
+                o->Alpha *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
             }
         }
     }
@@ -13257,7 +13265,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(o->Direction, Matrix, Position);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
                     CreateEffect(MODEL_PIER_PART, o->Position, o->Angle, o->Light, 1, o);
                 }
@@ -13282,7 +13290,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 AngleMatrix(o->Angle, Matrix);
                 VectorRotate(o->Direction, Matrix, Position);
-                VectorAdd(o->Position, Position, o->Position);
+                VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
                 if ((int)o->LifeTime % 3 == 0)
                 {
@@ -13295,7 +13303,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime < 5)
             {
-                o->Alpha /= 1.3f;
+                o->Alpha *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
             }
         }
         break;
@@ -13304,13 +13312,14 @@ void MoveEffect(OBJECT* o, int iIndex)
         break;
 
     case MODEL_DARKLORD_SKILL:
+        break;
         if (o->SubType <= 1)
         {
             o->Scale += (o->Velocity) * FPS_ANIMATION_FACTOR;
             o->Velocity += (0.02f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 7)
             {
-                o->BlendMeshLight /= 1.8f;
+                o->BlendMeshLight *= pow(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 2)
@@ -13319,7 +13328,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Velocity -= (0.06f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 8)
             {
-                o->BlendMeshLight /= 1.5f;
+                o->BlendMeshLight *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
             }
         }
         else
@@ -13328,7 +13337,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Velocity += (0.04f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 8)
             {
-                o->BlendMeshLight /= 1.8f;
+                o->BlendMeshLight *= pow(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
             }
         }
         break;
@@ -13348,8 +13357,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (o->LifeTime < 8)
         {
-            o->Alpha /= 1.3f;
-            o->BlendMeshLight /= 2.f;
+            o->Alpha *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
+            o->BlendMeshLight *= pow(1.0f / (2.f), FPS_ANIMATION_FACTOR);
         }
 
         Vector(0.79f, 0.72f, 0.49f, Light);
@@ -13514,9 +13523,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime < 6)
             {
-                o->Light[0] /= 1.3f;
-                o->Light[1] /= 1.3f;
-                o->Light[2] /= 1.3f;
+                o->Light[0] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
             }
         }
         break;
@@ -13715,7 +13724,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         if (o->LifeTime < 5)
         {
-            o->Alpha /= 1.3f;
+            o->Alpha *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
         }
         break;
     case MODEL_ARROW_TANKER_HIT:
@@ -13725,7 +13734,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Position[2] < Height + 80.0f)
         {
             if (o->Alpha <= 0.1f) o->LifeTime = 0;
-            o->Alpha /= 1.05f;
+            o->Alpha *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
 
             Vector(0.0f, 0.0f, -30.0f, o->Direction);
             Vector(1.f, 0.6f, 0.2f, Light);
@@ -13739,7 +13748,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
 
             EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
-            EarthQuake /= 2.f;
+            EarthQuake *= pow(1.0f / (2.f), FPS_ANIMATION_FACTOR);
 
             o->HiddenMesh = 99;
         }
@@ -13801,11 +13810,11 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             AngleMatrix(o->HeadAngle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
-            VectorAdd(o->Position, Position, o->Position);
+            VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
             if (o->LifeTime < 10)
             {
-                o->Alpha /= 1.5f;
+                o->Alpha *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
             }
 
             if ((int)o->LifeTime % 3 == 0)
@@ -13937,7 +13946,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                             CreateTerrainNormal_Part(CollisionX, CollisionY);
                             CreateTerrainLight_Part(CollisionX, CollisionY);
 
-                            EarthQuake /= 2.f;
+                            EarthQuake *= pow(1.0f / (2.f), FPS_ANIMATION_FACTOR);
                         }
                     }
                 }
@@ -14088,7 +14097,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         CreateTerrainNormal_Part(CollisionX, CollisionY);
                         CreateTerrainLight_Part(CollisionX, CollisionY);
 
-                        EarthQuake /= 2.f;
+                        EarthQuake *= pow(1.0f / (2.f), FPS_ANIMATION_FACTOR);
                     }
                 }
             }
@@ -14125,7 +14134,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             break;
         }
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         if (o->Type >= MODEL_WALL_PART1 && o->Type <= MODEL_WALL_PART2)
         {
             VectorScale(o->Direction, 0.9f, o->Direction);
@@ -14175,7 +14184,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_GATE_PART1:
     case MODEL_GATE_PART2:
     case MODEL_GATE_PART3:
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         VectorScale(o->Direction, 0.9f, o->Direction);
         o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
@@ -14342,9 +14351,9 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 o->Alpha -= (0.15f) * FPS_ANIMATION_FACTOR;
 
-                o->Light[0] /= 1.08f;
-                o->Light[1] /= 1.08f;
-                o->Light[2] /= 1.08f;
+                o->Light[0] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
             }
         }
     }
@@ -14396,9 +14405,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Live = false;
             }
 
-            o->Light[0] /= 1.02f;
-            o->Light[1] /= 1.02f;
-            o->Light[2] /= 1.02f;
+            o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
             if (timeGetTime() - o->m_dwTime > 1000)
             {
@@ -14439,9 +14448,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Live = false;
             }
 
-            o->Light[0] /= 1.04f;
-            o->Light[1] /= 1.04f;
-            o->Light[2] /= 1.04f;
+            o->Light[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
 
             if (o->SubType == 1)
                 o->Angle[0] = -(WorldTime * 0.3f);
@@ -14525,7 +14534,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         break;
 
     case MODEL_SKIN_SHELL:
-        VectorAdd(o->Position, o->Direction, o->Position);
+        VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         VectorScale(o->Direction, 0.9f, o->Direction);
         o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
@@ -14625,7 +14634,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             AngleMatrix(o->HeadAngle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
-            VectorAdd(o->Position, Position, o->Position);
+            VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
             o->Gravity = rand() % 30 + 30.f;
 
@@ -14639,7 +14648,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Gravity += (10.f) * FPS_ANIMATION_FACTOR;
             AngleMatrix(o->HeadAngle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
-            VectorAdd(o->Position, Position, o->Position);
+            VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
         }
         o->Angle[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
         o->BlendMeshLight = o->LifeTime / 10.f;
@@ -15093,7 +15102,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     EarthQuake = 0.f;
                 }
 
-                if (o->LifeTime == 23)
+                if ((int)o->LifeTime == 23)
                 {
                     Vector(0.3f, 0.3f, 1.0f, vLight);
                     CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o);
@@ -15122,9 +15131,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                 }
 
-                o->Light[0] /= 1.05f;
-                o->Light[1] /= 1.05f;
-                o->Light[2] /= 1.05f;
+                o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 1)
@@ -15152,7 +15161,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                 }
 
-                if (o->LifeTime == 23)
+                if ((int)o->LifeTime == 23)
                 {
                     vec3_t vLight;
                     Vector(0.5f, 0.5f, 1.f, vLight);
@@ -15177,9 +15186,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                 }
 
-                o->Light[0] /= 1.05f;
-                o->Light[1] /= 1.05f;
-                o->Light[2] /= 1.05f;
+                o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 2)
@@ -15194,7 +15203,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 EarthQuake = 0.f;
             }
 
-            if (o->LifeTime == 30)
+            if ((int)o->LifeTime == 30)
             {
                 Vector(1.0f, 1.0f, 1.0f, vLight);
                 vec3_t vDir, vPos, vAngle;
@@ -16798,9 +16807,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                 }
 
-                o->Light[0] /= 1.05f;
-                o->Light[1] /= 1.05f;
-                o->Light[2] /= 1.05f;
+                o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 1)
@@ -16854,9 +16863,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                 }
 
-                o->Light[0] /= 1.05f;
-                o->Light[1] /= 1.05f;
-                o->Light[2] /= 1.05f;
+                o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
             }
         }
     }
@@ -16870,11 +16879,11 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
 
-            o->Light[0] /= 1.1f;
-            o->Light[1] /= 1.1f;
-            o->Light[2] /= 1.1f;
+            o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
-            o->Alpha /= 1.1f;
+            o->Alpha *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
         }
     }break;
     case MODEL_EFFECT_UMBRELLA_DIE:
@@ -16909,9 +16918,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->LifeTime <= 18)
         {
-            o->Light[0] /= 1.4f;
-            o->Light[1] /= 1.4f;
-            o->Light[2] /= 1.4f;
+            o->Light[0] *= pow(1.0f / (1.4f), FPS_ANIMATION_FACTOR);
+            o->Light[1] *= pow(1.0f / (1.4f), FPS_ANIMATION_FACTOR);
+            o->Light[2] *= pow(1.0f / (1.4f), FPS_ANIMATION_FACTOR);
             o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
         }
         CreateSprite(BITMAP_SHOCK_WAVE, o->Position, o->Scale, o->Light, o->Owner);
@@ -18717,9 +18726,9 @@ void RenderEffects(bool bRenderBlendMesh)
                     float fLight = 1.035f;
                     if (o->LifeTime >= 35)
                     {
-                        o->Light[0] /= fLight;
-                        o->Light[1] /= fLight;
-                        o->Light[2] /= fLight;
+                        o->Light[0] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
@@ -19165,9 +19174,9 @@ void RenderEffectShadows()
                     {
                         RenderTerrainAlphaBitmap(BITMAP_MAGIC, o->Position[0], o->Position[1], o->Scale, o->Scale, o->Light, -o->Angle[2]);
 
-                        o->Light[0] /= 1.1f;
-                        o->Light[1] /= 1.1f;
-                        o->Light[2] /= 1.1f;
+                        o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                         o->Scale += (0.05f) * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->SubType == 8)
@@ -19259,9 +19268,9 @@ void RenderEffectShadows()
                     }
                     else if (o->SubType == 13)
                     {
-                        o->Light[0] /= 1.05f;
-                        o->Light[1] /= 1.05f;
-                        o->Light[2] /= 1.05f;
+                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                         Scale = o->Scale;
                     }
                     else

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -506,7 +506,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 1000;
                 o->Gravity = 1.0f;
                 o->Distance = 1.0f;
-                o->Position[2] += 3400.f;
+                o->Position[2] += (3400.f) * FPS_ANIMATION_FACTOR;
                 Vector(0.f, -35.0f, 0.f, o->Direction);
                 VectorCopy(o->Position, o->StartPosition);
                 Vector(1.0f, 1.0f, 1.0f, o->Light);
@@ -686,10 +686,10 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 1000;
                 o->Gravity = 1.0f;
                 o->Distance = 1.0f;
-                o->Position[2] += (float)(rand() % 200) - 100.f;
-                o->Position[1] += (float)(rand() % 200) - 100.f;
-                o->Position[0] += (float)(rand() % 200) - 100.f;
-                o->Angle[2] += (float)(rand() % 360);
+                o->Position[2] += ((float)(rand() % 200) - 100.f) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += ((float)(rand() % 200) - 100.f) * FPS_ANIMATION_FACTOR;
+                o->Position[0] += ((float)(rand() % 200) - 100.f) * FPS_ANIMATION_FACTOR;
+                o->Angle[2] += ((float)(rand() % 360)) * FPS_ANIMATION_FACTOR;
                 Vector(0.f, (float)(rand() % 8) * 0.1f - 5.0f, 0.f, o->Direction);
                 o->Scale = o->Scale + (float)(rand() % 5) / 40.f;
                 VectorCopy(o->Position, o->StartPosition);
@@ -697,7 +697,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
             }
             break;
             case MODEL_TREE_ATTACK:
-                o->Position[2] += 20.0f;
+                o->Position[2] += (20.0f) * FPS_ANIMATION_FACTOR;
                 o->LifeTime = 20;
                 o->LightEnable = false;
                 o->Scale = 0.05f;
@@ -728,12 +728,12 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 1000;
                 if (1 == o->SubType)
                 {
-                    o->LifeTime -= 60;
+                    o->LifeTime -= (60) * FPS_ANIMATION_FACTOR;
                 }
                 else if (2 == o->SubType)
                 {
                     o->LifeTime = 8;
-                    o->Position[2] += 150.f;
+                    o->Position[2] += (150.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 4)
                 {
@@ -917,7 +917,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->Alpha = 0.0f;
                 o->Velocity = 0.35f;
                 o->Skill = 0;
-                o->Position[2] += 10.0f;
+                o->Position[2] += (10.0f) * FPS_ANIMATION_FACTOR;
 
                 VectorCopy(Light, o->HeadTargetAngle);
                 Vector(1.0f, 1.0f, 1.0f, o->Light);
@@ -962,7 +962,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->LifeTime = 20;
                     Vector(0.f, -60.f, 0.f, o->Direction);
-                    o->Position[2] += 100.f;
+                    o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case MODEL_LIGHTNING_ORB:
@@ -971,7 +971,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->LifeTime = 20;
                     Vector(0.f, -60.f, 0.f, o->Direction);
-                    o->Position[2] += 100.f;
+                    o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
@@ -1008,7 +1008,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 if (o->SubType == 0 || o->SubType == 1 || o->SubType == 2)
                 {
                     o->LifeTime = 34;
-                    o->Position[2] += 100;
+                    o->Position[2] += (100) * FPS_ANIMATION_FACTOR;
                     VectorCopy(Light, o->Light);
                     o->AlphaEnable = true;
                     o->Alpha = 0.f;
@@ -1035,7 +1035,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
             case MODEL_ALICE_BUFFSKILL_EFFECT2:
             {
                 o->LifeTime = 35;
-                o->Position[2] += 100;
+                o->Position[2] += (100) * FPS_ANIMATION_FACTOR;
                 VectorCopy(Light, o->Light);
                 o->AlphaEnable = true;
                 o->Alpha = 0.f;
@@ -1049,7 +1049,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 if (o->SubType == 0)
                 {
                     o->LifeTime = 20;
-                    o->Position[2] += 280.f;
+                    o->Position[2] += (280.f) * FPS_ANIMATION_FACTOR;
                     o->Velocity = 0.0f;
                     o->Gravity = 1.0f;
                 }
@@ -1209,7 +1209,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 Vector(0.f, -60.f, 0.f, p1);
                 VectorRotate(p1, Matrix, p2);
                 VectorAdd(o->Position, p2, o->Position)
-                    o->Position[2] += 130.f;
+                    o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
                 break;
             case BITMAP_FLAME:
                 if (o->SubType == 0)
@@ -1246,7 +1246,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->LifeTime = 40;
                     o->Scale = Scale + 1.f;
-                    o->Position[2] += 30.f;
+                    o->Position[2] += (30.f) * FPS_ANIMATION_FACTOR;
                     o->Angle[2] = rand() % 360;
                 }
                 break;
@@ -1416,7 +1416,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->Alpha = 1.0f;
                     o->LifeTime = 30;
-                    o->Scale += (float)(rand() % 5) / 10.0f;
+                    o->Scale += ((float)(rand() % 5) / 10.0f) * FPS_ANIMATION_FACTOR;
                     o->Angle[1] = rand() % 360;
                 }break;
                 }
@@ -1450,7 +1450,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     VectorRotate(p1, Matrix, p2);
                     VectorAdd(o->Position, p2, o->Position);
 
-                    o->Position[2] += 150.f;
+                    o->Position[2] += (150.f) * FPS_ANIMATION_FACTOR;
                     break;
                 case 1:
                 case 2:
@@ -1471,15 +1471,15 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 20;
 
                 VectorCopy(o->Position, o->StartPosition);
-                o->StartPosition[2] += 800.0f;
+                o->StartPosition[2] += (800.0f) * FPS_ANIMATION_FACTOR;
             }
             break;
             case MODEL_STAFF + 8:
                 o->LifeTime = 30;
                 o->BlendMesh = -2;
                 o->Scale = 1.f;
-                o->Position[2] += 280.f;
-                o->Angle[0] += 20.f;
+                o->Position[2] += (280.f) * FPS_ANIMATION_FACTOR;
+                o->Angle[0] += (20.f) * FPS_ANIMATION_FACTOR;
                 Vector(0.f, -80.f, -10.f, o->Direction);
                 break;
             case MODEL_WAVE:
@@ -1487,7 +1487,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->BlendMeshLight = 1.5f;
                 o->Scale = 0.5f;
                 o->LifeTime = 15;
-                o->Position[2] -= 15.f;
+                o->Position[2] -= (15.f) * FPS_ANIMATION_FACTOR;
 
                 Vector(1.f, 1.f, 1.f, o->Light);
                 break;
@@ -1503,9 +1503,9 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 30;
                 o->BlendMesh = 0;
                 o->Scale = (float)(rand() % 8 + 10) * 0.1f;
-                o->Position[0] += rand() % 100 + 200;
-                o->Position[1] += rand() % 100 - 50;
-                o->Position[2] += rand() % 500 + 300;
+                o->Position[0] += (rand() % 100 + 200) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 100 - 50) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (rand() % 500 + 300) * FPS_ANIMATION_FACTOR;
                 Vector(0.f, 0.f, -50.f - rand() % 50, o->Direction);
                 Vector(0.f, 20.f, 0.f, o->Angle);
                 VectorCopy(o->Position, o->EyeLeft);
@@ -1714,7 +1714,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 30;
                 o->BlendMesh = -2;
                 o->Scale = 1.f;
-                o->Position[2] += 130.f;
+                o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
                 Vector(0.f, -70.f, 0.f, o->Direction);
                 VectorCopy(o->Position, o->EyeLeft);
                 CreateJoint(BITMAP_JOINT_ENERGY, o->Position, o->Position, o->Angle, 5, o, 100.f);
@@ -1733,7 +1733,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 30;
                 o->BlendMesh = -2;
                 o->Scale = 1.f;
-                o->Position[2] += 130.f;
+                o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
                 Vector(0.f, -70.f, 0.f, o->Direction);
                 VectorCopy(o->Position, o->EyeLeft);
                 CreateJoint(BITMAP_JOINT_ENERGY, o->Position, o->Position, o->Angle, 5, o, 100.f);
@@ -1752,7 +1752,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 30;
                 o->BlendMesh = -2;
                 o->Scale = 1.f;
-                o->Position[2] += 130.f;
+                o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
 
                 Vector(0.f, -60.f, 0.f, o->Direction);
                 AngleMatrix(o->Angle, Matrix);
@@ -1826,7 +1826,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 }
                 else if (Type == MODEL_ARROW_TANKER)
                 {
-                    o->Angle[0] -= 18.0f;
+                    o->Angle[0] -= (18.0f) * FPS_ANIMATION_FACTOR;
                     o->Scale = 1.0f;
                     o->Direction[1] = -42.0f;
                     o->Direction[2] = 4.0f;
@@ -1872,7 +1872,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                                     {
                                         CreateJoint(BITMAP_JOINT_FORCE, o->Position, o->Position, o->Angle, 20, o, 400.f, 40);
                                     }
-                                    o->Position[2] += 20.f;
+                                    o->Position[2] += (20.f) * FPS_ANIMATION_FACTOR;
                                     vec3_t ap, P, dp;
                                     VectorCopy(o->Position, ap);
                                     Vector(0.f, -20.f, 0.f, P);
@@ -1992,7 +1992,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 break;
             case MODEL_SAW:
                 o->LifeTime = 10;
-                o->Position[2] += 130.f;
+                o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
                 AngleMatrix(o->Angle, Matrix);
                 Vector(0.f, -60.f, 0.f, p1);
                 VectorRotate(p1, Matrix, o->Direction);
@@ -2015,7 +2015,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Scale = 1.3f;
                     o->RenderType = RENDER_DARK;
 
-                    o->Position[2] += 150.f;
+                    o->Position[2] += (150.f) * FPS_ANIMATION_FACTOR;
                     Vector(0.f, -1.f, 0.f, o->Direction);
                     Vector(1.f, 0.f, 0.f, o->Light);
                     Vector(30.f, 0.f, Angle[2], o->Angle);
@@ -2042,9 +2042,9 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
                 o->LifeTime = 20;//18;
                 o->SubType = rand() % 100;
-                o->Angle[2] += 330.f;
-                o->HeadAngle[0] += 80.f;
-                o->HeadAngle[2] += 180.f;
+                o->Angle[2] += (330.f) * FPS_ANIMATION_FACTOR;
+                o->HeadAngle[0] += (80.f) * FPS_ANIMATION_FACTOR;
+                o->HeadAngle[2] += (180.f) * FPS_ANIMATION_FACTOR;
                 o->Gravity = 50.f;
 
                 o->Weapon = CharacterMachine->PacketSerial++;
@@ -2244,7 +2244,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Scale = 0.7f;
                 else
                     o->Scale = 1.2f;
-                o->Angle[2] += rand() % 360;
+                o->Angle[2] += (rand() % 360) * FPS_ANIMATION_FACTOR;
             }
             break;
             case MODEL_STORM2:
@@ -2450,7 +2450,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     AngleMatrix(o->Angle, Matrix);
                     Vector(0.f, (float)(rand() % 128 + 64) * 0.1f, 0.f, p1);
                     VectorRotate(p1, Matrix, o->HeadAngle);
-                    o->HeadAngle[2] += 15.0f;
+                    o->HeadAngle[2] += (15.0f) * FPS_ANIMATION_FACTOR;
                     break;
                 }
                 else
@@ -2777,8 +2777,8 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->LifeTime = 40;
                     o->Scale = (float)(rand() % 10 + 15) * 0.1f;
-                    o->Position[0] += 130.f + rand() % 32;
-                    o->Position[2] += 400.f;
+                    o->Position[0] += (130.f + rand() % 32) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (400.f) * FPS_ANIMATION_FACTOR;
                     Vector(0.f, -(rand() % 20 + 10.f), -(rand() % 10 + 20.f), o->Direction);
                     Vector(0.f, 20.f, 0.f, o->Angle);
                 }
@@ -2795,9 +2795,9 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Scale = (float)(rand() % 8 + 15) * 0.1f;
                     o->PKKey = -1;
                     o->Velocity = PKKey;
-                    o->Position[0] += rand() % 100 + 200;
-                    o->Position[1] += rand() % 100 - 50;
-                    o->Position[2] += rand() % 300 + 500;
+                    o->Position[0] += (rand() % 100 + 200) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 100 - 50) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 300 + 500) * FPS_ANIMATION_FACTOR;
                     Vector(0.f, 0.f, -50.f - rand() % 50, o->Direction);
                     Vector(0.f, 20.f, 0.f, o->HeadAngle);
 
@@ -2810,9 +2810,9 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Scale = (float)(rand() % 8 + 15) * 0.1f;
                     o->PKKey = -1;
                     o->Velocity = PKKey;
-                    o->Position[0] += rand() % 100 + 200;
-                    o->Position[1] += rand() % 100 - 50;
-                    o->Position[2] += rand() % 300 + 500;
+                    o->Position[0] += (rand() % 100 + 200) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 100 - 50) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 300 + 500) * FPS_ANIMATION_FACTOR;
                     Vector(0.f, 0.f, -50.f - rand() % 50, o->Direction);
                     Vector(0.f, 20.f, 0.f, o->HeadAngle);
                 }
@@ -2825,7 +2825,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Velocity = PKKey;
                     //					o->Position[0] += rand()%100+200;
                     //					o->Position[1] += rand()%100-50;
-                    o->Position[2] += rand() % 300 + 500;
+                    o->Position[2] += (rand() % 300 + 500) * FPS_ANIMATION_FACTOR;
                     Vector(0.f, 0.f, -50.f - rand() % 50, o->Direction);
                     Vector(0.f, (float)(5 + rand() % 5), 0.f, o->HeadAngle);
 
@@ -2836,8 +2836,8 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->BlendMeshLight = 0.f;
                     o->LifeTime = 600;
                     o->Scale = (float)(rand() % 10 + 20) * 0.13f;
-                    o->Position[0] += 130.f + rand() % 32;
-                    o->Position[2] += 400.f + rand() % 32;
+                    o->Position[0] += (130.f + rand() % 32) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (400.f + rand() % 32) * FPS_ANIMATION_FACTOR;
                     Vector(0.f, -rand() % 5 - 8.0f, -10.f - rand() % 10, o->Direction);
                     Vector(0.f, 0.f, 0.f, o->Angle);
                 }
@@ -2845,14 +2845,14 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->LifeTime = 60;
                     o->Scale = (float)(rand() % 4 + 8) * 0.1f;
-                    o->Position[2] += 120.f;
+                    o->Position[2] += (120.f) * FPS_ANIMATION_FACTOR;
                     Vector(0.f, -50.f, 0.f, o->Direction);
                 }
                 break;
             case MODEL_BONE1:
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
             case MODEL_BONE2:
-                o->Position[2] += 100.f;
+                o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
             case MODEL_BIG_STONE1:
             case MODEL_BIG_STONE2:
                 if (o->SubType == 5)
@@ -2917,7 +2917,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     AngleMatrix(o->Angle, Matrix);
                     Vector(0.f, (float)(rand() % 128 + 64) * 0.1f, 0.f, p1);
                     VectorRotate(p1, Matrix, o->HeadAngle);
-                    o->HeadAngle[2] += 15.0f;
+                    o->HeadAngle[2] += (15.0f) * FPS_ANIMATION_FACTOR;
                     break;
                 }
 
@@ -2936,7 +2936,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->BlendMesh = 0;
                     o->BlendMeshLight = 0.3f;
                     Vector(0.f, (float)(rand() % 256 + 64) * 0.1f, 0.f, p1);
-                    o->Position[2] += 50.f;
+                    o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                     if (o->SubType == 13)
                     {
                         Vector(0.f, (float)(rand() % 256 + 64) * 0.2, 0.f, p1);
@@ -2954,7 +2954,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->BlendMesh = 0;
                     o->BlendMeshLight = 1.0f;
                     Vector(0.f, (float)(rand() % 256 + 64) * 0.1f, 0.f, p1);
-                    o->Position[2] += 50.f;
+                    o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
@@ -3028,7 +3028,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     AngleMatrix(o->Angle, Matrix);
                     Vector(0.f, (float)(rand() % 128 + 64) * 0.1f, 0.f, p1);
                     VectorRotate(p1, Matrix, o->HeadAngle);
-                    o->HeadAngle[2] += 25.0f;
+                    o->HeadAngle[2] += (25.0f) * FPS_ANIMATION_FACTOR;
                     break;
                 }
                 else if (o->SubType == 1)
@@ -3177,8 +3177,8 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 2;
                 o->BlendMesh = 0;
                 o->Scale = 10.f;
-                o->Position[1] += 200.f;
-                o->Position[2] -= 190.f;
+                o->Position[1] += (200.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] -= (190.f) * FPS_ANIMATION_FACTOR;
                 o->LightEnable = false;
                 break;
             case BITMAP_BLIZZARD:
@@ -3193,7 +3193,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     rangeX = 300; rangeY = 150; rangeZ = 700;
                     o->Scale = 0.5f;
-                    o->Gravity -= rand() % 20 + 10;
+                    o->Gravity -= (rand() % 20 + 10) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
@@ -3204,7 +3204,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->Position[0] = o->Position[0] + rand() % rangeX - rangeY;
                 o->Position[1] = o->Position[1] + rand() % rangeX - rangeY;
                 o->Position[2] = o->Position[2] + 500.f;
-                o->Position[0] += 100.f;
+                o->Position[0] += (100.f) * FPS_ANIMATION_FACTOR;
 
                 VectorCopy(o->Position, o->StartPosition);
                 PlayBuffer(SOUND_METEORITE01);
@@ -3248,7 +3248,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
             case MODEL_GATE:
             case MODEL_GATE + 1:
                 Vector(0.f, (float)(rand() % 128 + 64) * 0.1f, 0.f, p1);
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                 o->LifeTime = rand() % 16 + 32;
                 o->Scale = (float)(rand() % 4 + 8) * 0.1f;
                 o->Angle[2] = (float)(rand() % 360);
@@ -3258,7 +3258,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 if (o->Type == MODEL_GATE && o->SubType == 0)
                 {
                     o->SubType = 1;
-                    o->Gravity += (float)(rand() % 5);
+                    o->Gravity += ((float)(rand() % 5)) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
@@ -3273,7 +3273,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
             case MODEL_STONE_COFFIN:
             case MODEL_STONE_COFFIN + 1:
                 Vector(0.f, (float)(rand() % 128 + 32) * 0.1f, 0.f, p1);
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                 o->LifeTime = rand() % 16 + 32;
                 o->Scale = (float)(rand() % 4 + 8) * 0.1f;
                 o->Angle[2] = (float)(rand() % 360);
@@ -3283,7 +3283,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 if (o->Type == MODEL_STONE_COFFIN + 1 && o->SubType == 0)
                 {
                     o->SubType = 1;
-                    o->Gravity += (float)(rand() % 5);
+                    o->Gravity += ((float)(rand() % 5)) * FPS_ANIMATION_FACTOR;
                 }
 
                 o->Angle[0] = (float)(rand() % 360);
@@ -3318,12 +3318,12 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
                     rangeX = 300; rangeY = 150; rangeZ = 700;
                     o->Scale = 0.5f;
-                    o->Gravity -= rand() % 30 + 10;
+                    o->Gravity -= (rand() % 30 + 10) * FPS_ANIMATION_FACTOR;
 
                     o->Position[0] = o->Position[0] + rand() % rangeX - rangeY;
                     o->Position[1] = o->Position[1] + rand() % rangeX - rangeY;
                     o->Position[2] = o->Position[2] + 600.f;
-                    o->Position[0] += 100.f;
+                    o->Position[0] += (100.f) * FPS_ANIMATION_FACTOR;
 
                     VectorCopy(o->Position, o->StartPosition);
 
@@ -3349,7 +3349,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->BlendMesh = -2;
                     o->Scale = 1.f;
                     o->Gravity = -10.f;
-                    o->Position[2] += 130.f;
+                    o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
 
                     if (o->SubType != 0)
                     {
@@ -3373,7 +3373,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->BlendMeshLight = 1.f;
                 Vector(0.f, 0.f, 0.f, o->Angle);
                 VectorCopy(o->Position, o->StartPosition);
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
 
                 if (o->SubType == 0)
                 {
@@ -3404,7 +3404,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->BlendMeshLight = 1.f;
                 Vector(0.f, 0.f, 0.f, o->Angle);
                 VectorCopy(o->Position, o->StartPosition);
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
 
                 if (o->SubType == 0)
                 {
@@ -3417,7 +3417,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->LifeTime = 15;
                     o->RenderType = RENDER_NODEPTH;
-                    o->Position[2] += 80.f;
+                    o->Position[2] += (80.f) * FPS_ANIMATION_FACTOR;
                     o->Scale = 0.1f + rand() % 50 / 100.f;
                     o->Gravity = 0.01f;
 
@@ -3429,8 +3429,8 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                         CreateJoint(BITMAP_PIERCING, o->Position, o->Position, o->Angle, 0, NULL, (float)(rand() % 40 + 70));
                     }
 
-                    o->Position[0] += rand() % 100 - 50.f;
-                    o->Position[1] += rand() % 100 - 50.f;
+                    o->Position[0] += (rand() % 100 - 50.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 100 - 50.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2 || o->SubType == 3 || o->SubType == 4)
                 {
@@ -3438,7 +3438,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->PKKey = -1;
                     o->Scale = PKKey * 0.05f;
                     o->Gravity = 0.01f;
-                    o->Position[2] -= 50.f;
+                    o->Position[2] -= (50.f) * FPS_ANIMATION_FACTOR;
 
                     o->Angle[0] = 90.f;
                     o->Angle[2] = Angle[2];
@@ -3449,7 +3449,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->PKKey = -1;
                     o->Scale = PKKey * 0.05f;
                     o->Gravity = 0.08f;
-                    o->Position[2] -= 50.f;
+                    o->Position[2] -= (50.f) * FPS_ANIMATION_FACTOR;
 
                     o->Angle[0] = -90.f;
                     o->Angle[2] = Angle[2];
@@ -3470,7 +3470,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->BlendMesh = -2;
                 Vector(0.f, -60.f, 0.f, o->Direction);
                 VectorCopy(o->Position, o->StartPosition);
-                o->Position[2] += 130.f;
+                o->Position[2] += (130.f) * FPS_ANIMATION_FACTOR;
                 break;
             case MODEL_DEASULER:
                 if (o->SubType == 0)
@@ -3617,7 +3617,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->LifeTime = 20;
                     o->Velocity = 50.f;
                     o->HiddenMesh = -2;
-                    o->Position[2] -= 20.f;
+                    o->Position[2] -= (20.f) * FPS_ANIMATION_FACTOR;
 
                     Vector(0.f, -40.f, 0.f, o->Direction);
                     VectorCopy(o->Angle, o->HeadAngle);
@@ -3879,7 +3879,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->Alpha = 0;
                 vec3_t Position;
                 VectorCopy(o->Position, Position);
-                o->Position[2] += 100;
+                o->Position[2] += (100) * FPS_ANIMATION_FACTOR;
 
                 auto fAngle = float(rand() % 360);
                 auto fDistance = float(rand() % 600 + 200);
@@ -4021,7 +4021,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->Scale = 0.7f + (rand() % 10 - 5) * 0.02f;
                 if (o->Type == MODEL_XMAS_EVENT_BOX)
                 {
-                    o->Scale += 0.3f;
+                    o->Scale += (0.3f) * FPS_ANIMATION_FACTOR;
                 }
                 o->LifeTime = rand() % 10 + 50;
                 o->Angle[0] = (float)(rand() % 360);
@@ -4185,7 +4185,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Kind = Skill;
                     o->Skill = SkillIndex;
 
-                    switch (o->PKKey)
+                    switch ((int)o->PKKey)
                     {
                     case 1:
                         o->Velocity = 29.f;
@@ -4232,7 +4232,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Kind = Skill;
                     o->Skill = SkillIndex;
 
-                    switch (o->PKKey)
+                    switch ((int)o->PKKey)
                     {
                     case 1:
                         o->Velocity = 29.f;
@@ -4301,14 +4301,14 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->Angle[1] = (float)(rand() % 360);
                 o->Angle[2] = (float)(rand() % 360);
 
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                 break;
 
             case MODEL_GATE_PART1:
             case MODEL_GATE_PART2:
             case MODEL_GATE_PART3:
                 Vector(0.f, (float)(rand() % 128 + 64) * 0.1f, 0.f, p1);
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                 o->LifeTime = rand() % 16 + 32;
                 o->Scale = (float)(rand() % 2 + 7) * 0.1f;
                 o->Angle[2] = (float)(rand() % 360);
@@ -4318,7 +4318,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 if (o->Type == MODEL_GATE_PART1 && o->SubType == 0)
                 {
                     o->SubType = 1;
-                    o->Gravity += (float)(rand() % 5);
+                    o->Gravity += ((float)(rand() % 5)) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
@@ -4385,7 +4385,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Gravity = -(float)(rand() % 16 + 10);
 
                     o->ExtState = 0;
-                    o->Position[2] += 600.f;
+                    o->Position[2] += (600.f) * FPS_ANIMATION_FACTOR;
 
                     AngleMatrix(Angle, Matrix);
                     VectorRotate(p1, Matrix, o->StartPosition);
@@ -4406,7 +4406,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
             case MODEL_SKIN_SHELL:
                 Vector(0.f, (float)(rand() % 128 + 32) * 0.1f, 0.f, p1);
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                 o->LifeTime = rand() % 16 + 32;
                 o->Scale = (float)(rand() % 3 + 3) * 0.1f;
                 o->Alpha = 0.5f;
@@ -4414,7 +4414,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 VectorRotate(p1, Matrix, o->Direction);
                 o->Gravity = (float)(rand() % 5 + 2);
-                o->Gravity += (float)(rand() % 5);
+                o->Gravity += ((float)(rand() % 5)) * FPS_ANIMATION_FACTOR;
 
                 o->Angle[0] = (float)(rand() % 360);
                 o->Angle[1] = (float)(rand() % 360);
@@ -4439,7 +4439,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Alpha = 0.3f;
                     o->HiddenMesh = 0;
 
-                    o->Position[2] += 300.f;
+                    o->Position[2] += (300.f) * FPS_ANIMATION_FACTOR;
 
                     Vector(0.f, 0.f, 45.f, o->Angle);
                 }
@@ -4463,11 +4463,11 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 Vector(0.f, -5.f, 0.f, o->Direction);
                 VectorCopy(o->Angle, o->HeadAngle);
                 VectorCopy(o->Owner->Position, o->StartPosition);
-                o->Position[2] += 150.f;
+                o->Position[2] += (150.f) * FPS_ANIMATION_FACTOR;
 
                 float Ang = rand() % 80 + 10;
 
-                o->HeadAngle[2] += o->SubType * Ang - Ang;
+                o->HeadAngle[2] += (o->SubType * Ang - Ang) * FPS_ANIMATION_FACTOR;
             }
             break;
             case MODEL_FENRIR_THUNDER:
@@ -4496,7 +4496,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     }
                     else if (irandom == 3)
                     {
-                        o->Scale -= 0.2f;
+                        o->Scale -= (0.2f) * FPS_ANIMATION_FACTOR;
                         p_b->TransformPosition(BoneTransform[14], vPos, o->Position, false);
                     }
                     else if (irandom >= 4 && irandom <= 5)
@@ -4505,7 +4505,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     }
                     else if (irandom >= 6 && irandom <= 7)
                     {
-                        o->Scale -= 0.2f;
+                        o->Scale -= (0.2f) * FPS_ANIMATION_FACTOR;
                         if (rand() % 2 == 0)
                             p_b->TransformPosition(BoneTransform[50], vPos, o->Position, false);
                         else
@@ -4513,7 +4513,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     }
                     else if (irandom == 8)
                     {
-                        o->Scale -= 0.2f;
+                        o->Scale -= (0.2f) * FPS_ANIMATION_FACTOR;
                         p_b->TransformPosition(BoneTransform[53], vPos, o->Position, false);
                     }
                     else if (irandom >= 9 && irandom <= 10)
@@ -4523,10 +4523,10 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     }
                     else
                     {
-                        o->Scale += 0.1f;
-                        o->Position[0] += rand() % 240 - 120;
-                        o->Position[1] += rand() % 10 - 5;
-                        o->Position[2] += 110;
+                        o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
+                        o->Position[0] += (rand() % 240 - 120) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += (rand() % 10 - 5) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += (110) * FPS_ANIMATION_FACTOR;
                     }
 
                     vec3_t vLight;
@@ -4548,9 +4548,9 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
                     VectorCopy(Light, o->Light);
 
-                    o->Position[0] += rand() % 40 - 20;
-                    o->Position[1] += rand() % 40 - 20;
-                    o->Position[2] += rand() % 40 - 20;
+                    o->Position[0] += (rand() % 40 - 20) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 40 - 20) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 40 - 20) * FPS_ANIMATION_FACTOR;
 
                     vec3_t vLight;
                     vLight[0] = o->Light[0] - 0.3f;
@@ -4571,9 +4571,9 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
                     VectorCopy(Light, o->Light);
 
-                    o->Position[0] += rand() % 40 - 20;
-                    o->Position[1] += rand() % 40 - 20;
-                    o->Position[2] += rand() % 40 - 20;
+                    o->Position[0] += (rand() % 40 - 20) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 40 - 20) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 40 - 20) * FPS_ANIMATION_FACTOR;
 
                     vec3_t vLight;
                     vLight[0] = o->Light[0] - 0.3f;
@@ -4594,9 +4594,9 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
 
                     VectorCopy(Light, o->Light);
 
-                    o->Position[0] += rand() % 160 - 80;
-                    o->Position[1] += rand() % 160 - 80;
-                    o->Position[2] += rand() % 160 - 80;
+                    o->Position[0] += (rand() % 160 - 80) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 160 - 80) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 160 - 80) * FPS_ANIMATION_FACTOR;
 
                     vec3_t vLight;
                     vLight[0] = o->Light[0] - 0.3f;
@@ -4621,8 +4621,8 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Angle[1] = (float)(rand() % 360);
                     o->Angle[2] = (float)(rand() % 360);
 
-                    o->Position[0] += (float)(rand() % 100 - 50);
-                    o->Position[1] += (float)(rand() % 100 - 50);
+                    o->Position[0] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
 
                     o->Gravity = (float)(rand() % 10 + 10) * 0.5f;
                 }
@@ -4647,7 +4647,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     AngleMatrix(o->Angle, Matrix);
                     Vector(0.f, (float)(rand() % 60 + 30) * 0.1f, 0.f, p1);
                     VectorRotate(p1, Matrix, o->HeadAngle);
-                    o->HeadAngle[2] += 25.0f;
+                    o->HeadAngle[2] += (25.0f) * FPS_ANIMATION_FACTOR;
 
                     Vector(0, 0, 0, o->Direction);
                 }
@@ -4759,7 +4759,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->LifeTime = 15;
                     o->Scale = 0.f;
 
-                    o->Position[2] += 100.f;
+                    o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
                     Vector(0.f, -10.f, 0.f, o->Direction);
                 }
                 else if (o->SubType == 1 || o->SubType == 3)
@@ -4861,7 +4861,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 {
                     o->BlendMesh = 0;
                     o->BlendMeshLight = 1.0f;
-                    o->Position[2] += 100.f;
+                    o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
                     o->LifeTime = 17;
                     o->Scale = 1.1f;
                     VectorSubtract(o->Owner->Position, o->Position, o->Direction);
@@ -4925,16 +4925,16 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     vec3_t vOriginPos;
                     VectorCopy(o->Position, vOriginPos);
 
-                    o->Position[0] += (float)(rand() % 20 - 10) * 4.f;
-                    o->Position[1] += (float)(rand() % 20 - 10) * 4.f;
-                    o->Position[2] += (float)(rand() % 20 - 10) * 4.f;
+                    o->Position[0] += ((float)(rand() % 20 - 10) * 4.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10) * 4.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 20 - 10) * 4.f) * FPS_ANIMATION_FACTOR;
 
                     VectorSubtract(vOriginPos, o->Position, o->Direction);
                     VectorNormalize(o->Direction);
                     int iAddDirection = ((float)(rand() % 10 - 5) * 0.08f);
-                    o->Direction[0] += iAddDirection;
-                    o->Direction[1] += iAddDirection;
-                    o->Direction[2] += iAddDirection;
+                    o->Direction[0] += (iAddDirection) * FPS_ANIMATION_FACTOR;
+                    o->Direction[1] += (iAddDirection) * FPS_ANIMATION_FACTOR;
+                    o->Direction[2] += (iAddDirection) * FPS_ANIMATION_FACTOR;
 
                     o->Scale = o->Scale + ((float)(rand() % 20 - 10) * (o->Scale * 0.03f));
                     o->LifeTime = 30 + (rand() % 20 - 10);
@@ -4966,16 +4966,16 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     vec3_t vOriginPos;
                     VectorCopy(o->Position, vOriginPos);
 
-                    o->Position[0] += (float)(rand() % 20 - 10) * 4.f;
-                    o->Position[1] += (float)(rand() % 20 - 10) * 4.f;
-                    o->Position[2] += (float)(rand() % 20 - 10) * 4.f;
+                    o->Position[0] += ((float)(rand() % 20 - 10) * 4.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10) * 4.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 20 - 10) * 4.f) * FPS_ANIMATION_FACTOR;
 
                     VectorSubtract(vOriginPos, o->Position, o->Direction);
                     VectorNormalize(o->Direction);
                     int iAddDirection = ((float)(rand() % 10 - 5) * 0.08f);
-                    o->Direction[0] += iAddDirection;
-                    o->Direction[1] += iAddDirection;
-                    o->Direction[2] += iAddDirection;
+                    o->Direction[0] += (iAddDirection) * FPS_ANIMATION_FACTOR;
+                    o->Direction[1] += (iAddDirection) * FPS_ANIMATION_FACTOR;
+                    o->Direction[2] += (iAddDirection) * FPS_ANIMATION_FACTOR;
 
                     o->Scale = o->Scale + ((float)(rand() % 20 - 10) * (o->Scale * 0.03f));
                     o->LifeTime = 25;
@@ -5044,7 +5044,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Alpha = 1.f;
                     o->Angle[2] = rand() % 360;
                     o->Scale = Scale + rand() % 10 * 0.05f;
-                    o->Position[2] += 10.f;
+                    o->Position[2] += (10.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
@@ -5052,15 +5052,15 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Alpha = 1.f;
                     o->Angle[2] = rand() % 360;
                     o->Scale = Scale + rand() % 10 * 0.05f;
-                    o->Position[2] += 10.f;
+                    o->Position[2] += (10.f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case MODEL_KNIGHT_PLANCRACK_B:
             {
                 o->LifeTime = 25;
                 o->Alpha = 1.f;
-                o->Position[2] += 15.f;
-                o->Angle[2] += 90.f;
+                o->Position[2] += (15.f) * FPS_ANIMATION_FACTOR;
+                o->Angle[2] += (90.f) * FPS_ANIMATION_FACTOR;
             }
             break;
             case MODEL_EFFECT_FLAME_STRIKE:
@@ -6072,7 +6072,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                     o->Scale = 0.8f + rand() % 3 * 0.1f;
                     o->Direction[1] = -40.f;
                     o->LifeTime = 3 + rand() % 3;
-                    o->Angle[2] += (rand() % 10 - 5.0f);
+                    o->Angle[2] += ((rand() % 10 - 5.0f)) * FPS_ANIMATION_FACTOR;
                 }
             }
             break;
@@ -6441,7 +6441,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 AngleMatrix(o->Angle, Matrix);
                 Vector(0.f, (float)(rand() % 128 + 64) * 0.1f, 0.f, p1);
                 VectorRotate(p1, Matrix, o->HeadAngle);
-                o->HeadAngle[2] += 25.0f;
+                o->HeadAngle[2] += (25.0f) * FPS_ANIMATION_FACTOR;
             }
             break;
             case MODEL_PHOENIX_SHOT:
@@ -6488,8 +6488,8 @@ void MoveParticle(OBJECT* o, vec3_t angle)
 
 bool MoveJump(OBJECT* o)
 {
-    o->Position[2] += o->Gravity;
-    o->Gravity -= 1.f;
+    o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+    o->Gravity -= (1.f) * FPS_ANIMATION_FACTOR;
     float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
     if (o->Position[2] < Height)
     {
@@ -6906,7 +6906,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->Kind = 2;
             o->Distance = 0.0f;
-            o->Angle[2] += 0.5f * o->Distance / 2.0f;
+            o->Angle[2] += (0.5f * o->Distance / 2.0f) * FPS_ANIMATION_FACTOR;
             o->CollisionRange = true;
         }
         else
@@ -6919,12 +6919,12 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             if (o->Timer >= o->Angle[2] - 60.0f)
             {
-                o->Angle[2] += 0.5f * o->Gravity * 3.0f;
+                o->Angle[2] += (0.5f * o->Gravity * 3.0f) * FPS_ANIMATION_FACTOR;
                 o->Kind = 1;
             }
             else if (o->Timer <= o->Angle[2] + 60.0f)
             {
-                o->Angle[2] += 0.5f * o->Gravity * 3.0f;
+                o->Angle[2] += (0.5f * o->Gravity * 3.0f) * FPS_ANIMATION_FACTOR;
                 o->Kind = 0;
             }
             else
@@ -6950,7 +6950,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 0)
         {
             OBJECT* pOwn = o->Owner;
-            if (o->LifeTime % 10 == 0)
+            if ((int)o->LifeTime % 10 == 0)
             {
                 CreateEffect(MODEL_ARROW_AUTOLOAD, pOwn->Position, pOwn->Angle, pOwn->Light, 1, pOwn);
             }
@@ -6970,7 +6970,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorScale(o->Position, pOwner->Scale, o->Position);
             VectorAdd(o->Position, pOwner->Position, o->Position);
             VectorCopy(pOwner->Angle, o->Angle);
-            o->Angle[0] += 85.f; o->Angle[1] += -17.f; o->Angle[2] += 20.f;
+            o->Angle[0] += 85.f; o->Angle[1] += -17.f; o->Angle[2] += (20.f) * FPS_ANIMATION_FACTOR;
         }
     }
     break;
@@ -7151,17 +7151,17 @@ void MoveEffect(OBJECT* o, int iIndex)
     }
     break;
     case MODEL_MULTI_SHOT3:
-        o->Scale += 0.25f;
+        o->Scale += (0.25f) * FPS_ANIMATION_FACTOR;
         o->BlendMeshLight = (float)o->LifeTime / 18.f;
         o->Alpha = o->BlendMeshLight;
         break;
     case MODEL_MULTI_SHOT1:
-        o->Scale += 0.2f;
+        o->Scale += (0.2f) * FPS_ANIMATION_FACTOR;
         o->BlendMeshLight = (float)o->LifeTime / 18.f;
         o->Alpha = o->BlendMeshLight;
         break;
     case MODEL_MULTI_SHOT2:
-        o->Scale += 0.3f;
+        o->Scale += (0.3f) * FPS_ANIMATION_FACTOR;
         o->BlendMeshLight = (float)o->LifeTime / 18.f;
         o->Alpha = o->BlendMeshLight;
         break;
@@ -7169,7 +7169,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            o->Scale -= 0.1f;
+            o->Scale -= (0.1f) * FPS_ANIMATION_FACTOR;
             if (o->Scale < 0.8f)
                 o->Scale = 0.8f;
         }
@@ -7184,11 +7184,11 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 OBJECT* to = NULL;
 
-                if (o->LifeTime >= 3 && o->LifeTime % 2 == 0)
+                if (o->LifeTime >= 3 && (int)o->LifeTime % 2 == 0)
                 {
                     VectorCopy(o->Owner->Angle, Angle);
                     int Ran = -1;
-                    CHARACTER* c = &CharactersClient[o->PKKey];
+                    CHARACTER* c = &CharactersClient[(int)o->PKKey];
 
                     Ran = rand() % 6;
                     if (o->m_sTargetIndex > -1)
@@ -7272,7 +7272,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             //			CreateJoint ( BITMAP_FLARE+1, o->Position, o->Position, o->Angle, 9, o, 10.f, 40 );
         }
         //			else
-        o->Alpha += 0.001f;
+        o->Alpha += (0.001f) * FPS_ANIMATION_FACTOR;
     }
     break;
     case MODEL_WARP3:
@@ -7288,13 +7288,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             float fTemp2 = sinf(WorldTime * 0.0017f) * 0.2f;
             float fTemp3 = sinf(WorldTime * 0.0013f) * 0.2f;
             Vector(fTemp1 + 0.01f, fTemp2 + 0.01f, fTemp3 + 0.01f, o->Light);
-            o->Angle[1] += 4.0f + o->Gravity;
+            o->Angle[1] += (4.0f + o->Gravity) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 1)
         {
             float fTemp1 = sinf(WorldTime * 0.0011f) * 0.05f;
             Vector(0.0f + fTemp1, 0.2f + fTemp1, 0.1f + fTemp1, o->Light);
-            o->Angle[1] += 2.0f + o->Gravity;
+            o->Angle[1] += (2.0f + o->Gravity) * FPS_ANIMATION_FACTOR;
         }
     }
     break;
@@ -7321,8 +7321,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Kind = 1;
         }
 
-        o->Angle[2] += sinf((int)WorldTime % 10000 * 0.0001f) * o->Gravity;
-        o->Angle[0] += sinf((int)WorldTime % 10000 * 0.0001f) * o->Distance / 3.0f;
+        o->Angle[2] += (sinf((int)WorldTime % 10000 * 0.0001f) * o->Gravity) * FPS_ANIMATION_FACTOR;
+        o->Angle[0] += (sinf((int)WorldTime % 10000 * 0.0001f) * o->Distance / 3.0f) * FPS_ANIMATION_FACTOR;
 
         Vector(o->BlendMeshLight / 10.f, o->BlendMeshLight / 10.f, o->BlendMeshLight / 4.f, o->Light);
         CreateParticle(BITMAP_LIGHT, o->Position, o->Angle, o->Light, 9, o->Scale);
@@ -7332,10 +7332,10 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_TREE_ATTACK:
     {
         Vector(1.0f, 1.0f, 1.0f, Light);
-        o->Scale += 0.1f;
+        o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
         if (o->Scale >= 1.0f)
         {
-            o->Alpha -= 0.07f;
+            o->Alpha -= (0.07f) * FPS_ANIMATION_FACTOR;
             o->Scale = 1.0f;
         }
     }
@@ -7343,27 +7343,27 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_BUTTERFLY01:
     {
         if (o->Kind > 0)
-            o->Angle[2] += rand() % 10;
+            o->Angle[2] += (rand() % 10) * FPS_ANIMATION_FACTOR;
         else
-            o->Angle[2] -= rand() % 10;
+            o->Angle[2] -= (rand() % 10) * FPS_ANIMATION_FACTOR;
 
         if (rand() % 32 == 0)
         {
             o->Direction[2] = (float)(rand() % 15 - 7) * 1.f;
         }
-        o->Direction[2] += (float)(rand() % 15 - 7) * 0.2f;
+        o->Direction[2] += ((float)(rand() % 15 - 7) * 0.2f) * FPS_ANIMATION_FACTOR;
         float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height + 50.f)
         {
             o->Direction[2] *= 0.8f;
-            o->Direction[2] += 1.f;
+            o->Direction[2] += (1.f) * FPS_ANIMATION_FACTOR;
         }
         if (o->Position[2] > Height + 150.f)
         {
             o->Direction[2] *= 0.8f;
-            o->Direction[2] -= 1.f;
+            o->Direction[2] -= (1.f) * FPS_ANIMATION_FACTOR;
         }
-        o->Position[2] += (float)(rand() % 15 - 7) * 0.3f;
+        o->Position[2] += ((float)(rand() % 15 - 7) * 0.3f) * FPS_ANIMATION_FACTOR;
 
         float  Luminosity = (float)(rand() % 32 + 64) * 0.01f;
         if (o->SubType == 0) {
@@ -7393,8 +7393,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorScale(o->Direction, o->Velocity, Position);
         VectorAdd(Position, o->Position, o->Position);
         //        o->Position[2] -= o->Velocity;
-        o->Velocity += 3.f;
-        o->Angle[0] += 5.f * o->Velocity;//rand()%20+20.f;
+        o->Velocity += (3.f) * FPS_ANIMATION_FACTOR;
+        o->Angle[0] += (5.f * o->Velocity) * FPS_ANIMATION_FACTOR;//rand()%20+20.f) ;
 
         if (o->Position[2] < 350.f && o->PKKey == 0)
         {
@@ -7408,8 +7408,8 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_SKULL:
         if (o->SubType == 4)
         {
-            o->Direction[1] -= o->Velocity;
-            o->Angle[0] -= 1.f;
+            o->Direction[1] -= (o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] -= (1.f) * FPS_ANIMATION_FACTOR;
             CreateSprite(BITMAP_SKULL, o->Position, 10.0f, o->Light, NULL);
         }
         else
@@ -7529,16 +7529,16 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_HALLOWEEN_CANDY_STAR:
         if (o->SubType == 0 || o->SubType == 1)
         {
-            o->Angle[o->m_iAnimation] += 20.f;
-            o->Position[2] += (o->Gravity * 0.5f);
-            o->Gravity -= 1.5f;
+            o->Angle[o->m_iAnimation] += (20.f) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
+            o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < Height)
             {
                 o->Position[2] = Height;
                 o->Gravity = -o->Gravity * 0.3f;
-                o->LifeTime -= 2;
+                o->LifeTime -= 2 * FPS_ANIMATION_FACTOR;
             }
 
             VectorAdd(o->Position, o->Direction, o->Position);
@@ -7560,23 +7560,23 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_XMAS_EVENT_CANDY:
     case MODEL_XMAS_EVENT_TREE:
     case MODEL_XMAS_EVENT_SOCKS:
-        o->Angle[o->m_iAnimation] += 20.f;
-        o->Position[2] += (o->Gravity * 0.5f);
-        o->Gravity -= 1.5f;
+        o->Angle[o->m_iAnimation] += (20.f) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
+        o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height + 3.f)
         {
             o->Position[2] = Height + 3.f;
             o->Gravity = -o->Gravity * 0.3f;
-            o->LifeTime -= 2;
+            o->LifeTime -= 2 * FPS_ANIMATION_FACTOR;
         }
 
         VectorAdd(o->Position, o->Direction, o->Position);
         break;
 
     case MODEL_XMAS_EVENT_ICEHEART:
-        o->Angle[2] += 10.f;
+        o->Angle[2] += (10.f) * FPS_ANIMATION_FACTOR;
         if (o->Owner != NULL)
         {
             if (o->Owner->CurrentAction != PLAYER_SANTA_2)
@@ -7593,18 +7593,18 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_NEWYEARSDAY_EVENT_HOTPEPPER_RED:
     case MODEL_NEWYEARSDAY_EVENT_PIG:
     case MODEL_NEWYEARSDAY_EVENT_YUT:
-        o->Angle[o->m_iAnimation] += 10.f;
-        o->Position[0] += (o->Direction[0] * 1.2f);
-        o->Position[1] += (o->Direction[1] * 1.2f);
-        o->Position[2] += (o->Gravity * 1.5f);
-        o->Gravity -= 1.5f;
+        o->Angle[o->m_iAnimation] += (10.f) * FPS_ANIMATION_FACTOR;
+        o->Position[0] += ((o->Direction[0] * 1.2f)) * FPS_ANIMATION_FACTOR;
+        o->Position[1] += ((o->Direction[1] * 1.2f)) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += ((o->Gravity * 1.5f)) * FPS_ANIMATION_FACTOR;
+        o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.3f;
-            o->LifeTime -= 2;
+            o->LifeTime -= (2) * FPS_ANIMATION_FACTOR;
         }
 
         VectorAdd(o->Position, o->Direction, o->Position);
@@ -7612,12 +7612,12 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_MOONHARVEST_MOON:
         if (o->SubType == 0)
         {
-            o->Angle[2] += 5.0f;
+            o->Angle[2] += (5.0f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 25)
             {
-                o->Light[0] -= 0.05f;
-                o->Light[1] -= 0.06f;
-                o->Light[2] -= 0.05f;
+                o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                o->Light[1] -= (0.06f) * FPS_ANIMATION_FACTOR;
+                o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 1)
@@ -7634,24 +7634,24 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 2)
         {
-            o->Scale += 0.01f;
+            o->Scale += (0.01f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_MOONHARVEST_GAM:
     case MODEL_MOONHARVEST_SONGPUEN1:
     case MODEL_MOONHARVEST_SONGPUEN2:
-        o->Angle[0] += 10.f;
-        o->Position[0] += (o->Direction[0] * 2.2f);
-        o->Position[1] += (o->Direction[1] * 2.2f);
-        o->Position[2] += (o->Gravity * 1.5f);
-        o->Gravity -= 1.5f;
+        o->Angle[0] += (10.f) * FPS_ANIMATION_FACTOR;
+        o->Position[0] += ((o->Direction[0] * 2.2f)) * FPS_ANIMATION_FACTOR;
+        o->Position[1] += ((o->Direction[1] * 2.2f)) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += ((o->Gravity * 1.5f)) * FPS_ANIMATION_FACTOR;
+        o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.3f;
-            o->LifeTime -= 2;
+            o->LifeTime -= (2) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_SPEARSKILL:
@@ -7966,25 +7966,25 @@ void MoveEffect(OBJECT* o, int iIndex)
         switch (o->Type)
         {
         case MODEL_SUMMONER_CASTING_EFFECT1:
-            o->Angle[2] -= 3.0f;
+            o->Angle[2] -= (3.0f) * FPS_ANIMATION_FACTOR;
             break;
         case MODEL_SUMMONER_CASTING_EFFECT11:
-            o->Angle[2] += 3.0f;
+            o->Angle[2] += (3.0f) * FPS_ANIMATION_FACTOR;
             break;
         case MODEL_SUMMONER_CASTING_EFFECT111:
-            o->Angle[2] -= 3.0f;
+            o->Angle[2] -= (3.0f) * FPS_ANIMATION_FACTOR;
             break;
         case MODEL_SUMMONER_CASTING_EFFECT2:
-            o->Angle[2] += 3.0f;
+            o->Angle[2] += (3.0f) * FPS_ANIMATION_FACTOR;
             break;
         case MODEL_SUMMONER_CASTING_EFFECT22:
-            o->Angle[2] -= 3.0f;
+            o->Angle[2] -= (3.0f) * FPS_ANIMATION_FACTOR;
             break;
         case MODEL_SUMMONER_CASTING_EFFECT222:
-            o->Angle[2] += 3.0f;
+            o->Angle[2] += (3.0f) * FPS_ANIMATION_FACTOR;
             break;
         case MODEL_SUMMONER_CASTING_EFFECT4:
-            o->Scale += 0.6f;
+            o->Scale += (0.6f) * FPS_ANIMATION_FACTOR;
             break;
         }
     }
@@ -7993,7 +7993,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->LifeTime < 20) o->BlendMeshLight -= 0.03f;
         else if (o->BlendMeshLight < 0.5f) o->BlendMeshLight += 0.05f;
 
-        o->BlendMeshTexCoordV += 0.05f;
+        o->BlendMeshTexCoordV += (0.05f) * FPS_ANIMATION_FACTOR;
     }
     break;
     case MODEL_SUMMONER_SUMMON_SAHAMUTT:
@@ -8004,11 +8004,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->LifeTime < 20)
         {
             SetAction(o, 0);
-            o->Alpha -= 0.05f;
+            o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->CurrentAction == 0 && o->Alpha < 0.3f)
         {
-            o->Alpha += 0.05f;
+            o->Alpha += (0.05f) * FPS_ANIMATION_FACTOR;
             {
                 o->Angle[2] = CreateAngle2D(o->Position, o->HeadTargetAngle);
                 float dx = o->HeadTargetAngle[0] - o->Position[0];
@@ -8027,13 +8027,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->AnimationFrame >= 11.0f)
             {
                 if (o->Alpha > 0)
-                    o->Alpha -= 0.3f;
+                    o->Alpha -= (0.3f) * FPS_ANIMATION_FACTOR;
                 else
                     o->Alpha = 0;
             }
             else if (o->AnimationFrame < 3.0f && o->Alpha < 0.7f)
             {
-                o->Alpha += 0.05f;
+                o->Alpha += (0.05f) * FPS_ANIMATION_FACTOR;
             }
 
             if (o->AnimationFrame > 4.0f && o->AnimationFrame < 12.0f)
@@ -8144,7 +8144,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 0)
         {
             int anEffectVolume[3] = { 5, 4, 3 };
-            if (rand() % anEffectVolume[o->PKKey] == 0)
+            if (rand() % anEffectVolume[(int)o->PKKey] == 0)
             {
                 vec3_t vPos, vLight;
 
@@ -8210,16 +8210,16 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 8)
         {
-            o->Scale += 1.8f;
+            o->Scale += (1.8f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 9)
         {
             if (o->LifeTime < 20) o->Alpha -= 0.05f;
             else if (o->Alpha < 1.0f) o->Alpha += 0.05f;
 
-            o->HeadAngle[0] += 4.0f;
-            o->HeadAngle[1] -= 8.0f;
-            o->HeadAngle[2] += 4.0f;
+            o->HeadAngle[0] += (4.0f) * FPS_ANIMATION_FACTOR;
+            o->HeadAngle[1] -= (8.0f) * FPS_ANIMATION_FACTOR;
+            o->HeadAngle[2] += (4.0f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 10)
         {
@@ -8228,13 +8228,13 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 11)
         {
-            o->HeadAngle[0] += 2.0f;
-            o->HeadAngle[1] -= 2.0f;
-            o->HeadAngle[2] += 2.0f;
+            o->HeadAngle[0] += (2.0f) * FPS_ANIMATION_FACTOR;
+            o->HeadAngle[1] -= (2.0f) * FPS_ANIMATION_FACTOR;
+            o->HeadAngle[2] += (2.0f) * FPS_ANIMATION_FACTOR;
 
             if (o->LifeTime <= 10)
             {
-                o->Alpha -= 0.05f;
+                o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
                 o->Light[0] *= o->Alpha;
                 o->Light[1] *= o->Alpha;
                 o->Light[2] *= o->Alpha;
@@ -8244,14 +8244,14 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->Alpha > 0.0f)
             {
-                o->Alpha -= 0.05f;
+                o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
                 o->Alpha = 0.0f;
             }
 
-            o->Scale += o->Alpha * 1.0f;
+            o->Scale += (o->Alpha * 1.0f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 5.0f)
             {
                 //o->Scale = 5.0f;
@@ -8328,7 +8328,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 9)
         {
-            o->Scale += 0.3f;
+            o->Scale += (0.3f) * FPS_ANIMATION_FACTOR;
             o->Light[0] /= 1.1f;
             o->Light[1] /= 1.1f;
             o->Light[2] /= 1.1f;
@@ -8343,8 +8343,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             VectorCopy(o->Owner->Position, o->Position);
 
-            o->Alpha -= 0.02f;
-            o->Scale += 0.01f;
+            o->Alpha -= (0.02f) * FPS_ANIMATION_FACTOR;
+            o->Scale += (0.01f) * FPS_ANIMATION_FACTOR;
 
             if (o->Alpha < 0.f)
             {
@@ -8353,9 +8353,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
 
             if (o->LifeTime < 25)
-                o->AlphaTarget -= 0.02f;
+                o->AlphaTarget -= (0.02f) * FPS_ANIMATION_FACTOR;
             else if (o->AlphaTarget < 1.0f)
-                o->AlphaTarget += 0.02f;
+                o->AlphaTarget += (0.02f) * FPS_ANIMATION_FACTOR;
 
             if (1 == o->LifeTime)
                 o->LifeTime = 50;
@@ -8367,23 +8367,23 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
         case 0:
             if (o->LifeTime < 20)
-                o->Alpha -= 0.05f;
+                o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
             else if (o->Alpha < 1.0f)
-                o->Alpha += 0.05f;
+                o->Alpha += (0.05f) * FPS_ANIMATION_FACTOR;
             break;
         case 1:
             if (o->LifeTime < 20)
-                o->Alpha -= 0.03f;
+                o->Alpha -= (0.03f) * FPS_ANIMATION_FACTOR;
             else if (o->Alpha < 0.7f)
-                o->Alpha += 0.06f;
+                o->Alpha += (0.06f) * FPS_ANIMATION_FACTOR;
             break;
         case 2:
             if (o->Scale < 3.5f)
-                o->Scale += 0.1f;
+                o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 20)
-                o->Alpha -= 0.05f;
+                o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
             else if (o->Alpha < 1.0f)
-                o->Alpha += 0.05f;
+                o->Alpha += (0.05f) * FPS_ANIMATION_FACTOR;
             break;
         }
         break;
@@ -8445,7 +8445,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             VectorCopy(oj->Position, o->Position);
             VectorCopy(oj->Angle, o->Angle);
-            if (o->LifeTime % 10 == 0)
+            if ((int)o->LifeTime % 10 == 0)
             {
                 //						Vector(0.1f,0.1f,0.1f,Light);
                 CreateEffect(MODEL_FEATHER, o->Position, o->Angle, o->Light, 2, NULL, -1, 0, 0, 0, 1.4f);
@@ -8501,8 +8501,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else
             {
-                o->Scale -= 0.02f;
-                o->Alpha -= 0.001f;
+                o->Scale -= (0.02f) * FPS_ANIMATION_FACTOR;
+                o->Alpha -= (0.001f) * FPS_ANIMATION_FACTOR;
 
                 OBJECT* Owner = o->Owner;
                 BMD* pModel = &Models[o->Owner->Type];
@@ -8581,7 +8581,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->SubType == 1)
             {
-                if ((o->LifeTime % 2) == 0)
+                if (((int)o->LifeTime % 2) == 0)
                 {
                     CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 3, NULL, 10.f, 10, 10);
                 }
@@ -8593,7 +8593,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else if (o->SubType == 2)
             {
-                if ((o->LifeTime % 2) == 0)
+                if (((int)o->LifeTime % 2) == 0)
                 {
                     CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 3, NULL, 10.f, 10, 10);
                 }
@@ -8683,13 +8683,13 @@ void MoveEffect(OBJECT* o, int iIndex)
         float ScaleBk = 0.f;
         if (o->Scale < 2.f)
         {
-            o->Scale += 0.1f;
+            o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
             ScaleBk = o->Scale;
         }
         else
         {
             if (o->Scale < 2.4f)
-                o->Scale += 0.02f;
+                o->Scale += (0.02f) * FPS_ANIMATION_FACTOR;
             else
                 o->Scale = 2.f;
 
@@ -8702,8 +8702,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (o->LifeTime <= 40)
         {
-            o->Alpha -= 0.1f;
-            o->BlendMeshLight -= 0.1f;
+            o->Alpha -= (0.1f) * FPS_ANIMATION_FACTOR;
+            o->BlendMeshLight -= (0.1f) * FPS_ANIMATION_FACTOR;
         }
         float Matrix[3][4];
         Vector(-10.f, -30.f, 0.f, P);
@@ -8711,7 +8711,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         AngleMatrix(o->Owner->Angle, Matrix);
         VectorRotate(P, Matrix, dp);
         VectorAdd(dp, o->Owner->Position, o->Position);
-        o->Position[2] += 130;
+        o->Position[2] += (130) * FPS_ANIMATION_FACTOR;
         CreateSprite(BITMAP_IMPACT, o->Position, ScaleBk, Light, o);
         CreateSprite(BITMAP_SHINY + 1, o->Position, ScaleBk, Light, o, -WorldTime * 0.08f);
         if (o->Scale > 1.f)
@@ -8729,13 +8729,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorAdd(Position, o->Position, Position);
                 CreateParticle(BITMAP_FLAME, Position, o->Angle, Light);
             }
-            if (rand() % 8 == 0)
+            if ((int)WorldTime % 16)
                 CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
 
             Vector(Luminosity * 1.f, Luminosity * 0.4f, Luminosity * 0.f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
             if (o->Owner == &Hero->Object)
-                if (o->LifeTime % 20 == 0)
+                if ((int)o->LifeTime % 20 == 0)
                     AttackCharacterRange(o->Skill, o->Position, 150.f, o->Weapon, o->PKKey);
         }
         else if (o->SubType == 1 || o->SubType == 2)
@@ -8775,7 +8775,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 4)
         {
-            o->Scale += 20.f;
+            o->Scale += (20.f) * FPS_ANIMATION_FACTOR;
             for (int j = 0; j < 18; j++)
             {
                 Vector(0.f, 150.f - o->Scale, 0.f, p);
@@ -8805,13 +8805,13 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_RAKLION_BOSS_CRACKEFFECT:
         if (o->SubType == 0)
         {
-            o->Alpha -= 0.03f;
+            o->Alpha -= (0.03f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_RAKLION_BOSS_MAGIC:
         if (o->SubType == 0)
         {
-            o->Alpha -= 0.03f;
+            o->Alpha -= (0.03f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case BITMAP_FIRE_HIK2_MONO:
@@ -8853,7 +8853,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Light[0] /= 1.05f;
             o->Light[1] /= 1.05f;
             o->Light[2] /= 1.05f;
-            o->Scale += 0.03f;
+            o->Scale += (0.03f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case BITMAP_FIRE_RED:
@@ -9214,16 +9214,16 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
 
             VectorCopy(o->Owner->Position, o->Position);
-            o->Position[2] += 100;
+            o->Position[2] += (100) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime > 20)
             {
-                o->Alpha += 0.05f;
-                o->BlendMeshLight += 0.05f;
+                o->Alpha += (0.05f) * FPS_ANIMATION_FACTOR;
+                o->BlendMeshLight += (0.05f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
-                o->Alpha -= 0.05f;
-                o->BlendMeshLight -= 0.05f;
+                o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
+                o->BlendMeshLight -= (0.05f) * FPS_ANIMATION_FACTOR;
                 if (o->Alpha < 0.f)
                 {
                     o->Live = false;
@@ -9232,14 +9232,14 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->Type == MODEL_ALICE_BUFFSKILL_EFFECT)
             {
-                o->Angle[2] += 8.f;
+                o->Angle[2] += (8.f) * FPS_ANIMATION_FACTOR;
             }
             else if (o->Type == MODEL_ALICE_BUFFSKILL_EFFECT2)
             {
-                o->Angle[2] -= 8.f;
+                o->Angle[2] -= (8.f) * FPS_ANIMATION_FACTOR;
             }
 
-            o->Scale += 0.035f;
+            o->Scale += (0.035f) * FPS_ANIMATION_FACTOR;
 
             float fRot = (WorldTime * 0.0006f) * 360.0f;
             vec3_t vLight;
@@ -9381,8 +9381,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Owner->AnimationFrame > 6.0f || o->LifeTime < 15)
             {
                 Vector(0.f, -20.f, -75.f - o->Velocity, o->Direction);
-                o->Gravity += 0.1f;
-                o->Velocity += o->Gravity;
+                o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
+                o->Velocity += (o->Gravity) * FPS_ANIMATION_FACTOR;
             }
 
             OBJECT* pObject = o;
@@ -9541,7 +9541,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1)
         {
-            o->Alpha += 0.01f;
+            o->Alpha += (0.01f) * FPS_ANIMATION_FACTOR;
             if (o->Alpha >= 1.0f)
             {
                 o->Alpha = 1.0f;
@@ -9553,7 +9553,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             VectorAdd(o->Position, o->Direction, o->Position);
             //o->Direction[2] -= .35f;
-            o->Direction[2] -= .01f;
+            o->Direction[2] -= .01f * FPS_ANIMATION_FACTOR;
             //VectorScale( o->Light, 0.9f, o->Light);
             CreateParticle(BITMAP_LIGHT, o->Position, o->Angle, o->Light, 1, o->Scale);
             if (o->Direction[2] < -2.f)
@@ -9591,14 +9591,14 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (g_isCharacterBuff(o->Owner, eBuff_Cloaking)) break;
 
-            o->Velocity++;
+            o->Velocity += FPS_ANIMATION_FACTOR;
 
             if (((int)(o->Velocity) % 50) == 0)
             {
                 if (o->Owner != NULL)
                 {
                     vec3_t Position;
-                    o->Angle[2] += 50.f;
+                    o->Angle[2] += (50.f) * FPS_ANIMATION_FACTOR;
                     VectorCopy(o->Owner->Position, Position);
 
                     o->Position[0] = o->Owner->Position[0] + sinf(o->Angle[2] * 0.1f) * 80.f;
@@ -9609,16 +9609,16 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
             }
         }
-        else if (o->SubType == 3)
+        else if (o->SubType == 3) // Ancient blur
         {
-            o->Velocity++;
-
-            if ((o->LifeTime % 15) == 0)
+            o->Velocity += FPS_ANIMATION_FACTOR;
+            if (((int)o->LifeTime % 15) == 0)
             {
+                o->LifeTime = (int)o->LifeTime - 0.01;
                 if (o->Owner != NULL)
                 {
                     vec3_t Position;
-                    o->Angle[2] += 180;
+                    o->Angle[2] += (180) * FPS_ANIMATION_FACTOR;
                     VectorCopy(o->Owner->Position, Position);
 
                     o->Position[0] = o->Owner->Position[0] + sinf(o->Angle[2] * 0.1f) * 50.f;
@@ -9656,24 +9656,24 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_WAVE:
         if (o->Scale > 2.f)
         {
-            o->Scale += 0.1f;
-            o->Position[0] -= 1.f;
-            o->Position[2] -= 1.5f;
+            o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
+            o->Position[0] -= (1.f) * FPS_ANIMATION_FACTOR;
+            o->Position[2] -= (1.5f) * FPS_ANIMATION_FACTOR;
             o->BlendMeshLight = o->LifeTime / 30.f;
         }
         else
         {
-            o->Scale += 1.2f;
-            o->Position[0] -= 1.2f;
-            o->Position[2] -= 1.8f;
+            o->Scale += (1.2f) * FPS_ANIMATION_FACTOR;
+            o->Position[0] -= (1.2f) * FPS_ANIMATION_FACTOR;
+            o->Position[2] -= (1.8f) * FPS_ANIMATION_FACTOR;
         }
 
         Vector(-Luminosity * 0.5f, -Luminosity * 0.5f, -Luminosity * 0.5f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 5, PrimaryTerrainLight);
         break;
     case MODEL_TAIL:
-        o->Position[2] -= o->Gravity;
-        o->Gravity += 60.f;
+        o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+        o->Gravity += (60.f) * FPS_ANIMATION_FACTOR;
         o->BlendMeshLight = o->LifeTime / 20.f;
         break;
     case MODEL_WAVE_FORCE:
@@ -9684,11 +9684,11 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_SKILL_INFERNO:
         if (o->SubType == 2)
         {
-            o->Scale += 0.04f;
+            o->Scale += (0.04f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 8)
         {
-            o->Scale += 0.04f;
+            o->Scale += (0.04f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 10)
             {
                 o->Light[0] *= 0.8f;
@@ -9705,21 +9705,21 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             VectorCopy(o->Owner->Position, o->Position);
 
-            o->Scale += 0.003f;
-            o->Gravity += 0.8f * o->Scale * 30.f;
-            o->Position[2] += o->Gravity;
+            o->Scale += (0.003f) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.8f * o->Scale * 30.f) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 5)
         {
-            o->Position[2] += 2.f;
-            o->Angle[2] += 20.f;
+            o->Position[2] += (2.f) * FPS_ANIMATION_FACTOR;
+            o->Angle[2] += (20.f) * FPS_ANIMATION_FACTOR;
             o->BlendMeshLight = o->LifeTime / 20.f;
             Vector(Luminosity * 0.1f, Luminosity * 0.3f, Luminosity * 0.8f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 5, PrimaryTerrainLight);
         }
         else if (o->SubType == 6)
         {
-            o->Scale += 0.01f;
+            o->Scale += (0.01f) * FPS_ANIMATION_FACTOR;
             o->BlendMeshLight = o->LifeTime / 5.f * 0.1f;
             Vector(Luminosity * 0.8f, Luminosity * 0.3f, Luminosity * 0.1f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
@@ -9741,14 +9741,14 @@ void MoveEffect(OBJECT* o, int iIndex)
         else if (o->SubType == 9)
         {
             o->BlendMeshLight = o->LifeTime / 80.f;
-            o->Position[2] += o->Gravity;
+            o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Light[0] /= 1.04f;
             o->Light[2] /= 1.04f;
-            o->Alpha -= 0.01f;
+            o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 10)
         {
-            o->Scale += 0.04f;
+            o->Scale += (0.04f) * FPS_ANIMATION_FACTOR;
             BMD* b = &Models[o->Type];
             VectorCopy(o->Light, b->BodyLight);
         }
@@ -9756,20 +9756,20 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_MAGIC_CIRCLE1:
         if (o->SubType == 2)
         {
-            o->Scale += 0.015f;
+            o->Scale += (0.015f) * FPS_ANIMATION_FACTOR;
             VectorCopy(o->Owner->Position, o->Position);
             Vector(0.1f, 0.0f, 0.0f, o->Light);
         }
         else if (o->SubType == 1)
         {
-            o->Scale += 0.01f;
+            o->Scale += (0.01f) * FPS_ANIMATION_FACTOR;
             Vector(Luminosity * 1.0f, Luminosity * 0.0f, Luminosity * 0.0f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
         }
         else
         {
             VectorCopy(o->Owner->Position, o->Position);
-            o->Scale += 0.01f;
+            o->Scale += (0.01f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_BIG_METEO1:
@@ -9789,7 +9789,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
         }
         VectorAdd(o->Position, o->Direction, o->Position);
-        o->Angle[0] += 10.f / o->Scale;
+        o->Angle[0] += (10.f / o->Scale) * FPS_ANIMATION_FACTOR;
         CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
         //CreateParticle(BITMAP_ENERGY,o->Position,o->Angle,Light);
         //CreateParticle(BITMAP_SPARK+1,o->Position,o->Angle,Light,0,4.f);
@@ -9798,7 +9798,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->BlendMeshLight = 1.3f;
 
         VectorCopy(o->Owner->Position, o->Position);
-        o->Angle[2] += 10.f;
+        o->Angle[2] += (10.f) * FPS_ANIMATION_FACTOR;
         if (!o->Owner->Live || !o->Owner->Visible)
             o->Live = false;
         break;
@@ -9809,19 +9809,19 @@ void MoveEffect(OBJECT* o, int iIndex)
         AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
         break;
     case MODEL_SAW:
-        o->Angle[2] -= 30.f;
+        o->Angle[2] -= (30.f) * FPS_ANIMATION_FACTOR;
         break;
     case MODEL_LASER:
         if (o->SubType != 0 && o->SubType != 3)
         {
-            o->Direction[1] -= o->Velocity;
-            o->Velocity += 1.f;
+            o->Direction[1] -= (o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Velocity += (1.f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_MAGIC1:
         VectorCopy(o->Owner->Position, o->Position);
-        o->Position[2] += 100.f;
-        o->Angle[1] += 20.f;
+        o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
+        o->Angle[1] += (20.f) * FPS_ANIMATION_FACTOR;
         o->BlendMeshLight = o->LifeTime * 0.1f;
         break;
     case MODEL_SKILL_WHEEL1:
@@ -9883,7 +9883,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         Vector(1.f, 0.8f, 0.6f, Light);
         CreateSprite(BITMAP_LIGHT, Position, 2.f, Light, o);
 
-        if (gMapManager.InHellas() && (o->LifeTime % 4) == 0)
+        if (gMapManager.InHellas() && ((int)o->LifeTime % 4) == 0)
         {
             int PositionX = (int)(o->Position[0] / TERRAIN_SCALE);
             int PositionY = (int)(o->Position[1] / TERRAIN_SCALE);
@@ -10017,7 +10017,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->Kind == 0)
                 CreateEffect(MODEL_WAVE, o->StartPosition, Angle, o->Light);
 
-            o->StartPosition[2] -= 27;
+            o->StartPosition[2] -= (27) * FPS_ANIMATION_FACTOR;
 
             if (o->Owner != NULL)
             {
@@ -10158,24 +10158,24 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             float   angle = (20 - count) * addAngle;
 
-            o->Angle[0] += 80;
+            o->Angle[0] += (80) * FPS_ANIMATION_FACTOR;
             o->Direction[1] = sinf((float)((angle * 3.141592) / 180.f)) * 260;
             VectorCopy(o->StartPosition, o->Position);
             if (count < 12.5 || count>12.5)
             {
-                o->Gravity += 8.f;
+                o->Gravity += (8.f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
-                o->Gravity -= 8.f;
+                o->Gravity -= (8.f) * FPS_ANIMATION_FACTOR;
             }
 
             AngleMatrix(o->HeadAngle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
             VectorAdd(Position, o->StartPosition, o->Position);
 
-            o->Position[2] += o->Gravity;
-            o->Position[2] += 200;
+            o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += (200) * FPS_ANIMATION_FACTOR;
         }
     }
     break;
@@ -10183,9 +10183,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->BlendMeshLight = (o->LifeTime * 0.1f) / 3.f;
         if (o->LifeTime < 10)
         {
-            o->Position[2] -= 0.5f;
+            o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
         }
-        if (o->LifeTime > 15 && (o->LifeTime % 3) == 0)
+        if (o->LifeTime > 15 && ((int)o->LifeTime % 3) == 0)
         {
             EarthQuake = (float)(rand() % 8 - 4) * 0.1f;
         }
@@ -10194,7 +10194,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->BlendMeshLight = (o->LifeTime * 0.1f) / 10.f;
         if (o->LifeTime < 13)
         {
-            o->Position[2] -= 0.5f;
+            o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_SKILL_FURY_STRIKE + 2:
@@ -10205,7 +10205,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime < 5)
             {
-                o->Position[2] -= 0.5f;
+                o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
             }
             o->BlendMeshLight = (o->LifeTime * 0.1f);
 
@@ -10239,14 +10239,14 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->BlendMeshLight = (o->LifeTime * 0.1f) / 3.f;
         if (o->LifeTime < 10)
         {
-            o->Position[2] -= 0.5f;
+            o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_SKILL_FURY_STRIKE + 6:
         o->BlendMeshLight = (o->LifeTime * 0.1f) / 10.f;
         if (o->LifeTime < 13)
         {
-            o->Position[2] -= 0.5f;
+            o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_SKILL_FURY_STRIKE + 5:
@@ -10256,7 +10256,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime < 15)
             {
-                o->Position[2] -= 0.5f;
+                o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
             }
 
             o->BlendMeshLight = (o->LifeTime * 0.1f);
@@ -10292,7 +10292,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->BlendMeshLight = (o->LifeTime * 0.1f) / 3.f;
         if (o->LifeTime < 10)
         {
-            o->Position[2] -= 0.5f;
+            o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_SKILL_FURY_STRIKE + 8:
@@ -10304,7 +10304,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         if (o->LifeTime < 15)
         {
-            o->Position[2] -= 0.5f;
+            o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
         }
 
         if (o->LifeTime >= 13 && rand() % 5 == 0)
@@ -10405,7 +10405,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         if (o->SubType >= 1 && o->SubType <= 3)
         {
-            o->Scale += 0.02f;
+            o->Scale += (0.02f) * FPS_ANIMATION_FACTOR;
             o->BlendMeshLight = o->LifeTime * 0.005f;
         }
         else
@@ -10429,7 +10429,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 1)
         {
             o->BlendMeshLight = o->LifeTime * 0.015f;
-            o->Scale += 0.08f;
+            o->Scale += (0.08f) * FPS_ANIMATION_FACTOR;
         }
         //			Vector(Luminosity*0.3f,Luminosity*0.6f,Luminosity,Light);
         //			AddTerrainLight(Position[0],Position[1],Light,3,PrimaryTerrainLight);
@@ -10439,9 +10439,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         vec3_t  Go;
         if (o->Scale < 0.8f)
-            o->Scale += 0.2f;
+            o->Scale += (0.2f) * FPS_ANIMATION_FACTOR;
         else
-            o->Scale -= 0.4f;
+            o->Scale -= (0.4f) * FPS_ANIMATION_FACTOR;
         o->BlendMeshLight = o->LifeTime * 0.1f;
         o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.2f;
         Vector(0.0f, -500.f, 0.0f, Go);
@@ -10526,7 +10526,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     break;
                 }
             }
-            if (o->LifeTime % 15 == 0)
+            if ((int)o->LifeTime % 15 == 0)
                 if (o->Owner == &Hero->Object)
                     AttackCharacterRange(o->Skill, o->Position, 150.f, o->Weapon, o->PKKey);
             break;
@@ -10534,7 +10534,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         case 1:
             o->BlendMeshLight = o->LifeTime * 0.01f;
             o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.1f;
-            o->Angle[2] += rand() % 30 + 30.f;
+            o->Angle[2] += (rand() % 30 + 30.f) * FPS_ANIMATION_FACTOR;
 
             VectorCopy(o->Position, Position);
             Position[2] += 100.f;
@@ -10596,14 +10596,14 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Light[1] /= 1.08f;
             o->Light[2] /= 1.08f;
         }
-        o->Angle[2] += 1.0f;
+        o->Angle[2] += (1.0f) * FPS_ANIMATION_FACTOR;
     }
     break;
     case MODEL_STORM2:
     {
         if (o->SubType == 0)
         {
-            o->Angle[1] += 40.0f;
+            o->Angle[1] += (40.0f) * FPS_ANIMATION_FACTOR;
 
             if (o->LifeTime <= 5)
             {
@@ -10650,19 +10650,19 @@ void MoveEffect(OBJECT* o, int iIndex)
             Pos2[2] = Pos1[2];
             CreateEffect(MODEL_STONE1 + rand() % 2, Pos2, o->Angle, Light, 2);
 
-            o->Angle[2] += o->Gravity;
+            o->Angle[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Light[0] /= 1.02f;
             o->Light[1] /= 1.02f;
             o->Light[2] /= 1.02f;
 
-            o->Alpha += 0.01f;
+            o->Alpha += (0.01f) * FPS_ANIMATION_FACTOR;
 
             if (o->Light[0] <= 0.05f)
                 o->Live = false;
         }
         else if (o->SubType == 2)
         {
-            o->Angle[1] += 40.0f;
+            o->Angle[1] += (40.0f) * FPS_ANIMATION_FACTOR;
 
             if (o->LifeTime <= 5)
             {
@@ -10683,7 +10683,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Light[1] /= 1.1f;
             o->Light[2] /= 1.1f;
         }
-        o->Angle[1] += 30.0f;
+        o->Angle[1] += (30.0f) * FPS_ANIMATION_FACTOR;
 
         Vector(90.f, 0.f, o->Angle[2], Angle);
 
@@ -10713,8 +10713,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Light[1] /= 1.2f;
             o->Light[2] /= 1.2f;
         }
-        o->Scale += sinf(WorldTime * 0.005f) * 2.0f;
-        o->Angle[1] += 10.0f;
+        o->Scale += (sinf(WorldTime * 0.005f) * 2.0f) * FPS_ANIMATION_FACTOR;
+        o->Angle[1] += (10.0f) * FPS_ANIMATION_FACTOR;
         EarthQuake = (float)(rand() % 6 - 6) * 0.5f;
     }
     break;
@@ -10767,18 +10767,18 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         VectorAdd(o->Position, o->Direction, o->Position);
         VectorScale(o->Direction, 0.9f, o->Direction);
-        o->Position[2] += o->Gravity;
-        o->Gravity -= 3.f;
+        o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+        o->Gravity -= (3.f) * FPS_ANIMATION_FACTOR;
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.5f;
-            o->LifeTime -= 4;
-            o->Angle[0] -= o->Scale * 128.f;
+            o->LifeTime -= (4) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] -= (o->Scale * 128.f) * FPS_ANIMATION_FACTOR;
         }
         else
-            o->Angle[0] -= o->Scale * 32.f;
+            o->Angle[0] -= (o->Scale * 32.f) * FPS_ANIMATION_FACTOR;
 
         if (rand() % 10 == 0)
             CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 15);
@@ -11006,25 +11006,25 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 13 || o->SubType == 14)
         {
-            o->HeadAngle[2] -= o->Gravity;
+            o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
-            o->Position[0] += o->HeadAngle[0];
-            o->Position[1] += o->HeadAngle[1];
-            o->Position[2] += o->HeadAngle[2];
+            o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
-            o->Angle[0] += 0.5f * o->LifeTime;
-            o->Angle[1] += 0.5f * o->LifeTime;
+            o->Angle[0] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->Position[2] + o->Direction[2] <= Height)
             {
                 o->Position[2] = Height;
                 o->HeadAngle[0] *= 0.6f;
                 o->HeadAngle[1] *= 0.6f;
-                o->HeadAngle[2] += 1.0f * o->LifeTime;
+                o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                 if (o->HeadAngle[2] < 0.5f)
                     o->HeadAngle[2] = 0;
 
-                o->Alpha -= 0.1f;
+                o->Alpha -= (0.1f) * FPS_ANIMATION_FACTOR;
             }
 
             // 			if (rand()%3==0)
@@ -11055,13 +11055,13 @@ void MoveEffect(OBJECT* o, int iIndex)
         else if (o->Type == MODEL_EFFECT_SAPITRES_ATTACK_2 && o->SubType == 14)
         {
             auto fMoveSpeed = (float)(rand() % 5 + 25);
-            o->Position[0] -= (o->Direction[0] * fMoveSpeed);
-            o->Position[1] -= (o->Direction[1] * fMoveSpeed);
-            o->Position[2] -= (o->Direction[2] * fMoveSpeed);
+            o->Position[0] -= ((o->Direction[0] * fMoveSpeed)) * FPS_ANIMATION_FACTOR;
+            o->Position[1] -= ((o->Direction[1] * fMoveSpeed)) * FPS_ANIMATION_FACTOR;
+            o->Position[2] -= ((o->Direction[2] * fMoveSpeed)) * FPS_ANIMATION_FACTOR;
 
             if (o->LifeTime <= 10)
             {
-                o->BlendMeshLight -= 0.1f;
+                o->BlendMeshLight -= (0.1f) * FPS_ANIMATION_FACTOR;
             }
         }
         else
@@ -11071,20 +11071,20 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorAdd(o->Position, Position, o->Position);
         }
         VectorScale(o->Direction, 0.9f, o->Direction);
-        o->Position[2] += o->Gravity;
+        o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
         if (o->SubType == 0 || o->SubType == 10 || o->SubType == 12 || o->SubType == 13)
         {
-            o->Gravity -= 3.f;
+            o->Gravity -= (3.f) * FPS_ANIMATION_FACTOR;
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < Height)
             {
                 o->Position[2] = Height;
                 o->Gravity = -o->Gravity * 0.5f;
-                o->LifeTime -= 4;
-                o->Angle[0] -= o->Scale * 128.f;
+                o->LifeTime -= (4) * FPS_ANIMATION_FACTOR;
+                o->Angle[0] -= (o->Scale * 128.f) * FPS_ANIMATION_FACTOR;
             }
             else
-                o->Angle[0] -= o->Scale * 32.f;
+                o->Angle[0] -= (o->Scale * 32.f) * FPS_ANIMATION_FACTOR;
 
             if ((o->SubType == 0 || o->SubType == 12 || o->SubType == 13) && rand() % 10 == 0)
             {
@@ -11097,11 +11097,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
         }
         else if (o->SubType == 1)
-            o->Gravity += 0.5f;
+            o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
         else if (o->Type != MODEL_EFFECT_SAPITRES_ATTACK_2)
         {
-            o->Angle[2] += 20.f;
-            o->Gravity += 0.5f;
+            o->Angle[2] += (20.f) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_EFFECT_BROKEN_ICE0:
@@ -11122,25 +11122,25 @@ void MoveEffect(OBJECT* o, int iIndex)
 #endif	// ASG_ADD_KARUTAN_MONSTERS
         if (o->SubType == 0)
         {
-            o->HeadAngle[2] -= o->Gravity;
+            o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
-            o->Position[0] += o->HeadAngle[0];
-            o->Position[1] += o->HeadAngle[1];
-            o->Position[2] += o->HeadAngle[2];
+            o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
-            o->Angle[0] += 0.5f * o->LifeTime;
-            o->Angle[1] += 0.5f * o->LifeTime;
+            o->Angle[0] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->Position[2] + o->Direction[2] <= Height)
             {
                 o->Position[2] = Height;
                 o->HeadAngle[0] *= 0.6f;
                 o->HeadAngle[1] *= 0.6f;
-                o->HeadAngle[2] += 1.0f * o->LifeTime;
+                o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                 if (o->HeadAngle[2] < 0.5f)
                     o->HeadAngle[2] = 0;
 
-                o->Alpha -= 0.1f;
+                o->Alpha -= (0.1f) * FPS_ANIMATION_FACTOR;
             }
 
             if (rand() % 30 == 0)
@@ -11196,7 +11196,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 2)
         {
-            o->Position[2] -= o->Gravity;
+            o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
             float fHeight = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < fHeight)
@@ -11208,56 +11208,56 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         break;
     case MODEL_SNOW1:
-        o->Direction[2] -= 2.5f;
+        o->Direction[2] -= (2.5f) * FPS_ANIMATION_FACTOR;
         CheckTargetRange(o);
         break;
     case MODEL_WOOSISTONE:
         if (o->SubType == 1)
         {
-            o->HeadAngle[2] -= o->Gravity;
+            o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
-            o->Position[0] += o->HeadAngle[0];
-            o->Position[1] += o->HeadAngle[1];
-            o->Position[2] += o->HeadAngle[2];
+            o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
-            o->Angle[0] += 0.5f * o->LifeTime;
-            o->Angle[1] += 0.5f * o->LifeTime;
+            o->Angle[0] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->Position[2] + o->Direction[2] <= Height)
             {
                 o->Position[2] = Height;
                 o->HeadAngle[0] *= 0.6f;
                 o->HeadAngle[1] *= 0.6f;
-                o->HeadAngle[2] += 1.0f * o->LifeTime;
+                o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                 if (o->HeadAngle[2] < 0.5f)
                     o->HeadAngle[2] = 0;
 
-                o->Alpha -= 0.1f;
+                o->Alpha -= (0.1f) * FPS_ANIMATION_FACTOR;
             }
         }
         else
         {
-            o->Direction[2] -= 2.0f;
+            o->Direction[2] -= (2.0f) * FPS_ANIMATION_FACTOR;
             CheckTargetRange(o);
         }
         break;
     case MODEL_SKULL:
         if (o->SubType == 1 && o->Owner != NULL)
         {
-            if ((o->LifeTime % 10) == 0)
+            if (((int)o->LifeTime % 10) == 0)
             {
                 VectorCopy(o->Position, o->m_vDeadPosition);
             }
 
             VectorCopy(o->Owner->Position, o->StartPosition);
-            o->StartPosition[2] += 200.f;
+            o->StartPosition[2] += (200.f) * FPS_ANIMATION_FACTOR;
 
             MoveHumming(o->Position, o->Angle, o->StartPosition, 10.f);
 
-            o->HeadAngle[0] += (float)(rand() % 32 - 16) * 0.2f;
-            o->HeadAngle[2] += (float)(rand() % 32 - 16) * 0.8f;
-            o->Angle[0] += o->HeadAngle[0];
-            o->Angle[2] += o->HeadAngle[2];
+            o->HeadAngle[0] += ((float)(rand() % 32 - 16) * 0.2f) * FPS_ANIMATION_FACTOR;
+            o->HeadAngle[2] += ((float)(rand() % 32 - 16) * 0.8f) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+            o->Angle[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
             o->HeadAngle[0] *= 0.6f;
             o->HeadAngle[2] *= 0.8f;
 
@@ -11268,7 +11268,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 if (o->Angle[0] <= 80)
                 {
-                    o->Angle[0] += 5.f;
+                    o->Angle[0] += (5.f) * FPS_ANIMATION_FACTOR;
                 }
             }
             else
@@ -11304,7 +11304,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         switch (o->SubType)
         {
         case 1:
-            o->Alpha -= 0.01f;
+            o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
             break;
         case 2:
         case 3:
@@ -11319,7 +11319,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         o->Direction[1] = (float)((-1 + (rand() % 2)) * 2);
                         o->Direction[2] = 0;
                     }
-                    o->Direction[2] -= 6.0f;
+                    o->Direction[2] -= (6.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else// if (o->Direction[2] != o->StartPosition[2])
                 {
@@ -11381,7 +11381,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                     if (o->LifeTime < 100)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= (0.1f) * FPS_ANIMATION_FACTOR;
                     }
                 }
             }
@@ -11415,10 +11415,10 @@ void MoveEffect(OBJECT* o, int iIndex)
         case 4:
             if (o->LifeTime < 140)
             {
-                o->Alpha -= 0.01f;
+                o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
                 if (o->Position[2] > o->StartPosition[2])
                 {
-                    o->Direction[2] -= 3.5f;
+                    o->Direction[2] -= (3.5f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
@@ -11436,7 +11436,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         case 5:
             if (o->LifeTime < 150)
             {
-                o->Alpha -= 0.01f;
+                o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
@@ -11450,8 +11450,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorCopy(o->Light, Light);
         if (o->Position[2] > 290)//o->StartPosition[2])
         {
-            o->Direction[2] -= o->Gravity;
-            o->Angle[2] -= (float)(rand() % 10);
+            o->Direction[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Angle[2] -= ((float)(rand() % 10)) * FPS_ANIMATION_FACTOR;
         }
         else if (o->Position[2] < 290)
         {
@@ -11463,24 +11463,24 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else
         {
-            o->Alpha -= 0.01f;
+            o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_XMAS2008_SNOWMAN_HEAD:
     {
         if (o->LifeTime < 45)
         {
-            o->Position[0] += (o->Direction[0] * 1.2f);
-            o->Position[1] += (o->Direction[1] * 1.2f);
-            o->Position[2] += (o->Gravity * 1.5f);
-            o->Gravity -= 1.5f;
+            o->Position[0] += ((o->Direction[0] * 1.2f)) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += ((o->Direction[1] * 1.2f)) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += ((o->Gravity * 1.5f)) * FPS_ANIMATION_FACTOR;
+            o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < Height)
             {
                 o->Position[2] = Height;
                 o->Gravity = -o->Gravity * 0.3f;
-                o->LifeTime -= 2;
+                o->LifeTime -= (2) * FPS_ANIMATION_FACTOR;
             }
 
             VectorAdd(o->Position, o->Direction, o->Position);
@@ -11527,12 +11527,12 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_NARCONDRA_STOMACH:
     case MODEL_NARCONDRA_NECK:
 #endif	// ASG_ADD_KARUTAN_MONSTERS
-        o->HeadAngle[2] -= o->Gravity;
+        o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
         VectorCopy(o->Light, Light);
 
-        o->Position[0] += o->HeadAngle[0];
-        o->Position[1] += o->HeadAngle[1];
-        o->Position[2] += o->HeadAngle[2];
+        o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+        o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]) + 20;
 
@@ -11541,33 +11541,33 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Position[2] = Height;
             o->HeadAngle[0] *= 0.8f;
             o->HeadAngle[1] *= 0.8f;
-            o->HeadAngle[2] += 0.6f * o->LifeTime;
+            o->HeadAngle[2] += (0.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
 
-            o->Alpha -= 0.05f;
+            o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
         }
         else
         {
             if (o->SubType == 0)
             {
-                o->Angle[0] += 0.15f * o->LifeTime;
-                o->Angle[1] += 0.15f * o->LifeTime;
+                o->Angle[0] += (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] += (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             }
             else
             {
-                o->Angle[0] -= 0.15f * o->LifeTime;
-                o->Angle[1] -= 0.15f * o->LifeTime;
+                o->Angle[0] -= (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] -= (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             }
         }
         break;
     case MODEL_DOPPELGANGER_SLIME_CHIP:
-        o->HeadAngle[2] -= o->Gravity;
+        o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
         VectorCopy(o->Light, Light);
 
-        o->Position[0] += o->HeadAngle[0];
-        o->Position[1] += o->HeadAngle[1];
-        o->Position[2] += o->HeadAngle[2];
+        o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+        o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]) + 20;
 
@@ -11583,24 +11583,24 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Position[2] = Height;
             o->HeadAngle[0] *= 0.8f;
             o->HeadAngle[1] *= 0.8f;
-            o->HeadAngle[2] += 1.6f * o->LifeTime;
+            o->HeadAngle[2] += (1.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
         }
         else
         {
-            o->Scale += sinf(WorldTime * 0.015f) * 0.1f;
+            o->Scale += (sinf(WorldTime * 0.015f) * 0.1f) * FPS_ANIMATION_FACTOR;
         }
 
         if (o->SubType == 0)
         {
-            o->Angle[0] += 0.35f * o->LifeTime;
-            o->Angle[1] += 0.35f * o->LifeTime;
+            o->Angle[0] += (0.35f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] += (0.35f * o->LifeTime) * FPS_ANIMATION_FACTOR;
         }
         else
         {
-            o->Angle[0] -= 0.35f * o->LifeTime;
-            o->Angle[1] -= 0.35f * o->LifeTime;
+            o->Angle[0] -= (0.35f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] -= (0.35f * o->LifeTime) * FPS_ANIMATION_FACTOR;
         }
         break;
 
@@ -11626,12 +11626,12 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_ICE_GIANT_PART3:				case MODEL_ICE_GIANT_PART4:
     case MODEL_ICE_GIANT_PART5:				case MODEL_ICE_GIANT_PART6:
 
-        o->HeadAngle[2] -= o->Gravity;
+        o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
         VectorCopy(o->Light, Light);
 
-        o->Position[0] += o->HeadAngle[0];
-        o->Position[1] += o->HeadAngle[1];
-        o->Position[2] += o->HeadAngle[2];
+        o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+        o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]) + 20;
 
@@ -11640,33 +11640,33 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Position[2] = Height;
             o->HeadAngle[0] *= 0.5f;
             o->HeadAngle[1] *= 0.5f;
-            o->HeadAngle[2] += 0.6f * o->LifeTime;
+            o->HeadAngle[2] += (0.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
 
-            o->Alpha -= 0.05f;
+            o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
         }
         else
         {
             if (o->SubType == 0)
             {
-                o->Angle[0] += 0.15f * o->LifeTime;
-                o->Angle[1] += 0.15f * o->LifeTime;
+                o->Angle[0] += (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] += (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             }
             else
             {
-                o->Angle[0] -= 0.15f * o->LifeTime;
-                o->Angle[1] -= 0.15f * o->LifeTime;
+                o->Angle[0] -= (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] -= (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             }
         }
         break;
 
     case MODEL_WATER_WAVE:
-        o->Scale += 0.02f;
+        o->Scale += (0.02f) * FPS_ANIMATION_FACTOR;
         o->Position[2] = o->StartPosition[2] + o->Gravity;
 
-        o->Velocity -= 10.f;
-        o->Gravity -= 20.f;
+        o->Velocity -= (10.f) * FPS_ANIMATION_FACTOR;
+        o->Gravity -= (20.f) * FPS_ANIMATION_FACTOR;
         if (o->Gravity < 60) o->Gravity = 60;
 
         Vector(0.f, o->Velocity, 0.f, o->Direction);
@@ -11708,7 +11708,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(Luminosity*0.9f,Luminosity*0.4f,Luminosity*0.6f,Light);
             AddTerrainLight(o->StartPosition[0],o->StartPosition[1],Light,2,PrimaryTerrainLight);
         */
-        o->Gravity += 90.f;
+        o->Gravity += (90.f) * FPS_ANIMATION_FACTOR;
         VectorCopy(o->Owner->Angle, o->Angle);
         VectorCopy(o->Owner->Angle, o->HeadAngle);
         VectorCopy(o->Position, o->StartPosition);
@@ -11755,7 +11755,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->BlendMeshLight = 1.f;
         }
-        o->Angle[1] += rand() % 60 + 30.f;
+        o->Angle[1] += (rand() % 60 + 30.f) * FPS_ANIMATION_FACTOR;
         VectorCopy(o->Position, o->EyeLeft);
 
         VectorCopy(o->Angle, Angle);
@@ -11769,7 +11769,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         break;
 
     case MODEL_ARROW_DOUBLE:
-        o->Angle[1] += 30.f;
+        o->Angle[1] += (30.f) * FPS_ANIMATION_FACTOR;
         VectorCopy(o->Position, o->EyeLeft);
         Vector(Luminosity * 0.2f, Luminosity * 0.4f, Luminosity * 1.f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
@@ -11778,7 +11778,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_ARROW_HOLY:
         if (o->SubType == 1)
         {
-            o->Angle[1] += 60.f;
+            o->Angle[1] += (60.f) * FPS_ANIMATION_FACTOR;
 
             if (o->LifeTime == 13)
                 CreateEffect(MODEL_PIERCING, o->Position, o->Angle, o->Light, 3, o);
@@ -11789,7 +11789,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else
         {
-            o->Angle[1] += 30.f;
+            o->Angle[1] += (30.f) * FPS_ANIMATION_FACTOR;
 
             Vector(Luminosity * 0.2f, Luminosity * 0.4f, Luminosity * 1.f, Light);
             AddTerrainLight(o->StartPosition[0], o->StartPosition[1], Light, 2, PrimaryTerrainLight);
@@ -11816,7 +11816,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->SubType == 3)
             {
-                o->Angle[0] += o->Gravity;
+                o->Angle[0] += (o->Gravity) * FPS_ANIMATION_FACTOR;
             }
             if (o->Angle[0] > 50)
             {
@@ -11869,9 +11869,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(Luminosity * 0.2f, Luminosity * 0.8f, Luminosity * 0.2f, Light);
                 AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
 
-                o->Angle[1] += 60.f;
+                o->Angle[1] += (60.f) * FPS_ANIMATION_FACTOR;
 
-                if (o->LifeTime > 25 && (o->LifeTime % 2) == 0)
+                if (o->LifeTime > 25 && ((int)o->LifeTime % 2) == 0)
                 {
                     for (int j = 0; j < 2; j++)
                     {
@@ -11894,7 +11894,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     CreateParticle(BITMAP_FLOWER01 + rand() % 3, Position, o->Angle, o->Light);
                     //CreateParticle(BITMAP_BUBBLE,Position,o->Angle,o->Light);
                 }
-                o->Angle[1] += 30.f;
+                o->Angle[1] += (30.f) * FPS_ANIMATION_FACTOR;
 
                 Vector(Luminosity * 0.6f, Luminosity * 0.8f, Luminosity * 0.8f, Light);
                 AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
@@ -11902,9 +11902,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->Type == MODEL_LACEARROW)
         {
-            o->Angle[1] += 60.f;
+            o->Angle[1] += (60.f) * FPS_ANIMATION_FACTOR;
 
-            if ((o->LifeTime % 2) == 0)
+            if (((int)o->LifeTime % 2) == 0)
             {
                 for (int j = 0; j < 3; j++)
                 {
@@ -11943,11 +11943,11 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->Type == MODEL_DARK_SCREAM_FIRE)
         {
-            o->Scale -= 0.14f;
+            o->Scale -= (0.14f) * FPS_ANIMATION_FACTOR;
         }
         if (o->Type == MODEL_DARK_SCREAM)
         {
-            o->Scale -= 0.04f;
+            o->Scale -= (0.04f) * FPS_ANIMATION_FACTOR;
         }
         if (o->Scale < 0.1f)
         {
@@ -12046,7 +12046,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     break;
     case MODEL_ARROW_SPARK:
     {
-        o->Angle[1] += 35.0f;
+        o->Angle[1] += (35.0f) * FPS_ANIMATION_FACTOR;
         CheckClientArrow(o);
     }
     break;
@@ -12144,7 +12144,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         vec3_t vLight;
         Vector(0.2f, 0.8f, 0.5f, vLight);
 
-        o->Angle[1] += 60.f;
+        o->Angle[1] += (60.f) * FPS_ANIMATION_FACTOR;
 
         for (int j = 0; j < 2; j++)
         {
@@ -12180,15 +12180,15 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
     }break;
     case MODEL_DUNGEON_STONE01:
-        o->Position[2] += o->Gravity;
-        o->Gravity -= 1.f;
+        o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+        o->Gravity -= (1.f) * FPS_ANIMATION_FACTOR;
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.4f;
-            o->LifeTime -= 4;
-            o->Direction[1] -= 2.f;
+            o->LifeTime -= (4) * FPS_ANIMATION_FACTOR;
+            o->Direction[1] -= (2.f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_ICE:
@@ -12209,7 +12209,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light);
                 }
                 //AttackRange(o->Position,200.f,10);
-                o->Alpha -= 0.05f;
+                o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
                 if (o->Alpha < 0.f)
                     o->Live = false;
             }
@@ -12261,12 +12261,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
                 else
                 {
-                    o->Alpha -= 0.05f;
+                    o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
                 }
 
                 if (o->SubType == 1)
                 {
-                    o->HeadAngle[2] += 20.f;
+                    o->HeadAngle[2] += (20.f) * FPS_ANIMATION_FACTOR;
                     o->Gravity = sinf(WorldTime * 0.01f) * 20.f + 30;
 
                     Vector(60.f, 0.f, 0.f, p);
@@ -12419,14 +12419,14 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 5)
         {
-            o->Position[2] += o->Gravity;
-            o->Gravity -= 2.f;
+            o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity -= (2.f) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < Height)
             {
                 o->Gravity = 10.f;
-                o->Position[2] += 10.f;
+                o->Position[2] += (10.f) * FPS_ANIMATION_FACTOR;
                 o->Direction[1] *= 0.5f;
                 o->Scale *= 1.1f;
             }
@@ -12540,7 +12540,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorCopy(o->Owner->Position, o->Position);
         break;
     case BITMAP_FIRECRACKERRISE:
-        if (0 == (o->LifeTime % 5) && (0 == (rand() % 3)))
+        if (0 == ((int)o->LifeTime % 5) && (0 == (rand() % 3)))
         {
             CreateEffect(BITMAP_FIRECRACKER, o->Position, o->Angle, o->Light);
         }
@@ -12602,7 +12602,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else
         {
             iFrame = 6;
-            o->Position[2] -= 1.0f;
+            o->Position[2] -= (1.0f) * FPS_ANIMATION_FACTOR;
             o->Light[0] /= 1.05f;
             o->Light[1] /= 1.05f;
             o->Light[2] /= 1.05f;
@@ -12637,14 +12637,14 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 o->Position[0] = o->StartPosition[0] + sinf((rand() % 1000) * 0.01f) * 10.f;
                 o->Position[1] = o->StartPosition[1] + sinf((rand() % 1000) * 0.01f) * 10.f;
-                o->Position[2] += o->Gravity;
-                o->Gravity -= 2.f;
+                o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+                o->Gravity -= (2.f) * FPS_ANIMATION_FACTOR;
 
-                o->StartPosition[0] -= 10.f;
+                o->StartPosition[0] -= (10.f) * FPS_ANIMATION_FACTOR;
 
                 CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
 
-                o->Light[0] += 0.1f;
+                o->Light[0] += (0.1f) * FPS_ANIMATION_FACTOR;
                 o->Light[1] = o->Light[0];
                 o->Light[2] = o->Light[0];
                 CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 4 + 4) * 0.2f, o->Light, o, (float)(rand() % 360));
@@ -12654,14 +12654,14 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 o->Position[0] = o->StartPosition[0];
                 o->Position[1] = o->StartPosition[1];
-                o->Position[2] += o->Gravity;
-                o->Gravity -= 2.f;
+                o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+                o->Gravity -= (2.f) * FPS_ANIMATION_FACTOR;
 
-                o->StartPosition[0] -= 10.f;
+                o->StartPosition[0] -= (10.f) * FPS_ANIMATION_FACTOR;
 
                 CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 11, o->Scale);
 
-                o->Light[0] += 0.1f;
+                o->Light[0] += (0.1f) * FPS_ANIMATION_FACTOR;
                 o->Light[1] = o->Light[0];
                 o->Light[2] = o->Light[0];
                 CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 4 + 4) * 0.2f, o->Light, o, (float)(rand() % 360));
@@ -12714,24 +12714,24 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_GATE + 1:
         VectorAdd(o->Position, o->Direction, o->Position);
         VectorScale(o->Direction, 0.9f, o->Direction);
-        o->Position[2] += o->Gravity;
+        o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
         if (o->SubType == 1)
         {
             VectorScale(o->Direction, 1.1f, o->Direction);
         }
 
-        o->Gravity -= 4.f;
+        o->Gravity -= (4.f) * FPS_ANIMATION_FACTOR;
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.5f;
-            o->LifeTime -= 5;
-            o->Angle[0] -= o->Scale * 128.f;
+            o->LifeTime -= (5) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] -= (o->Scale * 128.f) * FPS_ANIMATION_FACTOR;
         }
         else
-            o->Angle[0] -= o->Scale * 16.f;
+            o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
 
         if ((rand() % 10) == 0)
         {
@@ -12743,24 +12743,24 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_STONE_COFFIN + 1:
         VectorAdd(o->Position, o->Direction, o->Position);
         VectorScale(o->Direction, 0.9f, o->Direction);
-        o->Position[2] += o->Gravity;
+        o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
         if (o->SubType == 1)
         {
             VectorScale(o->Direction, 1.1f, o->Direction);
         }
 
-        o->Gravity -= 3.f;
+        o->Gravity -= (3.f) * FPS_ANIMATION_FACTOR;
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.2f;
-            o->LifeTime -= 5;
-            o->Angle[0] -= o->Scale * 128.f;
+            o->LifeTime -= (5) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] -= (o->Scale * 128.f) * FPS_ANIMATION_FACTOR;
         }
         else
-            o->Angle[0] -= o->Scale * 16.f;
+            o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
 
         o->Alpha = o->LifeTime / 10.f;
         if ((rand() % 10) == 0)
@@ -12786,10 +12786,10 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->Position[0] = o->StartPosition[0] + sinf((rand() % 1000) * 0.01f) * 10.f;
             o->Position[1] = o->StartPosition[1] + sinf((rand() % 1000) * 0.01f) * 10.f;
-            o->Position[2] += o->Gravity;
-            o->Gravity -= rand() % 5;
+            o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity -= (rand() % 5) * FPS_ANIMATION_FACTOR;
 
-            o->StartPosition[0] -= 10.f;
+            o->StartPosition[0] -= (10.f) * FPS_ANIMATION_FACTOR;
 
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 0, 1.5f);
             if ((rand() % 2) == 0)
@@ -12801,7 +12801,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
             }
 
-            o->Light[0] += 0.1f;
+            o->Light[0] += (0.1f) * FPS_ANIMATION_FACTOR;
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
             CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 4 + 4) * 0.2f, o->Light, o, (float)(rand() % 360));
@@ -12836,10 +12836,10 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->Position[0] = o->StartPosition[0] + sinf((rand() % 1000) * 0.01f) * 50.f;
             o->Position[1] = o->StartPosition[1] + sinf((rand() % 1000) * 0.01f) * 50.f;
-            o->Position[2] += o->Gravity;
-            o->Gravity -= rand() % 5;
+            o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity -= (rand() % 5) * FPS_ANIMATION_FACTOR;
 
-            o->StartPosition[0] -= 10.f;
+            o->StartPosition[0] -= (10.f) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] > Height)
@@ -12849,7 +12849,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
                 }
 
-                o->Light[0] += 0.1f;
+                o->Light[0] += (0.1f) * FPS_ANIMATION_FACTOR;
                 o->Light[1] = o->Light[0];
                 o->Light[2] = o->Light[0];
                 CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 4 + 4) * 0.2f, o->Light, o, (float)(rand() % 360));
@@ -12861,7 +12861,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_ARROW_DRILL:
         if (o->SubType == 0 || o->SubType == 2)
         {
-            o->Angle[1] += 30.f;
+            o->Angle[1] += (30.f) * FPS_ANIMATION_FACTOR;
 
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
@@ -12889,8 +12889,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime > 4)
             {
-                o->Scale += o->Gravity;
-                o->Gravity += 0.1f;
+                o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+                o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
             }
             o->BlendMeshLight /= 1.4f;
         }
@@ -12900,56 +12900,56 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime > 4)
             {
-                o->Scale += o->Gravity;
-                o->Gravity += 0.1f;
+                o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+                o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
             }
             o->BlendMeshLight /= 1.4f;
         }
         else if (o->SubType == 1)
         {
-            o->Scale += o->Gravity;
-            o->Gravity += 0.07f;
+            o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.07f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 2.f) o->Scale = 2.f;
             o->BlendMeshLight /= 1.5f;
         }
         else if (o->SubType == 2)
         {
-            o->Scale += o->Gravity;
-            o->Gravity += 0.01f;
+            o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.01f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 1.5f) o->Scale = 1.5f;
             o->BlendMeshLight /= 1.5f;
         }
         else if (o->SubType == 3)
         {
-            o->Scale += o->Gravity;
-            o->Gravity += 0.005f;
+            o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.005f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 1.5f) o->Scale = 1.5f;
             o->BlendMeshLight /= 1.3f;
-            o->Angle[1] += 45.f;
+            o->Angle[1] += (45.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 4)
         {
-            o->Scale += o->Gravity;
-            o->Gravity += 0.002f;
+            o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.002f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 2.5f) o->Scale = 2.5f;
             o->BlendMeshLight /= 1.2f;
-            o->Angle[1] += 45.f;
+            o->Angle[1] += (45.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 5)
         {
-            o->Scale += o->Gravity;
-            o->Gravity += 0.015f;
+            o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.015f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 2.5f) o->Scale = 2.5f;
             o->BlendMeshLight /= 1.3f;
-            o->Angle[1] += 45.f;
+            o->Angle[1] += (45.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 6)
         {
-            o->Scale += o->Gravity;
-            o->Gravity += 0.015f;
+            o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.015f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 2.5f) o->Scale = 2.5f;
             o->BlendMeshLight /= 1.3f;
-            o->Angle[1] += 45.f;
+            o->Angle[1] += (45.f) * FPS_ANIMATION_FACTOR;
         }
         break;
     case MODEL_AIR_FORCE:
@@ -12961,7 +12961,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 0)
         {
             o->BlendMeshLight /= 1.5f;
-            o->Scale += 0.2f;
+            o->Scale += (0.2f) * FPS_ANIMATION_FACTOR;
         }
 
         if (o->SubType == 1)
@@ -12982,7 +12982,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorRotate(o->Direction, Matrix, Position);
         //		VectorAdd(o->Position,Position,o->Position);
 
-        o->Direction[1] += 12.f;
+        o->Direction[1] += (12.f) * FPS_ANIMATION_FACTOR;
         if (o->Direction[1] >= 0) o->Direction[1] = 0;
 
         if (o->SubType == 1) {
@@ -13157,16 +13157,16 @@ void MoveEffect(OBJECT* o, int iIndex)
                     if (rand() % 2 == 0)
                     {
                         if (o->Angle[0] < -90)
-                            o->Angle[0] += 20.f;//rand()%10+5.f;
+                            o->Angle[0] += (20.f) * FPS_ANIMATION_FACTOR;
                         else
-                            o->Angle[0] -= 20.f;//rand()%10+5.f;
+                            o->Angle[0] -= (20.f) * FPS_ANIMATION_FACTOR;
                     }
                     Distance = MoveHumming(o->Position, o->Angle, p, o->Velocity);
-                    o->Velocity += 0.4f;
+                    o->Velocity += (0.4f) * FPS_ANIMATION_FACTOR;
 
                     if (o->LifeTime < 10)
                     {
-                        o->Velocity += 0.1f;
+                        o->Velocity += (0.1f) * FPS_ANIMATION_FACTOR;
                         CreateEffect(BITMAP_MAGIC + 1, Position, o->Angle, o->Light, 1, o);
                     }
 
@@ -13181,7 +13181,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorCopy(o->Position, Position);
                     Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
                 }
-                o->Gravity += 0.1f;
+                o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
 
                 PlayBuffer(SOUND_ATTACK_FIRE_BUST_EXP);
             }
@@ -13209,16 +13209,16 @@ void MoveEffect(OBJECT* o, int iIndex)
                     if (rand() % 2 == 0)
                     {
                         if (o->Angle[0] < -90)
-                            o->Angle[0] += 20.f;//rand()%10+5.f;
+                            o->Angle[0] += (20.f) * FPS_ANIMATION_FACTOR;
                         else
-                            o->Angle[0] -= 20.f;//rand()%10+5.f;
+                            o->Angle[0] -= (20.f) * FPS_ANIMATION_FACTOR;
                     }
                     Distance = MoveHumming(o->Position, o->Angle, p, o->Velocity);
-                    o->Velocity += 0.4f;
+                    o->Velocity += (0.4f) * FPS_ANIMATION_FACTOR;
 
                     if (o->LifeTime < 10)
                     {
-                        o->Velocity += 0.1f;
+                        o->Velocity += (0.1f) * FPS_ANIMATION_FACTOR;
                     }
 
                     AngleMatrix(o->Angle, Matrix);
@@ -13232,7 +13232,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorCopy(o->Position, Position);
                     Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
                 }
-                o->Gravity += 0.1f;
+                o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
 
                 PlayBuffer(SOUND_ATTACK_FIRE_BUST_EXP);
             }
@@ -13244,13 +13244,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorCopy(o->Owner->Position, p);
 
                 MoveHumming(o->Position, o->Angle, p, o->Velocity);
-                o->Velocity += 2.4f;
+                o->Velocity += (2.4f) * FPS_ANIMATION_FACTOR;
 
                 AngleMatrix(o->Angle, Matrix);
                 VectorRotate(o->Direction, Matrix, Position);
                 VectorAdd(o->Position, Position, o->Position);
 
-                if (o->LifeTime % 3 == 0)
+                if ((int)o->LifeTime % 3 == 0)
                 {
                     Vector(-90.f, 0.f, o->Angle[2], Angle);
                     CreateJoint(BITMAP_JOINT_FORCE, o->Position, o->Position, Angle, 2, NULL, 150.f);
@@ -13272,8 +13272,8 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_DARKLORD_SKILL:
         if (o->SubType <= 1)
         {
-            o->Scale += o->Velocity;
-            o->Velocity += 0.02f;
+            o->Scale += (o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Velocity += (0.02f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 7)
             {
                 o->BlendMeshLight /= 1.8f;
@@ -13281,8 +13281,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 2)
         {
-            o->Scale += o->Velocity;
-            o->Velocity -= 0.06f;
+            o->Scale += (o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Velocity -= (0.06f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 8)
             {
                 o->BlendMeshLight /= 1.5f;
@@ -13290,8 +13290,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else
         {
-            o->Scale += o->Velocity;
-            o->Velocity += 0.04f;
+            o->Scale += (o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Velocity += (0.04f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 8)
             {
                 o->BlendMeshLight /= 1.8f;
@@ -13325,38 +13325,38 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            o->Scale -= 0.1f;
-            o->Angle[2] += 10.f;
+            o->Scale -= (0.1f) * FPS_ANIMATION_FACTOR;
+            o->Angle[2] += (10.f) * FPS_ANIMATION_FACTOR;
         }
         else
             if (o->SubType == 1)
             {
-                o->Scale -= 0.1f;
-                o->Angle[2] += 5.f;
+                o->Scale -= (0.1f) * FPS_ANIMATION_FACTOR;
+                o->Angle[2] += (5.f) * FPS_ANIMATION_FACTOR;
             }
             else
                 if (o->SubType == 2)
                 {
-                    o->Scale -= 0.1f;
-                    o->Angle[2] += 15.f;
+                    o->Scale -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Angle[2] += (15.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 3)
                 {
                     VectorCopy(o->Owner->Position, o->Position);
-                    o->Scale -= 0.15f;
-                    o->Angle[2] += 10.f;
+                    o->Scale -= (0.15f) * FPS_ANIMATION_FACTOR;
+                    o->Angle[2] += (10.f) * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime >= 20)
                     {
-                        o->Alpha += 0.1f;
-                        o->PKKey++;
+                        o->Alpha += 0.1f * FPS_ANIMATION_FACTOR;
+                        o->PKKey += FPS_ANIMATION_FACTOR;
                         o->Light[0] = o->EyeRight[0] * (o->PKKey * 0.1f);
                         o->Light[1] = o->EyeRight[1] * (o->PKKey * 0.1f);
                         o->Light[2] = o->EyeRight[2] * (o->PKKey * 0.1f);
                     }
                     else if (o->LifeTime <= 10)
                     {
-                        o->PKKey--;
-                        o->Alpha -= 0.1f;
+                        o->PKKey -= FPS_ANIMATION_FACTOR;
+                        o->Alpha -= 0.1f * FPS_ANIMATION_FACTOR;
                         o->Light[0] = o->EyeRight[0] * (o->PKKey * 0.1f);
                         o->Light[1] = o->EyeRight[1] * (o->PKKey * 0.1f);
                         o->Light[2] = o->EyeRight[2] * (o->PKKey * 0.1f);
@@ -13367,37 +13367,37 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_SHOCK_WAVE:
         if (o->SubType == 0)
         {
-            o->Scale -= 1.f;
+            o->Scale -= (1.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 1)
         {
-            o->Scale += (rand() % 5) / 10.f;
+            o->Scale += ((rand() % 5) / 10.f) * FPS_ANIMATION_FACTOR;
 
-            o->Position[0] += rand() % 8 - 4.f;
-            o->Position[1] += rand() % 8 - 4.f;
+            o->Position[0] += (rand() % 8 - 4.f) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (rand() % 8 - 4.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 2)
         {
-            o->Scale += (rand() % 5) / 40.f;
+            o->Scale += ((rand() % 5) / 40.f) * FPS_ANIMATION_FACTOR;
 
-            o->Position[0] += rand() % 8 - 4.f;
-            o->Position[1] += rand() % 8 - 4.f;
+            o->Position[0] += (rand() % 8 - 4.f) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (rand() % 8 - 4.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 3)
         {
-            o->Scale += 2.f;
+            o->Scale += (2.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 4)
         {
-            o->Scale += 0.3f;
+            o->Scale += (0.3f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 5)
         {
-            o->Scale -= 0.4f;
+            o->Scale -= (0.4f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 6)
         {
-            if ((o->LifeTime % 8) == 0)
+            if (((int)o->LifeTime % 8) == 0)
             {
                 CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, o->Light, 5);
             }
@@ -13405,54 +13405,54 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 7)
         {
-            o->Scale += 2.5f;
+            o->Scale += (2.5f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 8)
         {
-            o->Scale += 1.f;
+            o->Scale += (1.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 9)
         {
-            o->Scale += 0.8f;
+            o->Scale += (0.8f) * FPS_ANIMATION_FACTOR;
             VectorCopy(o->Owner->Position, o->Position);
         }
         else if (o->SubType == 10)
         {
-            o->Scale -= 0.02f;
+            o->Scale -= (0.02f) * FPS_ANIMATION_FACTOR;
             VectorCopy(o->Owner->Position, o->Position);
         }
         else if (o->SubType == 11)
         {
-            o->Scale += (rand() % 5) / 10.f;
+            o->Scale += ((rand() % 5) / 10.f) * FPS_ANIMATION_FACTOR;
 
-            o->Position[0] += rand() % 8 - 4.f;
-            o->Position[1] += rand() % 8 - 4.f;
+            o->Position[0] += (rand() % 8 - 4.f) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (rand() % 8 - 4.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 12)
         {
             if (o->LifeTime > 4.0f)
-                o->Scale += (o->LifeTime - 4.0f) * 0.25f;
+                o->Scale += ((o->LifeTime - 4.0f) * 0.25f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 13)
         {
-            o->Scale += 0.08f;
+            o->Scale += (0.08f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 14)
         {
             VectorCopy(o->Owner->Position, o->Position);
-            o->Scale -= 0.15f;
+            o->Scale -= (0.15f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime >= 20)
             {
-                o->Alpha += 0.1f;
-                o->PKKey++;
+                o->Alpha += 0.1f * FPS_ANIMATION_FACTOR;
+                o->PKKey += FPS_ANIMATION_FACTOR;
                 o->Light[0] = o->EyeRight[0] * (o->PKKey * 0.1f);
                 o->Light[1] = o->EyeRight[1] * (o->PKKey * 0.1f);
                 o->Light[2] = o->EyeRight[2] * (o->PKKey * 0.1f);
             }
             else if (o->LifeTime <= 10)
             {
-                o->PKKey--;
-                o->Alpha -= 0.1f;
+                o->PKKey -= FPS_ANIMATION_FACTOR;
+                o->Alpha -= 0.1f * FPS_ANIMATION_FACTOR;
                 o->Light[0] = o->EyeRight[0] * (o->PKKey * 0.1f);
                 o->Light[1] = o->EyeRight[1] * (o->PKKey * 0.1f);
                 o->Light[2] = o->EyeRight[2] * (o->PKKey * 0.1f);
@@ -13489,11 +13489,11 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_DAMAGE_01_MONO:
         if (o->SubType == 0)
         {
-            o->Scale += 5.f;
+            o->Scale += (5.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 1)
         {
-            o->Scale += 0.5f;
+            o->Scale += (0.5f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 3.5f)
             {
                 //o->Scale = 6.0f;
@@ -13521,7 +13521,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 CreateParticle(BITMAP_LIGHT, o->Position, o->Angle, Light, 5, fRandom);
             }
             else
-                if (o->LifeTime % 2 == 0)
+                if ((int)o->LifeTime % 2 == 0)
                 {
                     VectorCopy(o->Position, Position);
                     Position[2] += 100.f;
@@ -13536,7 +13536,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
         break;
     case BITMAP_JOINT_THUNDER + 1:
-        if (o->LifeTime < 5 && o->LifeTime % 2 == 0 && o->SubType == 0)
+        if (o->LifeTime < 5 && (int)o->LifeTime % 2 == 0 && o->SubType == 0)
         {
             VectorCopy(o->Position, Position);
 
@@ -13548,7 +13548,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         break;
 
     case MODEL_CUNDUN_DRAGON_HEAD:
-        o->Angle[2] += 10 + rand() % 10;
+        o->Angle[2] += (10 + rand() % 10) * FPS_ANIMATION_FACTOR;
 
         if (o->Position[2] > 300 && o->Position[2] < 600)
         {
@@ -13584,8 +13584,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->AnimationFrame > 6.0f)
         {
-            o->PKKey += 1;
-            o->Position[2] += (o->PKKey * 0.8f);
+            o->PKKey += (1) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += ((o->PKKey * 0.8f)) * FPS_ANIMATION_FACTOR;
 
             VectorCopy(o->Position, Position);
             Position[0] += rand() % 120 - 60;
@@ -13597,7 +13597,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else
         {
-            o->Skill += 1;
+            o->Skill += (1) * FPS_ANIMATION_FACTOR;
             if (o->Angle[2] < 45.0f) o->Angle[2] += o->Skill * 0.3f;
             if (o->Angle[2] > 45.0f) o->Angle[2] -= o->Skill * 0.3f;
 
@@ -13614,7 +13614,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(0.f, 0.f, rand() % 10 * 20.f, Angle);
             CreateEffect(MODEL_FIRE, Position, Angle, Light, 0, NULL, 0);
 
-            o->Scale += 0.02f;
+            o->Scale += (0.02f) * FPS_ANIMATION_FACTOR;
             //				o->Position[2] -= 0.5f;
             EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
         }
@@ -13670,7 +13670,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_MONSTER01 + 77:
         if (o->SubType == 0)
         {
-            if (o->LifeTime % 5 == 0)
+            if ((int)o->LifeTime % 5 == 0)
             {
                 VectorCopy(o->Position, Position);
 
@@ -13712,9 +13712,9 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (o->HiddenMesh == 99)
         {
-            o->Position[0] += (float)(rand() % 100 - 50);
-            o->Position[1] += (float)(rand() % 100 - 50);
-            o->Position[2] += (float)(rand() % 100 - 50);
+            o->Position[0] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
             o->Scale = 2.2f;
         }
 
@@ -13746,24 +13746,24 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 2)
         {
-            o->Position[2] -= o->Gravity;
-            o->Gravity += 1.9f;
+            o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (1.9f) * FPS_ANIMATION_FACTOR;
 
-            o->Angle[0] += rand() % 20 + 20.f;
-            o->Angle[1] += rand() % 5;
+            o->Angle[0] += (rand() % 20 + 20.f) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] += (rand() % 5) * FPS_ANIMATION_FACTOR;
 
             float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < Height)
             {
                 o->Position[2] = Height + 50;
                 o->Gravity = -o->Gravity * 0.2f;
-                o->LifeTime -= 5;
-                o->Angle[0] -= o->Scale * 128.f;
+                o->LifeTime -= (5) * FPS_ANIMATION_FACTOR;
+                o->Angle[0] -= (o->Scale * 128.f) * FPS_ANIMATION_FACTOR;
 
                 Vector(0.f, 5.f, 0.f, o->Direction);
             }
             else
-                o->Angle[0] -= o->Scale * 16.f;
+                o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
 
             AngleMatrix(o->HeadAngle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
@@ -13774,7 +13774,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Alpha /= 1.5f;
             }
 
-            if (o->LifeTime % 3 == 0)
+            if ((int)o->LifeTime % 3 == 0)
             {
                 Vector(1.f, 0.6f, 0.2f, Light);
                 CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light, 1, 0.2f);
@@ -13784,9 +13784,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->SubType <= 1)
             {
-                o->Position[0] += o->Direction[0] * o->Velocity;
-                o->Position[1] += o->Direction[1] * o->Velocity;
-                o->StartPosition[2] += o->Direction[2];
+                o->Position[0] += (o->Direction[0] * o->Velocity) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (o->Direction[1] * o->Velocity) * FPS_ANIMATION_FACTOR;
+                o->StartPosition[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
 
                 if (o->Position[2] > 1000.f)
                 {
@@ -13800,14 +13800,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                     CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 5, 2.f);
                 }
 
-                o->Velocity -= 0.45f;
+                o->Velocity -= (0.45f) * FPS_ANIMATION_FACTOR;
                 if (o->Velocity < 5.f) o->Velocity = 5.f;
 
-                o->Direction[2] += o->Gravity;
-                o->Gravity -= 0.1f;
+                o->Direction[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+                o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
 
-                o->Angle[0] += 5.f;
-                o->Angle[1] += 5.f;
+                o->Angle[0] += (5.f) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] += (5.f) * FPS_ANIMATION_FACTOR;
 
                 if (o->SubType == 0)
                 {
@@ -13934,9 +13934,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType <= 1)
         {
-            o->Position[0] += o->Direction[0] * o->Velocity;
-            o->Position[1] += o->Direction[1] * o->Velocity;
-            o->StartPosition[2] += o->Direction[2];
+            o->Position[0] += (o->Direction[0] * o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (o->Direction[1] * o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->StartPosition[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
 
             if (o->Position[2] > 1000.f)
             {
@@ -13954,14 +13954,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
             }
 
-            o->Velocity -= 0.45f;
+            o->Velocity -= (0.45f) * FPS_ANIMATION_FACTOR;
             if (o->Velocity < 5.f) o->Velocity = 5.f;
 
-            o->Direction[2] += o->Gravity;
-            o->Gravity -= 0.1f;
+            o->Direction[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
 
-            o->Angle[0] += 5.f;
-            o->Angle[1] += 5.f;
+            o->Angle[0] += (5.f) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] += (5.f) * FPS_ANIMATION_FACTOR;
 
             if (o->SubType == 0)
             {
@@ -14070,8 +14070,8 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_GOLEM_STONE:
         if (o->Type == MODEL_BIG_STONE_PART2 && o->SubType == 3)
         {
-            o->Direction[2] -= o->Velocity;
-            o->Velocity += 0.3f;
+            o->Direction[2] -= (o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Velocity += (0.3f) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < Height)
@@ -14095,26 +14095,26 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Type >= MODEL_WALL_PART1 && o->Type <= MODEL_WALL_PART2)
         {
             VectorScale(o->Direction, 0.9f, o->Direction);
-            o->Gravity -= 6.f;
+            o->Gravity -= (6.f) * FPS_ANIMATION_FACTOR;
         }
         else
         {
             VectorScale(o->Direction, 0.9f, o->Direction);
-            o->Gravity -= 3.f;
+            o->Gravity -= (3.f) * FPS_ANIMATION_FACTOR;
         }
-        o->Position[2] += o->Gravity;
+        o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.2f;
-            o->LifeTime -= 5;
-            o->Angle[0] -= o->Scale * 128.f;
+            o->LifeTime -= (5) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] -= (o->Scale * 128.f) * FPS_ANIMATION_FACTOR;
         }
         else
         {
-            o->Angle[0] -= o->Scale * 16.f;
+            o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
         }
 
         o->Alpha = o->LifeTime / 10.f;
@@ -14143,24 +14143,24 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_GATE_PART3:
         VectorAdd(o->Position, o->Direction, o->Position);
         VectorScale(o->Direction, 0.9f, o->Direction);
-        o->Position[2] += o->Gravity;
+        o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
         if (o->SubType == 1)
         {
             VectorScale(o->Direction, 1.1f, o->Direction);
         }
 
-        o->Gravity -= 4.f;
+        o->Gravity -= (4.f) * FPS_ANIMATION_FACTOR;
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.5f;
-            o->LifeTime -= 5;
-            o->Angle[0] -= o->Scale * 128.f;
+            o->LifeTime -= (5) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] -= (o->Scale * 128.f) * FPS_ANIMATION_FACTOR;
         }
         else
-            o->Angle[0] -= o->Scale * 16.f;
+            o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
 
         if ((rand() % 10) == 0)
         {
@@ -14195,7 +14195,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (o->m_iAnimation == 0)
                 {
-                    o->Alpha += 0.3f;
+                    o->Alpha += (0.3f) * FPS_ANIMATION_FACTOR;
                     if (o->Alpha >= 1.0f)
                     {
                         o->m_iAnimation = 1;
@@ -14209,16 +14209,16 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
                 else if (o->m_iAnimation == 1)
                 {
-                    o->Alpha -= 0.3f;
+                    o->Alpha -= (0.3f) * FPS_ANIMATION_FACTOR;
                     if (o->Alpha <= 0.0f)
                     {
                         o->Alpha = 0.0f;
                         o->Live = false;
                     }
                 }
-                o->Angle[0] += 0.15f;
-                o->Angle[1] += 0.15f;
-                o->Angle[2] += 0.15f;
+                o->Angle[0] += (0.15f) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] += (0.15f) * FPS_ANIMATION_FACTOR;
+                o->Angle[2] += (0.15f) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 1)
@@ -14227,7 +14227,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (o->m_iAnimation == 0)
                 {
-                    o->Alpha += 0.3f;
+                    o->Alpha += (0.3f) * FPS_ANIMATION_FACTOR;
                     if (o->Alpha >= 1.0f)
                     {
                         o->m_iAnimation = 1;
@@ -14241,16 +14241,16 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
                 else if (o->m_iAnimation == 1)
                 {
-                    o->Alpha -= 0.3f;
+                    o->Alpha -= (0.3f) * FPS_ANIMATION_FACTOR;
                     if (o->Alpha <= 0.0f)
                     {
                         o->Alpha = 0.0f;
                         o->Live = false;
                     }
                 }
-                o->Angle[0] += 0.15f;
-                o->Angle[1] += 0.15f;
-                o->Angle[2] += 0.15f;
+                o->Angle[0] += (0.15f) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] += (0.15f) * FPS_ANIMATION_FACTOR;
+                o->Angle[2] += (0.15f) * FPS_ANIMATION_FACTOR;
             }
         }
         break;
@@ -14258,16 +14258,16 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0 || o->SubType == 1)
         {
-            o->Position[2] -= o->Gravity;
-            o->Gravity += 0.1f;
-            o->Angle[0] += 0.5f;
-            o->Angle[1] += 0.5f;
-            o->Angle[2] += 0.5f;
+            o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] += (0.5f) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] += (0.5f) * FPS_ANIMATION_FACTOR;
+            o->Angle[2] += (0.5f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 2)
         {
-            o->Position[2] -= o->Gravity;
-            o->Gravity += 0.1f;
+            o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
 
             float fHeight = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < fHeight)
@@ -14288,25 +14288,25 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 3)
         {
-            o->HeadAngle[2] -= o->Gravity;
+            o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
-            o->Position[0] += o->HeadAngle[0];
-            o->Position[1] += o->HeadAngle[1];
-            o->Position[2] += o->HeadAngle[2];
+            o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
             float fHeight = RequestTerrainHeight(o->Position[0], o->Position[1]);
-            o->Angle[0] += 0.5f * o->LifeTime;
-            o->Angle[1] += 0.5f * o->LifeTime;
+            o->Angle[0] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+            o->Angle[1] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->Position[2] + o->Direction[2] <= fHeight)
             {
                 o->Position[2] = fHeight;
                 o->HeadAngle[0] *= 0.6f;
                 o->HeadAngle[1] *= 0.6f;
-                o->HeadAngle[2] += 1.0f * o->LifeTime;
+                o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                 if (o->HeadAngle[2] < 0.5f)
                     o->HeadAngle[2] = 0;
 
-                o->Alpha -= 0.15f;
+                o->Alpha -= (0.15f) * FPS_ANIMATION_FACTOR;
 
                 o->Light[0] /= 1.08f;
                 o->Light[1] /= 1.08f;
@@ -14318,28 +14318,28 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_FENRIR_FOOT_THUNDER:
         if (o->Live == true)
         {
-            o->Angle[0] += 0.1f;
+            o->Angle[0] += (0.1f) * FPS_ANIMATION_FACTOR;
 
             if (o->SubType == 1)
             {
-                o->Light[1] -= 0.05f;
-                o->Light[2] -= 0.05f;
+                o->Light[1] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
             }
             else if (o->SubType == 2)
             {
-                o->Light[0] -= 0.05f;
-                o->Light[1] -= 0.05f;
+                o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                o->Light[1] -= (0.05f) * FPS_ANIMATION_FACTOR;
             }
             else if (o->SubType == 3)
             {
-                o->Light[0] -= 0.05f;
-                o->Light[2] -= 0.05f;
+                o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
             }
             else if (o->SubType == 4)
             {
-                o->Light[2] -= 0.05f;
+                o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
             }
-            o->Alpha -= 0.05f;
+            o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
             if (o->Alpha <= 0.0f)
                 o->Live = false;
 
@@ -14356,7 +14356,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            o->Alpha -= 0.01f;
+            o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
             if (o->Alpha <= 0.0f)
             {
                 o->Live = false;
@@ -14382,7 +14382,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->m_iAnimation == 0)
             {
-                o->Scale -= 0.015f;
+                o->Scale -= (0.015f) * FPS_ANIMATION_FACTOR;
                 if (o->Scale <= 0.0f)
                 {
                     o->Scale = 0.0f;
@@ -14390,7 +14390,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else
             {
-                o->Scale += 0.02f;
+                o->Scale += (0.02f) * FPS_ANIMATION_FACTOR;
                 if (o->Scale >= 1.2f)
                 {
                     o->Scale = 1.2f;
@@ -14399,7 +14399,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1 || o->SubType == 2)
         {
-            o->Alpha -= 0.01f;
+            o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
             if (o->Alpha <= 0.0f)
             {
                 o->Live = false;
@@ -14414,7 +14414,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             else if (o->SubType == 2)
                 o->Angle[0] = -(WorldTime * 0.1f);
 
-            o->Scale -= 0.02f;
+            o->Scale -= (0.02f) * FPS_ANIMATION_FACTOR;
         }
     }
     break;
@@ -14450,8 +14450,8 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_STUN_STONE:
         if (o->SubType == 0)
         {
-            o->Position[2] += o->Gravity;
-            o->Gravity -= 15.f;
+            o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
+            o->Gravity -= (15.f) * FPS_ANIMATION_FACTOR;
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]) + 50;
             if (o->Position[2] <= Height)
@@ -14468,9 +14468,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorAdd(o->Position, o->StartPosition, o->Position);
                 VectorScale(o->StartPosition, 0.9f, o->StartPosition);
 
-                o->HeadAngle[0] -= o->Scale * 32.f;
+                o->HeadAngle[0] -= (o->Scale * 32.f) * FPS_ANIMATION_FACTOR;
 
-                if (o->LifeTime % 3 == 0)
+                if ((int)o->LifeTime % 3 == 0)
                 {
                     CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, o->Light, 1, 1.f);
                 }
@@ -14482,7 +14482,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1)
         {
-            if (o->LifeTime % 3 == 0)
+            if ((int)o->LifeTime % 3 == 0)
             {
                 CreateEffect(MODEL_STUN_STONE, o->Position, o->Angle, o->Light);
             }
@@ -14493,21 +14493,21 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_SKIN_SHELL:
         VectorAdd(o->Position, o->Direction, o->Position);
         VectorScale(o->Direction, 0.9f, o->Direction);
-        o->Position[2] += o->Gravity;
+        o->Position[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
         VectorScale(o->Direction, 1.1f, o->Direction);
 
-        o->Gravity -= 3.f;
+        o->Gravity -= (3.f) * FPS_ANIMATION_FACTOR;
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.2f;
-            o->LifeTime -= 5;
-            o->Angle[0] -= o->Scale * 128.f;
+            o->LifeTime -= (5) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] -= (o->Scale * 128.f) * FPS_ANIMATION_FACTOR;
         }
         else
-            o->Angle[0] -= o->Scale * 16.f;
+            o->Angle[0] -= (o->Scale * 16.f) * FPS_ANIMATION_FACTOR;
 
         o->Alpha = o->LifeTime / 10.f;
         break;
@@ -14525,8 +14525,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else if (o->LifeTime > 30)
             {
-                o->Scale += o->Gravity;
-                o->Gravity += 0.15f;
+                o->Scale += (o->Gravity) * FPS_ANIMATION_FACTOR;
+                o->Gravity += (0.15f) * FPS_ANIMATION_FACTOR;
                 if (o->Scale > 1.f)
                 {
                     o->Scale = 1.f;
@@ -14537,19 +14537,19 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else if (o->LifeTime < 15)
             {
-                o->Scale -= o->Gravity;
-                o->Gravity += 0.2f;
+                o->Scale -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+                o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                 if (o->Scale < 0.f)
                 {
                     o->Scale = 0.f;
                 }
                 o->Alpha = (o->LifeTime / 20.f);
-                o->Position[2] -= 10.f;
+                o->Position[2] -= (10.f) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 1)
         {
-            o->Scale -= 0.02f;
+            o->Scale -= (0.02f) * FPS_ANIMATION_FACTOR;
             if (o->Scale < 1.f)
             {
                 o->Scale = 1.f;
@@ -14562,10 +14562,10 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Owner != NULL)
         {
             VectorCopy(o->Owner->Position, o->StartPosition);
-            o->StartPosition[2] += 150.f;
+            o->StartPosition[2] += (150.f) * FPS_ANIMATION_FACTOR;
         }
 
-        o->Scale += 0.015f;
+        o->Scale += (0.015f) * FPS_ANIMATION_FACTOR;
         if (o->LifeTime < 25)
         {
             float Distance;
@@ -14575,9 +14575,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                 if (Distance < 100.f)
                 {
                     VectorCopy(o->StartPosition, o->Position);
-                    o->Scale += 0.04f;
+                    o->Scale += (0.04f) * FPS_ANIMATION_FACTOR;
 
-                    if (o->LifeTime % 3 == 0)
+                    if ((int)o->LifeTime % 3 == 0)
                     {
                         CreateParticle(BITMAP_POUNDING_BALL, o->Position, o->Angle, o->Light, 1);
                     }
@@ -14587,7 +14587,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     CreateParticle(BITMAP_POUNDING_BALL, o->Position, o->Angle, o->Light, 1);
                 }
             }
-            o->Velocity += 1.5f;
+            o->Velocity += (1.5f) * FPS_ANIMATION_FACTOR;
 
             AngleMatrix(o->HeadAngle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
@@ -14597,17 +14597,17 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->Direction[1] > -50.f)
             {
-                o->Direction[1] -= 8.f;
+                o->Direction[1] -= (8.f) * FPS_ANIMATION_FACTOR;
             }
         }
         else
         {
-            o->Gravity += 10.f;
+            o->Gravity += (10.f) * FPS_ANIMATION_FACTOR;
             AngleMatrix(o->HeadAngle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
             VectorAdd(o->Position, Position, o->Position);
         }
-        o->Angle[2] += o->Gravity;
+        o->Angle[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
         o->BlendMeshLight = o->LifeTime / 10.f;
         o->Alpha = o->BlendMeshLight;
 
@@ -14626,8 +14626,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         break;
 
     case MODEL_ARROW_IMPACT:
-        o->Angle[0] -= 5.f;
-        o->Direction[1] -= 8.f;
+        o->Angle[0] -= (5.f) * FPS_ANIMATION_FACTOR;
+        o->Direction[1] -= (8.f) * FPS_ANIMATION_FACTOR;
 
         if (o->LifeTime < 2 && o->SubType == 0 && o->Owner != NULL)
         {
@@ -14650,10 +14650,10 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_JOINT_FORCE:
         if (o->SubType == 0)
         {
-            if (o->LifeTime < 11 && o->LifeTime % 2 == 0)
+            if (o->LifeTime < 11 && (int)o->LifeTime % 2 == 0)
             {
                 Vector(90.f, 0.f, 0.f, o->Angle);
-                o->HeadAngle[2] += 72.f;
+                o->HeadAngle[2] += (72.f) * FPS_ANIMATION_FACTOR;
                 AngleMatrix(o->HeadAngle, Matrix);
                 VectorRotate(o->Direction, Matrix, Position);
                 VectorAdd(o->StartPosition, Position, Position);
@@ -14664,10 +14664,10 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1)
         {
-            if (o->LifeTime < 11 && o->LifeTime % 2 == 0)
+            if (o->LifeTime < 11 && (int)o->LifeTime % 2 == 0)
             {
                 Vector(90.f, 0.f, 0.f, o->Angle);
-                o->HeadAngle[2] += 72.f;
+                o->HeadAngle[2] += (72.f) * FPS_ANIMATION_FACTOR;
                 AngleMatrix(o->HeadAngle, Matrix);
                 VectorRotate(o->Direction, Matrix, Position);
                 VectorAdd(o->StartPosition, Position, Position);
@@ -14683,9 +14683,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->LifeTime > 12)
             {
-                o->Scale += 0.9f;
+                o->Scale += (0.9f) * FPS_ANIMATION_FACTOR;
 
-                o->Direction[1] -= 2.f;
+                o->Direction[1] -= (2.f) * FPS_ANIMATION_FACTOR;
                 if (o->SubType == 2)
                 {
                     CreateEffect(MODEL_SWORD_FORCE, o->Position, o->Angle, o->Light, 3, o);
@@ -14695,14 +14695,14 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             else
             {
-                o->Scale -= 0.05f;
+                o->Scale -= (0.05f) * FPS_ANIMATION_FACTOR;
                 o->BlendMeshLight = (float)o->LifeTime / 18.f;
                 o->Alpha = o->BlendMeshLight;
                 o->Light[0] = o->Alpha;
                 o->Light[1] = o->Alpha;
                 o->Light[2] = o->Alpha;
 
-                o->Direction[1] -= 2.f;
+                o->Direction[1] -= (2.f) * FPS_ANIMATION_FACTOR;
 
                 VectorCopy(o->Position, Position);
                 Position[0] += rand() % 30 - 15.f;
@@ -14770,9 +14770,9 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         float fHeight = o->Owner->Position[2] + tempPosition[2] - o->Owner->Position[2] + 60;
         if (fHeight < o->Position[2])
-            o->Position[2] += (fHeight - o->Position[2]) * 0.1f;
+            o->Position[2] += ((fHeight - o->Position[2]) * 0.1f) * FPS_ANIMATION_FACTOR;
         else
-            o->Position[2] += (fHeight - o->Position[2]) * 0.5f;
+            o->Position[2] += ((fHeight - o->Position[2]) * 0.5f) * FPS_ANIMATION_FACTOR;
 
         if (o->LifeTime < 60 && o->LifeTime > 39)
         {
@@ -14805,14 +14805,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                 CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 24, 1.0f, o);
             }
 
-            if (o->LifeTime % 15 == 0)
+            if ((int)o->LifeTime % 15 == 0)
             {
                 CreateEffect(BITMAP_TARGET_POSITION_EFFECT1, o->Position, vAngle, vLight, 0);//, NULL, -1, 0, 0, 0, fScale );
             }
 
             if (o->LifeTime <= 10)
             {
-                o->BlendMeshLight -= 0.05f;
+                o->BlendMeshLight -= (0.05f) * FPS_ANIMATION_FACTOR;
                 o->Light[0] *= o->BlendMeshLight;
                 o->Light[1] *= o->BlendMeshLight;
                 o->Light[2] *= o->BlendMeshLight;
@@ -14824,14 +14824,14 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            o->Scale -= 0.04f;
+            o->Scale -= (0.04f) * FPS_ANIMATION_FACTOR;
             if (o->Scale <= 0.2f)
             {
                 o->Live = false;
             }
             if (o->LifeTime <= 10)
             {
-                o->Alpha -= 0.05f;
+                o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
                 o->Light[0] *= o->Alpha;
                 o->Light[1] *= o->Alpha;
                 o->Light[2] *= o->Alpha;
@@ -14854,16 +14854,16 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->m_iAnimation == 0)
             {
-                o->Scale -= 0.15f;
+                o->Scale -= (0.15f) * FPS_ANIMATION_FACTOR;
             }
             else if (o->m_iAnimation == 1)
             {
-                o->Scale += 0.15f;
+                o->Scale += (0.15f) * FPS_ANIMATION_FACTOR;
             }
 
             if (o->LifeTime <= 10)
             {
-                o->Alpha -= 0.05f;
+                o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
                 o->Light[0] *= o->Alpha;
                 o->Light[1] *= o->Alpha;
                 o->Light[2] *= o->Alpha;
@@ -14873,10 +14873,10 @@ void MoveEffect(OBJECT* o, int iIndex)
     break;
     case MODEL_EFFECT_SAPITRES_ATTACK:
     {
-        if (o->LifeTime % 6 == 0)
+        if ((int)o->LifeTime % 6 == 0)
         {
-            o->Position[0] += (float)((rand() % 120) - 60);
-            o->Position[1] += (float)((rand() % 120) - 60);
+            o->Position[0] += ((float)((rand() % 120) - 60)) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += ((float)((rand() % 120) - 60)) * FPS_ANIMATION_FACTOR;
 
             CreateEffect(MODEL_EFFECT_SAPITRES_ATTACK_1, o->Position, o->Angle, o->Light, 0, o->Owner);
         }
@@ -14887,8 +14887,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 0)
         {
             float fMoveSpeed = 40.0f;
-            o->Position[0] += (o->Direction[0] * fMoveSpeed);
-            o->Position[1] += (o->Direction[1] * fMoveSpeed);
+            o->Position[0] += ((o->Direction[0] * fMoveSpeed)) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += ((o->Direction[1] * fMoveSpeed)) * FPS_ANIMATION_FACTOR;
 
             vec3_t vLight;
             Vector(0.1f, 0.3f, 1.0f, vLight);
@@ -15181,13 +15181,13 @@ void MoveEffect(OBJECT* o, int iIndex)
     break;
     case MODEL_NIGHTWATER_01:
     {
-        o->Alpha -= 0.04f;
+        o->Alpha -= (0.04f) * FPS_ANIMATION_FACTOR;
     }
     break;
     case MODEL_KNIGHT_PLANCRACK_A:
         if (o->SubType == 0)
         {
-            o->Alpha -= 0.04f;
+            o->Alpha -= (0.04f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 1)
         {
@@ -15200,7 +15200,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
     case MODEL_KNIGHT_PLANCRACK_B:
     {
-        o->Alpha -= 0.04f;
+        o->Alpha -= (0.04f) * FPS_ANIMATION_FACTOR;
     }
     break;
     case MODEL_EFFECT_FLAME_STRIKE:
@@ -15353,10 +15353,10 @@ void MoveEffect(OBJECT* o, int iIndex)
             vec3_t vPos;
             pModel->TransformByObjectBone(vPos, o->Owner, o->PKKey);
             VectorCopy(vPos, o->Position);
-            o->Scale -= 1.0f;
+            o->Scale -= (1.0f) * FPS_ANIMATION_FACTOR;
             if (o->LifeTime <= 15)
             {
-                o->Scale += 0.5f;
+                o->Scale += (0.5f) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 1)
@@ -15608,12 +15608,12 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_PKFIELD_ASSASSIN_EFFECT_GREEN_HEAD:
     case MODEL_PKFIELD_ASSASSIN_EFFECT_RED_HEAD:
     {
-        o->HeadAngle[2] -= o->Gravity;
+        o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
         VectorCopy(o->Light, Light);
 
-        o->Position[0] += o->HeadAngle[0];
-        o->Position[1] += o->HeadAngle[1];
-        o->Position[2] += o->HeadAngle[2];
+        o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+        o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]) + 20;
 
@@ -15622,23 +15622,23 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Position[2] = Height;
             o->HeadAngle[0] *= 0.8f;
             o->HeadAngle[1] *= 0.8f;
-            o->HeadAngle[2] += 0.6f * o->LifeTime;
+            o->HeadAngle[2] += (0.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
 
-            o->Alpha -= 0.05f;
+            o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
         }
         else
         {
             if (o->SubType == 0)
             {
-                o->Angle[0] += 0.15f * o->LifeTime;
-                o->Angle[1] += 0.15f * o->LifeTime;
+                o->Angle[0] += (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] += (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             }
             else
             {
-                o->Angle[0] -= 0.15f * o->LifeTime;
-                o->Angle[1] -= 0.15f * o->LifeTime;
+                o->Angle[0] -= (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] -= (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             }
         }
 
@@ -15673,9 +15673,9 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_LAVAGIANT_FOOTPRINT_R:
     case MODEL_LAVAGIANT_FOOTPRINT_V:
     {
-        o->Angle[0] += 0.1f;
+        o->Angle[0] += (0.1f) * FPS_ANIMATION_FACTOR;
 
-        o->Alpha -= 0.01f;
+        o->Alpha -= (0.01f) * FPS_ANIMATION_FACTOR;
         if (o->Alpha <= 0.0f)
             o->Live = false;
 
@@ -15709,12 +15709,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Direction[2] = o->Position[2] - o->StartPosition[2];
                 VectorNormalize(o->Direction);
             }
-            o->Angle[0] += 0.5f;
-            o->Velocity += 0.2f;
+            o->Angle[0] += (0.5f) * FPS_ANIMATION_FACTOR;
+            o->Velocity += (0.2f) * FPS_ANIMATION_FACTOR;
 
-            o->Position[0] += o->Direction[0] * o->Velocity;
-            o->Position[1] += o->Direction[1] * o->Velocity;
-            o->Position[2] += o->Direction[2];
+            o->Position[0] += (o->Direction[0] * o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (o->Direction[1] * o->Velocity) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
         }
     }
     break;
@@ -15734,12 +15734,12 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_STATUE_CRUSH_EFFECT_PIECE02:
     case MODEL_STATUE_CRUSH_EFFECT_PIECE03:
     {
-        o->HeadAngle[2] -= o->Gravity;
+        o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
         VectorCopy(o->Light, Light);
 
-        o->Position[0] += o->HeadAngle[0];
-        o->Position[1] += o->HeadAngle[1];
-        o->Position[2] += o->HeadAngle[2];
+        o->Position[0] += (o->HeadAngle[0]) * FPS_ANIMATION_FACTOR;
+        o->Position[1] += (o->HeadAngle[1]) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += (o->HeadAngle[2]) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]) + 20;
 
@@ -15748,11 +15748,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Position[2] = Height;
             o->HeadAngle[0] *= 0.8f;
             o->HeadAngle[1] *= 0.8f;
-            o->HeadAngle[2] += 0.6f * o->LifeTime;
+            o->HeadAngle[2] += (0.6f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 5.0f)
                 o->HeadAngle[2] = 0;
 
-            o->Alpha -= 0.05f;
+            o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
 
             if (rand() % 4 == 0)
             {
@@ -15769,13 +15769,13 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->SubType == 0)
             {
-                o->Angle[0] += 0.15f * o->LifeTime;
-                o->Angle[1] += 0.15f * o->LifeTime;
+                o->Angle[0] += (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] += (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             }
             else
             {
-                o->Angle[0] -= 0.15f * o->LifeTime;
-                o->Angle[1] -= 0.15f * o->LifeTime;
+                o->Angle[0] -= (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                o->Angle[1] -= (0.15f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             }
         }
 
@@ -15788,11 +15788,11 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_STATUE_CRUSH_EFFECT_PIECE04:
     case MODEL_DOOR_CRUSH_EFFECT_PIECE10:
     {
-        o->LifeTime -= 1;
+        o->LifeTime -= (1) * FPS_ANIMATION_FACTOR;
 
         if (o->LifeTime < 40)
         {
-            o->Alpha -= 0.1f;
+            o->Alpha -= (0.1f) * FPS_ANIMATION_FACTOR;
         }
     }
     break;
@@ -16834,7 +16834,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime == 20)
                 break;
 
-            o->Scale += 0.1f;
+            o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
 
             o->Light[0] /= 1.1f;
             o->Light[1] /= 1.1f;
@@ -16857,18 +16857,18 @@ void MoveEffect(OBJECT* o, int iIndex)
     }break;
     case MODEL_EFFECT_UMBRELLA_GOLD:
     {
-        o->Angle[0] += 10.f;
-        o->Position[0] += (o->Direction[0] * 2.2f);
-        o->Position[1] += (o->Direction[1] * 2.2f);
-        o->Position[2] += (o->Gravity * 1.5f);
-        o->Gravity -= 1.5f;
+        o->Angle[0] += (10.f) * FPS_ANIMATION_FACTOR;
+        o->Position[0] += ((o->Direction[0] * 2.2f)) * FPS_ANIMATION_FACTOR;
+        o->Position[1] += ((o->Direction[1] * 2.2f)) * FPS_ANIMATION_FACTOR;
+        o->Position[2] += ((o->Gravity * 1.5f)) * FPS_ANIMATION_FACTOR;
+        o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
             o->Position[2] = Height;
             o->Gravity = -o->Gravity * 0.3f;
-            o->LifeTime -= 2;
+            o->LifeTime -= (2) * FPS_ANIMATION_FACTOR;
         }
     }break;
     case MODEL_EFFECT_EG_GUARDIANDEFENDER_ATTACK2:
@@ -16899,9 +16899,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         BMD* b = &Models[o->Owner->Type];
         b->TransformByObjectBone(Temp_Pos, o->Owner, o->PKKey);
 
-        o->Timer += 0.1f;
-        o->Distance += 2.1f;
-        o->Angle[0] += 0.7f;
+        o->Timer += (0.1f) * FPS_ANIMATION_FACTOR;
+        o->Distance += (2.1f) * FPS_ANIMATION_FACTOR;
+        o->Angle[0] += (0.7f) * FPS_ANIMATION_FACTOR;
 
         o->Light[0] *= 0.95f;
         o->Light[1] *= 0.95f;
@@ -16976,11 +16976,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         else if (o->SubType == 1)
         {
-            o->Owner->Velocity += 2.5f;
+            o->Owner->Velocity += (2.5f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 2)
         {
-            o->Owner->Velocity += 5.5f;
+            o->Owner->Velocity += (5.5f) * FPS_ANIMATION_FACTOR;
         }
     }
     break;
@@ -17196,7 +17196,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else
         {
             o->Alpha = 1.0f;
-            o->Scale += 0.2f;
+            o->Scale += (0.2f) * FPS_ANIMATION_FACTOR;
             VectorScale(o->StartPosition, 0.99f, o->StartPosition);
             VectorSubtract(o->Position, o->StartPosition, o->Position);
             VectorScale(o->Light, 0.65f, o->Light);
@@ -17208,7 +17208,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         o->Alpha = 1.0f;
         VectorScale(o->Light, 0.8f, o->Light);
-        o->Scale += 0.1f;
+        o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
         VectorScale(o->StartPosition, 0.95f, o->StartPosition);
         VectorSubtract(o->Position, o->StartPosition, o->Position);
     }
@@ -17217,7 +17217,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->LifeTime < 17)
         {
-            if (o->LifeTime % 4 != 0)
+            if ((int)o->LifeTime % 4 != 0)
                 break;
 
             vec3_t vLight, vPosition;
@@ -17236,10 +17236,10 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_SHOCKWAVE_SPIN01:
     {
         o->Scale *= 1.01f;
-        o->Angle[1] -= 10.0f;
+        o->Angle[1] -= (10.0f) * FPS_ANIMATION_FACTOR;
         if (o->SubType == 1)
         {
-            o->Angle[1] += 20.0f;
+            o->Angle[1] += (20.0f) * FPS_ANIMATION_FACTOR;
         }
         VectorScale(o->Light, 0.9f, o->Light);
         o->Alpha = 1.0f;
@@ -17275,7 +17275,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (o->SubType == 0 || o->SubType == 4 || o->SubType == 5)
         {
-            o->Scale += 0.1f;
+            o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 3)
             {
                 o->Scale = 3;
@@ -17326,7 +17326,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else if (o->SubType == 2)
         {
             o->Angle[2] = -(int)WorldTime * 0.9f;
-            o->Scale += 0.1f;
+            o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 3)
             {
                 o->Scale = 3;
@@ -17344,7 +17344,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         else if (o->SubType == 3)
         {
             o->Angle[2] = -(int)WorldTime * 0.9f;
-            o->Scale += 0.1f;
+            o->Scale += (0.1f) * FPS_ANIMATION_FACTOR;
             if (o->Scale > 3)
             {
                 o->Scale = 3;
@@ -17414,7 +17414,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (g_isCharacterBuff(o->Owner, eBuff_Att_up_Ourforces))
             {
-                if (o->LifeTime % 2 == 0)
+                if ((int)o->LifeTime % 2 == 0)
                 {
                     VectorCopy(o->Position, Position);
                     Vector(1.0f, 0.12f, 0.0f, Light);
@@ -17449,7 +17449,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         vec3_t vLight;
         VectorCopy(o->Light, vLight);
         VectorScale(vLight, 0.1f, vLight);
-        if (o->LifeTime % 3 != 0)
+        if ((int)o->LifeTime % 3 != 0)
             CreateParticle(BITMAP_SWORD_EFFECT_MONO, o->Position, o->Angle, o->Light, 0, o->Scale, o);
 
         if (o->LifeTime == 14)
@@ -17475,7 +17475,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         if (o->SubType == 4 || o->SubType == 6)
         {
-            o->Owner->Velocity += 2.5f;
+            o->Owner->Velocity += (2.5f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 3)
         {
@@ -17875,28 +17875,28 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_VOLCANO_STONE:
     {
         float Height;
-        o->HeadAngle[2] -= o->Gravity;
+        o->HeadAngle[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
         o->Position[0] = o->Position[0] + o->HeadAngle[0];
         o->Position[1] = o->Position[1] + o->HeadAngle[1];
         o->Position[2] = o->Position[2] + o->HeadAngle[2];
 
         Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
-        o->Angle[0] += 0.3f * o->LifeTime;
-        o->Angle[1] += 0.3f * o->LifeTime;
+        o->Angle[0] += (0.3f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+        o->Angle[1] += (0.3f * o->LifeTime) * FPS_ANIMATION_FACTOR;
 
         if (o->Position[2] + o->Direction[2] <= Height)
         {
             o->Position[2] = Height;
             o->HeadAngle[0] *= 0.6f;
             o->HeadAngle[1] *= 0.6f;
-            o->HeadAngle[2] += 1.0f * o->LifeTime;
+            o->HeadAngle[2] += (1.0f * o->LifeTime) * FPS_ANIMATION_FACTOR;
             if (o->HeadAngle[2] < 0.5f)
                 o->HeadAngle[2] = 0;
 
-            o->Alpha -= 0.05f;
+            o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
         }
-        o->Scale -= 0.03f;
+        o->Scale -= (0.03f) * FPS_ANIMATION_FACTOR;
 
         vec3_t vLight;
         Vector(1.0f, 1.0f, 1.0f, vLight);
@@ -17982,7 +17982,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
         }
     }
-    o->LifeTime--;
+    o->LifeTime -= FPS_ANIMATION_FACTOR;
     if (o->LifeTime <= 0)
     {
         EffectDestructor(o);
@@ -17993,14 +17993,14 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
         case BITMAP_LIGHT:
         {
-            if (o->SubType == 0 && 0 != (o->LifeTime % 2))
+            if (o->SubType == 0 && 0 != ((int)o->LifeTime % 2))
                 MoveEffect(o, iIndex);
         }
         break;
         case MODEL_FIRE:
             if (o->SubType == 3)
             {
-                if (0 != (o->LifeTime % 2))
+                if (0 != ((int)o->LifeTime % 2))
                     MoveEffect(o, iIndex);
             }
             break;
@@ -18032,10 +18032,10 @@ void RenderWheelWeapon(OBJECT* o)
     VectorCopy(o->Position, TempPosition);
     VectorCopy(o->Angle, TempAngle);
 
-    o->Direction[2] -= 30;
-    o->Angle[2] += o->Direction[2];
+    o->Direction[2] -= (30) * FPS_ANIMATION_FACTOR;
+    o->Angle[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
     o->Angle[1] = 90;
-    o->Position[2] += 100.f;
+    o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
 
     float Alpha = o->Alpha;
 
@@ -18377,7 +18377,7 @@ void RenderEffects(bool bRenderBlendMesh)
                     {
                         if (o->SubType == 1)
                         {
-                            o->Angle[2] -= 0.1f;
+                            o->Angle[2] -= (0.1f) * FPS_ANIMATION_FACTOR;
                             Vector(1.0f, 1.0f, 1.0f, o->Light);
                             CreateSprite(BITMAP_FIRE + 1, Position, o->Scale, o->Light, o, o->Angle[2]);
                             EnableAlphaBlend();
@@ -18388,7 +18388,7 @@ void RenderEffects(bool bRenderBlendMesh)
                         else if (o->SubType == 2)
                         {
                             Vector(0.0f, 0.2f, 1.f, o->Light);
-                            o->Angle[2] -= 0.1f;
+                            o->Angle[2] -= (0.1f) * FPS_ANIMATION_FACTOR;
                             CreateSprite(BITMAP_FIRE + 1, Position, o->Scale, o->Light, o, o->Angle[2]);
                         }
                         else
@@ -19133,7 +19133,7 @@ void RenderEffectShadows()
                         o->Light[0] /= 1.1f;
                         o->Light[1] /= 1.1f;
                         o->Light[2] /= 1.1f;
-                        o->Scale += 0.05f;
+                        o->Scale += (0.05f) * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->SubType == 8)
                     {
@@ -19236,7 +19236,7 @@ void RenderEffectShadows()
                     if (o->SubType == 7)
                     {
                         VectorCopy(o->Owner->Position, o->Position);
-                        o->Angle[2] += 10.0f;
+                        o->Angle[2] += (10.0f) * FPS_ANIMATION_FACTOR;
                     }
                     if (o->SubType != 5 && o->SubType != 6 && o->SubType != 8)
                     {
@@ -19279,11 +19279,11 @@ void RenderEffectShadows()
                         }
                         RenderTerrainAlphaBitmap(BITMAP_MAGIC + 1, o->Position[0], o->Position[1], Scale, Scale, Light, -o->Angle[2]);
                     }
-                    else if (o->SubType == 6 && o->LifeTime % 25 == 0)
+                    else if (o->SubType == 6 && (int)o->LifeTime % 25 == 0)
                     {
                         CreateEffect(BITMAP_MAGIC + 1, o->Position, o->Angle, o->Light, 7, o->Owner);
                     }
-                    else if (o->SubType == 8 && o->LifeTime % 2 == 0)
+                    else if (o->SubType == 8 && (int)o->LifeTime % 2 == 0)
                     {
                         CreateEffect(BITMAP_MAGIC + 1, o->Position, o->Angle, o->Light, 9, o->Owner);
                     }
@@ -19419,7 +19419,7 @@ void RenderEffectShadows()
                     }
                     break;
                 case BITMAP_LIGHTNING + 1:
-                    o->Scale += 0.2f;
+                    o->Scale += (0.2f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) * 0.1f;
                     Vector(Luminosity, Luminosity, Luminosity, Light);
                     RenderTerrainAlphaBitmap(BITMAP_LIGHTNING + 1, o->Position[0], o->Position[1], o->Scale, o->Scale, Light, -o->Angle[2]);

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -511,7 +511,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 1000;
                 o->Gravity = 1.0f;
                 o->Distance = 1.0f;
-                o->Position[2] += (3400.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += 3400.f;
                 Vector(0.f, -35.0f, 0.f, o->Direction);
                 VectorCopy(o->Position, o->StartPosition);
                 Vector(1.0f, 1.0f, 1.0f, o->Light);
@@ -1476,7 +1476,7 @@ void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Sub
                 o->LifeTime = 20;
 
                 VectorCopy(o->Position, o->StartPosition);
-                o->StartPosition[2] += (800.0f) * FPS_ANIMATION_FACTOR;
+                o->StartPosition[2] += (800.0f);
             }
             break;
             case MODEL_STAFF + 8:
@@ -7851,9 +7851,12 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (pObject->Live)
                 o->LifeTime = 100.f;
 
-            vec3_t vLight;
-            Vector(o->Alpha * 0.3f, o->Alpha * 0.3f, o->Alpha * 0.3f, vLight);
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 1, 1, pObject);
+            if (rand_fps_check(1))
+            {
+                vec3_t vLight;
+                Vector(o->Alpha * 0.3f, o->Alpha * 0.3f, o->Alpha * 0.3f, vLight);
+                CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 1, 1, pObject);
+            }
         }
         else if (o->SubType == 1)
         {
@@ -7904,10 +7907,15 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             vec3_t vLight;
             Vector(o->Alpha, o->Alpha, o->Alpha, vLight);
-            CreateParticle(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
-            if (rand_fps_check(2))
+            if (rand_fps_check(1))
+            {
                 CreateParticle(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
+            }
 
+            if (rand_fps_check(2))
+            {
+                CreateParticle(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
+            }
             //DeleteJoint(MODEL_SPEARSKILL, o, 15);
         }
         else if (o->SubType == 1)
@@ -7953,9 +7961,12 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (pObject->Live)
             o->LifeTime = 100.f;
 
-        vec3_t vLight;
-        Vector(o->Alpha * 0.7f, o->Alpha * 0.3f, o->Alpha * 1.f, vLight);
-        CreateParticle(BITMAP_CLUD64, o->Position, o->Angle, vLight, 10, 1.f, pObject);
+        if (rand_fps_check(1))
+        {
+            vec3_t vLight;
+            Vector(o->Alpha * 0.7f, o->Alpha * 0.3f, o->Alpha * 1.f, vLight);
+            CreateParticle(BITMAP_CLUD64, o->Position, o->Angle, vLight, 10, 1.f, pObject);
+        }
     }
     case MODEL_SUMMONER_CASTING_EFFECT1:
     case MODEL_SUMMONER_CASTING_EFFECT11:
@@ -8565,7 +8576,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 1 || o->SubType == 2)
         {
             BMD* b = &Models[o->Owner->Type];
-            Vector(0.f, 0.f, 10.f, p);
+            Vector(0.f, 0.f, 10.f * FPS_ANIMATION_FACTOR, p);
             VectorCopy(o->StartPosition, b->BodyOrigin);
             b->TransformPosition(o->Owner->BoneTransform[33], p, o->Position, true);
         }
@@ -8583,6 +8594,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             AngleMatrix(Angle, Matrix);
             VectorRotate(p, Matrix, Position);
             VectorAdd(o->Position, Position, Position);
+
+            if (!rand_fps_check(1))
+            {
+                break;
+            }
 
             if (o->SubType == 1)
             {
@@ -8626,7 +8642,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         vPosition[0] += rand() % 100 - 50;
         vPosition[1] += rand() % 100 - 50;
 
-        if (rand() % 10 > 4)
+        if (rand_fps_check(2))
         {
             if (o->SubType == 1)
             {
@@ -9886,11 +9902,13 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorAdd(o->Owner->Position, Position, o->Position);
         o->Angle[2] -= 18 * FPS_ANIMATION_FACTOR;
 
-        CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
-        Vector(Luminosity * 0.3f, Luminosity * 0.3f, Luminosity * 0.3f, Light);
-        AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
-        Vector(1.f, 1.f, 1.f, Light);
+        if (rand_fps_check(1)) {
+            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
+            Vector(Luminosity * 0.3f, Luminosity * 0.3f, Luminosity * 0.3f, Light);
+            AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
+        }
 
+        Vector(1.f, 1.f, 1.f, Light);
         Height = 20.f;
         if (gMapManager.InHellas())
         {
@@ -10508,7 +10526,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         for (int j = 0; j < 6; j++)
         {
-            CreateParticle(BITMAP_SMOKE, Position, Angle, o->Light, 25);
+            if (rand_fps_check(1))
+                CreateParticle(BITMAP_SMOKE, Position, Angle, o->Light, 25);
         }
         Vector(Luminosity * 0.3f, Luminosity * 0.6f, Luminosity, Light);
         AddTerrainLight(Position[0], Position[1], Light, 3, PrimaryTerrainLight);
@@ -10521,7 +10540,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         //VectorAdd(o->Position,o->Direction,o->Position);
 
         for (int j = 0; j < 4; j++)
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
+            if (rand_fps_check(1))
+                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
 
         Vector(Luminosity * 0.3f, Luminosity * 0.6f, Luminosity, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
@@ -10533,7 +10553,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorCopy(o->Angle, Angle);
             VectorCopy(o->Position, Position);
             Angle[2] += rand() % 10 - 5;
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.015f);
+            if (rand_fps_check(1))
+                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.015f);
 
             Vector(1.f, 1.f, 1.f, Light2);
             Position[2] += 50.f;
@@ -12665,7 +12686,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     }
     break;
     case BITMAP_SWORD_FORCE:
-        if ((int)o->LifeTime == 30)
+        if (o->LifeTime == 30.f) // at the first frame of the effect
         {
             VectorCopy(o->Position, Position);
             Position[2] += 100.f;
@@ -17706,13 +17727,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->LifeTime = 0;
             break;
         }
-        if (o->Owner->AnimationFrame > 2 && o->Owner->AnimationFrame < 8)
+        if (o->Owner->AnimationFrame > 2 && o->Owner->AnimationFrame < 8 & rand_fps_check(1))
         {
             BMD* pModel = &Models[o->Owner->Type];
             vec3_t _StartPos, _EndPos;
 
-            float fDelay = o->Velocity * 10.0f;
-            float fActionSpeed = pModel->Actions[o->Owner->CurrentAction].PlaySpeed * FPS_ANIMATION_FACTOR;
+            float fDelay = o->Velocity * 10.0f * FPS_ANIMATION_FACTOR;
+            float fActionSpeed = pModel->Actions[o->Owner->CurrentAction].PlaySpeed;
             float fSpeedPerFrame = fActionSpeed / fDelay;
             float fAnimationFrame = o->Owner->AnimationFrame - fActionSpeed;
 

--- a/Source Main 5.2/source/ZzzEffectFireLeave.cpp
+++ b/Source Main 5.2/source/ZzzEffectFireLeave.cpp
@@ -141,6 +141,7 @@ bool CreateDevilSquareRain(PARTICLE* o, int Index)
             Hero->Object.Position[2] + (float)(rand() % 200 + 300),
             o->Position);
     }
+
     if (rand() % 2 == 0)
     {
         Vector((float)(-(rand() % 20 + 20)), 0.f, 0.f, o->Angle);
@@ -149,8 +150,9 @@ bool CreateDevilSquareRain(PARTICLE* o, int Index)
     {
         Vector((float)(-(rand() % 20 + 30 + RainAngle)), 0.f, 0.f, o->Angle);
     }
+
     vec3_t Velocity;
-    Vector(0.f, 0.f, -(float)(rand() % 40 + RainSpeed), Velocity);
+    Vector(0.f, 0.f, -(float)((rand() % 40 + RainSpeed) * FPS_ANIMATION_FACTOR), Velocity);
     float Matrix[3][4];
     AngleMatrix(o->Angle, Matrix);
     VectorRotate(Velocity, Matrix, o->Velocity);
@@ -190,7 +192,7 @@ bool CreateChaosCastleRain(PARTICLE* o, int Index)
         Vector((float)(-(rand() % 20 + 30 + RainAngle)), 0.f, 0.f, o->Angle);
     }
     vec3_t Velocity;
-    Vector(0.f, 0.f, -(float)(rand() % 40 + RainSpeed + 20), Velocity);
+    Vector(0.f, 0.f, -(float)((rand() % 40 + RainSpeed + 20) * FPS_ANIMATION_FACTOR), Velocity);
     float Matrix[3][4];
     AngleMatrix(o->Angle, Matrix);
     VectorRotate(Velocity, Matrix, o->Velocity);
@@ -210,9 +212,14 @@ bool CreateLorenciaLeaf(PARTICLE* o)
     VectorCopy(Position, o->Position);
     VectorCopy(Position, o->StartPosition);
     o->Velocity[0] = -(float)(rand() % 64 + 64) * 0.1f;
-    if (Position[1] < CameraPosition[1] + 400.f) o->Velocity[0] = -o->Velocity[0] + 3.2f;
-    o->Velocity[1] = (float)(rand() % 32 - 16) * 0.1f;
-    o->Velocity[2] = (float)(rand() % 32 - 16) * 0.1f;
+    if (Position[1] < CameraPosition[1] + 400.f)
+    {
+        o->Velocity[0] = -o->Velocity[0] + 3.2f;
+    }
+
+    o->Velocity[0] *= FPS_ANIMATION_FACTOR;
+    o->Velocity[1] = (float)(rand() % 32 - 16) * 0.1f * FPS_ANIMATION_FACTOR;
+    o->Velocity[2] = (float)(rand() % 32 - 16) * 0.1f * FPS_ANIMATION_FACTOR;
     o->TurningForce[0] = (float)(rand() % 16 - 8) * 0.1f;
     o->TurningForce[1] = (float)(rand() % 64 - 32) * 0.1f;
     o->TurningForce[2] = (float)(rand() % 16 - 8) * 0.1f;
@@ -228,12 +235,14 @@ bool CreateHeavenRain(PARTICLE* o, int index)
     if (index < Rainly)
     {
         o->Type = BITMAP_RAIN;
-        Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800), Hero->Object.Position[1] + (float)(rand() % 1400 - 500),
-            Hero->Object.Position[2] + (float)(rand() % 200 + 200),
+        Vector(
+            Hero->Object.Position[0] + (float)(rand() % 1600 - 800) * FPS_ANIMATION_FACTOR,
+            Hero->Object.Position[1] + (float)(rand() % 1400 - 500) * FPS_ANIMATION_FACTOR,
+            Hero->Object.Position[2] + (float)(rand() % 200 + 200) * FPS_ANIMATION_FACTOR,
             o->Position);
         Vector(-30.f, 0.f, 0.f, o->Angle);
         vec3_t Velocity;
-        Vector(0.f, 0.f, -(float)(rand() % 24 + 20), Velocity);
+        Vector(0.f, 0.f, -(float)(rand() % 24 + 20) * FPS_ANIMATION_FACTOR, Velocity);
         float Matrix[3][4];
         AngleMatrix(o->Angle, Matrix);
         VectorRotate(Velocity, Matrix, o->Velocity);
@@ -252,12 +261,13 @@ bool CreateDeviasSnow(PARTICLE* o)
         o->Type = BITMAP_LEAF2;
         o->Scale = 10.f;
     }
-    Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800), Hero->Object.Position[1] + (float)(rand() % 1400 - 500),
-        Hero->Object.Position[2] + (float)(rand() % 200 + 200),
+    Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800) * FPS_ANIMATION_FACTOR,
+        Hero->Object.Position[1] + (float)(rand() % 1400 - 500) * FPS_ANIMATION_FACTOR,
+        Hero->Object.Position[2] + (float)(rand() % 200 + 200) * FPS_ANIMATION_FACTOR,
         o->Position);
     Vector(-30.f, 0.f, 0.f, o->Angle);
     vec3_t Velocity;
-    Vector(0.f, 0.f, -(float)(rand() % 16 + 8), Velocity);
+    Vector(0.f, 0.f, -(float)(rand() % 16 + 8) * FPS_ANIMATION_FACTOR, Velocity);
     float Matrix[3][4];
     AngleMatrix(o->Angle, Matrix);
     VectorRotate(Velocity, Matrix, o->Velocity);
@@ -271,8 +281,9 @@ bool CreateAtlanseLeaf(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     vec3_t Position;
-    Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800), Hero->Object.Position[1] + (float)(rand() % 1400 - 500),
-        Hero->Object.Position[2] + (float)(rand() % 300 + 50),
+    Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800) * FPS_ANIMATION_FACTOR,
+        Hero->Object.Position[1] + (float)(rand() % 1400 - 500) * FPS_ANIMATION_FACTOR,
+        Hero->Object.Position[2] + (float)(rand() % 300 + 50) * FPS_ANIMATION_FACTOR,
         Position);
     VectorCopy(Position, o->Position);
     VectorCopy(Position, o->StartPosition);
@@ -421,8 +432,8 @@ bool MoveLeaves()
     else if (RainCurrent < RainTarget)
         RainCurrent++;
 
-    RainSpeed = (int)sinf(WorldTime * 0.001f) * 10 + 30;
-    RainAngle = (int)sinf(WorldTime * 0.0005f + 50.f) * 20;
+    RainSpeed = ((int)sinf(WorldTime * 0.001f) * 10 + 30) * FPS_ANIMATION_FACTOR;
+    RainAngle = (int)sinf(WorldTime * 0.0005f + 50.f) * 20 * FPS_ANIMATION_FACTOR;
     RainPosition += 20;
     RainPosition %= 2000;
 

--- a/Source Main 5.2/source/ZzzEffectFireLeave.cpp
+++ b/Source Main 5.2/source/ZzzEffectFireLeave.cpp
@@ -24,6 +24,7 @@
 #include "GM3rdChangeUp.h"
 #include "MapManager.h"
 #include "w_MapHeaders.h"
+#include "NewUISystem.h"
 
 float RainTarget = 0;
 float RainCurrent = 0.f;
@@ -229,6 +230,11 @@ bool CreateLorenciaLeaf(PARTICLE* o)
 
 bool CreateHeavenRain(PARTICLE* o, int index)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return false;
+    }
+
     if (gMapManager.WorldActive != WD_10HEAVEN) return false;
 
     int Rainly = RainCurrent * MAX_LEAVES / 100;
@@ -400,6 +406,11 @@ void MoveEtcLeaf(PARTICLE* o)
 
 bool MoveLeaves()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return false;
+    }
+
     int iMaxLeaves = (gMapManager.InDevilSquare() == true) ? MAX_LEAVES : 80;
 
     if (gMapManager.WorldActive == WD_10HEAVEN)
@@ -480,6 +491,11 @@ bool MoveLeaves()
 
 void RenderLeaves()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     if (gMapManager.WorldActive == WD_2DEVIAS || gMapManager.WorldActive == WD_7ATLANSE || gMapManager.WorldActive == WD_10HEAVEN
         || IsIceCity()
         || IsSantaTown()

--- a/Source Main 5.2/source/ZzzEffectFireLeave.cpp
+++ b/Source Main 5.2/source/ZzzEffectFireLeave.cpp
@@ -108,7 +108,7 @@ void CheckSkull(OBJECT* o)
     }
     VectorScale(o->Direction, 0.6f, o->Direction);
     VectorScale(o->HeadAngle, 0.6f, o->HeadAngle);
-    VectorAdd(o->Position, o->Direction, o->Position);
+    VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
     VectorAdd(o->Angle, o->HeadAngle, o->Angle);
 }
 
@@ -242,7 +242,7 @@ bool CreateHeavenRain(PARTICLE* o, int index)
             o->Position);
         Vector(-30.f, 0.f, 0.f, o->Angle);
         vec3_t Velocity;
-        Vector(0.f, 0.f, -(float)(rand() % 24 + 20) * FPS_ANIMATION_FACTOR, Velocity);
+        Vector(0.f, 0.f, -(float)(rand() % 24 + 20), Velocity);
         float Matrix[3][4];
         AngleMatrix(o->Angle, Matrix);
         VectorRotate(Velocity, Matrix, o->Velocity);
@@ -267,7 +267,7 @@ bool CreateDeviasSnow(PARTICLE* o)
         o->Position);
     Vector(-30.f, 0.f, 0.f, o->Angle);
     vec3_t Velocity;
-    Vector(0.f, 0.f, -(float)(rand() % 16 + 8) * FPS_ANIMATION_FACTOR, Velocity);
+    Vector(0.f, 0.f, -(float)(rand() % 16 + 8), Velocity);
     float Matrix[3][4];
     AngleMatrix(o->Angle, Matrix);
     VectorRotate(Velocity, Matrix, o->Velocity);
@@ -308,7 +308,7 @@ bool MoveDevilSquareRain(PARTICLE* o)
     if (gMapManager.WorldActive == WD_34CRYWOLF_1ST && weather != 1)
         return false;
 
-    VectorAdd(o->Position, o->Velocity, o->Position);
+    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
     float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
     if (o->Position[2] < Height)
     {
@@ -326,7 +326,7 @@ bool MoveChaosCastleRain(PARTICLE* o)
 {
     if (gMapManager.InChaosCastle() == false) return false;
 
-    VectorAdd(o->Position, o->Velocity, o->Position);
+    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
     float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
     if (o->Position[2] < Height && (TERRAIN_ATTRIBUTE(o->Position[0], o->Position[1]) & TW_NOGROUND) != TW_NOGROUND)
     {
@@ -346,7 +346,7 @@ bool MoveHeavenRain(PARTICLE* o)
 
     if (o->Type == BITMAP_RAIN)
     {
-        VectorAdd(o->Position, o->Velocity, o->Position);
+        VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
         float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
         if (o->Position[2] < Height)
         {
@@ -361,7 +361,7 @@ bool MoveHeavenRain(PARTICLE* o)
         o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
-        VectorAdd(o->Position, o->Velocity, o->Position);
+        VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
         o->TurningForce[0] += (float)(rand() % 8 - 4) * 0.02f * FPS_ANIMATION_FACTOR;
         o->TurningForce[1] += (float)(rand() % 16 - 8) * 0.02f * FPS_ANIMATION_FACTOR;
@@ -394,7 +394,7 @@ void MoveEtcLeaf(PARTICLE* o)
         o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
-        VectorAdd(o->Position, o->Velocity, o->Position);
+        VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
     }
 }
 

--- a/Source Main 5.2/source/ZzzEffectFireLeave.cpp
+++ b/Source Main 5.2/source/ZzzEffectFireLeave.cpp
@@ -25,8 +25,8 @@
 #include "MapManager.h"
 #include "w_MapHeaders.h"
 
-int RainTarget = 0;
-int RainCurrent = 0;
+float RainTarget = 0;
+float RainCurrent = 0.f;
 
 static  int RainSpeed = 30;
 static  int RainAngle = 0;
@@ -40,7 +40,7 @@ void CreateBonfire(vec3_t Position, vec3_t Angle)
     vec3_t Light;
     Vector(1.f, 1.f, 1.f, Light);
     CreateParticle(BITMAP_FIRE, Position, Angle, Light, rand() % 4);
-    if (rand() % 4 == 0)
+    if (rand_fps_check(4))
     {
         CreateParticle(BITMAP_SPARK, Position, Angle, Light);
         vec3_t a;
@@ -70,16 +70,16 @@ void CreateFire(int Type, OBJECT* o, float x, float y, float z)
     case 0:
         Luminosity = (float)(rand() % 6 + 6) * 0.1f;
         Vector(Luminosity, Luminosity * 0.6f, Luminosity * 0.4f, Light);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, rand() % 4);
         AddTerrainLight(Position[0], Position[1], Light, 4, PrimaryTerrainLight);
         break;
     case 1:
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light);
         break;
     case 2:
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light, 2);
         break;
     }
@@ -142,7 +142,7 @@ bool CreateDevilSquareRain(PARTICLE* o, int Index)
             o->Position);
     }
 
-    if (rand() % 2 == 0)
+    if (rand_fps_check(2))
     {
         Vector((float)(-(rand() % 20 + 20)), 0.f, 0.f, o->Angle);
     }
@@ -183,7 +183,7 @@ bool CreateChaosCastleRain(PARTICLE* o, int Index)
             Hero->Object.Position[2] + (float)(rand() % 200 + 300),
             o->Position);
     }
-    if (rand() % 2 == 0)
+    if (rand_fps_check(2))
     {
         Vector((float)(-(rand() % 20 + 20)), 0.f, 0.f, o->Angle);
     }
@@ -236,9 +236,9 @@ bool CreateHeavenRain(PARTICLE* o, int index)
     {
         o->Type = BITMAP_RAIN;
         Vector(
-            Hero->Object.Position[0] + (float)(rand() % 1600 - 800) * FPS_ANIMATION_FACTOR,
-            Hero->Object.Position[1] + (float)(rand() % 1400 - 500) * FPS_ANIMATION_FACTOR,
-            Hero->Object.Position[2] + (float)(rand() % 200 + 200) * FPS_ANIMATION_FACTOR,
+            Hero->Object.Position[0] + (float)(rand() % 1600 - 800),
+            Hero->Object.Position[1] + (float)(rand() % 1400 - 500),
+            Hero->Object.Position[2] + (float)(rand() % 200 + 200),
             o->Position);
         Vector(-30.f, 0.f, 0.f, o->Angle);
         vec3_t Velocity;
@@ -256,14 +256,14 @@ bool CreateDeviasSnow(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     o->Scale = 5.f;
-    if (rand() % 10 == 0)
+    if (rand_fps_check(10))
     {
         o->Type = BITMAP_LEAF2;
         o->Scale = 10.f;
     }
-    Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800) * FPS_ANIMATION_FACTOR,
-        Hero->Object.Position[1] + (float)(rand() % 1400 - 500) * FPS_ANIMATION_FACTOR,
-        Hero->Object.Position[2] + (float)(rand() % 200 + 200) * FPS_ANIMATION_FACTOR,
+    Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800),
+        Hero->Object.Position[1] + (float)(rand() % 1400 - 500),
+        Hero->Object.Position[2] + (float)(rand() % 200 + 200),
         o->Position);
     Vector(-30.f, 0.f, 0.f, o->Angle);
     vec3_t Velocity;
@@ -281,9 +281,9 @@ bool CreateAtlanseLeaf(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     vec3_t Position;
-    Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800) * FPS_ANIMATION_FACTOR,
-        Hero->Object.Position[1] + (float)(rand() % 1400 - 500) * FPS_ANIMATION_FACTOR,
-        Hero->Object.Position[2] + (float)(rand() % 300 + 50) * FPS_ANIMATION_FACTOR,
+    Vector(Hero->Object.Position[0] + (float)(rand() % 1600 - 800),
+        Hero->Object.Position[1] + (float)(rand() % 1400 - 500),
+        Hero->Object.Position[2] + (float)(rand() % 300 + 50),
         Position);
     VectorCopy(Position, o->Position);
     VectorCopy(Position, o->StartPosition);
@@ -314,7 +314,7 @@ bool MoveDevilSquareRain(PARTICLE* o)
     {
         o->Live = false;
         o->Position[2] = Height + 10.f;
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
             CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light);
         else
             CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light);
@@ -332,7 +332,7 @@ bool MoveChaosCastleRain(PARTICLE* o)
     {
         o->Live = false;
         o->Position[2] = Height + 10.f;
-        if (rand() % 4 == 0)
+        if (rand_fps_check(4))
             CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light);
         else
             CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light);
@@ -358,14 +358,14 @@ bool MoveHeavenRain(PARTICLE* o)
     }
     else
     {
-        o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f;
-        o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f;
-        o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f;
+        o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         VectorAdd(o->Position, o->Velocity, o->Position);
 
-        o->TurningForce[0] += (float)(rand() % 8 - 4) * 0.02f;
-        o->TurningForce[1] += (float)(rand() % 16 - 8) * 0.02f;
-        o->TurningForce[2] += (float)(rand() % 8 - 4) * 0.02f;
+        o->TurningForce[0] += (float)(rand() % 8 - 4) * 0.02f * FPS_ANIMATION_FACTOR;
+        o->TurningForce[1] += (float)(rand() % 16 - 8) * 0.02f * FPS_ANIMATION_FACTOR;
+        o->TurningForce[2] += (float)(rand() % 8 - 4) * 0.02f * FPS_ANIMATION_FACTOR;
         VectorAdd(o->Angle, o->TurningForce, o->Angle);
 
         vec3_t Range;
@@ -383,17 +383,17 @@ void MoveEtcLeaf(PARTICLE* o)
     if (o->Position[2] <= Height)
     {
         o->Position[2] = Height;
-        o->Light[0] -= 0.05f;
-        o->Light[1] -= 0.05f;
-        o->Light[2] -= 0.05f;
+        o->Light[0] -= 0.05f * FPS_ANIMATION_FACTOR;
+        o->Light[1] -= 0.05f * FPS_ANIMATION_FACTOR;
+        o->Light[2] -= 0.05f * FPS_ANIMATION_FACTOR;
         if (o->Light[0] <= 0.f)
             o->Live = false;
     }
     else
     {
-        o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f;
-        o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f;
-        o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f;
+        o->Velocity[0] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[1] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[2] += (float)(rand() % 16 - 8) * 0.1f * FPS_ANIMATION_FACTOR;
         VectorAdd(o->Position, o->Velocity, o->Position);
     }
 }
@@ -428,13 +428,13 @@ bool MoveLeaves()
                 iMaxLeaves = 50;
     }
     if (RainCurrent > RainTarget)
-        RainCurrent--;
+        RainCurrent -= FPS_ANIMATION_FACTOR;
     else if (RainCurrent < RainTarget)
-        RainCurrent++;
+        RainCurrent += FPS_ANIMATION_FACTOR;
 
     RainSpeed = ((int)sinf(WorldTime * 0.001f) * 10 + 30) * FPS_ANIMATION_FACTOR;
     RainAngle = (int)sinf(WorldTime * 0.0005f + 50.f) * 20 * FPS_ANIMATION_FACTOR;
-    RainPosition += 20;
+    RainPosition += 20 * FPS_ANIMATION_FACTOR;
     RainPosition %= 2000;
 
     for (int i = 0; i < iMaxLeaves; i++)

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -662,7 +662,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                             Position[0] = o->StartPosition[0];// + rand()%8-4;
                             Position[1] = o->StartPosition[1];// + rand()%8-4;
                         }
-                        VectorAdd(o->Position, Position, o->Position);
+                        VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                         CreateTail(o, Matrix);
                         o->Position[0] -= Position[0];
                         o->Position[0] += o->StartPosition[0];
@@ -1163,7 +1163,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                             Position[0] = o->StartPosition[0] + rand() % 16 - 8;
                             Position[1] = o->StartPosition[1] + rand() % 16 - 8;
                         }
-                        VectorAdd(o->Position, Position, o->Position);
+                        VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                         CreateTail(o, Matrix);
                         o->Position[0] -= Position[0];
                         o->Position[0] += o->StartPosition[0];
@@ -1213,7 +1213,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                             Position[0] = o->StartPosition[0];
                             Position[1] = o->StartPosition[1];
                         }
-                        VectorAdd(o->Position, Position, o->Position);
+                        VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                         CreateTail(o, Matrix);
                         o->Position[0] -= Position[0];
                         o->Position[0] += o->StartPosition[0];
@@ -1241,7 +1241,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                         if (Distance <= 400 && to->Live && tc->Dead == 0 && to->Kind == KIND_MONSTER && to->Visible && to != Target)
                         {
                             o->TargetIndex[(int)o->MultiUse] = j;
-                            o->MultiUse++;
+                            o->MultiUse += FPS_ANIMATION_FACTOR;
                         }
 
                         if (o->MultiUse > 5) break;
@@ -1446,7 +1446,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                     VectorRotate(p1, Matrix, p2);
 
                     Vector(p2[0] * o->Scale / 2.0f, p2[1] * o->Scale / 2.0f, p2[2] * o->Scale / 2.0f, p2);
-                    VectorAdd(o->Position, p2, o->Position);
+                    VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
                     VectorCopy(o->Position, o->StartPosition);
 
                     int iScale = 1;
@@ -1788,7 +1788,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                     o->Direction[1] = -15.f;
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(o->Direction, Matrix, Position);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                     VectorCopy(o->Position, o->StartPosition);
                     o->Direction[1] = -50.f;
                     o->m_bCreateTails = false;
@@ -1815,7 +1815,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                     AngleMatrix(o->Angle, Matrix);
                     Vector(0.f, 100, 0.f, p);
                     VectorRotate(p, Matrix, Position);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
                     CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 8 + 8) * 0.3f, o->Light, NULL, (float)(rand() % 360));
 
@@ -2242,7 +2242,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
 
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(p, Matrix, Position);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                     //					Vector(0.f,1.f,0.f,o->Light);
                 }
                 else if (o->SubType == 1)
@@ -2344,7 +2344,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
 
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(p, Matrix, Position);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                     //					Vector(1.f,1.f,1.f,o->Light);
                 }
                 else if (o->SubType == 20)	// SubType : 7
@@ -2444,7 +2444,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 o->Scale = Scale;
                 o->MultiUse = 1;
                 o->Velocity = -3.f;
-                o->Position[2] += 150.f;
+                o->Position[2] += 150.f * FPS_ANIMATION_FACTOR;
                 Vector(0.f, 0.f, 0.f, o->Direction);
                 Vector(0.f, 0.f, 0.f, o->TargetPosition);
                 Vector(1.f, 0.8f, 1.f, o->Light);
@@ -2788,55 +2788,9 @@ void CreateTailAxis(JOINT* o, float Matrix[3][4], BYTE axis)
     }
 }
 
-void CreateTailAxis(JOINT* o, float Matrix[3][4], float ScaleX, float ScaleY, BYTE axis)
-{
-    o->NumTails++;
-    if (o->NumTails > o->MaxTails - 1)
-    {
-        o->NumTails = o->MaxTails - 1;
-    }
-
-    for (int j = o->NumTails - 1; j >= 0; j--)
-    {
-        for (int k = 0; k < 4; k++)
-            VectorCopy(o->Tails[j][k], o->Tails[j + 1][k]);
-    }
-
-    vec3_t Position, p;
-    if (axis == 0)
-    {
-        Vector(-ScaleX * 0.5f, 0.f, 0.f, Position);
-        VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][0]);
-        Vector(ScaleX * 0.5f, 0.f, 0.f, Position);
-        VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][1]);
-        Vector(0.f, 0.f, -ScaleY * 0.5f, Position);
-        VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][2]);
-        Vector(0.f, 0.f, ScaleY * 0.5f, Position);
-        VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][3]);
-    }
-    else
-    {
-        Vector(-ScaleX * 0.5f, 0.f, 0.f, Position);
-        VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][0]);
-        Vector(ScaleX * 0.5f, 0.f, 0.f, Position);
-        VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][1]);
-        Vector(0.f, -ScaleY * 0.5f, 0.f, Position);
-        VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][2]);
-        Vector(0.f, ScaleY * 0.5f, 0.f, Position);
-        VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][3]);
-    }
-}
-
 void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
 {
+    //return; // TODO
     if (Blur == true)
     {
         int i = 0;
@@ -2859,12 +2813,14 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
                 vec3_t Position, p;
                 Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
+                // VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
                 VectorAdd(o->Position, p, o->Tails[0][0]);
                 o->Tails[0][0][0] = (o->Tails[0][0][0] + o->Tails[1][0][0]) / 2.f;
                 o->Tails[0][0][1] = (o->Tails[0][0][1] + o->Tails[1][0][1]) / 2.f;
                 o->Tails[0][0][2] = (o->Tails[0][0][2] + o->Tails[1][0][2]) / 2.f;
                 Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
+                // VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
                 VectorAdd(o->Position, p, o->Tails[0][1]);
                 o->Tails[0][1][0] = (o->Tails[0][1][0] + o->Tails[1][1][0]) / 2.f;
                 o->Tails[0][1][1] = (o->Tails[0][1][1] + o->Tails[1][1][1]) / 2.f;
@@ -2872,12 +2828,14 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
                 Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][2]);
+                //VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
                 o->Tails[0][2][0] = (o->Tails[0][2][0] + o->Tails[1][2][0]) / 2.f;
                 o->Tails[0][2][1] = (o->Tails[0][2][1] + o->Tails[1][2][1]) / 2.f;
                 o->Tails[0][2][2] = (o->Tails[0][2][2] + o->Tails[1][2][2]) / 2.f;
                 Vector(0.f, 0.f, o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][3]);
+                //VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
                 o->Tails[0][3][0] = (o->Tails[0][3][0] + o->Tails[1][3][0]) / 2.f;
                 o->Tails[0][3][1] = (o->Tails[0][3][1] + o->Tails[1][3][1]) / 2.f;
                 o->Tails[0][3][2] = (o->Tails[0][3][2] + o->Tails[1][3][2]) / 2.f;
@@ -2888,15 +2846,19 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
                 Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][0]);
+                //VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
                 Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][1]);
+                //VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
                 Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][2]);
+                //VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
                 Vector(0.f, 0.f, o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][3]);
+                //VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
             }
         }
     }
@@ -2918,46 +2880,22 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
         Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Tails[0][0]);
+        //VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
         Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Tails[0][1]);
+        //VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
         Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Tails[0][2]);
+        //VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
         Vector(0.f, 0.f, o->Scale * 0.5f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Tails[0][3]);
+        //VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
     }
 }
 
-void CreateTail(JOINT* o, float Matrix[3][4], float ScaleX, float ScaleY)
-{
-    o->NumTails++;
-    if (o->NumTails > o->MaxTails - 1)
-    {
-        o->NumTails = o->MaxTails - 1;
-    }
-
-    for (int j = o->NumTails - 1; j >= 0; j--)
-    {
-        for (int k = 0; k < 4; k++)
-            VectorCopy(o->Tails[j][k], o->Tails[j + 1][k]);
-    }
-
-    vec3_t Position, p;
-    Vector(-ScaleX * 0.5f, 0.f, 0.f, Position);
-    VectorRotate(Position, Matrix, p);
-    VectorAdd(o->Position, p, o->Tails[0][0]);
-    Vector(ScaleX * 0.5f, 0.f, 0.f, Position);
-    VectorRotate(Position, Matrix, p);
-    VectorAdd(o->Position, p, o->Tails[0][1]);
-    Vector(0.f, 0.f, -ScaleY * 0.5f, Position);
-    VectorRotate(Position, Matrix, p);
-    VectorAdd(o->Position, p, o->Tails[0][2]);
-    Vector(0.f, 0.f, ScaleY * 0.5f, Position);
-    VectorRotate(Position, Matrix, p);
-    VectorAdd(o->Position, p, o->Tails[0][3]);
-}
 
 /*void MoveShpere(vec3_t Position,vec3_t Angle)
 {
@@ -3000,9 +2938,9 @@ void MoveJoint(JOINT* o, int iIndex)
         AngleMatrix(o->Angle, Matrix);
         if (o->Velocity != 0.0f)
         {
-            Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
+            Vector(0.f, -o->Velocity, 0.f, p);
             VectorRotate(p, Matrix, Position);
-            VectorAdd(o->Position, Position, o->Position);
+            VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
         }
     }
 
@@ -3010,7 +2948,7 @@ void MoveJoint(JOINT* o, int iIndex)
     {
     case BITMAP_JOINT_LASER:
         VectorCopy(o->Target->Position, o->TargetPosition);
-        o->TargetPosition[2] += 130.f * FPS_ANIMATION_FACTOR;
+        o->TargetPosition[2] += 130.f;
 
         Distance = sqrtf(dx * dx + dy * dy);
         MoveHumming(o->Position, o->Angle, o->TargetPosition, 3000.f / Distance);
@@ -3254,7 +3192,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->Angle[2] += (10.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += (6.f) * FPS_ANIMATION_FACTOR;
                     //VectorCopy(o->Target->Position, o->TargetPosition);
-                    //o->TargetPosition[2] += (120.f) * FPS_ANIMATION_FACTOR;
+                    //o->TargetPosition[2] += (120.f);
                     //Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
                 else if (o->SubType == 12)
@@ -3301,7 +3239,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     if (o->Velocity >= 20.f) o->Velocity = 20.f;
 
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += (120.f) * FPS_ANIMATION_FACTOR;
+                    o->TargetPosition[2] += 120.f;
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
                 else
@@ -3352,13 +3290,13 @@ void MoveJoint(JOINT* o, int iIndex)
                 else if (o->SubType == 44)
                 {
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += (120.f) * FPS_ANIMATION_FACTOR;
+                    o->TargetPosition[2] += 120.f;
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
                 else
                 {
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += (120.f) * FPS_ANIMATION_FACTOR;
+                    o->TargetPosition[2] += 120.f;
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
                 if (Distance <= 35.f)
@@ -3433,7 +3371,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             float fOldAngle = o->Angle[2];
             VectorCopy(o->Target->Position, o->TargetPosition);
-            o->TargetPosition[2] += (260.f) * FPS_ANIMATION_FACTOR;
+            o->TargetPosition[2] += 260.f;
             Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
 
             if (Distance <= 35.f)
@@ -3463,7 +3401,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
 
             VectorCopy(o->Target->Position, o->TargetPosition);
-            o->TargetPosition[2] += (100.f) * FPS_ANIMATION_FACTOR;
+            o->TargetPosition[2] += 100.f;
             float TargetAngle;
             TargetAngle = CreateAngle2D(o->Position, o->TargetPosition);
             o->Angle[2] = TargetAngle;
@@ -3546,10 +3484,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 50)
             {
-                float divisor = 1.0f + (0.1f * FPS_ANIMATION_FACTOR);
-                o->Light[0] /= divisor;
-                o->Light[1] /= divisor;
-                o->Light[2] /= divisor;
+                VectorScale(o->Light, pow(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
             }
             else if (o->LifeTime > 80)
             {
@@ -3589,9 +3524,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 40)
             {
-                o->Light[0] /= 1.1f;
-                o->Light[1] /= 1.1f;
-                o->Light[2] /= 1.1f;
+                VectorScale(o->Light, pow(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
             }
             else if (o->LifeTime > 68)
             {
@@ -3616,9 +3549,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             MoveHumming(o->Position, o->Angle, p, 10.f);
 
-            o->Light[0] /= 1.08f;
-            o->Light[1] /= 1.08f;
-            o->Light[2] /= 1.08f;
+            VectorScale(o->Light, pow(1.f / 1.08f, FPS_ANIMATION_FACTOR), o->Light);
 
             CreateSprite(BITMAP_SHINY + 1, p, (float)(rand() % 4 + 4) * 0.2f, o->Light, o->Target, (float)(rand() % 360));
         }
@@ -3630,9 +3561,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             MoveHumming(o->Position, o->Angle, p, 10.f);
 
-            o->Light[0] /= 1.08f;
-            o->Light[1] /= 1.08f;
-            o->Light[2] /= 1.08f;
+            VectorScale(o->Light, pow(1.f / 1.08f, FPS_ANIMATION_FACTOR), o->Light);
 
             CreateSprite(BITMAP_SHINY + 1, p, (float)(rand() % 4 + 4) * 0.2f, o->Light, o->Target, (float)(rand() % 360), 1);
         }
@@ -3663,9 +3592,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     }
                     else if (o->LifeTime < 6)
                     {
-                        o->Light[0] /= 1.8f;
-                        o->Light[1] /= 1.8f;
-                        o->Light[2] /= 1.8f;
+                        VectorScale(o->Light, pow(1.f / 1.8f, FPS_ANIMATION_FACTOR), o->Light);
                     }
 
                     if (o->SubType == 13)
@@ -3770,7 +3697,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     if ((att & TW_NOATTACKZONE) == TW_NOATTACKZONE)
                     {
                         o->Velocity = 0.f;
-                        o->LifeTime /= 5.f;
+                        o->LifeTime *= pow(1.f / 5.f, FPS_ANIMATION_FACTOR);
                         break;
                     }
                 }
@@ -3788,7 +3715,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 CreateEffect(MODEL_SKULL, o->Position, o->Angle, o->Light);
             }
             VectorCopy(o->Target->Position, o->TargetPosition);
-            o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
+            o->TargetPosition[2] += 80.f;
 
             Distance = sqrtf(dx * dx + dy * dy);
             if (o->SubType == 5)
@@ -3884,9 +3811,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 if (o->LifeTime < 10)
                 {
-                    o->Light[0] /= 1.2f;
-                    o->Light[1] /= 1.2f;
-                    o->Light[2] /= 1.2f;
+                    VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
                     VectorCopy(o->Light, Light);
                 }
                 if (o->SubType == 13)
@@ -3928,9 +3853,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 10)
             {
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
                 VectorCopy(o->Light, Light);
             }
             else if (o->LifeTime > 18 && o->LifeTime < 20 && (o->SubType == 2 || o->SubType == 21))
@@ -3984,9 +3907,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 10)
             {
-                o->Light[0] /= 1.15f;
-                o->Light[1] /= 1.15f;
-                o->Light[2] /= 1.15f;
+                VectorScale(o->Light, pow(1.f / 1.15f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 11)
@@ -4185,9 +4106,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime < 10)
             {
-                o->Light[0] /= 1.45f;
-                o->Light[1] /= 1.45f;
-                o->Light[2] /= 1.45f;
+                VectorScale(o->Light, pow(1.f / 1.45f, FPS_ANIMATION_FACTOR), o->Light);
 
                 if (o->Light[0] < 0.2f)
                     o->Live = false;
@@ -4215,21 +4134,21 @@ void MoveJoint(JOINT* o, int iIndex)
         if (o->SubType == 1)
         {
             o->Velocity += FPS_ANIMATION_FACTOR * 0.3f;
-            o->Light[0] /= 1.4f;
+            o->Light[0] *= pow(1.f / 1.4f, FPS_ANIMATION_FACTOR);
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
         else if (o->SubType == 3)
         {
             o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
-            o->Light[0] /= 1.1f;
+            o->Light[0] *= pow(1.f / 1.1f, FPS_ANIMATION_FACTOR);
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
         else if (o->SubType == 4)
         {
             o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
-            o->Light[0] /= 1.1f;
+            o->Light[0] *= pow(1.f / 1.1f, FPS_ANIMATION_FACTOR);
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
@@ -4255,7 +4174,7 @@ void MoveJoint(JOINT* o, int iIndex)
         AddTerrainLight(o->Position[0], o->Position[1], Light, 4, PrimaryTerrainLight);
         Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
         VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Position);
+        VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
         break;
     case MODEL_SPEARSKILL:	// ¹æ¾î¸·
         CHARACTER* c;
@@ -4395,12 +4314,12 @@ void MoveJoint(JOINT* o, int iIndex)
                     }
                 }
             }
+
             if (o->LifeTime < 10)
             {
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
+
             o->Scale -= (5.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 8)
@@ -4497,7 +4416,7 @@ void MoveJoint(JOINT* o, int iIndex)
             else
             {
                 VectorCopy(o->Target->Position, o->TargetPosition);
-                o->TargetPosition[2] += (10.f) * FPS_ANIMATION_FACTOR;
+                o->TargetPosition[2] += 10.f;
             }
 
             if (0 == o->SubType || o->SubType == 4 || o->SubType == 9
@@ -4520,9 +4439,9 @@ void MoveJoint(JOINT* o, int iIndex)
             float fSpeed[3] = { 0.048f, 0.0613f, 0.1113f };
             if (o->SubType == 1)
             {
-                fSpeed[0] *= pow(0.5f, FPS_ANIMATION_FACTOR);
-                fSpeed[1] *= pow(0.5f, FPS_ANIMATION_FACTOR);
-                fSpeed[2] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                fSpeed[0] *= 0.5f;
+                fSpeed[1] *= 0.5f;
+                fSpeed[2] *= 0.5f;
             }
             vDirTemp[0] = sinf((float)(iFrame + 55555) * fSpeed[0]) * cosf((float)iFrame * fSpeed[1]);
             vDirTemp[1] = sinf((float)(iFrame + 55555) * fSpeed[0]) * sinf((float)iFrame * fSpeed[1]);
@@ -4533,6 +4452,7 @@ void MoveJoint(JOINT* o, int iIndex)
             vDir[2] = vDirTemp[0];
             vDir[1] = fSinAdd * vDirTemp[1] + fCosAdd * vDirTemp[2];
             vDir[0] = fCosAdd * vDirTemp[1] - fSinAdd * vDirTemp[2];
+            // VectorScale(vDir, FPS_ANIMATION_FACTOR, vDir);
 
             switch (o->SubType)
             {
@@ -4637,7 +4557,7 @@ void MoveJoint(JOINT* o, int iIndex)
             if (o->Target)
             {
                 VectorCopy(o->Target->Position, o->TargetPosition);
-                o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
+                o->TargetPosition[2] += 80.f;
             }
 
             Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 50.f);
@@ -4676,7 +4596,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
             VectorRotate(Position, Matrix, p);
-            VectorAdd(o->Position, p, o->Position);
+            VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
         }
         break;
     case BITMAP_BLUR + 1:
@@ -4691,7 +4611,7 @@ void MoveJoint(JOINT* o, int iIndex)
             else
             {
                 VectorCopy(o->Target->Position, o->TargetPosition);
-                o->TargetPosition[2] += 80.f * FPS_ANIMATION_FACTOR;
+                o->TargetPosition[2] += 80.f;
             }
 
             Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 25.f * FPS_ANIMATION_FACTOR);
@@ -4744,7 +4664,7 @@ void MoveJoint(JOINT* o, int iIndex)
             Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
             VectorRotate(Position, Matrix, p);
             VectorScale(p, FPS_ANIMATION_FACTOR, p)
-            VectorAdd(o->Position, p, o->Position);
+            VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
         }
         break;
     case BITMAP_JOINT_THUNDER:
@@ -4794,7 +4714,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (o->Target)
                 {
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
+                    o->TargetPosition[2] += 80.f;
                 }
 
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 50.f);
@@ -4850,7 +4770,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 25.f + o->Scale);
                 break;
             case 20:
-                o->TargetPosition[2] += (100.f) * FPS_ANIMATION_FACTOR;
+                o->TargetPosition[2] += 100.f;
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 100.f);
                 break;
                 // ChainLighting
@@ -4892,7 +4812,7 @@ void MoveJoint(JOINT* o, int iIndex)
                         VectorCopy(vPos, o->Position);
                         VectorCopy(pTargetObj->Position, o->TargetPosition);
 
-                        o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
+                        o->TargetPosition[2] += 80.f;
                     }
 
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
@@ -4908,7 +4828,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (o->Target)
                 {
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
+                    o->TargetPosition[2] += 80.f;
                 }
 
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 40.f);
@@ -5027,7 +4947,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
             VectorRotate(Position, Matrix, p);
-            VectorAdd(o->Position, p, o->Position);
+            VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
         }
         if (o->SubType == 7 || o->SubType == 18)
         {
@@ -5055,7 +4975,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     {
                         VectorCopy(to->Position, o->TargetPosition);
                         VectorCopy(o->Angle, Angle);
-                        o->TargetPosition[2] += (100.f) * FPS_ANIMATION_FACTOR;
+                        o->TargetPosition[2] += 100.f;
                         Angle[2] = CreateAngle2D(o->Position, o->TargetPosition);
 
                         CreateJoint(BITMAP_JOINT_THUNDER, Position, o->TargetPosition, Angle, 0, NULL, 50.f);
@@ -5069,7 +4989,7 @@ void MoveJoint(JOINT* o, int iIndex)
             if (o->MultiUse < o->Weapon)
             {
                 if (((int)o->LifeTime % 2) == 0)
-                    o->MultiUse++;
+                    o->MultiUse+=FPS_ANIMATION_FACTOR;
             }
         }
         break;
@@ -5102,7 +5022,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     vec3_t vTempPos;
                     VectorCopy(p, vTempPos);
                     VectorRotate(vTempPos, Matrix, p);
-                    VectorAdd(o->Position, p, o->Position);
+                    VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
                 }
             }
             else
@@ -5144,7 +5064,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             for (int i = o->MaxTails - 5; i < o->MaxTails - 1; ++i)
             {
-                VectorAdd(o->Position, Position, o->Position);
+                VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                 o->Position[0] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 o->Position[1] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
@@ -5154,9 +5074,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 4)
             {
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
 
             if (o->SubType == 2)
@@ -5192,7 +5110,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 for (int i = 0; i < o->TargetIndex[0]; ++i)
                 {
                     CreateTail(o, Matrix);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                     o->Position[0] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                     o->Position[1] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
@@ -5205,7 +5123,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 for (int i = o->TargetIndex[0]; i < o->TargetIndex[1]; ++i)
                 {
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                     CreateTail(o, Matrix);
                 }
                 VectorCopy(o->TargetPosition, o->Position);
@@ -5215,9 +5133,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 CreateSprite(BITMAP_SHINY + 1, o->TargetPosition, 1.5f, o->Light, NULL, (float)((rand() % 360)));
                 if (o->LifeTime < 8)
                 {
-                    o->Light[0] /= 1.4f;
-                    o->Light[1] /= 1.4f;
-                    o->Light[2] /= 1.4f;
+                    VectorScale(o->Light, pow(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
                 }
             }
             else
@@ -5241,7 +5157,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             for (int i = o->MaxTails - 5; i < o->MaxTails - 1; ++i)
             {
-                VectorAdd(o->Position, Position, o->Position);
+                VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                 o->Position[0] += (rand() % 10 - 5) * FPS_ANIMATION_FACTOR;
                 o->Position[1] += (rand() % 10 - 5) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
@@ -5251,9 +5167,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 4)
             {
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 9)
@@ -5270,7 +5184,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             for (int i = o->MaxTails - 5; i < o->MaxTails - 1; ++i)
             {
-                VectorAdd(o->Position, Position, o->Position);
+                VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                 o->Position[1] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 o->Position[2] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
@@ -5280,9 +5194,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 4)
             {
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 10)
@@ -5299,7 +5211,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             for (int i = o->MaxTails - 5; i < o->MaxTails - 1; ++i)
             {
-                VectorAdd(o->Position, Position, o->Position);
+                VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                 o->Position[0] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 o->Position[2] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
@@ -5309,9 +5221,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 4)
             {
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 11)
@@ -5324,7 +5234,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             for (int i = 0; i < o->MaxTails - 5; i++)
             {
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
                 CreateTail(o, Matrix);
                 VectorCopy(o->Position, o->TargetPosition);
             }
@@ -5333,7 +5243,7 @@ void MoveJoint(JOINT* o, int iIndex)
             for (int i = 0; i < o->MaxTails - 5; i++)
             {
                 int iScale = 1;
-                VectorAdd(o->Position, p2, o->Position);
+                VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
                 iScale = (int)(o->Scale / 8.0f);
                 o->Position[0] += (rand() % (iScale * 2) - iScale) * FPS_ANIMATION_FACTOR;
                 o->Position[1] += (rand() % (iScale * 2) - iScale) * FPS_ANIMATION_FACTOR;
@@ -5357,7 +5267,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 CreateTail(o, Matrix);
                 VectorSubtract(o->TargetPosition, o->Position, Position);
                 VectorScale(Position, 0.08f, Position);
-                VectorAdd(o->Position, Position, o->Position);
+                VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
             }
             VectorCopy(o->TargetPosition, o->Position);
             CreateTail(o, Matrix);
@@ -5387,7 +5297,7 @@ void MoveJoint(JOINT* o, int iIndex)
         if (o->SubType == 1)
         {
             o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
-            o->Light[0] /= 1.1f;
+            o->Light[0] *= pow(1.f / 1.1f, FPS_ANIMATION_FACTOR);
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
@@ -5395,9 +5305,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 5)
             {
-                o->Light[0] /= 1.3f;
-                o->Light[1] /= 1.3f;
-                o->Light[2] /= 1.3f;
+                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         break;
     case BITMAP_FLARE:
@@ -5518,9 +5426,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
                 o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
-                o->Light[0] /= 1.1f;
-                o->Light[1] /= 1.1f;
-                o->Light[2] /= 1.1f;
+                VectorScale(o->Light, pow(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
             }
             AddTerrainLight(o->Position[0], o->Position[1], o->Light, 1, PrimaryTerrainLight);
         }
@@ -5657,9 +5563,9 @@ void MoveJoint(JOINT* o, int iIndex)
             float fSpeed[3] = { 0.048f, 0.0613f, 0.1113f };
             if (o->SubType == 11)
             {
-                fSpeed[0] *= pow(1.5f, FPS_ANIMATION_FACTOR);
-                fSpeed[1] *= pow(1.5f, FPS_ANIMATION_FACTOR);
-                fSpeed[2] *= pow(1.5f, FPS_ANIMATION_FACTOR);
+                fSpeed[0] *= 1.5f;
+                fSpeed[1] *= 1.5f;
+                fSpeed[2] *= 1.5f;
             }
             vDirTemp[0] = sinf((float)(iFrame + 55555) * fSpeed[0]) * cosf((float)iFrame * fSpeed[1]);
             vDirTemp[1] = sinf((float)(iFrame + 55555) * fSpeed[0]) * sinf((float)iFrame * fSpeed[1]);
@@ -5670,6 +5576,8 @@ void MoveJoint(JOINT* o, int iIndex)
             vDir[2] = vDirTemp[0];
             vDir[1] = fSinAdd * vDirTemp[1] + fCosAdd * vDirTemp[2];
             vDir[0] = fCosAdd * vDirTemp[1] - fSinAdd * vDirTemp[2];
+
+            // VectorScale(vDir, FPS_ANIMATION_FACTOR, vDir);
 
             float fLife = (float)o->LifeTime * 40.f / 30.f;
             float fPos;
@@ -5697,7 +5605,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
             }
             fPos = fPos / (float)(30 + o->MultiUse) * 30.f;
-            if (o->LifeTime == 30)
+            if ((int)o->LifeTime == 30)
             {
                 PlayBuffer(SOUND_METEORITE01);
             }
@@ -5728,7 +5636,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             if (o->SubType != 11 && o->SubType != 25)
             {
-                o->Position[2] += (100.0f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += 100.0f;
             }
 
             vec3_t Light = { .5f, .5f, 1.0f };
@@ -5765,7 +5673,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
             }
 
-            if (o->SubType != 11 && 1 == o->LifeTime && o->SubType != 45 && o->SubType != 46 && o->SubType != 47)
+            if (o->SubType != 11 && 1 == (int)o->LifeTime && o->SubType != 45 && o->SubType != 46 && o->SubType != 47)
             {
                 vec3_t Angle = { 0.0f, 0.0f, 0.0f };
                 vec3_t Light = { 1.f, 1.f, 1.f };
@@ -5780,7 +5688,7 @@ void MoveJoint(JOINT* o, int iIndex)
             VectorAdd(o->StartPosition, Position, o->Position);
             AngleMatrix(o->Angle, Matrix);
 
-            o->TargetPosition[2] += (10.f) * FPS_ANIMATION_FACTOR;
+            o->TargetPosition[2] += 10.f;
         }
         else if (o->SubType == 9)
         {
@@ -5822,9 +5730,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 12)
             {
-                o->Light[0] /= 1.3f;
-                o->Light[1] /= 1.3f;
-                o->Light[2] /= 1.3f;
+                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 16 && o->Target != NULL)
@@ -5840,9 +5746,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 20)
             {
-                o->Light[0] /= 1.1f;
-                o->Light[1] /= 1.1f;
-                o->Light[2] /= 1.1f;
+                VectorScale(o->Light, pow(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
             }
             else if (o->LifeTime < 40)
             {
@@ -5940,9 +5844,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->Position[0] = o->TargetPosition[0];
                     o->Position[1] = o->TargetPosition[1];
                     o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    VectorScale(o->Light, pow(1.f / 1.05f, FPS_ANIMATION_FACTOR), o->Light);
 
                     CreateSprite(BITMAP_PIN_LIGHT, o->Position, 1.5f, o->Light, NULL);
                     CreateSprite(BITMAP_PIN_LIGHT, o->Position, 0.5f, o->Light, NULL);
@@ -5959,9 +5861,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime < 10)
             {
-                o->Light[0] /= 1.3f;
-                o->Light[1] /= 1.3f;
-                o->Light[2] /= 1.3f;
+                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
 
@@ -6003,7 +5903,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 10)
                 {
-                    o->Light[0] /= 1.2f;
+                    o->Light[0] *= pow(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
                 }
@@ -6038,7 +5938,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 10)
                 {
-                    o->Light[0] /= 1.2f;
+                    o->Light[0] *= pow(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
                 }
@@ -6078,7 +5978,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 15)
                 {
-                    o->Light[0] /= 1.2f;
+                    o->Light[0] *= pow(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
                 }
@@ -6101,9 +6001,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 15)
             {
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 8 || o->SubType == 9)
@@ -6157,9 +6055,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 15)
                 {
-                    o->Light[0] /= 1.2f;
-                    o->Light[1] /= 1.2f;
-                    o->Light[2] /= 1.2f;
+                    VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
                 }
 
                 if (o->SubType != 18)
@@ -6185,7 +6081,9 @@ void MoveJoint(JOINT* o, int iIndex)
             //VectorCopy( o->Target->HeadAngle, Angle );
             AngleMatrix(o->Angle, Mat);
 
-            pos[0] /= 3.f; pos[1] /= 3.f; pos[2] /= 3.f;
+            pos[0] /= 3.f;
+            pos[1] /= 3.f;
+            pos[2] /= 3.f;
             //Angle[1] += (o->Velocity - 90) * FPS_ANIMATION_FACTOR;
 
             for (int j = 0; j < 3; j++)
@@ -6214,7 +6112,9 @@ void MoveJoint(JOINT* o, int iIndex)
             //VectorCopy( o->Target->HeadAngle, Angle );
             AngleMatrix(o->Angle, Mat);
 
-            pos[0] /= 3.f; pos[1] /= 3.f; pos[2] /= 3.f;
+            pos[0] /= 3.f;
+            pos[1] /= 3.f;
+            pos[2] /= 3.f;
             //Angle[1] += (o->Velocity - 90) * FPS_ANIMATION_FACTOR;
 
             for (int j = 0; j < 3; j++)
@@ -6261,9 +6161,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 15)
                 {
-                    o->Light[0] /= 1.5f;//o->LifeTime/60.f;
-                    o->Light[1] /= 1.5f;
-                    o->Light[2] /= 1.5f;
+                    VectorScale(o->Light, pow(1.f / 1.5f, FPS_ANIMATION_FACTOR), o->Light);
                 }
             }
             else
@@ -6322,7 +6220,7 @@ void MoveJoint(JOINT* o, int iIndex)
                                 if ((att & TW_NOATTACKZONE) == TW_NOATTACKZONE)
                                 {
                                     o->Velocity = 0.f;
-                                    o->LifeTime /= 5.f;
+                                    o->LifeTime *= pow(1.f / 5.f, FPS_ANIMATION_FACTOR);
                                     break;
                                 }
                             }
@@ -6394,7 +6292,7 @@ void MoveJoint(JOINT* o, int iIndex)
                                     if ((att & TW_NOATTACKZONE) == TW_NOATTACKZONE)
                                     {
                                         o->Velocity = 0.f;
-                                        o->LifeTime /= 5.f;
+                                        o->LifeTime *= pow(1.f / 5.f, FPS_ANIMATION_FACTOR);
                                         break;
                                     }
                                 }
@@ -6425,9 +6323,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 15)
                 {
-                    o->Light[0] /= 1.3f;
-                    o->Light[1] /= 1.3f;
-                    o->Light[2] /= 1.3f;
+                    VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
                 }
             }
             else if (o->SubType >= 2 && o->SubType <= 6)
@@ -6450,9 +6346,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 if (o->LifeTime < o->MultiUse)
                 {
-                    o->Light[0] /= 1.3f;
-                    o->Light[1] /= 1.3f;
-                    o->Light[2] /= 1.3f;
+                    VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
                 }
                 if ((int)o->LifeTime % 5 == 0 && o->SubType == 2)
                 {
@@ -6484,9 +6378,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 if (o->LifeTime < o->MultiUse)
                 {
-                    o->Light[0] /= 1.3f;
-                    o->Light[1] /= 1.3f;
-                    o->Light[2] /= 1.3f;
+                    VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
                 }
                 o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]) + 3.f;
             }
@@ -6528,9 +6420,8 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
             }
         }
-        o->Light[0] /= 1.2f;
-        o->Light[1] /= 1.2f;
-        o->Light[2] /= 1.2f;
+
+        VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
         break;
     case BITMAP_PIERCING:
         if (o->SubType == 0)
@@ -6545,14 +6436,12 @@ void MoveJoint(JOINT* o, int iIndex)
 
                     Vector(0.f, 0.f, -o->Velocity * FPS_ANIMATION_FACTOR, p);
                     VectorRotate(p, Matrix, Position);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                 }
             }
             o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
 
-            o->Light[0] /= 1.4f;
-            o->Light[1] /= 1.4f;
-            o->Light[2] /= 1.4f;
+            VectorScale(o->Light, pow(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
         }
         else if (o->SubType == 1)
         {
@@ -6566,14 +6455,12 @@ void MoveJoint(JOINT* o, int iIndex)
 
                     Vector(0.f, 0.f, -o->Velocity * FPS_ANIMATION_FACTOR, p);
                     VectorRotate(p, Matrix, Position);
-                    VectorAdd(o->Position, Position, o->Position);
+                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
                 }
             }
             o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
 
-            o->Light[0] /= 1.4f;
-            o->Light[1] /= 1.4f;
-            o->Light[2] /= 1.4f;
+            VectorScale(o->Light, pow(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
         }
         break;
     case BITMAP_FLARE_FORCE:
@@ -6583,7 +6470,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 vec3_t Direction, Angle;
 
-                Vector(0.f, 20.f * FPS_ANIMATION_FACTOR, 0.f, p);
+                Vector(0.f, 20.f, 0.f, p);
                 VectorCopy(o->Direction, Direction);
                 BMD* b = &Models[o->Target->Type];
                 VectorCopy(o->Target->Position, b->BodyOrigin);
@@ -6598,23 +6485,26 @@ void MoveJoint(JOINT* o, int iIndex)
                 for (int i = 0; i < MaxTails; ++i)
                 {
                     VectorRotate(Direction, o->Target->BoneTransform[(int)o->MultiUse], Position);
-                    VectorAdd(o->StartPosition, Position, o->StartPosition);
+                    VectorAddScaled(o->StartPosition, Position, o->StartPosition, FPS_ANIMATION_FACTOR);
+                    // VectorAdd(o->StartPosition, Position, o->StartPosition);
 
                     if (o->SubType % 2)
                     {
-                        o->TargetPosition[1] += (40.f) * FPS_ANIMATION_FACTOR;
+                        o->TargetPosition[1] += (40.f);
                     }
                     else
                     {
-                        o->TargetPosition[1] -= (40.f) * FPS_ANIMATION_FACTOR;
+                        o->TargetPosition[1] -= (40.f);
                     }
+
                     Vector(o->TargetPosition[1], 0.f, 0.f, Angle);
                     AngleMatrix(Angle, Matrix);
                     Vector(0.f, 0.f, o->TargetPosition[0], p);
                     VectorRotate(p, Matrix, Position);
                     VectorAdd(o->StartPosition, Position, o->Position);
+                    // VectorAddScaled(o->StartPosition, Position, o->Position, FPS_ANIMATION_FACTOR);
 
-                    CreateTail(o, o->Target->BoneTransform[(int)o->MultiUse]);
+                    CreateTail(o, o->Target->BoneTransform[0]);//(int)o->MultiUse]);
 
                     o->TargetPosition[0] -= (0.15f) * FPS_ANIMATION_FACTOR;
 
@@ -6634,9 +6524,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             if (o->LifeTime < 7)
             {
-                o->Light[0] /= 1.5f;
-                o->Light[1] /= 1.5f;
-                o->Light[2] /= 1.5f;
+                VectorScale(o->Light, pow(1.f / 1.5f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->NumTails < o->MaxTails - 1)
@@ -6719,9 +6607,7 @@ void MoveJoint(JOINT* o, int iIndex)
             || (o->SubType >= 11 && o->SubType <= 13)
             ) && o->LifeTime < 10)
         {
-            o->Light[0] /= 1.3f;
-            o->Light[1] /= 1.3f;
-            o->Light[2] /= 1.3f;
+            VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
         }
         break;
 
@@ -6744,7 +6630,7 @@ void MoveJoint(JOINT* o, int iIndex)
             AngleMatrix(o->HeadAngle, Matrix);
             Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
             VectorRotate(p, Matrix, Position);
-            VectorAdd(o->Position, Position, o->Position);
+            VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]) - o->MultiUse;
             if (o->Position[2] < Height)
@@ -6793,9 +6679,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->m_bCreateTails = false;
                 }
 
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
             if (o->SubType < 2)
             {
@@ -6823,9 +6707,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 15)
             {
-                o->Light[0] /= 1.3f;
-                o->Light[1] /= 1.3f;
-                o->Light[2] /= 1.3f;
+                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 6)
@@ -6837,7 +6719,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             AngleMatrix(o->Angle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
-            VectorAdd(o->Position, Position, o->Position);
+            VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
             if ((o->Weapon - o->LifeTime) < 10)
             {
@@ -6867,9 +6749,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < (o->Weapon / 2))
             {
-                o->Light[0] /= 1.3f;
-                o->Light[1] /= 1.3f;
-                o->Light[2] /= 1.3f;
+                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         break;
@@ -6891,9 +6771,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 10)
             {
-                o->Light[0] /= 1.2f;
-                o->Light[1] /= 1.2f;
-                o->Light[2] /= 1.2f;
+                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
                 VectorCopy(o->Light, Light);
             }
 
@@ -7389,7 +7267,7 @@ void RenderJoints(BYTE bRenderOneMore)
             {
                 vec3_t Light;
                 EnableAlphaBlend();
-                o->Velocity /= 1.1f;
+                o->Velocity *= pow(1.f / 1.1f, FPS_ANIMATION_FACTOR);
                 Vector(o->Velocity, o->Velocity, o->Velocity, Light);
                 RenderTerrainAlphaBitmap(BITMAP_MAGIC + 1, o->TargetPosition[0], o->TargetPosition[1], 2.f, 2.f, Light);
                 DisableAlphaBlend();

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -2743,13 +2743,13 @@ bool SearchJoint(int Type, OBJECT* Target, int SubType)
 
 void CreateTailAxis(JOINT* o, float Matrix[3][4], BYTE axis)
 {
-    o->NumTails++;
+    o->NumTails += FPS_ANIMATION_FACTOR;
     if (o->NumTails > o->MaxTails - 1)
     {
         o->NumTails = o->MaxTails - 1;
     }
 
-    for (int j = o->NumTails - 1; j >= 0; j--)
+    for (int j = (int)(o->NumTails - 1); j >= 0; j--)
     {
         for (int k = 0; k < 4; k++)
             VectorCopy(o->Tails[j][k], o->Tails[j + 1][k]);
@@ -2796,7 +2796,7 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
         int i = 0;
         for (i = 0; i < 2; i++)
         {
-            o->NumTails++;
+            o->NumTails += FPS_ANIMATION_FACTOR;
             if (o->NumTails > o->MaxTails - 1)
             {
                 o->NumTails = o->MaxTails - 1;
@@ -2808,34 +2808,34 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
                     VectorCopy(o->Tails[j][k], o->Tails[j + 1][k]);
             }
 
-            if (i == 0 && o->NumTails > 1)
+            if (i == 0 && (int)o->NumTails > 1)
             {
                 vec3_t Position, p;
                 Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
-                // VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
+                //VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
                 VectorAdd(o->Position, p, o->Tails[0][0]);
                 o->Tails[0][0][0] = (o->Tails[0][0][0] + o->Tails[1][0][0]) / 2.f;
                 o->Tails[0][0][1] = (o->Tails[0][0][1] + o->Tails[1][0][1]) / 2.f;
                 o->Tails[0][0][2] = (o->Tails[0][0][2] + o->Tails[1][0][2]) / 2.f;
                 Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
-                // VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
+                //VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
                 VectorAdd(o->Position, p, o->Tails[0][1]);
                 o->Tails[0][1][0] = (o->Tails[0][1][0] + o->Tails[1][1][0]) / 2.f;
                 o->Tails[0][1][1] = (o->Tails[0][1][1] + o->Tails[1][1][1]) / 2.f;
                 o->Tails[0][1][2] = (o->Tails[0][1][2] + o->Tails[1][1][2]) / 2.f;
                 Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
-                VectorAdd(o->Position, p, o->Tails[0][2]);
-                //VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
+                // VectorAdd(o->Position, p, o->Tails[0][2]);
+                VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
                 o->Tails[0][2][0] = (o->Tails[0][2][0] + o->Tails[1][2][0]) / 2.f;
                 o->Tails[0][2][1] = (o->Tails[0][2][1] + o->Tails[1][2][1]) / 2.f;
                 o->Tails[0][2][2] = (o->Tails[0][2][2] + o->Tails[1][2][2]) / 2.f;
                 Vector(0.f, 0.f, o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
-                VectorAdd(o->Position, p, o->Tails[0][3]);
-                //VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
+                // VectorAdd(o->Position, p, o->Tails[0][3]);
+                VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
                 o->Tails[0][3][0] = (o->Tails[0][3][0] + o->Tails[1][3][0]) / 2.f;
                 o->Tails[0][3][1] = (o->Tails[0][3][1] + o->Tails[1][3][1]) / 2.f;
                 o->Tails[0][3][2] = (o->Tails[0][3][2] + o->Tails[1][3][2]) / 2.f;
@@ -2843,28 +2843,32 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
             else
             {
                 vec3_t Position, p;
+
                 Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][0]);
                 //VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
+
                 Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][1]);
                 //VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
+
                 Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
-                VectorAdd(o->Position, p, o->Tails[0][2]);
-                //VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
+                // VectorAdd(o->Position, p, o->Tails[0][2]);
+                VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
+
                 Vector(0.f, 0.f, o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
-                VectorAdd(o->Position, p, o->Tails[0][3]);
-                //VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
+                // VectorAdd(o->Position, p, o->Tails[0][3]);
+                VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
             }
         }
     }
     else
     {
-        o->NumTails++;
+        o->NumTails += FPS_ANIMATION_FACTOR;
         if (o->NumTails > o->MaxTails - 1)
         {
             o->NumTails = o->MaxTails - 1;
@@ -2877,22 +2881,26 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
         }
 
         vec3_t Position, p;
+
         Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Tails[0][0]);
         //VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
+
         Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Tails[0][1]);
-        //VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
+        // VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
+
         Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
         VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][2]);
-        //VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
+        // VectorAdd(o->Position, p, o->Tails[0][2]);
+        VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
+
         Vector(0.f, 0.f, o->Scale * 0.5f, Position);
         VectorRotate(Position, Matrix, p);
-        VectorAdd(o->Position, p, o->Tails[0][3]);
-        //VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
+        //VectorAdd(o->Position, p, o->Tails[0][3]);
+        VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
     }
 }
 
@@ -3783,9 +3791,9 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (rand_fps_check(2))
                 {
                     if (o->Angle[0] < -90)
-                        o->Angle[0] += (20.f) * FPS_ANIMATION_FACTOR;
+                        o->Angle[0] += (20.f);
                     else
-                        o->Angle[0] -= (20.f) * FPS_ANIMATION_FACTOR;
+                        o->Angle[0] -= (20.f);
                 }
                 float Distance;
                 if (o->SubType == 13)
@@ -4553,7 +4561,6 @@ void MoveJoint(JOINT* o, int iIndex)
     case MODEL_FENRIR_SKILL_THUNDER:
         for (int j = 0; j < o->MaxTails; j++)
         {
-            if (!rand_fps_check(1)) continue;
             if (o->Target)
             {
                 VectorCopy(o->Target->Position, o->TargetPosition);
@@ -4604,7 +4611,6 @@ void MoveJoint(JOINT* o, int iIndex)
 
         for (int j = 0; j < o->MaxTails; j++)
         {
-            if (!rand_fps_check(1)) continue;
             if (o->SubType == 2)
             {
             }
@@ -4700,7 +4706,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->SubType == 15)
                 break;
-            if (!rand_fps_check(1)) continue;
+
             switch (o->SubType)
             {
             case 0:
@@ -5006,7 +5012,6 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 for (int j = 0; j < o->MaxTails; j++)
                 {
-                    if (!rand_fps_check(1)) continue;
                     Distance = MoveHumming(o->Position, o->Angle, Position, (float)(rand() % 80 + 60.f));
 
                     o->Direction[0] = (float)(rand() % 1400 - 700) / o->Scale;
@@ -5472,7 +5477,9 @@ void MoveJoint(JOINT* o, int iIndex)
             vec3_t vPos;
             vec3_t backPos;
             o->m_bCreateTails = false;
-            if (o->NumTails != 0) o->NumTails = 0;
+            o->NumTails = 0;
+            
+
             VectorCopy(o->Position, backPos);
             for (int i = 0; i < MAX_TAILS; ++i)
             {
@@ -6097,7 +6104,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 VectorRotate(o->Direction, Matrix, position);
                 VectorAdd(o->TargetPosition, position, o->Position);
 
-                if (o->NumTails < (o->MaxTails - 1) || o->Skill != 0)
+                if ((int)o->NumTails < (o->MaxTails - 1) || o->Skill != 0)
                     CreateTail(o, Mat);
             }
         }
@@ -6126,7 +6133,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 VectorRotate(o->Direction, Matrix, position);
                 VectorAdd(o->TargetPosition, position, o->Position);
 
-                if (o->NumTails < (o->MaxTails - 1) || o->Skill != 0)
+                if ((int)o->NumTails < (o->MaxTails - 1) || o->Skill != 0)
                     CreateTail(o, Mat);
             }
         }
@@ -6155,7 +6162,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     VectorRotate(o->Direction, Matrix, position);
                     VectorAdd(o->TargetPosition, position, o->Position);
 
-                    if (o->NumTails < (o->MaxTails - 1) || o->Skill != 0)
+                    if ((int)o->NumTails < (o->MaxTails - 1) || o->Skill != 0)
                         CreateTail(o, Mat);
                 }
 
@@ -6180,8 +6187,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             for (int j = 0; j < 8; ++j)
             {
-                if (!rand_fps_check(1)) continue;
-                if (o->NumTails < o->MaxTails - 1)
+                if ((int)o->NumTails < o->MaxTails - 1)
                 {
                     VectorCopy(o->Position, Light);
                     AngleMatrix(o->Direction, Matrix);
@@ -6257,8 +6263,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 for (int j = 0; j < 8; ++j)
                 {
-                    if (!rand_fps_check(1)) continue;
-                    if (o->NumTails < o->MaxTails - 1)
+                    if ((int)o->NumTails < o->MaxTails - 1)
                     {
                         VectorCopy(o->Position, Light);
                         AngleMatrix(o->Direction, Matrix);
@@ -6990,15 +6995,13 @@ void RenderJoints(BYTE bRenderOneMore)
 
             BindTexture(o->TexType);
 
-            for (int j = 0; j < o->NumTails; j++)
+            for (int j = 0; j < (int)o->NumTails; j++)
             {
-                if (!rand_fps_check(1)) continue;
-
                 if (o->Type == BITMAP_SMOKE && o->SubType == 0 && j < 1)
                 {
                     continue;
                 }
-                else if (o->Type == BITMAP_JOINT_HEALING && (o->SubType == 9 || o->SubType == 10) && j == o->NumTails - 1)
+                else if (o->Type == BITMAP_JOINT_HEALING && (o->SubType == 9 || o->SubType == 10) && j == (int)o->NumTails - 1)
                 {
                     continue;
                 }
@@ -7006,8 +7009,8 @@ void RenderJoints(BYTE bRenderOneMore)
                 float Light1, Light2;
                 if (o->bTileMapping)
                 {
-                    Light1 = (o->NumTails - (j)) / 16.f;
-                    Light2 = (o->NumTails - (j + 1)) / 16.f;
+                    Light1 = ((int)o->NumTails - (j)) / 16.f;
+                    Light2 = ((int)o->NumTails - (j + 1)) / 16.f;
                 }
                 else if (o->m_byReverseUV == 3)
                 {
@@ -7016,8 +7019,8 @@ void RenderJoints(BYTE bRenderOneMore)
                 }
                 else
                 {
-                    Light1 = (o->NumTails - (j)) / (float)(o->MaxTails - 1);
-                    Light2 = (o->NumTails - (j + 1)) / (float)(o->MaxTails - 1);
+                    Light1 = ((int)o->NumTails - (j)) / (float)(o->MaxTails - 1);
+                    Light2 = ((int)o->NumTails - (j + 1)) / (float)(o->MaxTails - 1);
                 }
 
                 float Scroll = (float)((int)WorldTime % 1000) * 0.001f;
@@ -7032,8 +7035,8 @@ void RenderJoints(BYTE bRenderOneMore)
                     || (o->SubType >= 11 && o->SubType <= 13)	//^ 펜릴 스킬 관련
                     )
                 {
-                    Light1 = (o->NumTails - (j)) / (float)((o->MaxTails - 1) / 2);
-                    Light2 = (o->NumTails - (j + 1)) / (float)((o->MaxTails - 1) / 2);
+                    Light1 = ((int)o->NumTails - (j)) / (float)((o->MaxTails - 1) / 2);
+                    Light2 = ((int)o->NumTails - (j + 1)) / (float)((o->MaxTails - 1) / 2);
                     Light1 -= Scroll;
                     Light2 -= Scroll;
                 }
@@ -7091,7 +7094,7 @@ void RenderJoints(BYTE bRenderOneMore)
                             glColor3f(1.f, 1.f, 1.f);
                         }
 
-                        if (j == (o->NumTails / 2))
+                        if (j == ((int)o->NumTails / 2))
                         {
                             vec3_t  Position;
 
@@ -7182,13 +7185,13 @@ void RenderJoints(BYTE bRenderOneMore)
                         || (o->SubType >= 11 && o->SubType <= 13)
                         )
                     {
-                        float Luminosity = ((float)((o->NumTails - 1 - j) / (float)(o->MaxTails)) * 2);
+                        float Luminosity = ((float)(((int)o->NumTails - 1 - j) / (float)(o->MaxTails)) * 2);
 
                         glColor3f(o->Light[0] * Luminosity, o->Light[1] * Luminosity, o->Light[2] * Luminosity);
                     }
                     else if (o->Type == BITMAP_JOINT_FORCE && o->SubType == 1)
                     {
-                        float Luminosity = (1.f - (o->NumTails - j) / (float)(o->NumTails)) * 2.f;
+                        float Luminosity = (1.f - ((int)o->NumTails - j) / (float)(o->NumTails)) * 2.f;
 
                         glColor3f(o->Light[0] * Luminosity, o->Light[1] * Luminosity, o->Light[2] * Luminosity);
                     }

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -3629,7 +3629,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else if (o->SubType != 7 && o->SubType != 8 && o->SubType != 12)
             {
-                if (o->LifeTime == 1)
+                if ((int)o->LifeTime == 1)
                 {
                     CreateSprite(BITMAP_SHINY + 1, p, (float)(rand() % 8 + 8) * 0.2f, o->Light, o->Target, (float)(rand() % 360));
                 }
@@ -4017,7 +4017,7 @@ void MoveJoint(JOINT* o, int iIndex)
             vec3_t Position, Angle;
             VectorCopy(o->Position, Position);
 
-            if (o->LifeTime == 100)//% 10 == 0)
+            if ((int)o->LifeTime == 100)//% 10 == 0)
             {
                 for (int i = 0; i < 120; ++i)
                 {
@@ -4124,7 +4124,7 @@ void MoveJoint(JOINT* o, int iIndex)
             CreateSprite(BITMAP_LIGHT, o->Position, 0.5f, o->Light, o->Target);
             CreateSprite(BITMAP_DS_SHOCK, o->Position, 0.15f, o->Light, o->Target);
 
-            if (o->LifeTime == 10)
+            if ((int)o->LifeTime == 10)
             {
                 CreateEffect(BITMAP_FIRECRACKER0002, o->Position, o->Angle, o->Light, o->Skill);
             }

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -1240,7 +1240,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                         float Distance = sqrtf(dx * dx + dy * dy);
                         if (Distance <= 400 && to->Live && tc->Dead == 0 && to->Kind == KIND_MONSTER && to->Visible && to != Target)
                         {
-                            o->TargetIndex[o->MultiUse] = j;
+                            o->TargetIndex[(int)o->MultiUse] = j;
                             o->MultiUse++;
                         }
 
@@ -1952,7 +1952,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                     VectorCopy(o->Angle, o->HeadAngle);
 
                     o->MultiUse = PKKey;
-                    switch (o->MultiUse)
+                    switch ((int)o->MultiUse)
                     {
                     case 0: o->HeadAngle[2] += 90.f; o->Position[2] += 200.f; break;
                     case 1: o->HeadAngle[2] += 90.f; o->Position[2] += 10.f; break;
@@ -3010,7 +3010,7 @@ void MoveJoint(JOINT* o, int iIndex)
     {
     case BITMAP_JOINT_LASER:
         VectorCopy(o->Target->Position, o->TargetPosition);
-        o->TargetPosition[2] += 130.f;
+        o->TargetPosition[2] += 130.f * FPS_ANIMATION_FACTOR;
 
         Distance = sqrtf(dx * dx + dy * dy);
         MoveHumming(o->Position, o->Angle, o->TargetPosition, 3000.f / Distance);
@@ -3260,8 +3260,8 @@ void MoveJoint(JOINT* o, int iIndex)
                 else if (o->SubType == 12)
                 {
                     o->Angle[2] += 15.f;
-                    o->Position[0] += o->MultiUse * rand() % 5;
-                    o->Position[1] += o->MultiUse * rand() % 5;
+                    o->Position[0] += o->MultiUse * (rand() % 5);
+                    o->Position[1] += o->MultiUse * (rand() % 5);
                     o->Position[2] += 6.f;
                 }
                 else if (o->SubType == 16
@@ -3276,15 +3276,15 @@ void MoveJoint(JOINT* o, int iIndex)
                 else if (o->SubType == 13)
                 {
                     o->Angle[2] -= 20.f;
-                    o->Position[0] += o->MultiUse * rand() % 5;
-                    o->Position[1] += o->MultiUse * rand() % 5;
+                    o->Position[0] += o->MultiUse * (rand() % 5);
+                    o->Position[1] += o->MultiUse * (rand() % 5);
                     o->Position[2] += 6.f;
                 }
                 else if (o->SubType == 44)
                 {
                     o->Angle[2] -= 20.f;
-                    o->Position[0] += o->MultiUse * rand() % 5 + cosf(Q_PI / (float)(rand() % 180) * 20.0f);
-                    o->Position[1] += o->MultiUse * rand() % 5 + sinf(Q_PI / (float)(rand() % 180) * 20.0f);
+                    o->Position[0] += o->MultiUse * (rand() % 5) + cosf(Q_PI / (float)(rand() % 180) * 20.0f);
+                    o->Position[1] += o->MultiUse * (rand() % 5) + sinf(Q_PI / (float)(rand() % 180) * 20.0f);
                     o->Position[2] += 6.f;
                 }
                 else
@@ -3297,7 +3297,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 if (o->LifeTime >= 20)
                 {
-                    o->Velocity += 10.f;
+                    o->Velocity += FPS_ANIMATION_FACTOR * 10.f;
                     if (o->Velocity >= 20.f) o->Velocity = 20.f;
 
                     VectorCopy(o->Target->Position, o->TargetPosition);
@@ -3306,7 +3306,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 else
                 {
-                    o->Velocity += 12.f;
+                    o->Velocity += FPS_ANIMATION_FACTOR * 12.f;
                     if (o->Velocity >= 20.f) o->Velocity = 20.f;
 
                     //VectorCopy(o->Target->Position, o->TargetPosition);
@@ -3328,13 +3328,13 @@ void MoveJoint(JOINT* o, int iIndex)
                     || o->SubType == 46
                     )
                 {
-                    o->Velocity += 7.f;
+                    o->Velocity += FPS_ANIMATION_FACTOR * 7.f;
                     if (o->Velocity >= 40.f)
                         o->Velocity = 40.f;
                 }
                 else
                 {
-                    o->Velocity += 5.f;
+                    o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
                     if (o->Velocity >= 30.f)
                         o->Velocity = 30.f;
                 }
@@ -3370,7 +3370,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 else if (Distance <= 70.0f && fabs(fOldAngle - o->Angle[2]) > 20.0f)
                 {
                     if (o->Velocity >= 20.f)
-                        o->Velocity -= 10.f;
+                        o->Velocity -= FPS_ANIMATION_FACTOR * 10.f;
                 }
             }
             Luminosity = (float)(rand() % 4 + 8) * 0.03f;
@@ -3424,7 +3424,7 @@ void MoveJoint(JOINT* o, int iIndex)
             else
             {
                 Vector(0.4f, 0.3f, 2.2f, o->Light);
-                o->Velocity += 5.f;
+                o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
                 if (o->Velocity >= 30.f)
                 {
                     o->Velocity = 30.f;
@@ -3444,7 +3444,7 @@ void MoveJoint(JOINT* o, int iIndex)
             else if (Distance <= 70.0f && fabs(fOldAngle - o->Angle[2]) > 20.0f)
             {
                 if (o->Velocity >= 20.f)
-                    o->Velocity -= 10.f;
+                    o->Velocity -= FPS_ANIMATION_FACTOR * 10.f;
             }
 
             Luminosity = (float)(rand() % 4 + 8) * 0.03f;
@@ -3456,7 +3456,7 @@ void MoveJoint(JOINT* o, int iIndex)
         break;
         case 43:
         {
-            o->Velocity += 5.f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
             if (o->Velocity >= 40.f)
             {
                 o->Velocity = 40.f;
@@ -3510,8 +3510,8 @@ void MoveJoint(JOINT* o, int iIndex)
             VectorCopy(o->Target->Position, o->Position);
             VectorAdd(o->TargetPosition, o->Position, o->Position);
 
-            o->Position[2] += o->Velocity;
-            o->Velocity += 10.f;
+            o->Position[2] += o->Velocity * FPS_ANIMATION_FACTOR;
+            o->Velocity += FPS_ANIMATION_FACTOR * 10.f;
             Luminosity = (12 - o->LifeTime) * 0.1f;
             Vector(Luminosity * 0.4f, Luminosity * 0.6f, Luminosity * 1.f, o->Light);
         }
@@ -3522,6 +3522,7 @@ void MoveJoint(JOINT* o, int iIndex)
         }
         else if (o->SubType == 9)
         {
+            // Ancient blur
             VectorSubtract(o->TargetPosition, o->Target->Position, Position);
             VectorCopy(o->Target->Position, o->TargetPosition);
             for (int j = o->NumTails - 1; j >= 0; j--)
@@ -3534,8 +3535,8 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Position[1] = o->TargetPosition[1] + cosf(o->MultiUse * 0.1f) * o->Direction[0];
             o->Position[2] = o->TargetPosition[2] + 10 + (90 - o->LifeTime);
 
-            o->MultiUse += 2;
-            o->Direction[0] -= 1.f;
+            o->MultiUse += 2 * FPS_ANIMATION_FACTOR;
+            o->Direction[0] -= 1.f * FPS_ANIMATION_FACTOR;
 
             if (o->Direction[0] < 0)
             {
@@ -3545,13 +3546,15 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 50)
             {
-                o->Light[0] /= 1.1f;
-                o->Light[1] /= 1.1f;
-                o->Light[2] /= 1.1f;
+                float divisor = 1.0f + (0.1f * FPS_ANIMATION_FACTOR);
+                o->Light[0] /= divisor;
+                o->Light[1] /= divisor;
+                o->Light[2] /= divisor;
             }
             else if (o->LifeTime > 80)
             {
-                VectorScale(o->Light, 1.25f, o->Light);
+                float mult = 1.0f + (0.25f * FPS_ANIMATION_FACTOR);
+                VectorScale(o->Light, mult, o->Light);
             }
         }
         else if (o->SubType == 10)
@@ -3607,7 +3610,7 @@ void MoveJoint(JOINT* o, int iIndex)
         }
         else if (o->SubType == 15)
         {
-            o->Velocity += 4.f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 4.f;
 
             VectorCopy(o->Target->Position, p);
 
@@ -3621,7 +3624,7 @@ void MoveJoint(JOINT* o, int iIndex)
         }
         else if (o->SubType == 16)
         {
-            o->Velocity += 4.f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 4.f;
 
             VectorCopy(o->Target->Position, p);
 
@@ -3637,11 +3640,11 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->SubType == 6 || o->SubType == 7)
             {
-                o->Velocity += 2.f;
+                o->Velocity += FPS_ANIMATION_FACTOR * 2.f;
             }
             else
             {
-                o->Velocity += 4.f;
+                o->Velocity += FPS_ANIMATION_FACTOR * 4.f;
             }
 
             if (o->SubType == 6 || o->SubType == 7 || o->SubType == 12)
@@ -3673,9 +3676,9 @@ void MoveJoint(JOINT* o, int iIndex)
                 else
                 {
                     VectorCopy(o->Target->Position, p);
-                    p[2] += 120.f;
+                    p[2] += 120.f * FPS_ANIMATION_FACTOR;
 
-                    MoveHumming(o->Position, o->Angle, p, 10.f);
+                    MoveHumming(o->Position, o->Angle, p, 10.f * FPS_ANIMATION_FACTOR);
                 }
             }
             Luminosity = (12 - o->LifeTime) * 0.1f;
@@ -3716,7 +3719,7 @@ void MoveJoint(JOINT* o, int iIndex)
     {
         if (o->SubType == 0)
         {
-            if (o->LifeTime % 16 <= 7)
+            if ((int)o->LifeTime % 16 <= 7)
             {
                 o->m_sTargetIndex = 10;
                 o->Angle[2] += o->m_sTargetIndex;
@@ -3773,7 +3776,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
 
 #ifndef CSK_EVIL_SKILL
-                if (o->LifeTime % 15 == 0)
+                if ((int)o->LifeTime % 15 == 0)
                 {
                     if (o->Target == &Hero->Object)
                         AttackCharacterRange(o->Skill, o->Position, 150.f, o->Weapon, o->PKKey, o->m_bySkillSerialNum);
@@ -3877,7 +3880,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (Distance < 50.f)
                 {
-                    o->LifeTime--;
+                    o->LifeTime -= FPS_ANIMATION_FACTOR;
                 }
                 if (o->LifeTime < 10)
                 {
@@ -3949,7 +3952,7 @@ void MoveJoint(JOINT* o, int iIndex)
             else
                 CreateSprite(BITMAP_LIGHT, o->Position, (4.0f + (20 - o->LifeTime) / 5), Light, o->Target, (float)(rand() % 360), 0);
 
-            o->Velocity += 5.f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
         }
         else if (8 == o->SubType)
         {
@@ -3977,7 +3980,7 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Position[0] += rand() % 10 - 5.f;
             o->Position[1] += rand() % 10 - 5.f;
             o->Position[2] += o->Velocity;
-            o->Velocity += 1.f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 1.f;
 
             if (o->LifeTime < 10)
             {
@@ -4041,7 +4044,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, 7, 1.0f);
 
-                if (rand() % 2 == 0)//if (o->LifeTime % 2 == 0)
+                if (rand() % 2 == 0)//if ((int)o->LifeTime % 2 == 0)
                 {
                     Position[0] -= sinf(o->Angle[2]) * (40.0f - o->PKKey * 0.1f);
                     Position[1] += cosf(o->Angle[2]) * (40.0f - o->PKKey * 0.1f);
@@ -4104,10 +4107,10 @@ void MoveJoint(JOINT* o, int iIndex)
         }
         else if (o->SubType == 18)
         {
-            o->Velocity += 3.0f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 3.0f;
             o->Angle[0] = -90.0f;
 
-            int add = o->LifeTime % 12;
+            int add = (int)o->LifeTime % 12;
             if (add <= 5)
                 o->PKKey += 6;
             else
@@ -4194,7 +4197,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Position[0] += rand() % 16 - 8.f;
                 o->Position[1] += rand() % 16 - 8.f;
                 o->Position[2] += o->Velocity;
-                //o->Velocity += 1.f;
+                //o->Velocity += FPS_ANIMATION_FACTOR * 1.f;
 
                 o->Scale += 3.0f;
             }
@@ -4211,21 +4214,21 @@ void MoveJoint(JOINT* o, int iIndex)
     case BITMAP_JOINT_SPARK:
         if (o->SubType == 1)
         {
-            o->Velocity += 0.3f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 0.3f;
             o->Light[0] /= 1.4f;
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
         else if (o->SubType == 3)
         {
-            o->Velocity += 0.1f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
             o->Light[0] /= 1.1f;
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
         else if (o->SubType == 4)
         {
-            o->Velocity += 0.1f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
             o->Light[0] /= 1.1f;
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
@@ -4324,11 +4327,11 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             if ((rand() % 5) == 0)
             {
-                o->LifeTime -= 5;
+                o->LifeTime -= 5 * FPS_ANIMATION_FACTOR;
             }
             else if ((rand() % 2) == 0)
             {
-                o->LifeTime++;
+                o->LifeTime += FPS_ANIMATION_FACTOR;
             }
             o->Direction[0] = sinf((o->LifeTime - o->Direction[1]) * 0.05f) * 3.f;
             o->Position[0] += o->Direction[0];
@@ -4686,12 +4689,13 @@ void MoveJoint(JOINT* o, int iIndex)
             else
             {
                 VectorCopy(o->Target->Position, o->TargetPosition);
-                o->TargetPosition[2] += 80.f;
+                o->TargetPosition[2] += 80.f * FPS_ANIMATION_FACTOR;
             }
-            Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 25.f);
+
+            Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 25.f * FPS_ANIMATION_FACTOR);
             //float Distance = MoveHumming(o,0.f);
-            o->Direction[0] += (float)(rand() % 256 - 128) / o->Scale;
-            o->Direction[2] += (float)(rand() % 256 - 128) / o->Scale;
+            o->Direction[0] += (float)(FPS_ANIMATION_FACTOR * (rand() % 256 - 128) / o->Scale);
+            o->Direction[2] += (float)(FPS_ANIMATION_FACTOR * (rand() % 256 - 128) / o->Scale);
             VectorScale(o->Direction, 0.8f, o->Direction);
 
             vec3_t Angle;
@@ -4700,7 +4704,7 @@ void MoveJoint(JOINT* o, int iIndex)
             AngleMatrix(Angle, Matrix);
             CreateTail(o, Matrix);
 
-            if (Distance <= o->Velocity * 2.f)
+            if (Distance <= o->Velocity * 2.f * FPS_ANIMATION_FACTOR)
             {
                 vec3_t Position;
                 if (rand() % 2 == 0)
@@ -4737,6 +4741,7 @@ void MoveJoint(JOINT* o, int iIndex)
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
             Vector(0.f, -o->Velocity, 0.f, Position);
             VectorRotate(Position, Matrix, p);
+            VectorScale(p, FPS_ANIMATION_FACTOR, p)
             VectorAdd(o->Position, p, o->Position);
         }
         break;
@@ -5027,7 +5032,7 @@ void MoveJoint(JOINT* o, int iIndex)
             VectorCopy(o->TargetPosition, o->Position);
         }
 
-        else if (o->SubType == 15 && (o->LifeTime % 2) == 0)
+        else if (o->SubType == 15 && ((int)o->LifeTime % 2) == 0)
         {
             CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->StartPosition, o->Angle, 0, NULL, 50.f);
             CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->StartPosition, o->Angle, 0, NULL, 10.f);
@@ -5061,7 +5066,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->MultiUse < o->Weapon)
             {
-                if ((o->LifeTime % 2) == 0)
+                if (((int)o->LifeTime % 2) == 0)
                     o->MultiUse++;
             }
         }
@@ -5378,7 +5383,7 @@ void MoveJoint(JOINT* o, int iIndex)
         }
         if (o->SubType == 1)
         {
-            o->Velocity += 0.1f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
             o->Light[0] /= 1.1f;
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
@@ -5423,7 +5428,7 @@ void MoveJoint(JOINT* o, int iIndex)
             else if (o->SubType == 18)
             {
                 o->Position[2] += (o->Direction[2] * 1.1f);
-                o->Velocity += 0.1f;
+                o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
                 o->Scale += 0.2f;
             }
         }
@@ -5456,7 +5461,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Position[2] += o->Direction[2];
                 if (o->LifeTime < 20)
                 {
-                    o->Velocity += 5.f;
+                    o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
                 }
                 o->Scale += 1;
                 o->Direction[1] += 4;
@@ -5800,7 +5805,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 (o->Target->CurrentAction >= PLAYER_ATTACK_SKILL_SWORD1 && o->Target->CurrentAction <= PLAYER_ATTACK_SKILL_SWORD5)
                 && (o->Target->CurrentAction != PLAYER_RAGE_UNI_STOP_ONE_RIGHT)))
             {
-                o->LifeTime -= 10;
+                o->LifeTime -= 10 * FPS_ANIMATION_FACTOR;
             }
             else
             {
@@ -5865,7 +5870,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     for (float i = 0; i < o->Direction[2]; ++i)
                     {
                         o->Direction[1] += 1.5f;
-                        switch (o->MultiUse)
+                        switch ((int)o->MultiUse)
                         {
                         case 0: o->HeadAngle[0] += 3.f; o->HeadAngle[2] -= o->Direction[1]; break;
                         case 1: o->HeadAngle[0] -= 3.f; o->HeadAngle[2] -= o->Direction[1]; break;
@@ -5979,7 +5984,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Velocity += 5.f;
+                o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
                 if (o->Velocity >= 30.f)
                     o->Velocity = 30.f;
 
@@ -5990,7 +5995,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (Distance <= 70.0f && fabs(fOldAngle - o->Angle[2]) > 20.0f)
                 {
                     if (o->Velocity >= 20.f)
-                        o->Velocity -= 5.f;
+                        o->Velocity -= FPS_ANIMATION_FACTOR * 5.f;
                 }
 
                 if (o->LifeTime < 10)
@@ -6013,7 +6018,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Velocity += 5.f;
+                o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
                 if (o->Velocity >= 30.f)
                     o->Velocity = 30.f;
 
@@ -6025,7 +6030,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (Distance <= 70.0f && fabs(fOldAngle - o->Angle[2]) > 20.0f)
                 {
                     if (o->Velocity >= 20.f)
-                        o->Velocity -= 10.f;
+                        o->Velocity -= FPS_ANIMATION_FACTOR * 10.f;
                 }
 
                 if (o->LifeTime < 10)
@@ -6049,7 +6054,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->Position[2] += 2.5f;
                 }
 
-                o->Velocity += 5.f;
+                o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
                 if (o->Velocity >= 30.f)
                     o->Velocity = 30.f;
 
@@ -6065,7 +6070,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (Distance <= 70.0f && fabs(fOldAngle - o->Angle[2]) > 20.0f)
                 {
                     if (o->Velocity >= 20.f)
-                        o->Velocity -= 10.f;
+                        o->Velocity -= FPS_ANIMATION_FACTOR * 10.f;
                 }
 
                 if (o->LifeTime < 15)
@@ -6088,7 +6093,7 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Position[0] = o->StartPosition[0] + sinf(o->LifeTime / 2.5f) * o->Direction[0];
             o->Position[1] = o->StartPosition[1];
             o->Position[2] += o->Velocity;
-            o->Velocity -= 0.1f;
+            o->Velocity -= FPS_ANIMATION_FACTOR * 0.1f;
             o->Direction[0] -= 0.1f;
 
             if (o->LifeTime < 15)
@@ -6422,7 +6427,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else if (o->SubType >= 2 && o->SubType <= 6)
             {
-                o->Velocity += o->Direction[2];
+                o->Velocity += FPS_ANIMATION_FACTOR * o->Direction[2];
                 if (o->LifeTime < 15)
                 {
                     o->Direction[2] += 0.5f;
@@ -6444,7 +6449,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->Light[1] /= 1.3f;
                     o->Light[2] /= 1.3f;
                 }
-                if (o->LifeTime % 5 == 0 && o->SubType == 2)
+                if ((int)o->LifeTime % 5 == 0 && o->SubType == 2)
                 {
                     CreateEffect(MODEL_SKILL_INFERNO, o->StartPosition, o->HeadAngle, o->Light, 6, NULL, 20, 0);
                 }
@@ -6459,7 +6464,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else if (o->SubType == 7 || o->SubType == 20)
             {
-                o->Velocity += o->Direction[2];
+                o->Velocity += FPS_ANIMATION_FACTOR * o->Direction[2];
                 if (o->LifeTime < 20)
                 {
                     o->Direction[2] += 0.5f;
@@ -6514,7 +6519,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     vec3_t vPos;
                     VectorRotate(p, Matrix, vPos);
                     VectorAdd(o->Position, vPos, o->Position);
-                    o->Velocity += 0.5f;
+                    o->Velocity += FPS_ANIMATION_FACTOR * 0.5f;
                 }
             }
         }
@@ -6538,7 +6543,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     VectorAdd(o->Position, Position, o->Position);
                 }
             }
-            o->Velocity -= 2.f;
+            o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
 
             o->Light[0] /= 1.4f;
             o->Light[1] /= 1.4f;
@@ -6559,7 +6564,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     VectorAdd(o->Position, Position, o->Position);
                 }
             }
-            o->Velocity -= 2.f;
+            o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
 
             o->Light[0] /= 1.4f;
             o->Light[1] /= 1.4f;
@@ -6577,7 +6582,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 VectorCopy(o->Direction, Direction);
                 BMD* b = &Models[o->Target->Type];
                 VectorCopy(o->Target->Position, b->BodyOrigin);
-                b->TransformPosition(o->Target->BoneTransform[o->MultiUse], p, o->StartPosition, true);
+                b->TransformPosition(o->Target->BoneTransform[(int)o->MultiUse], p, o->StartPosition, true);
                 VectorCopy(o->StartPosition, o->Position);
 
                 o->NumTails = 0;
@@ -6587,7 +6592,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 for (int i = 0; i < MaxTails; ++i)
                 {
-                    VectorRotate(Direction, o->Target->BoneTransform[o->MultiUse], Position);
+                    VectorRotate(Direction, o->Target->BoneTransform[(int)o->MultiUse], Position);
                     VectorAdd(o->StartPosition, Position, o->StartPosition);
 
                     if (o->SubType % 2)
@@ -6604,7 +6609,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     VectorRotate(p, Matrix, Position);
                     VectorAdd(o->StartPosition, Position, o->Position);
 
-                    CreateTail(o, o->Target->BoneTransform[o->MultiUse]);
+                    CreateTail(o, o->Target->BoneTransform[(int)o->MultiUse]);
 
                     o->TargetPosition[0] -= 0.15f;
 
@@ -6645,7 +6650,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->Position[0] = o->StartPosition[0];
                     o->Position[1] = o->StartPosition[1];
                     o->Position[2] = o->StartPosition[2];
-                    o->Velocity -= 2.f;
+                    o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
                 }
                 o->MultiUse += 2;
             }
@@ -6693,7 +6698,7 @@ void MoveJoint(JOINT* o, int iIndex)
                         o->Position[0] = Position[0];
                         o->Position[1] = Position[1];
                         o->Position[2] = Position[2];
-                        o->Velocity -= 2.f;
+                        o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
                         o->TargetPosition[0] -= 2.5f;
                     }
                     o->MultiUse += 2;
@@ -6723,14 +6728,14 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Angle[2] += rand() % 10 + 10.f;
             }
 
-            o->Velocity += 10.f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 10.f;
             if (o->m_bCreateTails)
             {
                 AngleMatrix(o->Angle, Matrix);
                 CreateTail(o, Matrix);
             }
 
-            o->Velocity += 10.f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 10.f;
             AngleMatrix(o->HeadAngle, Matrix);
             Vector(0.f, -o->Velocity, 0.f, p);
             VectorRotate(p, Matrix, Position);
@@ -6877,7 +6882,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             Distance = MoveHumming(o->Position, o->Angle, vTargetPos, o->Velocity);
 
-            o->Velocity += 2.f;
+            o->Velocity += FPS_ANIMATION_FACTOR * 2.f;
 
             if (o->LifeTime < 10)
             {
@@ -6898,7 +6903,7 @@ void MoveJoint(JOINT* o, int iIndex)
     }break;
     case BITMAP_PIN_LIGHT:
     {
-        o->Velocity += 0.1f;
+        o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
         VectorScale(o->Light, 0.9f, o->Light);
     }
     break;
@@ -6982,12 +6987,12 @@ void MoveJoint(JOINT* o, int iIndex)
             CreateTail(o, Matrix);
     }
 
-    o->LifeTime--;
+    o->LifeTime -= FPS_ANIMATION_FACTOR;
     if (o->LifeTime < 0)
     {
         o->Live = false;
     }
-    else if (0 != (o->LifeTime % 12))
+    else if (0 != (((int)o->LifeTime) % 12))
     {
         switch (o->Type)
         {

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -965,7 +965,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 break;
             case MODEL_FENRIR_SKILL_THUNDER:
                 o->Scale = Scale;
-                o->MaxTails = MAX_TAILS;
+                o->MaxTails = 50;
                 o->Velocity = 50.f;
                 o->LifeTime = 20;
                 o->bTileMapping = true;
@@ -1017,7 +1017,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
             case BITMAP_BLUR + 1:
                 o->Scale = 60.f;
                 o->Velocity = 40.f;
-                o->MaxTails = MAX_TAILS;
+                o->MaxTails = 50;
                 o->LifeTime = 2;
                 if (o->SubType == 0)
                 {
@@ -1043,7 +1043,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 break;
             case BITMAP_JOINT_THUNDER:
                 o->Scale = Scale;
-                o->MaxTails = MAX_TAILS;
+                o->MaxTails = 50;
                 o->Velocity = 50.f;
                 switch (o->SubType)
                 {
@@ -1324,7 +1324,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
 
                 if (o->SubType == 0)
                 {
-                    o->MaxTails = MAX_TAILS;
+                    o->MaxTails = 50;
 
                     o->Velocity = 80.f + (float)(rand() % 20);
                     o->LifeTime = 20;
@@ -1334,7 +1334,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 }
                 else if (o->SubType == 1 || o->SubType == 2 || o->SubType == 3 || o->SubType == 5 || o->SubType == 6 || o->SubType == 7)
                 {
-                    o->MaxTails = MAX_TAILS;
+                    o->MaxTails = 50;
                     o->LifeTime = 20;
                     o->Position[0] += (float)(rand() % 10 - 5);
                     o->Position[1] += rand() % 10 - 5;
@@ -1370,7 +1370,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 }
                 else if (o->SubType == 4)
                 {
-                    o->MaxTails = MAX_TAILS;
+                    o->MaxTails = 50;
                     o->LifeTime = 20;
                     o->m_bCreateTails = false;
                     o->byOnlyOneRender = 2;
@@ -1386,7 +1386,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 }
                 else if (o->SubType == 8)
                 {
-                    o->MaxTails = MAX_TAILS;
+                    o->MaxTails = 50;
                     o->LifeTime = 20;
                     o->m_bCreateTails = false;
 
@@ -1400,7 +1400,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 }
                 else if (o->SubType == 9)
                 {
-                    o->MaxTails = MAX_TAILS;
+                    o->MaxTails = 50;
                     o->LifeTime = 20;
                     o->m_bCreateTails = false;
 
@@ -1412,7 +1412,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 }
                 else if (o->SubType == 10)
                 {
-                    o->MaxTails = MAX_TAILS;
+                    o->MaxTails = 50;
                     o->LifeTime = 20;
                     o->m_bCreateTails = false;
 
@@ -1764,7 +1764,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 {
                     o->Scale = Scale;
                     o->LifeTime = 50;
-                    o->MaxTails = MAX_TAILS;
+                    o->MaxTails = 50;
                     Vector(1.f, 1.f, 1.f, o->Light);
 
                     o->Direction[0] = -2.0f * (float)sinf(-o->Angle[2] * Q_PI / 180.0f);
@@ -1777,7 +1777,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 {
                     o->Scale = Scale;
                     o->LifeTime = 40;
-                    o->MaxTails = MAX_TAILS;
+                    o->MaxTails = 50;
                     float rbias = (float)(rand() % 300) / 1000;
                     float gbias = (float)(rand() % 300) / 1000;
                     Vector(1.f - rbias, 1.f - gbias, 1.f, o->Light);
@@ -2012,7 +2012,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
             case BITMAP_FLARE + 1:
                 o->LifeTime = PKKey;
                 o->PKKey = 0;
-                o->MaxTails = MAX_TAILS;
+                o->MaxTails = 50;
                 switch (o->Skill)
                 {
                 case 0:
@@ -2242,7 +2242,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
 
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(p, Matrix, Position);
-                    VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
+                    VectorAdd(o->Position, Position, o->Position);
                     //					Vector(0.f,1.f,0.f,o->Light);
                 }
                 else if (o->SubType == 1)
@@ -2696,8 +2696,15 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
             }
             break;
             }
+
+            // Because the Tails will be too short when FPS is high, we need to
+            // increase the MaxTails.
+            o->MaxTails = static_cast<int>(o->MaxTails / FPS_ANIMATION_FACTOR);
             if (o->MaxTails > MAX_TAILS)
+            {
                 o->MaxTails = MAX_TAILS;
+            }
+
             return;
         }
     }
@@ -2796,7 +2803,7 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
         int i = 0;
         for (i = 0; i < 2; i++)
         {
-            o->NumTails += FPS_ANIMATION_FACTOR;
+            o->NumTails++;
             if (o->NumTails > o->MaxTails - 1)
             {
                 o->NumTails = o->MaxTails - 1;
@@ -2813,29 +2820,25 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
                 vec3_t Position, p;
                 Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
-                //VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
                 VectorAdd(o->Position, p, o->Tails[0][0]);
                 o->Tails[0][0][0] = (o->Tails[0][0][0] + o->Tails[1][0][0]) / 2.f;
                 o->Tails[0][0][1] = (o->Tails[0][0][1] + o->Tails[1][0][1]) / 2.f;
                 o->Tails[0][0][2] = (o->Tails[0][0][2] + o->Tails[1][0][2]) / 2.f;
                 Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
-                //VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
                 VectorAdd(o->Position, p, o->Tails[0][1]);
                 o->Tails[0][1][0] = (o->Tails[0][1][0] + o->Tails[1][1][0]) / 2.f;
                 o->Tails[0][1][1] = (o->Tails[0][1][1] + o->Tails[1][1][1]) / 2.f;
                 o->Tails[0][1][2] = (o->Tails[0][1][2] + o->Tails[1][1][2]) / 2.f;
                 Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
-                // VectorAdd(o->Position, p, o->Tails[0][2]);
-                VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
+                VectorAdd(o->Position, p, o->Tails[0][2]);
                 o->Tails[0][2][0] = (o->Tails[0][2][0] + o->Tails[1][2][0]) / 2.f;
                 o->Tails[0][2][1] = (o->Tails[0][2][1] + o->Tails[1][2][1]) / 2.f;
                 o->Tails[0][2][2] = (o->Tails[0][2][2] + o->Tails[1][2][2]) / 2.f;
                 Vector(0.f, 0.f, o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
-                // VectorAdd(o->Position, p, o->Tails[0][3]);
-                VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
+                VectorAdd(o->Position, p, o->Tails[0][3]);
                 o->Tails[0][3][0] = (o->Tails[0][3][0] + o->Tails[1][3][0]) / 2.f;
                 o->Tails[0][3][1] = (o->Tails[0][3][1] + o->Tails[1][3][1]) / 2.f;
                 o->Tails[0][3][2] = (o->Tails[0][3][2] + o->Tails[1][3][2]) / 2.f;
@@ -2847,33 +2850,31 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
                 Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][0]);
-                //VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
 
                 Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
                 VectorRotate(Position, Matrix, p);
                 VectorAdd(o->Position, p, o->Tails[0][1]);
-                //VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
 
                 Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
-                // VectorAdd(o->Position, p, o->Tails[0][2]);
-                VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
+                VectorAdd(o->Position, p, o->Tails[0][2]);
 
                 Vector(0.f, 0.f, o->Scale * 0.5f, Position);
                 VectorRotate(Position, Matrix, p);
-                // VectorAdd(o->Position, p, o->Tails[0][3]);
-                VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
+                VectorAdd(o->Position, p, o->Tails[0][3]);
             }
         }
     }
     else
     {
-        o->NumTails += FPS_ANIMATION_FACTOR;
+        o->NumTails++;
         if (o->NumTails > o->MaxTails - 1)
         {
             o->NumTails = o->MaxTails - 1;
         }
 
+        // TODO: Instead of copying, leave it and add new tail values at the end
+        // We need something like a circular buffer here ...
         for (int j = o->NumTails - 1; j >= 0; j--)
         {
             for (int k = 0; k < 4; k++)
@@ -2885,22 +2886,18 @@ void CreateTail(JOINT* o, float Matrix[3][4], bool Blur)
         Vector(-o->Scale * 0.5f, 0.f, 0.f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Tails[0][0]);
-        //VectorAddScaled(o->Position, p, o->Tails[0][0], FPS_ANIMATION_FACTOR);
 
         Vector(o->Scale * 0.5f, 0.f, 0.f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Tails[0][1]);
-        // VectorAddScaled(o->Position, p, o->Tails[0][1], FPS_ANIMATION_FACTOR);
 
         Vector(0.f, 0.f, -o->Scale * 0.5f, Position);
         VectorRotate(Position, Matrix, p);
-        // VectorAdd(o->Position, p, o->Tails[0][2]);
-        VectorAddScaled(o->Position, p, o->Tails[0][2], FPS_ANIMATION_FACTOR);
+        VectorAdd(o->Position, p, o->Tails[0][2]);
 
         Vector(0.f, 0.f, o->Scale * 0.5f, Position);
         VectorRotate(Position, Matrix, p);
-        //VectorAdd(o->Position, p, o->Tails[0][3]);
-        VectorAddScaled(o->Position, p, o->Tails[0][3], FPS_ANIMATION_FACTOR);
+        VectorAdd(o->Position, p, o->Tails[0][3]);
     }
 }
 
@@ -3492,12 +3489,11 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 50)
             {
-                VectorScale(o->Light, pow(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
             }
             else if (o->LifeTime > 80)
             {
-                float mult = 1.0f + (0.25f * FPS_ANIMATION_FACTOR);
-                VectorScale(o->Light, mult, o->Light);
+                VectorScale(o->Light, powf(1.f / 1.25f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 10)
@@ -3532,21 +3528,21 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 40)
             {
-                VectorScale(o->Light, pow(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
             }
             else if (o->LifeTime > 68)
             {
-                VectorScale(o->Light, 1.2f, o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 14)
         {
             if (o->LifeTime < 5)
             {
-                float fLumi = o->LifeTime / 5.f;
+                float fLumi = o->LifeTime / 5.f; VectorScale(o->Light, powf(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
                 VectorScale(o->Light, fLumi, o->Light);
             }
-            o->Scale *= pow(1.05f, FPS_ANIMATION_FACTOR);
+            o->Scale *= powf(1.05f, FPS_ANIMATION_FACTOR);
             VectorCopy(o->Target->Position, o->Position);
         }
         else if (o->SubType == 15)
@@ -3557,7 +3553,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             MoveHumming(o->Position, o->Angle, p, 10.f);
 
-            VectorScale(o->Light, pow(1.f / 1.08f, FPS_ANIMATION_FACTOR), o->Light);
+            VectorScale(o->Light, powf(1.f / 1.08f, FPS_ANIMATION_FACTOR), o->Light);
 
             CreateSprite(BITMAP_SHINY + 1, p, (float)(rand() % 4 + 4) * 0.2f, o->Light, o->Target, (float)(rand() % 360));
         }
@@ -3569,7 +3565,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             MoveHumming(o->Position, o->Angle, p, 10.f);
 
-            VectorScale(o->Light, pow(1.f / 1.08f, FPS_ANIMATION_FACTOR), o->Light);
+            VectorScale(o->Light, powf(1.f / 1.08f, FPS_ANIMATION_FACTOR), o->Light);
 
             CreateSprite(BITMAP_SHINY + 1, p, (float)(rand() % 4 + 4) * 0.2f, o->Light, o->Target, (float)(rand() % 360), 1);
         }
@@ -3600,7 +3596,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     }
                     else if (o->LifeTime < 6)
                     {
-                        VectorScale(o->Light, pow(1.f / 1.8f, FPS_ANIMATION_FACTOR), o->Light);
+                        VectorScale(o->Light, powf(1.f / 1.8f, FPS_ANIMATION_FACTOR), o->Light);
                     }
 
                     if (o->SubType == 13)
@@ -3613,7 +3609,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     VectorCopy(o->Target->Position, p);
                     p[2] += 120.f * FPS_ANIMATION_FACTOR;
 
-                    MoveHumming(o->Position, o->Angle, p, 10.f * FPS_ANIMATION_FACTOR);
+                    MoveHumming(o->Position, o->Angle, p, 10.f);
                 }
             }
             Luminosity = (12 - o->LifeTime) * 0.1f;
@@ -3697,7 +3693,9 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (o->SubType == 5)
                     CreateEffect(MODEL_LASER, o->Position, o->Angle, o->Light, 3);
                 else
+                {
                     CreateEffect(MODEL_LASER, o->Position, o->Angle, o->Light);
+                }
 
                 if (battleCastle::IsBattleCastleStart())
                 {
@@ -3705,7 +3703,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     if ((att & TW_NOATTACKZONE) == TW_NOATTACKZONE)
                     {
                         o->Velocity = 0.f;
-                        o->LifeTime *= pow(1.f / 5.f, FPS_ANIMATION_FACTOR);
+                        o->LifeTime *= powf(1.f / 5.f, FPS_ANIMATION_FACTOR);
                         break;
                     }
                 }
@@ -3727,10 +3725,14 @@ void MoveJoint(JOINT* o, int iIndex)
 
             Distance = sqrtf(dx * dx + dy * dy);
             if (o->SubType == 5)
+            {
                 MoveHumming(o->Position, o->Angle, o->TargetPosition, 2.f);
+            }
             else
+            {
                 MoveHumming(o->Position, o->Angle, o->TargetPosition, 10.f);
-            if (!o->Collision && Distance <= o->Velocity * 2.f)
+            }
+            if (!o->Collision && Distance <= o->Velocity * 2.f * FPS_ANIMATION_FACTOR)
             {
                 o->Collision = true;
             }
@@ -3740,12 +3742,12 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Direction[0] += ((float)(rand() % 32 - 16) * 0.2f) * FPS_ANIMATION_FACTOR;
-                o->Direction[2] += ((float)(rand() % 32 - 16) * 0.8f) * FPS_ANIMATION_FACTOR;
+                o->Direction[0] += ((float)(rand() % 32 - 16) * 0.2f);
+                o->Direction[2] += ((float)(rand() % 32 - 16) * 0.8f);
                 o->Angle[0] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
                 o->Angle[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
-                o->Direction[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
-                o->Direction[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+                o->Direction[0] *= 0.6f;// powf(0.6f, FPS_ANIMATION_FACTOR);
+                o->Direction[2] *= 0.8f; // powf(0.8f, FPS_ANIMATION_FACTOR);
             }
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
@@ -3819,7 +3821,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 if (o->LifeTime < 10)
                 {
-                    VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                    VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
                     VectorCopy(o->Light, Light);
                 }
                 if (o->SubType == 13)
@@ -3861,7 +3863,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 10)
             {
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
                 VectorCopy(o->Light, Light);
             }
             else if (o->LifeTime > 18 && o->LifeTime < 20 && (o->SubType == 2 || o->SubType == 21))
@@ -3915,7 +3917,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 10)
             {
-                VectorScale(o->Light, pow(1.f / 1.15f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.15f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 11)
@@ -4093,8 +4095,8 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Direction[2] += ((float)(rand() % 32 - 16) * 0.8f) * FPS_ANIMATION_FACTOR;
             o->Angle[0] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
             o->Angle[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
-            o->Direction[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
-            o->Direction[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+            o->Direction[0] *= powf(0.6f, FPS_ANIMATION_FACTOR);
+            o->Direction[2] *= powf(0.8f, FPS_ANIMATION_FACTOR);
 
             if (o->LifeTime < 30)
                 Luminosity = o->LifeTime / 30.f;
@@ -4114,7 +4116,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime < 10)
             {
-                VectorScale(o->Light, pow(1.f / 1.45f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.45f, FPS_ANIMATION_FACTOR), o->Light);
 
                 if (o->Light[0] < 0.2f)
                     o->Live = false;
@@ -4142,21 +4144,21 @@ void MoveJoint(JOINT* o, int iIndex)
         if (o->SubType == 1)
         {
             o->Velocity += FPS_ANIMATION_FACTOR * 0.3f;
-            o->Light[0] *= pow(1.f / 1.4f, FPS_ANIMATION_FACTOR);
+            o->Light[0] *= powf(1.f / 1.4f, FPS_ANIMATION_FACTOR);
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
         else if (o->SubType == 3)
         {
             o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
-            o->Light[0] *= pow(1.f / 1.1f, FPS_ANIMATION_FACTOR);
+            o->Light[0] *= powf(1.f / 1.1f, FPS_ANIMATION_FACTOR);
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
         else if (o->SubType == 4)
         {
             o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
-            o->Light[0] *= pow(1.f / 1.1f, FPS_ANIMATION_FACTOR);
+            o->Light[0] *= powf(1.f / 1.1f, FPS_ANIMATION_FACTOR);
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
@@ -4294,7 +4296,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->Weapon == 0)
                 {
-                    o->Direction[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Direction[1] *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     if (o->Direction[1] < 10.f) o->Direction[1] = -10.f;
                 }
                 if (o->Weapon > 40)
@@ -4325,7 +4327,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 10)
             {
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
 
             o->Scale -= (5.f) * FPS_ANIMATION_FACTOR;
@@ -4357,7 +4359,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (rand_fps_check(10))
                 {
-                    fLumi *= pow(0.2f, FPS_ANIMATION_FACTOR);
+                    fLumi *= powf(0.2f, FPS_ANIMATION_FACTOR);
                     Vector(0.9f + fLumi, 0.5f + fLumi, 0.5f + fLumi, Light);
                     CreateParticle(BITMAP_SPARK + 1, o->Position, o->Angle, Light, 19);
                 }
@@ -4620,11 +4622,11 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->TargetPosition[2] += 80.f;
             }
 
-            Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 25.f * FPS_ANIMATION_FACTOR);
+            Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 25.f);
             //float Distance = MoveHumming(o,0.f);
             o->Direction[0] += (float)(FPS_ANIMATION_FACTOR * (rand() % 256 - 128) / o->Scale);
             o->Direction[2] += (float)(FPS_ANIMATION_FACTOR * (rand() % 256 - 128) / o->Scale);
-            VectorScale(o->Direction, 0.8f, o->Direction);
+            VectorScale(o->Direction, powf(0.8f, FPS_ANIMATION_FACTOR), o->Direction);
 
             vec3_t Angle;
             VectorAdd(o->Angle, o->Direction, Angle);
@@ -4891,7 +4893,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
 
             vec3_t Angle;
-            VectorAdd(o->Angle, o->Direction, Angle);
+            VectorAddScaled(o->Angle, o->Direction, Angle, FPS_ANIMATION_FACTOR);
             float Matrix[3][4];
             AngleMatrix(Angle, Matrix);
             CreateTail(o, Matrix);
@@ -5079,7 +5081,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 4)
             {
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
 
             if (o->SubType == 2)
@@ -5138,7 +5140,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 CreateSprite(BITMAP_SHINY + 1, o->TargetPosition, 1.5f, o->Light, NULL, (float)((rand() % 360)));
                 if (o->LifeTime < 8)
                 {
-                    VectorScale(o->Light, pow(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
+                    VectorScale(o->Light, powf(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
                 }
             }
             else
@@ -5172,7 +5174,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 4)
             {
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 9)
@@ -5199,7 +5201,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 4)
             {
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 10)
@@ -5226,7 +5228,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 4)
             {
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 11)
@@ -5302,7 +5304,7 @@ void MoveJoint(JOINT* o, int iIndex)
         if (o->SubType == 1)
         {
             o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
-            o->Light[0] *= pow(1.f / 1.1f, FPS_ANIMATION_FACTOR);
+            o->Light[0] *= powf(1.f / 1.1f, FPS_ANIMATION_FACTOR);
             o->Light[1] = o->Light[0];
             o->Light[2] = o->Light[0];
         }
@@ -5310,7 +5312,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 5)
             {
-                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         break;
     case BITMAP_FLARE:
@@ -5327,7 +5329,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 count = (o->Direction[1] + (o->LifeTime * 2)) * 0.1f;
                 if (o->Skill == 1)
                 {
-                    count *= pow(-1, FPS_ANIMATION_FACTOR);
+                    count *= powf(-1, FPS_ANIMATION_FACTOR);
                 }
             }
             else
@@ -5370,7 +5372,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 count = o->Direction[1] * 0.1f;
                 if (o->SubType == 15)
                 {
-                    count *= pow(-1, FPS_ANIMATION_FACTOR);
+                    count *= powf(-1, FPS_ANIMATION_FACTOR);
                 }
                 o->Position[0] = o->TargetPosition[0] + cosf(count) * o->Velocity;
                 o->Position[1] = o->TargetPosition[1] - sinf(count) * o->Velocity;
@@ -5431,7 +5433,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
                 o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
-                VectorScale(o->Light, pow(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
             }
             AddTerrainLight(o->Position[0], o->Position[1], o->Light, 1, PrimaryTerrainLight);
         }
@@ -5500,7 +5502,7 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Position[1] += (o->Direction[1] * 12) * FPS_ANIMATION_FACTOR;
             VectorCopy(o->Position, o->TargetPosition);
 
-            o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
+            o->Scale *= powf(1.1f, FPS_ANIMATION_FACTOR);
             o->Light[0] = 0.5f + (float)(rand() % 64) / 255;
             o->Light[1] = 0.5f + (float)(rand() % 64) / 255;
             o->Light[2] = 0.5f + (float)(rand() % 128) / 255;
@@ -5633,12 +5635,11 @@ void MoveJoint(JOINT* o, int iIndex)
             float fLastTarget;
             for (int k = 0; k < 3; ++k)
             {
-                if (o->SubType == 11)
-                    fLastTarget = (100.f - fPos) * (o->Target->StartPosition[k] + 25.f * cosf((float)(iIndex * 51231 + k * 3711 + iFrame / 10) * 0.01f));
-                else if (o->SubType == 25)
+                if (o->SubType == 11 || o->SubType == 25)
                     fLastTarget = (100.f - fPos) * (o->Target->StartPosition[k] + 25.f * cosf((float)(iIndex * 51231 + k * 3711 + iFrame / 10) * 0.01f));
                 else
                     fLastTarget = (100.f - fPos) * (o->Target->Position[k] + 25.f * cosf((float)(iIndex * 51231 + k * 3711 + iFrame / 10) * 0.01f));
+
                 o->Position[k] = (fPos * o->Position[k] + fLastTarget) * 0.01f;
             }
             if (o->SubType != 11 && o->SubType != 25)
@@ -5737,7 +5738,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 12)
             {
-                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 16 && o->Target != NULL)
@@ -5753,7 +5754,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 20)
             {
-                VectorScale(o->Light, pow(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.1f, FPS_ANIMATION_FACTOR), o->Light);
             }
             else if (o->LifeTime < 40)
             {
@@ -5763,9 +5764,9 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Light[0] *= pow(1.04f, FPS_ANIMATION_FACTOR);
-                o->Light[1] *= pow(1.04f, FPS_ANIMATION_FACTOR);
-                o->Light[2] *= pow(1.04f, FPS_ANIMATION_FACTOR);
+                o->Light[0] *= powf(1.04f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= powf(1.04f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= powf(1.04f, FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 23)
@@ -5851,7 +5852,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->Position[0] = o->TargetPosition[0];
                     o->Position[1] = o->TargetPosition[1];
                     o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
-                    VectorScale(o->Light, pow(1.f / 1.05f, FPS_ANIMATION_FACTOR), o->Light);
+                    VectorScale(o->Light, powf(1.f / 1.05f, FPS_ANIMATION_FACTOR), o->Light);
 
                     CreateSprite(BITMAP_PIN_LIGHT, o->Position, 1.5f, o->Light, NULL);
                     CreateSprite(BITMAP_PIN_LIGHT, o->Position, 0.5f, o->Light, NULL);
@@ -5868,7 +5869,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime < 10)
             {
-                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
 
@@ -5910,7 +5911,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 10)
                 {
-                    o->Light[0] *= pow(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
                 }
@@ -5945,7 +5946,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 10)
                 {
-                    o->Light[0] *= pow(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
                 }
@@ -5985,7 +5986,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 15)
                 {
-                    o->Light[0] *= pow(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / 1.2f, FPS_ANIMATION_FACTOR);
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
                 }
@@ -6008,7 +6009,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 15)
             {
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 8 || o->SubType == 9)
@@ -6062,7 +6063,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 15)
                 {
-                    VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                    VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
                 }
 
                 if (o->SubType != 18)
@@ -6168,7 +6169,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 15)
                 {
-                    VectorScale(o->Light, pow(1.f / 1.5f, FPS_ANIMATION_FACTOR), o->Light);
+                    VectorScale(o->Light, powf(1.f / 1.5f, FPS_ANIMATION_FACTOR), o->Light);
                 }
             }
             else
@@ -6226,7 +6227,7 @@ void MoveJoint(JOINT* o, int iIndex)
                                 if ((att & TW_NOATTACKZONE) == TW_NOATTACKZONE)
                                 {
                                     o->Velocity = 0.f;
-                                    o->LifeTime *= pow(1.f / 5.f, FPS_ANIMATION_FACTOR);
+                                    o->LifeTime *= powf(1.f / 5.f, FPS_ANIMATION_FACTOR);
                                     break;
                                 }
                             }
@@ -6297,7 +6298,7 @@ void MoveJoint(JOINT* o, int iIndex)
                                     if ((att & TW_NOATTACKZONE) == TW_NOATTACKZONE)
                                     {
                                         o->Velocity = 0.f;
-                                        o->LifeTime *= pow(1.f / 5.f, FPS_ANIMATION_FACTOR);
+                                        o->LifeTime *= powf(1.f / 5.f, FPS_ANIMATION_FACTOR);
                                         break;
                                     }
                                 }
@@ -6328,7 +6329,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->LifeTime < 15)
                 {
-                    VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+                    VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
                 }
             }
             else if (o->SubType >= 2 && o->SubType <= 6)
@@ -6351,7 +6352,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 if (o->LifeTime < o->MultiUse)
                 {
-                    VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+                    VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
                 }
                 if ((int)o->LifeTime % 5 == 0 && o->SubType == 2)
                 {
@@ -6383,7 +6384,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 if (o->LifeTime < o->MultiUse)
                 {
-                    VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+                    VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
                 }
                 o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]) + 3.f;
             }
@@ -6426,7 +6427,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
         }
 
-        VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+        VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
         break;
     case BITMAP_PIERCING:
         if (o->SubType == 0)
@@ -6446,7 +6447,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
 
-            VectorScale(o->Light, pow(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
+            VectorScale(o->Light, powf(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
         }
         else if (o->SubType == 1)
         {
@@ -6465,7 +6466,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
 
-            VectorScale(o->Light, pow(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
+            VectorScale(o->Light, powf(1.f / 1.4f, FPS_ANIMATION_FACTOR), o->Light);
         }
         break;
     case BITMAP_FLARE_FORCE:
@@ -6529,7 +6530,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             if (o->LifeTime < 7)
             {
-                VectorScale(o->Light, pow(1.f / 1.5f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.5f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->NumTails < o->MaxTails - 1)
@@ -6612,7 +6613,7 @@ void MoveJoint(JOINT* o, int iIndex)
             || (o->SubType >= 11 && o->SubType <= 13)
             ) && o->LifeTime < 10)
         {
-            VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+            VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
         }
         break;
 
@@ -6684,7 +6685,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->m_bCreateTails = false;
                 }
 
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
             }
             if (o->SubType < 2)
             {
@@ -6712,7 +6713,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 15)
             {
-                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         else if (o->SubType == 6)
@@ -6754,7 +6755,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < (o->Weapon / 2))
             {
-                VectorScale(o->Light, pow(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.3f, FPS_ANIMATION_FACTOR), o->Light);
             }
         }
         break;
@@ -6776,7 +6777,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 10)
             {
-                VectorScale(o->Light, pow(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
+                VectorScale(o->Light, powf(1.f / 1.2f, FPS_ANIMATION_FACTOR), o->Light);
                 VectorCopy(o->Light, Light);
             }
 
@@ -6792,7 +6793,7 @@ void MoveJoint(JOINT* o, int iIndex)
     case BITMAP_PIN_LIGHT:
     {
         o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
-        VectorScale(o->Light, 0.9f, o->Light);
+        VectorScale(o->Light, powf(0.9f, FPS_ANIMATION_FACTOR), o->Light);
     }
     break;
     case BITMAP_FORCEPILLAR:
@@ -6835,7 +6836,7 @@ void MoveJoint(JOINT* o, int iIndex)
         Models[o->Target->Type].TransformByObjectBone(o->Position, o->Target, 2);
 
         o->Position[2] += (20.0f) * FPS_ANIMATION_FACTOR;
-        VectorScale(o->Light, 0.7f, o->Light);
+        VectorScale(o->Light, powf(0.7f, FPS_ANIMATION_FACTOR), o->Light);
     }
     break;
     case BITMAP_LAVA:
@@ -6848,7 +6849,7 @@ void MoveJoint(JOINT* o, int iIndex)
         int TempFrame = 0;
         TempFrame = o->SubType;
         if (o->SubType >= 7)
-            TempFrame -= (7) * FPS_ANIMATION_FACTOR;
+            TempFrame -= 7;
 
         float TargetAniFrame = o->Target->AnimationFrame - (((o->Velocity * 10.0f) - TempFrame) * 0.1f);
         Models[o->Target->Type].Animation(BoneTransform, TargetAniFrame, o->Target->PriorAnimationFrame,
@@ -6862,7 +6863,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             Models[o->Target->Type].TransformByObjectBone(o->Position, o->Target, 36);
         }
-        VectorScale(o->Light, 0.8f, o->Light);
+        VectorScale(o->Light, powf(0.8f, FPS_ANIMATION_FACTOR), o->Light);
     }
     break;
     }
@@ -7001,10 +7002,14 @@ void RenderJoints(BYTE bRenderOneMore)
                 {
                     continue;
                 }
-                else if (o->Type == BITMAP_JOINT_HEALING && (o->SubType == 9 || o->SubType == 10) && j == (int)o->NumTails - 1)
+
+                if (o->Type == BITMAP_JOINT_HEALING && (o->SubType == 9 || o->SubType == 10) && j == (int)o->NumTails - 1)
                 {
                     continue;
                 }
+
+                auto currentTail = o->Tails[j];
+                auto nextTail = o->Tails[j + 1];
 
                 float Light1, Light2;
                 if (o->bTileMapping)
@@ -7026,8 +7031,8 @@ void RenderJoints(BYTE bRenderOneMore)
                 float Scroll = (float)((int)WorldTime % 1000) * 0.001f;
                 if (o->Type == BITMAP_JOINT_THUNDER || o->Type == BITMAP_JOINT_THUNDER + 1)
                 {
-                    Light1 *= pow(2.f, FPS_ANIMATION_FACTOR);
-                    Light2 *= pow(2.f, FPS_ANIMATION_FACTOR);
+                    Light1 *= powf(2.f, FPS_ANIMATION_FACTOR);
+                    Light2 *= powf(2.f, FPS_ANIMATION_FACTOR);
                     Light1 -= Scroll;
                     Light2 -= Scroll;
                 }
@@ -7042,23 +7047,23 @@ void RenderJoints(BYTE bRenderOneMore)
                 }
                 if (o->bTileMapping)
                 {
-                    Scroll *= pow(2.f, FPS_ANIMATION_FACTOR);
-                    Light1 *= pow(2.f, FPS_ANIMATION_FACTOR);
-                    Light2 *= pow(2.f, FPS_ANIMATION_FACTOR);
+                    Scroll *= powf(2.f, FPS_ANIMATION_FACTOR);
+                    Light1 *= powf(2.f, FPS_ANIMATION_FACTOR);
+                    Light2 *= powf(2.f, FPS_ANIMATION_FACTOR);
                     Light1 -= Scroll;
                     Light2 -= Scroll;
                 }
                 if (o->Type == BITMAP_JOINT_FORCE && o->SubType == 0)
                 {
                     float Luminosity = ((float)((o->MaxTails - j) / (float)(o->MaxTails)) * 2);
-                    Luminosity *= pow(o->Light[0], FPS_ANIMATION_FACTOR);
+                    Luminosity *= powf(o->Light[0], FPS_ANIMATION_FACTOR);
                     glColor3f(Luminosity, Luminosity, Luminosity);
 
                     glBegin(GL_QUADS);
-                    glTexCoord2f(Light1, 0.f); glVertex3fv(o->Tails[j][0]);
-                    glTexCoord2f(Light1, 1.f); glVertex3fv(o->Tails[j][1]);
-                    glTexCoord2f(Light2, 1.f); glVertex3fv(o->Tails[j + 1][1]);
-                    glTexCoord2f(Light2, 0.f); glVertex3fv(o->Tails[j + 1][0]);
+                    glTexCoord2f(Light1, 0.f); glVertex3fv(currentTail[0]);
+                    glTexCoord2f(Light1, 1.f); glVertex3fv(currentTail[1]);
+                    glTexCoord2f(Light2, 1.f); glVertex3fv(nextTail[1]);
+                    glTexCoord2f(Light2, 0.f); glVertex3fv(nextTail[0]);
                     glEnd();
                 }
                 else
@@ -7074,9 +7079,9 @@ void RenderJoints(BYTE bRenderOneMore)
                             float fJointHeight;
 
                             if (o->SubType == 9)
-                                fJointHeight = (o->Tails[j][0][2] - (o->Target->Position[2] + 180)) * 0.01f;
+                                fJointHeight = (currentTail[0][2] - (o->Target->Position[2] + 180)) * 0.01f;
                             else
-                                fJointHeight = (o->Tails[j][0][2] - (o->Target->Position[2] + 50)) * 0.01f;
+                                fJointHeight = (currentTail[0][2] - (o->Target->Position[2] + 50)) * 0.01f;
 
                             if (fJointHeight > 0)
                             {
@@ -7101,7 +7106,7 @@ void RenderJoints(BYTE bRenderOneMore)
                             Vector(0.f, 0.f, 0.f, Position);
                             for (int k = 0; k < 4; ++k)
                             {
-                                VectorAdd(o->Tails[j][k], Position, Position);
+                                VectorAdd(currentTail[k], Position, Position);
                             }
                             VectorScale(Position, 0.25f, Position);
 
@@ -7115,7 +7120,7 @@ void RenderJoints(BYTE bRenderOneMore)
                             float  scale = 0.7f;
                             vec3_t Light;
                             float  fJointHeight = (j) * 0.01f;
-                            VectorScale(o->Light, 0.9978f, o->Light);
+                            VectorScale(o->Light, powf(0.9978f, FPS_ANIMATION_FACTOR), o->Light);
                             Vector(o->Light[0] - fJointHeight, o->Light[1] - fJointHeight, o->Light[2] - fJointHeight, Light);
                             glColor3fv(Light);
 
@@ -7124,7 +7129,7 @@ void RenderJoints(BYTE bRenderOneMore)
                             Vector(0.f, 0.f, 0.f, Position);
                             for (int k = 0; k < 4; ++k)
                             {
-                                VectorAdd(o->Tails[j][k], Position, Position);
+                                VectorAdd(currentTail[k], Position, Position);
                             }
                             VectorScale(Position, 0.25f, Position);
 
@@ -7157,7 +7162,7 @@ void RenderJoints(BYTE bRenderOneMore)
                             Vector(0.f, 0.f, 0.f, Position);
                             for (int k = 0; k < 4; ++k)
                             {
-                                VectorAdd(o->Tails[j][k], Position, Position);
+                                VectorAdd(currentTail[k], Position, Position);
                             }
                             VectorScale(Position, 0.25f, Position);
 
@@ -7173,7 +7178,7 @@ void RenderJoints(BYTE bRenderOneMore)
                             Vector(0.f, 0.f, 0.f, Position);
                             for (int k = 0; k < 4; ++k)
                             {
-                                VectorAdd(o->Tails[j][k], Position, Position);
+                                VectorAdd(currentTail[k], Position, Position);
                             }
                             VectorScale(Position, 0.25f, Position);
 
@@ -7205,12 +7210,12 @@ void RenderJoints(BYTE bRenderOneMore)
                         glTranslatef(t_bias[0], t_bias[1], t_bias[2]);
 
                         glBegin(GL_QUADS);
-                        glTexCoord2f(Light1, 1.f); glVertex3fv(o->Tails[j][2]);
-                        glTexCoord2f(Light1, 0.f); glVertex3fv(o->Tails[j][3]);
+                        glTexCoord2f(Light1, 1.f); glVertex3fv(currentTail[2]);
+                        glTexCoord2f(Light1, 0.f); glVertex3fv(currentTail[3]);
                         glTexCoord2f(Light2, 0.f); glVertex3fv(o->Tails[j + 1][3]);
                         glTexCoord2f(Light2, 1.f); glVertex3fv(o->Tails[j + 1][2]);
-                        glTexCoord2f(Light1, 0.f); glVertex3fv(o->Tails[j][0]);
-                        glTexCoord2f(Light1, 1.f); glVertex3fv(o->Tails[j][1]);
+                        glTexCoord2f(Light1, 0.f); glVertex3fv(currentTail[0]);
+                        glTexCoord2f(Light1, 1.f); glVertex3fv(currentTail[1]);
                         glTexCoord2f(Light2, 1.f); glVertex3fv(o->Tails[j + 1][1]);
                         glTexCoord2f(Light2, 0.f); glVertex3fv(o->Tails[j + 1][0]);
                         glEnd();
@@ -7238,10 +7243,10 @@ void RenderJoints(BYTE bRenderOneMore)
                     if ((o->RenderFace & RENDER_FACE_ONE) == RENDER_FACE_ONE)
                     {
                         glBegin(GL_QUADS);
-                        glTexCoord2f(L1, V2); glVertex3fv(o->Tails[j][2]);
-                        glTexCoord2f(L1, V1); glVertex3fv(o->Tails[j][3]);
-                        glTexCoord2f(L2, V1); glVertex3fv(o->Tails[j + 1][3]);
-                        glTexCoord2f(L2, V2); glVertex3fv(o->Tails[j + 1][2]);
+                        glTexCoord2f(L1, V2); glVertex3fv(currentTail[2]);
+                        glTexCoord2f(L1, V1); glVertex3fv(currentTail[3]);
+                        glTexCoord2f(L2, V1); glVertex3fv(nextTail[3]);
+                        glTexCoord2f(L2, V2); glVertex3fv(nextTail[2]);
                         glEnd();
                     }
 
@@ -7253,10 +7258,10 @@ void RenderJoints(BYTE bRenderOneMore)
                             L2 += Scroll * 2.f;
                         }
                         glBegin(GL_QUADS);
-                        glTexCoord2f(L1, V1); glVertex3fv(o->Tails[j][0]);
-                        glTexCoord2f(L1, V2); glVertex3fv(o->Tails[j][1]);
-                        glTexCoord2f(L2, V2); glVertex3fv(o->Tails[j + 1][1]);
-                        glTexCoord2f(L2, V1); glVertex3fv(o->Tails[j + 1][0]);
+                        glTexCoord2f(L1, V1); glVertex3fv(currentTail[0]);
+                        glTexCoord2f(L1, V2); glVertex3fv(currentTail[1]);
+                        glTexCoord2f(L2, V2); glVertex3fv(nextTail[1]);
+                        glTexCoord2f(L2, V1); glVertex3fv(nextTail[0]);
                         glEnd();
                     }
                 }
@@ -7267,10 +7272,10 @@ void RenderJoints(BYTE bRenderOneMore)
                 EnableDepthTest();
             }
             if (o->Type == BITMAP_JOINT_THUNDER + 1 && o->SubType == 6)
-            {
+            { 
                 vec3_t Light;
                 EnableAlphaBlend();
-                o->Velocity *= pow(1.f / 1.1f, FPS_ANIMATION_FACTOR);
+                o->Velocity *= powf(1.f / 1.1f, FPS_ANIMATION_FACTOR);
                 Vector(o->Velocity, o->Velocity, o->Velocity, Light);
                 RenderTerrainAlphaBitmap(BITMAP_MAGIC + 1, o->TargetPosition[0], o->TargetPosition[1], 2.f, 2.f, Light);
                 DisableAlphaBlend();
@@ -7285,9 +7290,9 @@ void GetMagicScrew(int iParam, vec3_t vResult, float fSpeedRate)
 
     vec3_t vDirTemp;
     float fSpeed[3] = { 0.048f, 0.0613f, 0.1113f };
-    fSpeed[0] *= pow(fSpeedRate, FPS_ANIMATION_FACTOR);
-    fSpeed[1] *= pow(fSpeedRate, FPS_ANIMATION_FACTOR);
-    fSpeed[2] *= pow(fSpeedRate, FPS_ANIMATION_FACTOR);
+    fSpeed[0] *= powf(fSpeedRate, FPS_ANIMATION_FACTOR);
+    fSpeed[1] *= powf(fSpeedRate, FPS_ANIMATION_FACTOR);
+    fSpeed[2] *= powf(fSpeedRate, FPS_ANIMATION_FACTOR);
     vDirTemp[0] = sinf((float)(iParam + 55555) * fSpeed[0]) * cosf((float)iParam * fSpeed[1]);
     vDirTemp[1] = sinf((float)(iParam + 55555) * fSpeed[0]) * sinf((float)iParam * fSpeed[1]);
     vDirTemp[2] = cosf((float)(iParam + 55555) * fSpeed[0]);

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -2974,7 +2974,7 @@ Angle[2] = TurnAngle2(Angle[2],Rotation,FarAngle(Angle[2],Rotation)*0.2f);
 else Angle[2] = TurnAngle2(Angle[2],0.f,FarAngle(Angle[2],0.f)*0.5f);
 }*/
 
-LONG FAR PASCAL WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+//LONG FAR PASCAL WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 void MoveJoint(JOINT* o, int iIndex)
 {
@@ -3000,7 +3000,7 @@ void MoveJoint(JOINT* o, int iIndex)
         AngleMatrix(o->Angle, Matrix);
         if (o->Velocity != 0.0f)
         {
-            Vector(0.f, -o->Velocity, 0.f, p);
+            Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
             VectorRotate(p, Matrix, Position);
             VectorAdd(o->Position, Position, o->Position);
         }
@@ -3016,7 +3016,7 @@ void MoveJoint(JOINT* o, int iIndex)
         MoveHumming(o->Position, o->Angle, o->TargetPosition, 3000.f / Distance);
         //MoveHumming(o->Position,o->Angle,o->TargetPosition,10.f);
         //MoveHumming(o->Position,o->Angle,o->TargetPosition,0.f);
-        if (!o->Collision && Distance <= o->Velocity * 2.f)
+        if (!o->Collision && Distance <= o->Velocity * 2.f * FPS_ANIMATION_FACTOR)
         {
             o->Collision = true;
             o->LifeTime = 5;
@@ -3098,7 +3098,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 VectorCopy(o->Target->EyeLeft, o->Position);
                 if (o->SubType == 8)
                 {
-                    o->Scale += 10.1f;
+                    o->Scale += (10.1f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case 20:
@@ -3246,51 +3246,51 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 if (o->SubType == 0)
                 {
-                    o->Angle[2] += 10.f;
-                    o->Position[2] += 6.f;
+                    o->Angle[2] += (10.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (6.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 45)
                 {
-                    o->Angle[2] += 10.f;
-                    o->Position[2] += 6.f;
+                    o->Angle[2] += (10.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (6.f) * FPS_ANIMATION_FACTOR;
                     //VectorCopy(o->Target->Position, o->TargetPosition);
-                    //o->TargetPosition[2] += 120.f;
+                    //o->TargetPosition[2] += (120.f) * FPS_ANIMATION_FACTOR;
                     //Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
                 else if (o->SubType == 12)
                 {
-                    o->Angle[2] += 15.f;
-                    o->Position[0] += o->MultiUse * (rand() % 5);
-                    o->Position[1] += o->MultiUse * (rand() % 5);
-                    o->Position[2] += 6.f;
+                    o->Angle[2] += (15.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->MultiUse * (rand() % 5)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->MultiUse * (rand() % 5)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (6.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 16
                     || o->SubType == 46
                     )
                 {
-                    o->Angle[2] -= o->MultiUse * 20.f;
-                    o->Position[0] += o->MultiUse * (rand() % 5 + 3);
-                    o->Position[1] += o->MultiUse * (rand() % 5 + 3);
-                    o->Position[2] += 8.f;
+                    o->Angle[2] -= (o->MultiUse * 20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->MultiUse * (rand() % 5 + 3)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->MultiUse * (rand() % 5 + 3)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (8.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 13)
                 {
-                    o->Angle[2] -= 20.f;
-                    o->Position[0] += o->MultiUse * (rand() % 5);
-                    o->Position[1] += o->MultiUse * (rand() % 5);
-                    o->Position[2] += 6.f;
+                    o->Angle[2] -= (20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->MultiUse * (rand() % 5)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->MultiUse * (rand() % 5)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (6.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 44)
                 {
-                    o->Angle[2] -= 20.f;
-                    o->Position[0] += o->MultiUse * (rand() % 5) + cosf(Q_PI / (float)(rand() % 180) * 20.0f);
-                    o->Position[1] += o->MultiUse * (rand() % 5) + sinf(Q_PI / (float)(rand() % 180) * 20.0f);
-                    o->Position[2] += 6.f;
+                    o->Angle[2] -= (20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->MultiUse * (rand() % 5) + cosf(Q_PI / (float)(rand() % 180) * 20.0f)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->MultiUse * (rand() % 5) + sinf(Q_PI / (float)(rand() % 180) * 20.0f)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (6.f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
-                    o->Angle[2] -= 10.f;
-                    o->Position[2] += 5.f;
+                    o->Angle[2] -= (10.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (5.f) * FPS_ANIMATION_FACTOR;
                 }
             }
             else if (o->SubType == 44 && o->LifeTime <= 120 && o->LifeTime >= 10)
@@ -3301,7 +3301,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     if (o->Velocity >= 20.f) o->Velocity = 20.f;
 
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += 120.f;
+                    o->TargetPosition[2] += (120.f) * FPS_ANIMATION_FACTOR;
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
                 else
@@ -3315,9 +3315,9 @@ void MoveJoint(JOINT* o, int iIndex)
                     //o->Angle[1] = o->TargetPosition[1]-o->Position[1];
                     //o->Angle[2] = o->TargetPosition[2]-o->Position[2];
 
-                    o->Position[0] += cosf(Q_PI / (float)(rand() % 180 + 150));
-                    o->Position[1] += sinf(Q_PI / (float)(rand() % 180 + 150));
-                    //o->Position[2] += cosf(Q_PI / (float)(rand()%180));
+                    o->Position[0] += (cosf(Q_PI / (float)(rand() % 180 + 150))) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (sinf(Q_PI / (float)(rand() % 180 + 150))) * FPS_ANIMATION_FACTOR;
+                    //o->Position[2] += (cosf(Q_PI / (float)(rand()%180))) * FPS_ANIMATION_FACTOR;
 
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
@@ -3347,18 +3347,18 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 else if (o->SubType == 7)
                 {
-                    o->Position[2] += o->Velocity;
+                    o->Position[2] += (o->Velocity) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 44)
                 {
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += 120.f;
+                    o->TargetPosition[2] += (120.f) * FPS_ANIMATION_FACTOR;
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
                 else
                 {
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += 120.f;
+                    o->TargetPosition[2] += (120.f) * FPS_ANIMATION_FACTOR;
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
                 }
                 if (Distance <= 35.f)
@@ -3416,10 +3416,10 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime >= 60)
             {
-                o->Position[2] += 1.f;
-                o->Light[0] += 0.4f * 0.005f;
-                o->Light[1] += 0.3f * 0.005f;
-                o->Light[2] += 2.2f * 0.005f;
+                o->Position[2] += (1.f) * FPS_ANIMATION_FACTOR;
+                o->Light[0] += (0.4f * 0.005f) * FPS_ANIMATION_FACTOR;
+                o->Light[1] += (0.3f * 0.005f) * FPS_ANIMATION_FACTOR;
+                o->Light[2] += (2.2f * 0.005f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
@@ -3433,7 +3433,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             float fOldAngle = o->Angle[2];
             VectorCopy(o->Target->Position, o->TargetPosition);
-            o->TargetPosition[2] += 260.f;
+            o->TargetPosition[2] += (260.f) * FPS_ANIMATION_FACTOR;
             Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
 
             if (Distance <= 35.f)
@@ -3463,7 +3463,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
 
             VectorCopy(o->Target->Position, o->TargetPosition);
-            o->TargetPosition[2] += 100.f;
+            o->TargetPosition[2] += (100.f) * FPS_ANIMATION_FACTOR;
             float TargetAngle;
             TargetAngle = CreateAngle2D(o->Position, o->TargetPosition);
             o->Angle[2] = TargetAngle;
@@ -3474,7 +3474,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Live = false;
                 vec3_t vPos;
                 VectorCopy(o->Position, vPos);
-                vPos[2] -= 60.f;
+                vPos[2] -= (60.f) * FPS_ANIMATION_FACTOR;
                 CreateBomb(vPos, true, 4);
             }
             else if (Distance >= 550.0f)
@@ -3573,13 +3573,13 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->Collision)
             {
-                o->MultiUse += 2;
+                o->MultiUse += (2) * FPS_ANIMATION_FACTOR;
             }
             else
             {
-                o->MultiUse -= 2;
+                o->MultiUse -= (2) * FPS_ANIMATION_FACTOR;
             }
-            o->Direction[0] -= 1.f;
+            o->Direction[0] -= (1.f) * FPS_ANIMATION_FACTOR;
 
             if (o->Direction[0] < 0)
             {
@@ -3722,12 +3722,12 @@ void MoveJoint(JOINT* o, int iIndex)
             if ((int)o->LifeTime % 16 <= 7)
             {
                 o->m_sTargetIndex = 10;
-                o->Angle[2] += o->m_sTargetIndex;
+                o->Angle[2] += (o->m_sTargetIndex) * FPS_ANIMATION_FACTOR;
             }
             else
             {
                 o->m_sTargetIndex = -10;
-                o->Angle[2] += o->m_sTargetIndex;
+                o->Angle[2] += (o->m_sTargetIndex) * FPS_ANIMATION_FACTOR;
             }
             CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 59, 1.0f);
         }
@@ -3788,7 +3788,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 CreateEffect(MODEL_SKULL, o->Position, o->Angle, o->Light);
             }
             VectorCopy(o->Target->Position, o->TargetPosition);
-            o->TargetPosition[2] += 80.f;
+            o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
 
             Distance = sqrtf(dx * dx + dy * dy);
             if (o->SubType == 5)
@@ -3805,10 +3805,10 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Direction[0] += (float)(rand() % 32 - 16) * 0.2f;
-                o->Direction[2] += (float)(rand() % 32 - 16) * 0.8f;
-                o->Angle[0] += o->Direction[0];
-                o->Angle[2] += o->Direction[2];
+                o->Direction[0] += ((float)(rand() % 32 - 16) * 0.2f) * FPS_ANIMATION_FACTOR;
+                o->Direction[2] += ((float)(rand() % 32 - 16) * 0.8f) * FPS_ANIMATION_FACTOR;
+                o->Angle[0] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
+                o->Angle[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
                 o->Direction[0] *= 0.6f;
                 o->Direction[2] *= 0.8f;
             }
@@ -3856,17 +3856,17 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (rand() % 2 == 0)
                 {
                     if (o->Angle[0] < -90)
-                        o->Angle[0] += 20.f;
+                        o->Angle[0] += (20.f) * FPS_ANIMATION_FACTOR;
                     else
-                        o->Angle[0] -= 20.f;
+                        o->Angle[0] -= (20.f) * FPS_ANIMATION_FACTOR;
                 }
                 float Distance;
                 if (o->SubType == 13)
                 {
                     VectorCopy(o->Target->Position, Position);
-                    Position[0] += rand() % 150 - 70.f;
-                    Position[1] += rand() % 150 - 70.f;
-                    Position[2] += 50.f;
+                    Position[0] += (rand() % 150 - 70.f) * FPS_ANIMATION_FACTOR;
+                    Position[1] += (rand() % 150 - 70.f) * FPS_ANIMATION_FACTOR;
+                    Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                     Distance = MoveHumming(o->Position, o->Angle, Position, (o->Velocity - 20));
                 }
                 else
@@ -3876,7 +3876,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (o->Velocity > 50.f)
                     o->Velocity = 50.f;
                 else
-                    o->Velocity++;
+                    o->Velocity += FPS_ANIMATION_FACTOR;
 
                 if (Distance < 50.f)
                 {
@@ -3962,7 +3962,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (o->Angle[0] <= 180.0f)
                     o->Angle[0] = 180.0f;
                 if (o->Angle[0] <= 360.0f)
-                    o->Angle[0] += rand() % 3 + 2.0f;
+                    o->Angle[0] += (rand() % 3 + 2.0f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
@@ -3973,13 +3973,13 @@ void MoveJoint(JOINT* o, int iIndex)
         else if (10 == o->SubType)
         {
             o->Velocity = 50.f;
-            o->Angle[2] -= 50.0f;
+            o->Angle[2] -= (50.0f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 9)
         {
-            o->Position[0] += rand() % 10 - 5.f;
-            o->Position[1] += rand() % 10 - 5.f;
-            o->Position[2] += o->Velocity;
+            o->Position[0] += (rand() % 10 - 5.f) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (rand() % 10 - 5.f) * FPS_ANIMATION_FACTOR;
+            o->Position[2] += (o->Velocity) * FPS_ANIMATION_FACTOR;
             o->Velocity += FPS_ANIMATION_FACTOR * 1.f;
 
             if (o->LifeTime < 10)
@@ -4002,8 +4002,8 @@ void MoveJoint(JOINT* o, int iIndex)
                 CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, o->Angle, 12, NULL, 0.9f);
             }
             //			CreateSprite(BITMAP_FIRE+1,Position,2.0f,Light,o->Target,(float)(rand()%360),0);
-            o->Position[0] += cosf(o->Angle[2]) * 20.0f;
-            o->Position[1] += sinf(o->Angle[2]) * 20.0f;
+            o->Position[0] += (cosf(o->Angle[2]) * 20.0f) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (sinf(o->Angle[2]) * 20.0f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 12)
         {
@@ -4024,7 +4024,7 @@ void MoveJoint(JOINT* o, int iIndex)
             vec3_t Position;
             VectorCopy(o->Position, Position);
 
-            o->Angle[0] -= 2.0f;
+            o->Angle[0] -= (2.0f) * FPS_ANIMATION_FACTOR;
             int r = rand() % 5;
             if (r == 0)
                 CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, o->Light, 2);
@@ -4038,7 +4038,7 @@ void MoveJoint(JOINT* o, int iIndex)
             Vector(1, 1, 1, Light);
             vec3_t Position;
             VectorCopy(o->Position, Position);
-            o->PKKey += 30;
+            o->PKKey += (30) * FPS_ANIMATION_FACTOR;
 
             if (o->LifeTime < 35)
             {
@@ -4046,8 +4046,8 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (rand() % 2 == 0)//if ((int)o->LifeTime % 2 == 0)
                 {
-                    Position[0] -= sinf(o->Angle[2]) * (40.0f - o->PKKey * 0.1f);
-                    Position[1] += cosf(o->Angle[2]) * (40.0f - o->PKKey * 0.1f);
+                    Position[0] -= (sinf(o->Angle[2]) * (40.0f - o->PKKey * 0.1f)) * FPS_ANIMATION_FACTOR;
+                    Position[1] += (cosf(o->Angle[2]) * (40.0f - o->PKKey * 0.1f)) * FPS_ANIMATION_FACTOR;
                     Position[2] = 350;
                     vec3_t Angle;
 
@@ -4064,8 +4064,8 @@ void MoveJoint(JOINT* o, int iIndex)
                     if (o->Target->LifeTime > 5)
                         o->Target->Alpha = 1.0f;
                     VectorCopy(o->Position, Position);
-                    Position[0] += sinf(o->Angle[2]) * (30.0f + o->PKKey * 0.1f);
-                    Position[1] -= cosf(o->Angle[2]) * (30.0f + o->PKKey * 0.1f);
+                    Position[0] += (sinf(o->Angle[2]) * (30.0f + o->PKKey * 0.1f)) * FPS_ANIMATION_FACTOR;
+                    Position[1] -= (cosf(o->Angle[2]) * (30.0f + o->PKKey * 0.1f)) * FPS_ANIMATION_FACTOR;
                     //Position[2] = 350;
                     VectorCopy(Position, o->Target->Position);
                     if (o->Target->Angle[0] != 0)
@@ -4076,8 +4076,8 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             //CreateParticle(BITMAP_FIRE+1,Position,o->Angle,Light,5,0.9f);
             //			CreateSprite(BITMAP_FIRE+1,Position,2.0f,Light,o->Target,(float)(rand()%360),0);
-            o->Position[0] += sinf(o->Angle[2]) * (30.0f + o->PKKey * 0.1f);
-            o->Position[1] -= cosf(o->Angle[2]) * (30.0f + o->PKKey * 0.1f);
+            o->Position[0] += (sinf(o->Angle[2]) * (30.0f + o->PKKey * 0.1f)) * FPS_ANIMATION_FACTOR;
+            o->Position[1] -= (cosf(o->Angle[2]) * (30.0f + o->PKKey * 0.1f)) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 16)
         {
@@ -4087,8 +4087,8 @@ void MoveJoint(JOINT* o, int iIndex)
 
             o->Angle[0] = (float)o->LifeTime;
             CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, o->Light, 4);
-            o->Position[0] += cosf(o->Angle[2]) * 30.0f;
-            o->Position[1] += sinf(o->Angle[2]) * 30.0f;
+            o->Position[0] += (cosf(o->Angle[2]) * 30.0f) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (sinf(o->Angle[2]) * 30.0f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 17)
         {
@@ -4112,12 +4112,12 @@ void MoveJoint(JOINT* o, int iIndex)
 
             int add = (int)o->LifeTime % 12;
             if (add <= 5)
-                o->PKKey += 6;
+                o->PKKey += (6) * FPS_ANIMATION_FACTOR;
             else
-                o->PKKey -= 6;
+                o->PKKey -= (6) * FPS_ANIMATION_FACTOR;
 
-            o->Angle[0] -= o->PKKey;
-            o->Angle[2] += 10;
+            o->Angle[0] -= (o->PKKey) * FPS_ANIMATION_FACTOR;
+            o->Angle[2] += (10) * FPS_ANIMATION_FACTOR;
 
             if (o->Target != NULL)
             {
@@ -4138,7 +4138,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (o->Angle[0] <= 180.0f)
                     o->Angle[0] = 180.0f;
                 if (o->Angle[0] <= 360.0f)
-                    o->Angle[0] += rand() % 3 + 2.0f;
+                    o->Angle[0] += (rand() % 3 + 2.0f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
@@ -4156,14 +4156,14 @@ void MoveJoint(JOINT* o, int iIndex)
 
             vec3_t vPos;
             VectorCopy(o->TargetPosition, vPos);
-            vPos[2] += 80.f;
+            vPos[2] += (80.f) * FPS_ANIMATION_FACTOR;
 
             MoveHumming(o->Position, o->Angle, vPos, 5.f);
 
-            o->Direction[0] += (float)(rand() % 32 - 16) * 0.2f;
-            o->Direction[2] += (float)(rand() % 32 - 16) * 0.8f;
-            o->Angle[0] += o->Direction[0];
-            o->Angle[2] += o->Direction[2];
+            o->Direction[0] += ((float)(rand() % 32 - 16) * 0.2f) * FPS_ANIMATION_FACTOR;
+            o->Direction[2] += ((float)(rand() % 32 - 16) * 0.8f) * FPS_ANIMATION_FACTOR;
+            o->Angle[0] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
+            o->Angle[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             o->Direction[0] *= 0.6f;
             o->Direction[2] *= 0.8f;
 
@@ -4194,12 +4194,12 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Position[0] += rand() % 16 - 8.f;
-                o->Position[1] += rand() % 16 - 8.f;
-                o->Position[2] += o->Velocity;
+                o->Position[0] += (rand() % 16 - 8.f) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 16 - 8.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (o->Velocity) * FPS_ANIMATION_FACTOR;
                 //o->Velocity += FPS_ANIMATION_FACTOR * 1.f;
 
-                o->Scale += 3.0f;
+                o->Scale += (3.0f) * FPS_ANIMATION_FACTOR;
             }
 
             CreateSprite(BITMAP_LIGHT, o->Position, 0.5f, o->Light, o->Target);
@@ -4253,7 +4253,7 @@ void MoveJoint(JOINT* o, int iIndex)
         Luminosity = (float)(rand() % 4 + 4) * 0.1f;
         Vector(Luminosity, Luminosity * 0.6f, Luminosity * 0.2f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 4, PrimaryTerrainLight);
-        Vector(0.f, -o->Velocity, 0.f, Position);
+        Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
         VectorRotate(Position, Matrix, p);
         VectorAdd(o->Position, p, o->Position);
         break;
@@ -4310,7 +4310,7 @@ void MoveJoint(JOINT* o, int iIndex)
             VectorAdd(MagicPos, o->TargetPosition, MagicPos);
             vec3_t TargetPos;
             VectorCopy(o->Target->m_vPosSword, TargetPos);
-            //TargetPos[2] += 120.0f;
+            //TargetPos[2] += (120.0f) * FPS_ANIMATION_FACTOR;
 
             for (int i = 0; i < 3; ++i)
             {
@@ -4334,7 +4334,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->LifeTime += FPS_ANIMATION_FACTOR;
             }
             o->Direction[0] = sinf((o->LifeTime - o->Direction[1]) * 0.05f) * 3.f;
-            o->Position[0] += o->Direction[0];
+            o->Position[0] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
 
             float fAlpha;
             if (o->Target != NULL)
@@ -4359,7 +4359,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             for (int i = 0; i < 3; ++i)
             {
-                o->Angle[2] += 10.f;
+                o->Angle[2] += (10.f) * FPS_ANIMATION_FACTOR;
                 AngleMatrix(o->Angle, Matrix);
                 VectorRotate(o->Direction, Matrix, Position);
                 VectorAdd(o->StartPosition, Position, o->Position);
@@ -4372,9 +4372,9 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 if (o->Weapon > 40)
                 {
-                    o->Direction[1] -= 20.f;
-                    o->Angle[2] -= 5.f;
-                    o->Scale += 15.f;
+                    o->Direction[1] -= (20.f) * FPS_ANIMATION_FACTOR;
+                    o->Angle[2] -= (5.f) * FPS_ANIMATION_FACTOR;
+                    o->Scale += (15.f) * FPS_ANIMATION_FACTOR;
                 }
                 if (o->Direction[1] < 0)
                 {
@@ -4382,7 +4382,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     {
                         CreateEffect(BITMAP_SHOCK_WAVE, o->StartPosition, o->Angle, o->Light, 3);
                     }
-                    o->Weapon++;
+                    o->Weapon += FPS_ANIMATION_FACTOR;
 
                     if (o->Weapon < 20)
                     {
@@ -4391,7 +4391,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     }
                     else
                     {
-                        o->StartPosition[2] += 5.f;
+                        o->StartPosition[2] += (5.f) * FPS_ANIMATION_FACTOR;
                     }
                 }
             }
@@ -4401,17 +4401,17 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Light[1] /= 1.2f;
                 o->Light[2] /= 1.2f;
             }
-            o->Scale -= 5.f;
+            o->Scale -= (5.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 8)
         {
-            o->Angle[2] += 25.f;
+            o->Angle[2] += (25.f) * FPS_ANIMATION_FACTOR;
             AngleMatrix(o->Angle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
             VectorAdd(o->StartPosition, Position, o->Position);
             CreateTail(o, Matrix);
 
-            o->StartPosition[2] += 15.f;
+            o->StartPosition[2] += (15.f) * FPS_ANIMATION_FACTOR;
         }
         else
         {
@@ -4497,7 +4497,7 @@ void MoveJoint(JOINT* o, int iIndex)
             else
             {
                 VectorCopy(o->Target->Position, o->TargetPosition);
-                o->TargetPosition[2] += 10.f;
+                o->TargetPosition[2] += (10.f) * FPS_ANIMATION_FACTOR;
             }
 
             if (0 == o->SubType || o->SubType == 4 || o->SubType == 9
@@ -4636,7 +4636,7 @@ void MoveJoint(JOINT* o, int iIndex)
             if (o->Target)
             {
                 VectorCopy(o->Target->Position, o->TargetPosition);
-                o->TargetPosition[2] += 80.f;
+                o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
             }
 
             Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 50.f);
@@ -4673,7 +4673,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
             }
 
-            Vector(0.f, -o->Velocity, 0.f, Position);
+            Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
             VectorRotate(Position, Matrix, p);
             VectorAdd(o->Position, p, o->Position);
         }
@@ -4739,7 +4739,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 Vector(Luminosity * 0.f, Luminosity * 0.1f, Luminosity * 0.2f, Light);
             }
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
-            Vector(0.f, -o->Velocity, 0.f, Position);
+            Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
             VectorRotate(Position, Matrix, p);
             VectorScale(p, FPS_ANIMATION_FACTOR, p)
             VectorAdd(o->Position, p, o->Position);
@@ -4757,7 +4757,7 @@ void MoveJoint(JOINT* o, int iIndex)
             if (o->SubType == 4)
             {
                 VectorCopy(o->TargetPosition, Position);
-                Position[2] += 30.f;
+                Position[2] += (30.f) * FPS_ANIMATION_FACTOR;
                 CreateSprite(BITMAP_SHINY + 1, Position, (float)(rand() % 8 + 8) * 0.2f, o->Light, NULL, (float)(rand() % 360));
             }
             break;
@@ -4792,7 +4792,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (o->Target)
                 {
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += 80.f;
+                    o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
                 }
 
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 50.f);
@@ -4819,9 +4819,9 @@ void MoveJoint(JOINT* o, int iIndex)
 
             case 6:
                 VectorCopy(o->Target->Position, o->TargetPosition);
-                o->TargetPosition[0] += (2050.f + rand() % 200);
-                o->TargetPosition[1] += (2050.f + rand() % 200);
-                o->TargetPosition[2] -= 10000.f;
+                o->TargetPosition[0] += ((2050.f + rand() % 200)) * FPS_ANIMATION_FACTOR;
+                o->TargetPosition[1] += ((2050.f + rand() % 200)) * FPS_ANIMATION_FACTOR;
+                o->TargetPosition[2] -= (10000.f) * FPS_ANIMATION_FACTOR;
 
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, (float)(rand() % 100 + 50));//-25.f);
                 break;
@@ -4848,7 +4848,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 25.f + o->Scale);
                 break;
             case 20:
-                o->TargetPosition[2] += 100.f;
+                o->TargetPosition[2] += (100.f) * FPS_ANIMATION_FACTOR;
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 100.f);
                 break;
                 // ChainLighting
@@ -4877,7 +4877,7 @@ void MoveJoint(JOINT* o, int iIndex)
                         else if (o->SubType == 24)
                         {
                             VectorCopy(pSourceObj->Position, vPos);
-                            vPos[2] += 80.0f;
+                            vPos[2] += (80.0f) * FPS_ANIMATION_FACTOR;
                         }
 
                         o->Direction[0] = (float)(rand() % 1024 - 512 / o->Scale);
@@ -4890,7 +4890,7 @@ void MoveJoint(JOINT* o, int iIndex)
                         VectorCopy(vPos, o->Position);
                         VectorCopy(pTargetObj->Position, o->TargetPosition);
 
-                        o->TargetPosition[2] += 80.f;
+                        o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
                     }
 
                     Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, o->Velocity);
@@ -4906,7 +4906,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (o->Target)
                 {
                     VectorCopy(o->Target->Position, o->TargetPosition);
-                    o->TargetPosition[2] += 80.f;
+                    o->TargetPosition[2] += (80.f) * FPS_ANIMATION_FACTOR;
                 }
 
                 Distance = MoveHumming(o->Position, o->Angle, o->TargetPosition, 40.f);
@@ -5023,7 +5023,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
             }
 
-            Vector(0.f, -o->Velocity, 0.f, Position);
+            Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
             VectorRotate(Position, Matrix, p);
             VectorAdd(o->Position, p, o->Position);
         }
@@ -5040,7 +5040,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             vec3_t Angle;
             VectorCopy(o->StartPosition, Position);
-            Position[2] += 100.f;
+            Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
 
             for (int i = 0; i < o->MultiUse; ++i)
             {
@@ -5053,7 +5053,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     {
                         VectorCopy(to->Position, o->TargetPosition);
                         VectorCopy(o->Angle, Angle);
-                        o->TargetPosition[2] += 100.f;
+                        o->TargetPosition[2] += (100.f) * FPS_ANIMATION_FACTOR;
                         Angle[2] = CreateAngle2D(o->Position, o->TargetPosition);
 
                         CreateJoint(BITMAP_JOINT_THUNDER, Position, o->TargetPosition, Angle, 0, NULL, 50.f);
@@ -5095,7 +5095,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     AngleMatrix(Angle, Matrix);
                     CreateTail(o, Matrix);
 
-                    Vector(0.f, -o->Velocity, 0.f, p);
+                    Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
                     vec3_t vTempPos;
                     VectorCopy(p, vTempPos);
                     VectorRotate(vTempPos, Matrix, p);
@@ -5104,7 +5104,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Light[2] -= 10.12f;
+                o->Light[2] -= (10.12f) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 1 || o->SubType == 2 || o->SubType == 3 || o->SubType == 5 || o->SubType == 6 || o->SubType == 7) //  위에서 아래로 내려오는 번개.
@@ -5116,22 +5116,22 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 if (o->SubType == 6)
                 {
-                    o->Position[0] += rand() % 20 - 10;
-                    o->Position[1] += rand() % 20 - 10;
-                    o->Position[2] -= 13.f;
+                    o->Position[0] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (13.f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
-                    o->Position[0] += rand() % 20 - 10;
-                    o->Position[1] += rand() % 20 - 10;
+                    o->Position[0] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
 
                     if (o->SubType == 7)
                     {
-                        o->Position[2] -= 20.0f;
+                        o->Position[2] -= (20.0f) * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
-                        o->Position[2] -= 16.f;
+                        o->Position[2] -= (16.f) * FPS_ANIMATION_FACTOR;
                     }
                 }
                 CreateTail(o, Matrix);
@@ -5142,8 +5142,8 @@ void MoveJoint(JOINT* o, int iIndex)
             for (int i = o->MaxTails - 5; i < o->MaxTails - 1; ++i)
             {
                 VectorAdd(o->Position, Position, o->Position);
-                o->Position[0] += rand() % 20 - 10;
-                o->Position[1] += rand() % 20 - 10;
+                o->Position[0] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
             }
             VectorCopy(o->TargetPosition, o->Position);
@@ -5190,9 +5190,9 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     CreateTail(o, Matrix);
                     VectorAdd(o->Position, Position, o->Position);
-                    o->Position[0] += rand() % 20 - 10;
-                    o->Position[1] += rand() % 20 - 10;
-                    o->Position[2] += rand() % 20 - 10;
+                    o->Position[0] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 }
 
                 float width = o->TargetIndex[1] / 2.f;
@@ -5228,9 +5228,9 @@ void MoveJoint(JOINT* o, int iIndex)
             AngleMatrix(o->Angle, Matrix);
             for (int i = 0; i < o->MaxTails - 5; ++i)
             {
-                o->Position[0] += rand() % 10 - 5;
-                o->Position[1] += rand() % 10 - 5;
-                o->Position[2] -= 20.0f;
+                o->Position[0] += (rand() % 10 - 5) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 10 - 5) * FPS_ANIMATION_FACTOR;
+                o->Position[2] -= (20.0f) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
             }
             VectorSubtract(o->TargetPosition, o->Position, Position);
@@ -5239,8 +5239,8 @@ void MoveJoint(JOINT* o, int iIndex)
             for (int i = o->MaxTails - 5; i < o->MaxTails - 1; ++i)
             {
                 VectorAdd(o->Position, Position, o->Position);
-                o->Position[0] += rand() % 10 - 5;
-                o->Position[1] += rand() % 10 - 5;
+                o->Position[0] += (rand() % 10 - 5) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 10 - 5) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
             }
             VectorCopy(o->TargetPosition, o->Position);
@@ -5259,7 +5259,7 @@ void MoveJoint(JOINT* o, int iIndex)
             AngleMatrix(o->Angle, Matrix);
             for (int i = 0; i < o->MaxTails - 5; ++i)
             {
-                o->Position[0] += 21.0f;
+                o->Position[0] += (21.0f) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
             }
             VectorSubtract(o->TargetPosition, o->Position, Position);
@@ -5268,8 +5268,8 @@ void MoveJoint(JOINT* o, int iIndex)
             for (int i = o->MaxTails - 5; i < o->MaxTails - 1; ++i)
             {
                 VectorAdd(o->Position, Position, o->Position);
-                o->Position[1] += rand() % 20 - 10;
-                o->Position[2] += rand() % 20 - 10;
+                o->Position[1] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
             }
             VectorCopy(o->TargetPosition, o->Position);
@@ -5288,7 +5288,7 @@ void MoveJoint(JOINT* o, int iIndex)
             AngleMatrix(o->Angle, Matrix);
             for (int i = 0; i < o->MaxTails - 5; ++i)
             {
-                o->Position[1] += 20.0f;
+                o->Position[1] += (20.0f) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
             }
             VectorSubtract(o->TargetPosition, o->Position, Position);
@@ -5297,8 +5297,8 @@ void MoveJoint(JOINT* o, int iIndex)
             for (int i = o->MaxTails - 5; i < o->MaxTails - 1; ++i)
             {
                 VectorAdd(o->Position, Position, o->Position);
-                o->Position[0] += rand() % 20 - 10;
-                o->Position[2] += rand() % 20 - 10;
+                o->Position[0] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (rand() % 20 - 10) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
             }
             VectorCopy(o->TargetPosition, o->Position);
@@ -5332,9 +5332,9 @@ void MoveJoint(JOINT* o, int iIndex)
                 int iScale = 1;
                 VectorAdd(o->Position, p2, o->Position);
                 iScale = (int)(o->Scale / 8.0f);
-                o->Position[0] += rand() % (iScale * 2) - iScale;
-                o->Position[1] += rand() % (iScale * 2) - iScale;
-                o->Position[2] += rand() % (iScale * 2) - iScale;
+                o->Position[0] += (rand() % (iScale * 2) - iScale) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % (iScale * 2) - iScale) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (rand() % (iScale * 2) - iScale) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
             }
             VectorCopy(o->TargetPosition, o->Position);
@@ -5348,9 +5348,9 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 int iScale = 1;
                 iScale = (int)(o->Scale / 5.0f);
-                o->Position[0] += rand() % (iScale * 2) - iScale;
-                o->Position[1] += rand() % (iScale * 2) - iScale;
-                o->Position[2] += rand() % (iScale * 2) - iScale;
+                o->Position[0] += (rand() % (iScale * 2) - iScale) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % (iScale * 2) - iScale) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (rand() % (iScale * 2) - iScale) * FPS_ANIMATION_FACTOR;
                 CreateTail(o, Matrix);
                 VectorSubtract(o->TargetPosition, o->Position, Position);
                 VectorScale(Position, 0.08f, Position);
@@ -5376,10 +5376,10 @@ void MoveJoint(JOINT* o, int iIndex)
     case BITMAP_SPARK + 1:
         if (o->SubType == 0)
         {
-            o->Direction[2] += 5.f;
+            o->Direction[2] += (5.f) * FPS_ANIMATION_FACTOR;
             o->Position[0] = o->TargetPosition[0];
             o->Position[1] = o->TargetPosition[1];
-            o->Position[2] += o->Direction[2];
+            o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
         }
         if (o->SubType == 1)
         {
@@ -5422,14 +5422,14 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Position[1] = o->TargetPosition[1] - sinf(count) * o->Velocity;
 
             if (o->SubType == 0)
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             else if (o->SubType == 10)
-                o->Position[2] -= o->Direction[2];
+                o->Position[2] -= (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             else if (o->SubType == 18)
             {
-                o->Position[2] += (o->Direction[2] * 1.1f);
+                o->Position[2] += ((o->Direction[2] * 1.1f)) * FPS_ANIMATION_FACTOR;
                 o->Velocity += FPS_ANIMATION_FACTOR * 0.1f;
-                o->Scale += 0.2f;
+                o->Scale += (0.2f) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 20)
@@ -5458,31 +5458,31 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 o->Position[0] = o->TargetPosition[0] + cosf(count) * o->Velocity;
                 o->Position[1] = o->TargetPosition[1] - sinf(count) * o->Velocity;
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
                 if (o->LifeTime < 20)
                 {
                     o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
                 }
-                o->Scale += 1;
-                o->Direction[1] += 4;
-                o->Direction[2] += (rand() % 200 + 200) / 100.f;
+                o->Scale += (1) * FPS_ANIMATION_FACTOR;
+                o->Direction[1] += (4) * FPS_ANIMATION_FACTOR;
+                o->Direction[2] += ((rand() % 200 + 200) / 100.f) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 2 || o->SubType == 24 || o->SubType == 50 || o->SubType == 51)
         {
             if (o->SubType == 51)
             {
-                o->Direction[2] += 10.f;
+                o->Direction[2] += (10.f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             }
             if (o->LifeTime <= 25 || o->SubType == 50)
             {
-                o->Direction[2] += 5.f;
+                o->Direction[2] += (5.f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             }
         }
 #ifdef GUILD_WAR_EVENT
@@ -5490,20 +5490,20 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime <= 25)
             {
-                o->Direction[2] += 5.f;
+                o->Direction[2] += (5.f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 22)
         {
             if (o->LifeTime <= 25)
             {
-                o->Direction[2] += 5.f;
+                o->Direction[2] += (5.f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             }
         }
 #endif //GUILD_WAR_EVENT
@@ -5511,10 +5511,10 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime <= 20)
             {
-                o->Direction[2] += 1.f;
+                o->Direction[2] += (1.f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
                 o->Light[0] /= 1.1f;
                 o->Light[1] /= 1.1f;
                 o->Light[2] /= 1.1f;
@@ -5523,7 +5523,7 @@ void MoveJoint(JOINT* o, int iIndex)
         }
         else if (o->SubType == 42)
         {
-            o->Angle[2] += 15.f;
+            o->Angle[2] += (15.f) * FPS_ANIMATION_FACTOR;
 
             if (o->Target->Live)
                 o->LifeTime = 100.f;
@@ -5550,10 +5550,10 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime <= 25)
             {
-                o->Direction[2] -= 5.f;
+                o->Direction[2] -= (5.f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 40)
@@ -5573,15 +5573,15 @@ void MoveJoint(JOINT* o, int iIndex)
                 vPos[0] = rCos * cosf((90.f - o->Angle[2]) * Q_PI / 180.f);
                 vPos[1] = rCos * sinf((90.f - o->Angle[2]) * Q_PI / 180.f);
                 vPos[2] = rSin;
-                o->TargetPosition[0] += o->Direction[0] * (lMax - o->LifeTime);
-                o->TargetPosition[1] += o->Direction[1] * (lMax - o->LifeTime);
+                o->TargetPosition[0] += (o->Direction[0] * (lMax - o->LifeTime)) * FPS_ANIMATION_FACTOR;
+                o->TargetPosition[1] += (o->Direction[1] * (lMax - o->LifeTime)) * FPS_ANIMATION_FACTOR;
                 VectorAdd(o->TargetPosition, vPos, o->Position);
                 AngleMatrix(o->Angle, Matrix);
                 CreateTail(o, Matrix);
             }
             VectorCopy(backPos, o->Position);
-            o->Position[0] += o->Direction[0] * 12;
-            o->Position[1] += o->Direction[1] * 12;
+            o->Position[0] += (o->Direction[0] * 12) * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (o->Direction[1] * 12) * FPS_ANIMATION_FACTOR;
             VectorCopy(o->Position, o->TargetPosition);
 
             o->Scale *= 1.1f;
@@ -5619,18 +5619,18 @@ void MoveJoint(JOINT* o, int iIndex)
                 vPos[1] = sinf(count) * ((float)max(o->LifeTime + 40, 10) * .65f);
             }
             vPos[2] = 0.0f;
-            o->TargetPosition[0] += o->Direction[1];
-            o->TargetPosition[1] += o->Direction[2];
+            o->TargetPosition[0] += (o->Direction[1]) * FPS_ANIMATION_FACTOR;
+            o->TargetPosition[1] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             o->Position[0] = vPos[0] * sinf((90.0f - o->Angle[2]) * Q_PI / 180.0f) + o->TargetPosition[0];
             o->Position[1] = vPos[0] * cosf((90.0f - o->Angle[2]) * Q_PI / 180.0f) + o->TargetPosition[1];
             o->Position[2] = vPos[1] + o->TargetPosition[2];
         }
         else if (o->SubType == 5)
         {
-            o->Direction[2] -= 60.f;
+            o->Direction[2] -= (60.f) * FPS_ANIMATION_FACTOR;
             o->Position[0] = o->TargetPosition[0];
             o->Position[1] = o->TargetPosition[1];
-            o->Position[2] += o->Direction[2];
+            o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             o->Scale = rand() % 4 + 6.f;
         }
         else if (o->SubType == 7 || o->SubType == 11 || o->SubType == 25 || o->SubType == 45 || o->SubType == 46 || o->SubType == 47)
@@ -5725,7 +5725,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             if (o->SubType != 11 && o->SubType != 25)
             {
-                o->Position[2] += 100.0f;
+                o->Position[2] += (100.0f) * FPS_ANIMATION_FACTOR;
             }
 
             vec3_t Light = { .5f, .5f, 1.0f };
@@ -5777,7 +5777,7 @@ void MoveJoint(JOINT* o, int iIndex)
             VectorAdd(o->StartPosition, Position, o->Position);
             AngleMatrix(o->Angle, Matrix);
 
-            o->TargetPosition[2] += 10.f;
+            o->TargetPosition[2] += (10.f) * FPS_ANIMATION_FACTOR;
         }
         else if (o->SubType == 9)
         {
@@ -5793,10 +5793,10 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime <= 25)
             {
-                o->Direction[2] += 1.f;
+                o->Direction[2] += (1.f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] = o->TargetPosition[0];
                 o->Position[1] = o->TargetPosition[1];
-                o->Position[2] += o->Direction[2];
+                o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 17)
@@ -5809,9 +5809,9 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Direction[0] += sinf(rand() % 360 * 0.1f) * 4.f;
-                o->Direction[1] += cosf(rand() % 360 * 0.1f) * 4.f;
-                o->Direction[2] += o->Velocity;
+                o->Direction[0] += (sinf(rand() % 360 * 0.1f) * 4.f) * FPS_ANIMATION_FACTOR;
+                o->Direction[1] += (cosf(rand() % 360 * 0.1f) * 4.f) * FPS_ANIMATION_FACTOR;
+                o->Direction[2] += (o->Velocity) * FPS_ANIMATION_FACTOR;
                 o->Position[0] = o->TargetPosition[0] + o->Direction[0];
                 o->Position[1] = o->TargetPosition[1] + o->Direction[1];
                 o->Position[2] = o->TargetPosition[2] + o->Direction[2];
@@ -5869,15 +5869,15 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     for (float i = 0; i < o->Direction[2]; ++i)
                     {
-                        o->Direction[1] += 1.5f;
+                        o->Direction[1] += (1.5f) * FPS_ANIMATION_FACTOR;
                         switch ((int)o->MultiUse)
                         {
-                        case 0: o->HeadAngle[0] += 3.f; o->HeadAngle[2] -= o->Direction[1]; break;
-                        case 1: o->HeadAngle[0] -= 3.f; o->HeadAngle[2] -= o->Direction[1]; break;
-                        case 2: o->HeadAngle[0] += 3.f; o->HeadAngle[2] += o->Direction[1]; break;
-                        case 3: o->HeadAngle[0] -= 3.f; o->HeadAngle[2] += o->Direction[1]; break;
-                        case 4: o->HeadAngle[2] -= o->Direction[1]; break;
-                        case 5: o->HeadAngle[0] -= o->Direction[1]; break;
+                        case 0: o->HeadAngle[0] += 3.f * FPS_ANIMATION_FACTOR; o->HeadAngle[2] -= o->Direction[1] * FPS_ANIMATION_FACTOR; break;
+                        case 1: o->HeadAngle[0] -= 3.f * FPS_ANIMATION_FACTOR; o->HeadAngle[2] -= o->Direction[1] * FPS_ANIMATION_FACTOR; break;
+                        case 2: o->HeadAngle[0] += 3.f * FPS_ANIMATION_FACTOR; o->HeadAngle[2] += o->Direction[1] * FPS_ANIMATION_FACTOR; break;
+                        case 3: o->HeadAngle[0] -= 3.f * FPS_ANIMATION_FACTOR; o->HeadAngle[2] += o->Direction[1] * FPS_ANIMATION_FACTOR; break;
+                        case 4: o->HeadAngle[2] -= o->Direction[1] * FPS_ANIMATION_FACTOR; break;
+                        case 5: o->HeadAngle[0] -= o->Direction[1] * FPS_ANIMATION_FACTOR; break;
                         }
                         if (o->Direction[1] > 15.f)
                         {
@@ -5885,7 +5885,7 @@ void MoveJoint(JOINT* o, int iIndex)
                         }
 
                         AngleMatrix(o->HeadAngle, Matrix);
-                        Vector(0.f, -o->Velocity, 0.f, p);
+                        Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
                         VectorRotate(p, Matrix, Position);
                         VectorAdd(o->StartPosition, Position, o->Position);
 
@@ -5897,7 +5897,7 @@ void MoveJoint(JOINT* o, int iIndex)
                             break;
                         }
                     }
-                    o->Direction[2] += 4.f;
+                    o->Direction[2] += (4.f) * FPS_ANIMATION_FACTOR;
                 }
             }
         }
@@ -5910,9 +5910,9 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (rand() % 3 == 0)
                 {
                     VectorCopy(o->Target->Position, o->Position);
-                    o->Position[2] += 30.f;
-                    o->Position[0] += (rand() % 60 - 30);
-                    o->Position[1] += (rand() % 60 - 30);
+                    o->Position[2] += (30.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += ((rand() % 60 - 30)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((rand() % 60 - 30)) * FPS_ANIMATION_FACTOR;
                     CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 44, o->Target, o->Scale, 0, 0, 0, 0, o->Light);
                 }
             }
@@ -5933,10 +5933,10 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 if (o->LifeTime <= 20)
                 {
-                    o->Direction[2] += 1.0f;
+                    o->Direction[2] += (1.0f) * FPS_ANIMATION_FACTOR;
                     o->Position[0] = o->TargetPosition[0];
                     o->Position[1] = o->TargetPosition[1];
-                    o->Position[2] += o->Direction[2];
+                    o->Position[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.05f;
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
@@ -5979,8 +5979,8 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime >= 25)
             {
-                o->Angle[2] -= 10.f;
-                o->Position[2] += 2.5f;
+                o->Angle[2] -= (10.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (2.5f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
@@ -6013,8 +6013,8 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->LifeTime >= 25)
             {
-                o->Angle[2] -= 10.f;
-                o->Position[2] += 2.5f;
+                o->Angle[2] -= (10.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (2.5f) * FPS_ANIMATION_FACTOR;
             }
             else
             {
@@ -6050,8 +6050,8 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 if (o->LifeTime >= 30)
                 {
-                    o->Angle[2] -= 10.f;
-                    o->Position[2] += 2.5f;
+                    o->Angle[2] -= (10.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (2.5f) * FPS_ANIMATION_FACTOR;
                 }
 
                 o->Velocity += FPS_ANIMATION_FACTOR * 5.f;
@@ -6060,7 +6060,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 float fOldAngle = o->Angle[2];
                 VectorCopy(o->Target->Position, Position);
-                Position[2] += 150.f;
+                Position[2] += (150.f) * FPS_ANIMATION_FACTOR;
                 Distance = MoveHumming(o->Position, o->Angle, Position, o->Velocity);
 
                 //박종훈테스트
@@ -6092,9 +6092,9 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             o->Position[0] = o->StartPosition[0] + sinf(o->LifeTime / 2.5f) * o->Direction[0];
             o->Position[1] = o->StartPosition[1];
-            o->Position[2] += o->Velocity;
+            o->Position[2] += o->Velocity * FPS_ANIMATION_FACTOR;
             o->Velocity -= FPS_ANIMATION_FACTOR * 0.1f;
-            o->Direction[0] -= 0.1f;
+            o->Direction[0] -= 0.1f * FPS_ANIMATION_FACTOR;
 
             if (o->LifeTime < 15)
             {
@@ -6120,7 +6120,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else if (o->SubType == 9)
             {
-                o->Position[2] += o->MultiUse;
+                o->Position[2] += (o->MultiUse) * FPS_ANIMATION_FACTOR;
             }
         }
         else if (o->SubType == 12 || o->SubType == 13 || o->SubType == 14 || o->SubType == 17 || o->SubType == 15 || o->SubType == 18)
@@ -6183,11 +6183,11 @@ void MoveJoint(JOINT* o, int iIndex)
             AngleMatrix(o->Angle, Mat);
 
             pos[0] /= 3.f; pos[1] /= 3.f; pos[2] /= 3.f;
-            //Angle[1] += o->Velocity - 90;
+            //Angle[1] += (o->Velocity - 90) * FPS_ANIMATION_FACTOR;
 
             for (int j = 0; j < 3; j++)
             {
-                Angle[1] += 30.f;
+                Angle[1] += (30.f) * FPS_ANIMATION_FACTOR;
 
                 VectorAdd(o->TargetPosition, pos, o->TargetPosition);
 
@@ -6212,7 +6212,7 @@ void MoveJoint(JOINT* o, int iIndex)
             AngleMatrix(o->Angle, Mat);
 
             pos[0] /= 3.f; pos[1] /= 3.f; pos[2] /= 3.f;
-            //Angle[1] += o->Velocity - 90;
+            //Angle[1] += (o->Velocity - 90) * FPS_ANIMATION_FACTOR;
 
             for (int j = 0; j < 3; j++)
             {
@@ -6240,11 +6240,11 @@ void MoveJoint(JOINT* o, int iIndex)
                 AngleMatrix(o->Angle, Mat);
 
                 pos[0] /= 3.f; pos[1] /= 3.f; pos[2] /= 3.f;
-                Angle[1] += o->Velocity - 90;
+                Angle[1] += (o->Velocity - 90) * FPS_ANIMATION_FACTOR;
 
                 for (int j = 0; j < 3; j++)
                 {
-                    Angle[1] += 30.f;
+                    Angle[1] += (30.f) * FPS_ANIMATION_FACTOR;
                     VectorAdd(o->TargetPosition, pos, o->TargetPosition);
 
                     vec3_t  position;
@@ -6267,7 +6267,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 o->LifeTime = -1;
                 VectorCopy(o->TargetPosition, o->Position);
-                o->Position[2] += 50.f;
+                o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
             }
         }
         break;
@@ -6288,7 +6288,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     AngleMatrix(o->Angle, Matrix);
                     CreateTail(o, Matrix);
 
-                    o->Direction[2] -= 11.f;
+                    o->Direction[2] -= (11.f) * FPS_ANIMATION_FACTOR;
                     if (o->SubType == 10)
                     {
                         if ((rand() % 2) == 0)
@@ -6364,7 +6364,7 @@ void MoveJoint(JOINT* o, int iIndex)
                         AngleMatrix(o->Angle, Matrix);
                         CreateTail(o, Matrix);
 
-                        o->Direction[2] -= 11.f;
+                        o->Direction[2] -= (11.f) * FPS_ANIMATION_FACTOR;
                         if (o->SubType == 0)
                         {
                             if ((rand() % 2) == 0)
@@ -6415,8 +6415,8 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Live = o->Target->Live;
                 VectorCopy(o->Target->Position, o->Position);
 
-                o->Scale -= 1.f;
-                o->Position[2] += 100.f;
+                o->Scale -= (1.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (100.f) * FPS_ANIMATION_FACTOR;
 
                 if (o->LifeTime < 15)
                 {
@@ -6430,11 +6430,11 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Velocity += FPS_ANIMATION_FACTOR * o->Direction[2];
                 if (o->LifeTime < 15)
                 {
-                    o->Direction[2] += 0.5f;
+                    o->Direction[2] += (0.5f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
-                    o->Direction[2] += o->Direction[0];
+                    o->Direction[2] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
                 }
                 if (o->SubType != 4)
                 {
@@ -6467,11 +6467,11 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Velocity += FPS_ANIMATION_FACTOR * o->Direction[2];
                 if (o->LifeTime < 20)
                 {
-                    o->Direction[2] += 0.5f;
+                    o->Direction[2] += (0.5f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
-                    o->Direction[2] += o->Direction[0];
+                    o->Direction[2] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
                 }
                 if (o->NumTails >= o->MaxTails - 1)
                 {
@@ -6498,7 +6498,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     CreateTail(o, Matrix);
 
-                    Vector(0.f, -o->Velocity, 0.f, p);
+                    Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
                     vec3_t vPos;
                     VectorRotate(p, Matrix, vPos);
                     VectorAdd(o->Position, vPos, o->Position);
@@ -6515,7 +6515,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     CreateTail(o, Matrix);
 
-                    Vector(0.f, -o->Velocity, 0.f, p);
+                    Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
                     vec3_t vPos;
                     VectorRotate(p, Matrix, vPos);
                     VectorAdd(o->Position, vPos, o->Position);
@@ -6538,7 +6538,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     CreateTail(o, Matrix);
 
-                    Vector(0.f, 0.f, -o->Velocity, p);
+                    Vector(0.f, 0.f, -o->Velocity * FPS_ANIMATION_FACTOR, p);
                     VectorRotate(p, Matrix, Position);
                     VectorAdd(o->Position, Position, o->Position);
                 }
@@ -6559,7 +6559,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     CreateTail(o, Matrix);
 
-                    Vector(0.f, 0.f, -o->Velocity, p);
+                    Vector(0.f, 0.f, -o->Velocity * FPS_ANIMATION_FACTOR, p);
                     VectorRotate(p, Matrix, Position);
                     VectorAdd(o->Position, Position, o->Position);
                 }
@@ -6578,7 +6578,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 vec3_t Direction, Angle;
 
-                Vector(0.f, 20.f, 0.f, p);
+                Vector(0.f, 20.f * FPS_ANIMATION_FACTOR, 0.f, p);
                 VectorCopy(o->Direction, Direction);
                 BMD* b = &Models[o->Target->Type];
                 VectorCopy(o->Target->Position, b->BodyOrigin);
@@ -6597,11 +6597,11 @@ void MoveJoint(JOINT* o, int iIndex)
 
                     if (o->SubType % 2)
                     {
-                        o->TargetPosition[1] += 40.f;
+                        o->TargetPosition[1] += (40.f) * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
-                        o->TargetPosition[1] -= 40.f;
+                        o->TargetPosition[1] -= (40.f) * FPS_ANIMATION_FACTOR;
                     }
                     Vector(o->TargetPosition[1], 0.f, 0.f, Angle);
                     AngleMatrix(Angle, Matrix);
@@ -6611,10 +6611,10 @@ void MoveJoint(JOINT* o, int iIndex)
 
                     CreateTail(o, o->Target->BoneTransform[(int)o->MultiUse]);
 
-                    o->TargetPosition[0] -= 0.15f;
+                    o->TargetPosition[0] -= (0.15f) * FPS_ANIMATION_FACTOR;
 
                     if (o->PKKey == -1)
-                        Direction[1] -= 0.1f;
+                        Direction[1] -= (0.1f) * FPS_ANIMATION_FACTOR;
 
                     if ((i % 2) == 0)
                     {
@@ -6643,7 +6643,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     AngleMatrix(o->Angle, Matrix);
 
                     CreateTail(o, Matrix);
-                    Vector(0.f, o->Velocity, 0.f, p);
+                    Vector(0.f, o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
                     VectorRotate(p, Matrix, Position);
                     VectorAdd(o->StartPosition, Position, o->StartPosition);
 
@@ -6652,7 +6652,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->Position[2] = o->StartPosition[2];
                     o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
                 }
-                o->MultiUse += 2;
+                o->MultiUse += (2) * FPS_ANIMATION_FACTOR;
             }
             else if (o->SubType >= 1 && o->SubType <= 4
                 || (o->SubType >= 11 && o->SubType <= 13)
@@ -6665,21 +6665,21 @@ void MoveJoint(JOINT* o, int iIndex)
                     {
                         AngleMatrix(o->Angle, Matrix);
                         CreateTail(o, Matrix);
-                        Vector(0.f, o->Velocity, 0.f, p);
+                        Vector(0.f, o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
                         VectorRotate(p, Matrix, Position);
                         VectorAdd(o->StartPosition, Position, o->StartPosition);
 
                         if (o->SubType == 2 || o->SubType == 4)
                         {
-                            o->TargetPosition[1] -= 20.f;
+                            o->TargetPosition[1] -= (20.f) * FPS_ANIMATION_FACTOR;
                         }
                         else if (o->SubType >= 11 || o->SubType <= 13)
                         {
-                            o->TargetPosition[1] -= 20.f;
+                            o->TargetPosition[1] -= (20.f) * FPS_ANIMATION_FACTOR;
                         }
                         else
                         {
-                            o->TargetPosition[1] += 20.f;
+                            o->TargetPosition[1] += (20.f) * FPS_ANIMATION_FACTOR;
                         }
                         Vector(0.f, o->TargetPosition[1], o->Angle[2], Angle);
                         AngleMatrix(Angle, Matrix);
@@ -6699,13 +6699,13 @@ void MoveJoint(JOINT* o, int iIndex)
                         o->Position[1] = Position[1];
                         o->Position[2] = Position[2];
                         o->Velocity -= FPS_ANIMATION_FACTOR * 2.f;
-                        o->TargetPosition[0] -= 2.5f;
+                        o->TargetPosition[0] -= (2.5f) * FPS_ANIMATION_FACTOR;
                     }
-                    o->MultiUse += 2;
+                    o->MultiUse += (2) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
-                    o->Weapon--;
+                    o->Weapon -= FPS_ANIMATION_FACTOR;
                 }
             }
         }
@@ -6725,7 +6725,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->SubType == 2)
             {
-                o->Angle[2] += rand() % 10 + 10.f;
+                o->Angle[2] += (rand() % 10 + 10.f) * FPS_ANIMATION_FACTOR;
             }
 
             o->Velocity += FPS_ANIMATION_FACTOR * 10.f;
@@ -6737,7 +6737,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             o->Velocity += FPS_ANIMATION_FACTOR * 10.f;
             AngleMatrix(o->HeadAngle, Matrix);
-            Vector(0.f, -o->Velocity, 0.f, p);
+            Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, p);
             VectorRotate(p, Matrix, Position);
             VectorAdd(o->Position, Position, o->Position);
 
@@ -6826,9 +6826,9 @@ void MoveJoint(JOINT* o, int iIndex)
         else if (o->SubType == 6)
         {
             int fr = rand() % 5 - 2;
-            //			o->Direction[0] += fr;
-            o->Direction[1] += fr;
-            o->Direction[2] -= 10.f;
+            //			o->Direction[0] += (fr) * FPS_ANIMATION_FACTOR;
+            o->Direction[1] += (fr) * FPS_ANIMATION_FACTOR;
+            o->Direction[2] -= (10.f) * FPS_ANIMATION_FACTOR;
 
             AngleMatrix(o->Angle, Matrix);
             VectorRotate(o->Direction, Matrix, Position);
@@ -6946,7 +6946,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
         Models[o->Target->Type].TransformByObjectBone(o->Position, o->Target, 2);
 
-        o->Position[2] += 20.0f;
+        o->Position[2] += (20.0f) * FPS_ANIMATION_FACTOR;
         VectorScale(o->Light, 0.7f, o->Light);
     }
     break;
@@ -6960,7 +6960,7 @@ void MoveJoint(JOINT* o, int iIndex)
         int TempFrame = 0;
         TempFrame = o->SubType;
         if (o->SubType >= 7)
-            TempFrame -= 7;
+            TempFrame -= (7) * FPS_ANIMATION_FACTOR;
 
         float TargetAniFrame = o->Target->AnimationFrame - (((o->Velocity * 10.0f) - TempFrame) * 0.1f);
         Models[o->Target->Type].Animation(BoneTransform, TargetAniFrame, o->Target->PriorAnimationFrame,

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -548,7 +548,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 {
                     o->RenderType = RENDER_TYPE_ALPHA_BLEND_MINUS;
                     o->Velocity = 40.f + rand() % 20;
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                         o->LifeTime = 67;
                     else
                         o->LifeTime = 75;
@@ -581,7 +581,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                     o->Position[0] += vRandPos[0];
                     o->Position[1] += vRandPos[1];
                     o->Position[2] = (rand() % 100) + 200;
-                    o->TargetPosition[2] = o->Position[2] - (rand() % 100 - 100) * (rand() % 2 == 0 ? 1 : -1);
+                    o->TargetPosition[2] = o->Position[2] - (rand() % 100 - 100) * (rand_fps_check(2) ? 1 : -1);
 
                     VectorSubtract(o->TargetPosition, o->Position, o->Direction);
 
@@ -2404,7 +2404,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                     o->Velocity = 20.f;
                     Vector(-90.f, 0.f, Angle[2], o->Angle);
                     Vector(0.f, 0.f, 0.f, o->Direction);
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         Vector(1.f, 0.8f, 0.6f, o->Light);
                     }
@@ -2425,7 +2425,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                     o->Velocity = 20.f;
                     Vector(-90.f, 0.f, Angle[2], o->Angle);
                     Vector(0.f, 0.f, 0.f, o->Direction);
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         Vector(1.f, 0.8f, 0.6f, o->Light);
                     }
@@ -2620,7 +2620,7 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                     o->RenderType = RENDER_TYPE_ALPHA_BLEND;
 
                     // o->Target
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         o->Angle[2] += 90.f;
                     }
@@ -3605,7 +3605,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 float fLumi = o->LifeTime / 5.f;
                 VectorScale(o->Light, fLumi, o->Light);
             }
-            o->Scale *= 1.05f;
+            o->Scale *= pow(1.05f, FPS_ANIMATION_FACTOR);
             VectorCopy(o->Target->Position, o->Position);
         }
         else if (o->SubType == 15)
@@ -3809,8 +3809,8 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Direction[2] += ((float)(rand() % 32 - 16) * 0.8f) * FPS_ANIMATION_FACTOR;
                 o->Angle[0] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
                 o->Angle[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
-                o->Direction[0] *= 0.6f;
-                o->Direction[2] *= 0.8f;
+                o->Direction[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                o->Direction[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
             }
 
             Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
@@ -3853,7 +3853,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else if (o->Target != NULL)
             {
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     if (o->Angle[0] < -90)
                         o->Angle[0] += (20.f) * FPS_ANIMATION_FACTOR;
@@ -3997,7 +3997,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             o->Angle[0] = (float)o->LifeTime;	// 임시로 -_-
             CreateParticle(BITMAP_FIRE + 1, Position, o->Angle, Light, 5, 0.9f);
-            if (rand() % 200 == 0)
+            if (rand_fps_check(200))
             {
                 CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, o->Angle, 12, NULL, 0.9f);
             }
@@ -4044,7 +4044,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, 7, 1.0f);
 
-                if (rand() % 2 == 0)//if ((int)o->LifeTime % 2 == 0)
+                if (rand_fps_check(2))//if ((int)o->LifeTime % 2 == 0)
                 {
                     Position[0] -= (sinf(o->Angle[2]) * (40.0f - o->PKKey * 0.1f)) * FPS_ANIMATION_FACTOR;
                     Position[1] += (cosf(o->Angle[2]) * (40.0f - o->PKKey * 0.1f)) * FPS_ANIMATION_FACTOR;
@@ -4164,8 +4164,8 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Direction[2] += ((float)(rand() % 32 - 16) * 0.8f) * FPS_ANIMATION_FACTOR;
             o->Angle[0] += (o->Direction[0]) * FPS_ANIMATION_FACTOR;
             o->Angle[2] += (o->Direction[2]) * FPS_ANIMATION_FACTOR;
-            o->Direction[0] *= 0.6f;
-            o->Direction[2] *= 0.8f;
+            o->Direction[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+            o->Direction[2] *= pow(0.8f, FPS_ANIMATION_FACTOR);
 
             if (o->LifeTime < 30)
                 Luminosity = o->LifeTime / 30.f;
@@ -4325,11 +4325,11 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->Live = false;
                 break;
             }
-            if ((rand() % 5) == 0)
+            if (rand_fps_check(5))
             {
                 o->LifeTime -= 5 * FPS_ANIMATION_FACTOR;
             }
-            else if ((rand() % 2) == 0)
+            else if (rand_fps_check(2))
             {
                 o->LifeTime += FPS_ANIMATION_FACTOR;
             }
@@ -4367,7 +4367,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 if (o->Weapon == 0)
                 {
-                    o->Direction[1] *= 0.95f;
+                    o->Direction[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     if (o->Direction[1] < 10.f) o->Direction[1] = -10.f;
                 }
                 if (o->Weapon > 40)
@@ -4428,9 +4428,9 @@ void MoveJoint(JOINT* o, int iIndex)
                 Vector(fLumi * 1.5f, fLumi * 0.6f, fLumi * 0.6f, Light);
                 AddTerrainLight(o->Position[0], o->Position[1], Light, 1, PrimaryTerrainLight);
 
-                if (rand() % 10 == 0)
+                if (rand_fps_check(10))
                 {
-                    fLumi *= 0.2f;
+                    fLumi *= pow(0.2f, FPS_ANIMATION_FACTOR);
                     Vector(0.9f + fLumi, 0.5f + fLumi, 0.5f + fLumi, Light);
                     CreateParticle(BITMAP_SPARK + 1, o->Position, o->Angle, Light, 19);
                 }
@@ -4520,9 +4520,9 @@ void MoveJoint(JOINT* o, int iIndex)
             float fSpeed[3] = { 0.048f, 0.0613f, 0.1113f };
             if (o->SubType == 1)
             {
-                fSpeed[0] *= 0.5f;
-                fSpeed[1] *= 0.5f;
-                fSpeed[2] *= 0.5f;
+                fSpeed[0] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                fSpeed[1] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                fSpeed[2] *= pow(0.5f, FPS_ANIMATION_FACTOR);
             }
             vDirTemp[0] = sinf((float)(iFrame + 55555) * fSpeed[0]) * cosf((float)iFrame * fSpeed[1]);
             vDirTemp[1] = sinf((float)(iFrame + 55555) * fSpeed[0]) * sinf((float)iFrame * fSpeed[1]);
@@ -4633,6 +4633,7 @@ void MoveJoint(JOINT* o, int iIndex)
     case MODEL_FENRIR_SKILL_THUNDER:
         for (int j = 0; j < o->MaxTails; j++)
         {
+            if (!rand_fps_check(1)) continue;
             if (o->Target)
             {
                 VectorCopy(o->Target->Position, o->TargetPosition);
@@ -4656,7 +4657,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     CreateParticle(BITMAP_ENERGY, o->Position, o->Angle, o->Light);
                     vec3_t Position;
-                    if (rand() % 8 == 0)
+                    if (rand_fps_check(8))
                     {
                         Vector((float)(rand() % 64 - 32), (float)(rand() % 64 - 32), (float)(rand() % 64 - 32), Position);
                         VectorAdd(Position, o->TargetPosition, Position);
@@ -4683,6 +4684,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
         for (int j = 0; j < o->MaxTails; j++)
         {
+            if (!rand_fps_check(1)) continue;
             if (o->SubType == 2)
             {
             }
@@ -4707,7 +4709,7 @@ void MoveJoint(JOINT* o, int iIndex)
             if (Distance <= o->Velocity * 2.f * FPS_ANIMATION_FACTOR)
             {
                 vec3_t Position;
-                if (rand() % 2 == 0)
+                if (rand_fps_check(2))
                 {
                     Vector((float)(rand() % 64 - 32), (float)(rand() % 64 - 32), (float)(rand() % 64 - 32), Position);
                     VectorAdd(Position, o->TargetPosition, Position);
@@ -4778,7 +4780,7 @@ void MoveJoint(JOINT* o, int iIndex)
         {
             if (o->SubType == 15)
                 break;
-
+            if (!rand_fps_check(1)) continue;
             switch (o->SubType)
             {
             case 0:
@@ -4982,7 +4984,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     CreateParticle(BITMAP_ENERGY, o->Position, o->Angle, o->Light);
                     vec3_t Position;
-                    if (rand() % 8 == 0)
+                    if (rand_fps_check(8))
                     {
                         Vector((float)(rand() % 64 - 32), (float)(rand() % 64 - 32), (float)(rand() % 64 - 32), Position);
                         VectorAdd(Position, o->TargetPosition, Position);
@@ -4990,7 +4992,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     }
                     if (o->SubType == 0 || o->SubType == 27)
                     {
-                        if ((int)WorldTime % 1000 < 500 && rand() % 16 == 0)
+                        if ((int)WorldTime % 1000 < 500 && rand_fps_check(16))
                         {
                             Vector((float)(rand() % 100 - 50), (float)(rand() % 100 - 50), (float)(rand() % 120 - 60), Position);
                             VectorAdd(Position, o->TargetPosition, Position);
@@ -5084,6 +5086,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 for (int j = 0; j < o->MaxTails; j++)
                 {
+                    if (!rand_fps_check(1)) continue;
                     Distance = MoveHumming(o->Position, o->Angle, Position, (float)(rand() % 80 + 60.f));
 
                     o->Direction[0] = (float)(rand() % 1400 - 700) / o->Scale;
@@ -5411,7 +5414,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 count = (o->Direction[1] + (o->LifeTime * 2)) * 0.1f;
                 if (o->Skill == 1)
                 {
-                    count *= -1;
+                    count *= pow(-1, FPS_ANIMATION_FACTOR);
                 }
             }
             else
@@ -5454,7 +5457,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 count = o->Direction[1] * 0.1f;
                 if (o->SubType == 15)
                 {
-                    count *= -1;
+                    count *= pow(-1, FPS_ANIMATION_FACTOR);
                 }
                 o->Position[0] = o->TargetPosition[0] + cosf(count) * o->Velocity;
                 o->Position[1] = o->TargetPosition[1] - sinf(count) * o->Velocity;
@@ -5584,7 +5587,7 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Position[1] += (o->Direction[1] * 12) * FPS_ANIMATION_FACTOR;
             VectorCopy(o->Position, o->TargetPosition);
 
-            o->Scale *= 1.1f;
+            o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
             o->Light[0] = 0.5f + (float)(rand() % 64) / 255;
             o->Light[1] = 0.5f + (float)(rand() % 64) / 255;
             o->Light[2] = 0.5f + (float)(rand() % 128) / 255;
@@ -5654,9 +5657,9 @@ void MoveJoint(JOINT* o, int iIndex)
             float fSpeed[3] = { 0.048f, 0.0613f, 0.1113f };
             if (o->SubType == 11)
             {
-                fSpeed[0] *= 1.5f;
-                fSpeed[1] *= 1.5f;
-                fSpeed[2] *= 1.5f;
+                fSpeed[0] *= pow(1.5f, FPS_ANIMATION_FACTOR);
+                fSpeed[1] *= pow(1.5f, FPS_ANIMATION_FACTOR);
+                fSpeed[2] *= pow(1.5f, FPS_ANIMATION_FACTOR);
             }
             vDirTemp[0] = sinf((float)(iFrame + 55555) * fSpeed[0]) * cosf((float)iFrame * fSpeed[1]);
             vDirTemp[1] = sinf((float)(iFrame + 55555) * fSpeed[0]) * sinf((float)iFrame * fSpeed[1]);
@@ -5849,9 +5852,9 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                o->Light[0] *= 1.04f;
-                o->Light[1] *= 1.04f;
-                o->Light[2] *= 1.04f;
+                o->Light[0] *= pow(1.04f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.04f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.04f, FPS_ANIMATION_FACTOR);
             }
         }
         else if (o->SubType == 23)
@@ -5907,7 +5910,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 o->LifeTime = 100.f; //무한
 
-                if (rand() % 3 == 0)
+                if (rand_fps_check(3))
                 {
                     VectorCopy(o->Target->Position, o->Position);
                     o->Position[2] += (30.f) * FPS_ANIMATION_FACTOR;
@@ -6279,6 +6282,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             for (int j = 0; j < 8; ++j)
             {
+                if (!rand_fps_check(1)) continue;
                 if (o->NumTails < o->MaxTails - 1)
                 {
                     VectorCopy(o->Position, Light);
@@ -6291,7 +6295,7 @@ void MoveJoint(JOINT* o, int iIndex)
                     o->Direction[2] -= (11.f) * FPS_ANIMATION_FACTOR;
                     if (o->SubType == 10)
                     {
-                        if ((rand() % 2) == 0)
+                        if (rand_fps_check(2))
                         {
                             CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 0);
                         }
@@ -6355,6 +6359,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 for (int j = 0; j < 8; ++j)
                 {
+                    if (!rand_fps_check(1)) continue;
                     if (o->NumTails < o->MaxTails - 1)
                     {
                         VectorCopy(o->Position, Light);
@@ -6367,7 +6372,7 @@ void MoveJoint(JOINT* o, int iIndex)
                         o->Direction[2] -= (11.f) * FPS_ANIMATION_FACTOR;
                         if (o->SubType == 0)
                         {
-                            if ((rand() % 2) == 0)
+                            if (rand_fps_check(2))
                             {
                                 CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 0);
                             }
@@ -7109,6 +7114,8 @@ void RenderJoints(BYTE bRenderOneMore)
 
             for (int j = 0; j < o->NumTails; j++)
             {
+                if (!rand_fps_check(1)) continue;
+
                 if (o->Type == BITMAP_SMOKE && o->SubType == 0 && j < 1)
                 {
                     continue;
@@ -7138,8 +7145,8 @@ void RenderJoints(BYTE bRenderOneMore)
                 float Scroll = (float)((int)WorldTime % 1000) * 0.001f;
                 if (o->Type == BITMAP_JOINT_THUNDER || o->Type == BITMAP_JOINT_THUNDER + 1)
                 {
-                    Light1 *= 2.f;
-                    Light2 *= 2.f;
+                    Light1 *= pow(2.f, FPS_ANIMATION_FACTOR);
+                    Light2 *= pow(2.f, FPS_ANIMATION_FACTOR);
                     Light1 -= Scroll;
                     Light2 -= Scroll;
                 }
@@ -7154,16 +7161,16 @@ void RenderJoints(BYTE bRenderOneMore)
                 }
                 if (o->bTileMapping)
                 {
-                    Scroll *= 2.f;
-                    Light1 *= 2.f;
-                    Light2 *= 2.f;
+                    Scroll *= pow(2.f, FPS_ANIMATION_FACTOR);
+                    Light1 *= pow(2.f, FPS_ANIMATION_FACTOR);
+                    Light2 *= pow(2.f, FPS_ANIMATION_FACTOR);
                     Light1 -= Scroll;
                     Light2 -= Scroll;
                 }
                 if (o->Type == BITMAP_JOINT_FORCE && o->SubType == 0)
                 {
                     float Luminosity = ((float)((o->MaxTails - j) / (float)(o->MaxTails)) * 2);
-                    Luminosity *= o->Light[0];
+                    Luminosity *= pow(o->Light[0], FPS_ANIMATION_FACTOR);
                     glColor3f(Luminosity, Luminosity, Luminosity);
 
                     glBegin(GL_QUADS);
@@ -7397,9 +7404,9 @@ void GetMagicScrew(int iParam, vec3_t vResult, float fSpeedRate)
 
     vec3_t vDirTemp;
     float fSpeed[3] = { 0.048f, 0.0613f, 0.1113f };
-    fSpeed[0] *= fSpeedRate;
-    fSpeed[1] *= fSpeedRate;
-    fSpeed[2] *= fSpeedRate;
+    fSpeed[0] *= pow(fSpeedRate, FPS_ANIMATION_FACTOR);
+    fSpeed[1] *= pow(fSpeedRate, FPS_ANIMATION_FACTOR);
+    fSpeed[2] *= pow(fSpeedRate, FPS_ANIMATION_FACTOR);
     vDirTemp[0] = sinf((float)(iParam + 55555) * fSpeed[0]) * cosf((float)iParam * fSpeed[1]);
     vDirTemp[1] = sinf((float)(iParam + 55555) * fSpeed[0]) * sinf((float)iParam * fSpeed[1]);
     vDirTemp[2] = cosf((float)(iParam + 55555) * fSpeed[0]);

--- a/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
+++ b/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
@@ -300,7 +300,7 @@ void CreateArrows(CHARACTER* c, OBJECT* o, OBJECT* to, WORD SkillIndex, WORD Ski
             for (int i = 0; i < 15; ++i)
             {
                 Vector((float)(rand() % 360), 0.f, 0.f, a);
-                if ((rand() % 2) == 0)
+                if (rand_fps_check(2))
                 {
                     CreateJoint(BITMAP_JOINT_SPARK, Position, Position, a, 3);
                 }

--- a/Source Main 5.2/source/ZzzEffectNoUse.cpp
+++ b/Source Main 5.2/source/ZzzEffectNoUse.cpp
@@ -76,7 +76,7 @@ void MovePlanes()
         OBJECT* o = &Planes[i];
         if (o->Live)
         {
-            o->LifeTime--;
+            o->LifeTime -= FPS_ANIMATION_FACTOR;
             if (o->LifeTime <= 0)
                 o->Live = false;
             MoveParticle(o, true);
@@ -85,7 +85,7 @@ void MovePlanes()
                 float Light = (float)o->LifeTime * 0.1f;
                 Vector(Light * 0.6f, Light, Light * 0.8f, o->Light);
             }
-            o->Angle[2] -= o->LifeTime;
+            o->Angle[2] -= o->LifeTime * FPS_ANIMATION_FACTOR;
         }
     }
 }
@@ -107,7 +107,7 @@ void RenderShpere(int Type, vec3_t ShperePosition, float Scale, vec3_t ShpereLig
 {
     vec3_t ObjectPosition;
     VectorCopy(ShperePosition, ObjectPosition);
-    ObjectPosition[2] += Scale;
+    ObjectPosition[2] += Scale * FPS_ANIMATION_FACTOR;
     BindTexture(Type);
 
     float Width = 18.f;

--- a/Source Main 5.2/source/ZzzEffectNoUse.cpp
+++ b/Source Main 5.2/source/ZzzEffectNoUse.cpp
@@ -347,7 +347,7 @@ void MappingEffect(int SrcIndex, int DstIndex, int Flag)
             int Index = (i * 256 + j) * 3;
             if (s[Index] >= 96)
             {
-                //if(rand()%2==0)
+                //if(rand_fps_check(2))
                 {
                     for (k = 0; k < 3; k++)
                     {

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -3911,30 +3911,30 @@ void MoveParticles()
                 {
                     if (o->SubType == 2)
                     {
-                        o->Light[0] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.16f, FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.16f, FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.16f, FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.16f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.16f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.16f, FPS_ANIMATION_FACTOR);
                     }
                 }
                 else
                 {
                     if (o->SubType == 2)
                     {
-                        o->Light[0] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
                     }
                 }
                 o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
@@ -3985,8 +3985,8 @@ void MoveParticles()
                 else if (o->SubType == 1)
                 {
                     o->Light[0] *= 0.99f + (0.01f * 1 - FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     o->Scale += 1.5f * FPS_ANIMATION_FACTOR;
                 }
                 break;
@@ -4050,8 +4050,8 @@ void MoveParticles()
                     }
                     if (o->LifeTime < 20)
                     {
-                        o->TurningForce[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
-                        o->TurningForce[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[0] *= powf(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[1] *= powf(0.6f, FPS_ANIMATION_FACTOR);
                     }
                     Vector(o->Alpha * 1.0f, o->Alpha * 0.0f, o->Alpha * 0.6f, o->Light);
 
@@ -4082,8 +4082,8 @@ void MoveParticles()
                     }
                     if (o->LifeTime < 20)
                     {
-                        o->TurningForce[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
-                        o->TurningForce[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[0] *= powf(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[1] *= powf(0.6f, FPS_ANIMATION_FACTOR);
                     }
                     Vector(o->Alpha * 1.0f, o->Alpha * 1.0f, o->Alpha * 1.0f, o->Light);
 
@@ -4115,8 +4115,8 @@ void MoveParticles()
                     }
                     if (o->LifeTime < 20)
                     {
-                        o->TurningForce[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
-                        o->TurningForce[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[0] *= powf(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[1] *= powf(0.6f, FPS_ANIMATION_FACTOR);
                     }
                     Vector(o->Alpha * o->Light[0], o->Alpha * o->Light[1], o->Alpha * o->Light[2], o->Light);
 
@@ -4156,9 +4156,9 @@ void MoveParticles()
             break;
             case BITMAP_MAGIC + 1:
             {
-                o->Light[0] *= pow(0.9f, FPS_ANIMATION_FACTOR);
-                o->Light[1] *= pow(0.9f, FPS_ANIMATION_FACTOR);
-                o->Light[2] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                o->Light[0] *= powf(0.9f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= powf(0.9f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= powf(0.9f, FPS_ANIMATION_FACTOR);
                 o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
             }
             break;
@@ -4592,7 +4592,7 @@ void MoveParticles()
                 {
                     o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     o->Rotation += (5) * FPS_ANIMATION_FACTOR;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -4628,7 +4628,7 @@ void MoveParticles()
                 {
                     o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
@@ -4661,9 +4661,9 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     if (o->Light[2] <= 0.05f || o->Scale <= 0.0f)
                         o->Live = false;
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -4675,9 +4675,9 @@ void MoveParticles()
                     o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     if (o->Light[2] <= 0.05f || o->Scale <= 0.0f)
                         o->Live = false;
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -4687,10 +4687,10 @@ void MoveParticles()
                 case 16:
                 {
                     o->Frame = (3 - o->LifeTime);
-                    o->Light[0] *= pow(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
-                    o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.1f, FPS_ANIMATION_FACTOR);
                 }break;
                 case 18:
                 {
@@ -4778,9 +4778,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.13f;
                     o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 0)
                 {
@@ -4816,7 +4816,7 @@ void MoveParticles()
                     if ((int)o->LifeTime == 10)
                     {
                         o->Velocity[1] += (32 * 0.2f) * FPS_ANIMATION_FACTOR;
-                        o->Scale *= pow(0.8f, FPS_ANIMATION_FACTOR);
+                        o->Scale *= powf(0.8f, FPS_ANIMATION_FACTOR);
                     }
                     o->Rotation = (float)(rand() % 360);
                     o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
@@ -4826,9 +4826,9 @@ void MoveParticles()
                 case 2:
                     if (o->LifeTime < 10)
                     {
-                        //                        o->Light[0] *= pow(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
-                        //                        o->Light[1] *= pow(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
-                        //                        o->Light[2] *= pow(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
+                        //                        o->Light[0] *= powf(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
+                        //                        o->Light[1] *= powf(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
+                        //                        o->Light[2] *= powf(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
                     }
                     o->Rotation = (float)(rand() % 360);
                     o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
@@ -4863,9 +4863,9 @@ void MoveParticles()
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
-                    o->Light[0] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 7:
@@ -4880,9 +4880,9 @@ void MoveParticles()
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
-                    o->Light[0] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 9:
@@ -4897,15 +4897,15 @@ void MoveParticles()
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
-                    o->Light[0] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 10:
                     VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
-                    o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
-                    o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[0] *= powf(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[1] *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     o->Light[0] = (float)(o->LifeTime) / 10.f;
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
@@ -4913,9 +4913,9 @@ void MoveParticles()
                     o->Scale += FPS_ANIMATION_FACTOR * 0.07f;
                     break;
                 case 11:
-                    o->Light[0] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 break;
@@ -4990,9 +4990,9 @@ void MoveParticles()
                         o->Position[2] += (80.f) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 7)
                 {
@@ -5058,22 +5058,22 @@ void MoveParticles()
 
                     if (o->LifeTime <= 30)
                     {
-                        o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->LifeTime <= 20)
                 {
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 11)
                 {
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     o->Scale += 1.5f * FPS_ANIMATION_FACTOR;
                 }
                 else
@@ -5090,9 +5090,9 @@ void MoveParticles()
                         o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
                         if (o->LifeTime <= 35)
                         {
-                            o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                            o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                            o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                            o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                            o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                            o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                         }
                     }
                 if (o->SubType == 0)
@@ -5127,9 +5127,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.5f;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -5138,9 +5138,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -5149,9 +5149,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -5220,12 +5220,12 @@ void MoveParticles()
                 }
                 else if (o->SubType == 9)
                 {
-                    o->Scale *= pow(0.98f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.98f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
 
-                    o->Light[0] *= pow(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
-                    o->Alpha *= pow(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
+                    o->Alpha *= powf(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 10)
                 {
@@ -5281,9 +5281,9 @@ void MoveParticles()
 
                 o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
-                o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
             }
             break;
             case BITMAP_SMOKE:
@@ -5313,15 +5313,15 @@ void MoveParticles()
                     o->Position[1] -= (o->TurningForce[1] * 0.8f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
                     o->Rotation += (0.01f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     break;
                 case 38:
                     o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
-                    o->Light[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
                     break;
                 case 33:
                     Luminosity = (float)(o->LifeTime) / 8.f;
@@ -5528,15 +5528,15 @@ void MoveParticles()
                     o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     break;
                 case 35:
-                    o->Light[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
                     break;
                 case 34:
-                    o->Light[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
                     break;
                 case 26:
@@ -5551,13 +5551,13 @@ void MoveParticles()
                 case 28:
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime >= 9) o->Scale -= FPS_ANIMATION_FACTOR* 0.4f;
-                    else o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
+                    else o->Scale *= powf(1.2f, FPS_ANIMATION_FACTOR);
                     Vector(o->Light[0] * 0.92f, o->Light[1] * 0.92f, o->Light[2] * 0.92f, o->Light);
                     break;
                 case 29:
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime >= 9) o->Scale -= FPS_ANIMATION_FACTOR * 0.4f;
-                    else o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
+                    else o->Scale *= powf(1.2f, FPS_ANIMATION_FACTOR);
                     Vector(1.0f, 1.0f, 1.0f, o->Light);
                     break;
                 case 30:
@@ -5567,9 +5567,9 @@ void MoveParticles()
                     break;
                 case 31:
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     if (o->Scale <= 0.0f && o->Light[2] <= 0.0f)
                         o->Live = false;
                     break;
@@ -5601,9 +5601,9 @@ void MoveParticles()
                     break;
                 case 43:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
                 }
                 break;
@@ -5611,15 +5611,15 @@ void MoveParticles()
                 {
                     if (o->LifeTime >= 30)
                     {
-                        o->Light[0] *= pow(1.07f, FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.07f, FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.07f, FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.07f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.07f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.07f, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
                     }
                     o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
                     o->Position[2] += (0.8f) * FPS_ANIMATION_FACTOR;
@@ -5628,16 +5628,16 @@ void MoveParticles()
                 break;
                 case 45:
                 {
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 46:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
@@ -5649,9 +5649,9 @@ void MoveParticles()
                 break;
                 case 47:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
@@ -5673,15 +5673,15 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 100)
                     {
-                        o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(0.97f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(0.97f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(0.97f, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.03f, FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.03f, FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.03f, FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.03f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.03f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.03f, FPS_ANIMATION_FACTOR);
                     }
 
                     if (o->Light[0] <= 0.01f)
@@ -5724,9 +5724,9 @@ void MoveParticles()
                 {
                     VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
-                    o->Light[0] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 53:
@@ -5737,9 +5737,9 @@ void MoveParticles()
                     break;
                 case 54:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
@@ -5755,9 +5755,9 @@ void MoveParticles()
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
 
-                    o->Light[0] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 56:
@@ -5809,9 +5809,9 @@ void MoveParticles()
                 break;
                 case 63:
                 {
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.5f;
                     o->Velocity[1] += (1.5f) * FPS_ANIMATION_FACTOR;
                 }
@@ -5848,9 +5848,9 @@ void MoveParticles()
                 break;
                 case 66:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
@@ -5869,9 +5869,9 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
 
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Rotation += (0.01f) * FPS_ANIMATION_FACTOR;
@@ -5951,9 +5951,9 @@ void MoveParticles()
                 case 3:
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
-                    o->Light[0] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Rotation += (o->Gravity / 2.0f) * FPS_ANIMATION_FACTOR;
 
@@ -5964,9 +5964,9 @@ void MoveParticles()
                 case 4:
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
-                    o->Light[0] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Rotation += (o->Gravity / 2.0f) * FPS_ANIMATION_FACTOR;
 
@@ -6079,9 +6079,9 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
                 }
                 break;
             case BITMAP_LIGHTNING_MEGA1:
@@ -6536,21 +6536,21 @@ void MoveParticles()
             case BITMAP_LIGHT + 1:
                 if (o->SubType == 2)
                 {
-                    o->Scale *= pow(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.92f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Scale *= pow(1.3f, FPS_ANIMATION_FACTOR);
-                    o->Light[0] *= pow(0.9f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(0.9f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.3f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(0.9f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(0.9f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(0.9f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 5)
                 {
                     o->LifeTime = 5;
-                    o->Light[0] *= pow(0.7f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(0.7f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(0.7f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(0.7f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(0.7f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(0.7f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 4)
                 {
@@ -6560,7 +6560,7 @@ void MoveParticles()
                     o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Position[1] -= (1.f) * FPS_ANIMATION_FACTOR;
                     o->Gravity += (1.f) * FPS_ANIMATION_FACTOR;
-                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
                 }
                 break;
             case BITMAP_BLOOD:
@@ -6596,9 +6596,9 @@ void MoveParticles()
                 }
                 else if (o->SubType == 8 || o->SubType == 10)
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                 }
                 if (o->SubType == 7)
                     o->Gravity -= (0.6f) * FPS_ANIMATION_FACTOR;
@@ -6643,11 +6643,11 @@ void MoveParticles()
                     o->Light[2] = o->LifeTime / 5.f;
 
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
-                    VectorAdd(o->StartPosition, o->Velocity, o->Position);
+                    VectorAddScaled(o->StartPosition, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     VectorCopy(o->Position, o->StartPosition);
                     break;
                 case 3:
-                    o->Scale *= pow(0.8f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.8f, FPS_ANIMATION_FACTOR);
                     break;
                 case 4:
                     if (o->LifeTime <= 0) o->Live = false;
@@ -6659,7 +6659,7 @@ void MoveParticles()
 
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
 
-                    VectorAdd(o->StartPosition, o->Velocity, o->Position);
+                    VectorAdd(o->StartPosition, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     VectorCopy(o->Position, o->StartPosition);
 
                     vec3_t p;
@@ -6667,10 +6667,10 @@ void MoveParticles()
                     VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
                     break;
                 case 5:
-                    o->Scale *= pow(0.9f, FPS_ANIMATION_FACTOR);
-                    o->Light[0] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.9f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     break;
                 case 6:
                 {
@@ -6711,9 +6711,9 @@ void MoveParticles()
                 break;
                 case 10:
                 {
-                    o->Light[0] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.03f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6722,9 +6722,9 @@ void MoveParticles()
                 case 13:
                 case 11:
                 {
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6741,9 +6741,9 @@ void MoveParticles()
                 break;
                 case 14:
                 {
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6751,9 +6751,9 @@ void MoveParticles()
                 break;
                 case 15:
                 {
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -6768,12 +6768,12 @@ void MoveParticles()
 
                     if (o->Frame == 77)
                     {
-                        o->Gravity *= pow(1.03f, FPS_ANIMATION_FACTOR);
+                        o->Gravity *= powf(1.03f, FPS_ANIMATION_FACTOR);
                         o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->Frame == 88)
                     {
-                        o->Gravity *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                        o->Gravity *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                         if (o->Gravity <= 0.1f)
                         {
                             o->Gravity = 0.1f;
@@ -6783,7 +6783,7 @@ void MoveParticles()
                     }
                     else if (o->Frame == 99)
                     {
-                        o->Gravity *= pow(1.2f, FPS_ANIMATION_FACTOR);
+                        o->Gravity *= powf(1.2f, FPS_ANIMATION_FACTOR);
                         o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     }
 
@@ -6796,9 +6796,9 @@ void MoveParticles()
                 {
                     if (o->Position[2] >= o->StartPosition[2] + 350.0f)
                     {
-                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     }
 
                     if (o->Light[0] <= 0.05f)
@@ -6817,16 +6817,16 @@ void MoveParticles()
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 20:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -6845,16 +6845,16 @@ void MoveParticles()
                 break;
                 case 21:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 22:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -6878,9 +6878,9 @@ void MoveParticles()
                         VectorScale(o->Velocity, -1, o->Velocity);
                         o->Rotation = 1;
                     }
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.0001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6897,9 +6897,9 @@ void MoveParticles()
                     if (o->LifeTime <= 10)
                     {
                         o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
-                        o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(o->Alpha, FPS_ANIMATION_FACTOR);
                     }
 
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
@@ -6914,9 +6914,9 @@ void MoveParticles()
                         o->Velocity[2] -= (1.f) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale = sinf(o->LifeTime * (Q_PI / 40.f));
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6927,31 +6927,31 @@ void MoveParticles()
                     if (o->LifeTime <= 0)
                         o->Live = false;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
-                    VectorAdd(o->StartPosition, o->Velocity, o->Position);
+                    VectorAddScaled(o->StartPosition, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     VectorCopy(o->Position, o->StartPosition);
                 }
                 break;
                 case 27:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
-                    o->Scale *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 28:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
-                    o->Scale *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.03f)
                         o->Live = false;
@@ -6970,11 +6970,11 @@ void MoveParticles()
                 break;
                 case 29:
                 {
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
-                    o->Scale *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.03f)
                         o->Live = false;
@@ -6999,9 +6999,9 @@ void MoveParticles()
                         o->Velocity[1] += (cosf(Q_PI / 180.0f * float(rand() % 360))) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
 
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
 
@@ -7098,17 +7098,17 @@ void MoveParticles()
                     o->Velocity[2] -= ((float)(rand() % 8) * 0.05f) * FPS_ANIMATION_FACTOR;
                     VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
 
                     CreateSprite(BITMAP_LIGHT, o->Position, o->Scale / 1.5f, o->Light, NULL);
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -7118,9 +7118,9 @@ void MoveParticles()
                     o->Rotation += (20.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
@@ -7132,24 +7132,24 @@ void MoveParticles()
                     o->Rotation += (10.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                 }
                 else if (o->SubType == 6)
                 {
-                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] < 0.2f)
                     {
                         o->Live = false;
                     }
 
-                    o->StartPosition[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->StartPosition[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
                     if (o->LifeTime < 60 && rand_fps_check(2))
                     {
                         o->Scale = 0;
@@ -7161,9 +7161,9 @@ void MoveParticles()
 
                     if (o->LifeTime < 60)
                     {
-                        o->Velocity[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                        o->Velocity[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                        o->Velocity[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[0] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[1] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[2] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
 
                         o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
                         o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
@@ -7175,16 +7175,16 @@ void MoveParticles()
                 }
                 else if (o->SubType == 8)
                 {
-                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] < 0.2f)
                     {
                         o->Live = false;
                     }
 
-                    o->StartPosition[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->StartPosition[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
                     if (o->LifeTime < 60 && rand_fps_check(2))
                     {
                         o->Scale = 0;
@@ -7196,9 +7196,9 @@ void MoveParticles()
 
                     if (o->LifeTime < 60)
                     {
-                        o->Velocity[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                        o->Velocity[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                        o->Velocity[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[0] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[1] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[2] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
 
                         o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
                         o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
@@ -7206,16 +7206,16 @@ void MoveParticles()
                 }
                 else if (o->SubType == 9)
                 {
-                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] < 0.2f)
                     {
                         o->Live = false;
                     }
 
-                    o->StartPosition[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->StartPosition[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
                     if (o->LifeTime < 60 && rand_fps_check(2))
                     {
                         o->Scale = 0;
@@ -7227,9 +7227,9 @@ void MoveParticles()
 
                     if (o->LifeTime < 60)
                     {
-                        o->Velocity[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                        o->Velocity[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
-                        o->Velocity[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[0] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[1] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[2] *= powf(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
 
                         o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
                         o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
@@ -7249,7 +7249,7 @@ void MoveParticles()
                     o->Scale = sinf(o->LifeTime * 10.f * (Q_PI / 180.f));
                     if (o->SubType == 1)
                     {
-                        o->Scale *= pow(0.75f, FPS_ANIMATION_FACTOR);
+                        o->Scale *= powf(0.75f, FPS_ANIMATION_FACTOR);
                         o->Rotation -= (12.f) * FPS_ANIMATION_FACTOR;
                     }
                 }
@@ -7272,9 +7272,9 @@ void MoveParticles()
                         o->Velocity[2] -= (1.f) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     //o->Scale = sinf(o->LifeTime*(Q_PI/240.f));
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
@@ -7311,7 +7311,7 @@ void MoveParticles()
                 {
                     VectorCopy(o->Target->Position, o->Position);
                     o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
-                    //                    o->Scale *= pow(0.75f, FPS_ANIMATION_FACTOR);
+                    //                    o->Scale *= powf(0.75f, FPS_ANIMATION_FACTOR);
                     o->Rotation -= (1.f) * FPS_ANIMATION_FACTOR;
                 }
                 else
@@ -7328,7 +7328,7 @@ void MoveParticles()
                         //Luminosity = (float)(o->LifeTime)/36.f;
                         //Vector(Luminosity*0.6f,Luminosity*0.8f,Luminosity,o->Light);
                         if (o->SubType >= 2) {
-                            o->Scale *= pow(0.75f, FPS_ANIMATION_FACTOR);
+                            o->Scale *= powf(0.75f, FPS_ANIMATION_FACTOR);
                             o->Rotation -= (12.f) * FPS_ANIMATION_FACTOR;
                         }
                         HandPosition(o);
@@ -7356,14 +7356,14 @@ void MoveParticles()
                     }
                     if (o->LifeTime < 6)
                     {
-                        o->Light[0] *= pow(0.5f, FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(0.5f, FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(0.5f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(0.5f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(0.5f, FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->SubType == 2)
                 {
-                    o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.1f, FPS_ANIMATION_FACTOR);
                     VectorScale(o->Light, 0.9f, o->Light);
                 }
                 break;
@@ -7453,9 +7453,9 @@ void MoveParticles()
                 o->Scale += fScale * FPS_ANIMATION_FACTOR;
                 if (o->Scale >= 0.8f)
                 {
-                    o->Light[0] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (fLight), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (fLight), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (fLight), FPS_ANIMATION_FACTOR);
                 }
             }
             break;
@@ -7464,9 +7464,9 @@ void MoveParticles()
                 o->Rotation += (20.f) * FPS_ANIMATION_FACTOR;
                 o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
 
-                o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                 o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
                 if (o->LifeTime < 10)
@@ -7551,9 +7551,9 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                     }
 
                     if (fTemp > 500.0f)
@@ -7567,8 +7567,8 @@ void MoveParticles()
                 if (o->SubType == 6)
                 {
                     VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
-                    o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
-                    o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[0] *= powf(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[1] *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
                     o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
                     o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
@@ -7630,9 +7630,9 @@ void MoveParticles()
                     }
                     else if (fTemp > 300.0f && fTemp <= 500.0f)
                     {
-                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
@@ -7662,8 +7662,8 @@ void MoveParticles()
                 else if (o->SubType == 14)
                 {
                     VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
-                    o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
-                    o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[0] *= powf(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[1] *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
                     o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
                     o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
@@ -7702,9 +7702,9 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                         if (o->Light[0] < 0.001f)
                             o->Live = false;
@@ -7740,9 +7740,9 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
 
                         if (o->Light[0] < 0.001f)
                             o->Live = false;
@@ -7780,9 +7780,9 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                         if (o->Light[0] < 0.015f)
                             o->Live = false;
@@ -7914,8 +7914,8 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Velocity[0] *= pow(0.7f, FPS_ANIMATION_FACTOR);
-                        o->Velocity[1] *= pow(0.7f, FPS_ANIMATION_FACTOR);
+                        o->Velocity[0] *= powf(0.7f, FPS_ANIMATION_FACTOR);
+                        o->Velocity[1] *= powf(0.7f, FPS_ANIMATION_FACTOR);
 
                         if (o->Alpha > 0.0f)
                             o->Alpha -= FPS_ANIMATION_FACTOR * (rand() % 10 * 0.01f);
@@ -7965,17 +7965,17 @@ void MoveParticles()
                     if (o->SubType == 7)
                     {
                         fScale = sinf(WorldTime + o->LifeTime) * 5.f + 10.f;
-                        o->Position[2] += (fScale) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += fScale * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
-                        vRandom[0] = ((float)(rand() % 2001 - 1000)) * (0.001f * 0.4f);
-                        vRandom[1] = ((float)(rand() % 2001 - 1000)) * (0.001f * 0.4f);
+                        vRandom[0] = ((float)(rand() % 2001 - 1000)) * (0.001f * 0.4f) * FPS_ANIMATION_FACTOR;
+                        vRandom[1] = ((float)(rand() % 2001 - 1000)) * (0.001f * 0.4f) * FPS_ANIMATION_FACTOR;
                         vRandom[2] = 0.f;
                         VectorAdd(vRandom, g_vParticleWind, vRandom);
                         VectorScale(vRandom, fScale, vRandom);
                         VectorAdd(o->Position, vRandom, o->Position);
-                        o->Position[2] += (5.f * fScale) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += 5.f * fScale * FPS_ANIMATION_FACTOR;
                     }
                     if (0 == o->SubType || o->SubType == 8)
                     {
@@ -7988,23 +7988,23 @@ void MoveParticles()
                     }
                     else if (1 == o->SubType)
                     {
-                        o->Scale *= pow(0.98f, FPS_ANIMATION_FACTOR);
+                        o->Scale *= powf(0.98f, FPS_ANIMATION_FACTOR);
                     }
                     else if (5 == o->SubType)
                     {
-                        o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                        o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                        o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     }
                     if (o->SubType == 7)
                     {
                         if (o->LifeTime < 10)
                         {
-                            o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
-                            o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
-                            o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                            o->Light[0] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                            o->Light[1] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                            o->Light[2] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                         }
                     }
                     else
@@ -8033,18 +8033,18 @@ void MoveParticles()
                 {
                     float fScale = 0.5f;
                     vec3_t vRandom;
-                    vRandom[0] = ((float)(rand() % 2001 - 1000)) * (0.001f * 0.4f);
-                    vRandom[1] = ((float)(rand() % 2001 - 1000)) * (0.001f * 0.4f);
+                    vRandom[0] = ((float)(rand() % 2001 - 1000)) * (0.001f * 0.4f) * FPS_ANIMATION_FACTOR;
+                    vRandom[1] = ((float)(rand() % 2001 - 1000)) * (0.001f * 0.4f) * FPS_ANIMATION_FACTOR;
                     vRandom[2] = 0.f;
                     VectorScale(vRandom, fScale, vRandom);
                     VectorAdd(o->Position, vRandom, o->Position);
                     o->Position[2] += (5.f * fScale) * FPS_ANIMATION_FACTOR;
-                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
 
                     //                    Vector(o->Scale,o->Scale,o->Scale,o->Light);
-                    o->Light[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(0.95f, FPS_ANIMATION_FACTOR);
                     if (o->Scale <= 0.1f)
                     {
                         o->LifeTime = -1;
@@ -8054,17 +8054,17 @@ void MoveParticles()
                 else if (1 == o->SubType)
                 {
                     VectorScale(o->Light, 0.9f, o->Light);
-                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
                 }
                 else if (5 == o->SubType)
                 {
                     VectorScale(o->Light, 0.9f, o->Light);
-                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
                 }
                 else if (3 == o->SubType)
                 {
                     VectorScale(o->Light, 0.9f, o->Light);
-                    o->Scale *= pow(0.85f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.85f, FPS_ANIMATION_FACTOR);
                     o->Gravity += (5.f) * FPS_ANIMATION_FACTOR;
 
                     VectorCopy(o->Target->Position, o->Position);
@@ -8093,9 +8093,9 @@ void MoveParticles()
                     o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 400 + 400) / 10000.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= pow(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 9)
                 {
@@ -8107,15 +8107,15 @@ void MoveParticles()
 
                     if (o->LifeTime >= 75)
                     {
-                        o->Light[0] *= pow(1.05f, FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.05f, FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.05f, FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.05f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.05f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.05f, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->SubType == 10)
@@ -8150,7 +8150,7 @@ void MoveParticles()
                 else if (o->SubType == 14)
                 {
                     VectorScale(o->Light, 0.98f, o->Light);
-                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.95f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 15)
                 {
@@ -8234,8 +8234,8 @@ void MoveParticles()
                 break;
             case BITMAP_ADV_SMOKE:
                 VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
-                o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
-                o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[0] *= powf(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[1] *= powf(0.95f, FPS_ANIMATION_FACTOR);
                 o->Light[0] = (float)(o->LifeTime) / 10.f;
                 o->Light[1] = o->Light[0];
                 o->Light[2] = o->Light[0];
@@ -8264,8 +8264,8 @@ void MoveParticles()
                 break;
             case BITMAP_ADV_SMOKE + 1:
                 VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
-                o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
-                o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[0] *= powf(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[1] *= powf(0.95f, FPS_ANIMATION_FACTOR);
                 o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
                 o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
@@ -8340,8 +8340,8 @@ void MoveParticles()
                 if (o->Scale < 0)
                     o->Scale = 0.f;
 
-                o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
-                o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[0] *= powf(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[1] *= powf(0.95f, FPS_ANIMATION_FACTOR);
 
                 if (o->Type == 6)
                     o->Position[2] += (2.0f) * FPS_ANIMATION_FACTOR;
@@ -8360,31 +8360,31 @@ void MoveParticles()
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.08f;
                     if (o->LifeTime < 10)
                     {
-                        o->Light[0] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->LifeTime < 30)
                 {
-                    o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.1f, FPS_ANIMATION_FACTOR);
                 }
                 break;
             case BITMAP_WATERFALL_1:
                 o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                 if (o->LifeTime < 5)
                 {
-                    o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->LifeTime > 20)
                 {
-                    o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.1f, FPS_ANIMATION_FACTOR);
                 }
                 o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
 
@@ -8446,18 +8446,18 @@ void MoveParticles()
                     o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += (o->Velocity[2]) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 8)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 9)
@@ -8468,15 +8468,15 @@ void MoveParticles()
 
                 if (o->LifeTime < 8)
                 {
-                    o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->LifeTime > 20)
                 {
-                    o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.1f, FPS_ANIMATION_FACTOR);
                 }
                 break;
 
@@ -8501,9 +8501,9 @@ void MoveParticles()
                     o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR + o->Velocity[2];
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
 
@@ -8513,24 +8513,24 @@ void MoveParticles()
                 o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
                 if (o->LifeTime < 10)
                 {
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
 
                 if (o->SubType == 1)
                 {
-                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                 }
                 if (o->SubType == 3)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.038f;
                     o->Velocity[2] -= (0.02f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                 }
                 if (o->SubType == 4)
                 {
@@ -8549,9 +8549,9 @@ void MoveParticles()
                     VectorAdd(o->StartPosition, TargetPosition, o->Position);
                     o->Scale += (1.0 / o->LifeTime) * 2.0f * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(0.77f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(0.77f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(0.8f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(0.77f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(0.77f, FPS_ANIMATION_FACTOR);
 
                     VectorCopy(o->StartPosition, o->Position);
                     o->StartPosition[2] = o->StartPosition[2] + rand() % 5 + 10.0f;
@@ -8567,27 +8567,27 @@ void MoveParticles()
                     o->Position[1] += ((float)(sin(o->Angle[2]) * 20.0f)) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += (1) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 3)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                     o->Velocity[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(0.97f, FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 5)
                 {
                     o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 6)
@@ -8597,26 +8597,26 @@ void MoveParticles()
 
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.01f;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 7)
                 {
                     o->Velocity[2] += (0.01f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(0.97f, FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 8)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 10)
@@ -8625,28 +8625,28 @@ void MoveParticles()
                     o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 11)
                 {
                     VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 12)
                 {
                     o->Rotation += (((int)WorldTime % 360) * 0.01f) * FPS_ANIMATION_FACTOR;
-                    o->Scale *= pow(0.92f, FPS_ANIMATION_FACTOR);
-                    o->Light[0] *= pow(0.92f, FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(0.92f, FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(0.92f, FPS_ANIMATION_FACTOR);
-                    o->Alpha *= pow(0.8f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Alpha *= powf(0.8f, FPS_ANIMATION_FACTOR);
 
                     break;
                 }
@@ -8654,9 +8654,9 @@ void MoveParticles()
                 {
                     o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.001f;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     break;
                 }
@@ -8664,9 +8664,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 15)
                 {
@@ -8675,9 +8675,9 @@ void MoveParticles()
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     //o->Velocity[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
 #ifdef ASG_ADD_MAP_KARUTAN
@@ -8687,49 +8687,49 @@ void MoveParticles()
                     o->Velocity[2] -= (0.1f) * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime < 8)
                     {
-                        o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                     }
                     else if (o->LifeTime > 20)
                     {
-                        o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
-                        o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
-                        o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                        o->Light[0] *= powf(1.1f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= powf(1.1f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= powf(1.1f, FPS_ANIMATION_FACTOR);
                     }
                     break;
                 }
 #endif	// ASG_ADD_MAP_KARUTAN
                 o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                 o->Velocity[2] -= (2.5f) * FPS_ANIMATION_FACTOR;
-                o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 break;
 
             case BITMAP_SHOCK_WAVE:
             {
                 if (o->SubType == 3)
                 {
-                    o->Light[0] *= pow(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.3f;
                 }
                 else if (o->SubType == 0)
                 {
-                    o->Light[0] *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.8f;
                 }
                 if (o->SubType == 4)
                 {
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
-                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
-                    o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
-                    o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= powf(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= powf(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     o->Scale += (o->Gravity * 0.015f) * FPS_ANIMATION_FACTOR;
                     o->Gravity += (2.4f) * FPS_ANIMATION_FACTOR;
                 }
@@ -8737,9 +8737,9 @@ void MoveParticles()
             break;
             case BITMAP_CURSEDTEMPLE_EFFECT_MASKER:
             {
-                o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
-                o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[0] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= powf(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                 o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
 
@@ -8836,17 +8836,17 @@ void MoveParticles()
 
                 if (o->SubType == 0)
                 {
-                    o->Scale *= pow(1.05f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.05f, FPS_ANIMATION_FACTOR);
                     Temp_Pos[2] -= (10.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
-                    o->Scale *= pow(1.02f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.02f, FPS_ANIMATION_FACTOR);
                     Temp_Pos[2] += (10.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
-                    o->Scale *= pow(1.03f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.03f, FPS_ANIMATION_FACTOR);
                     Temp_Pos[2] += (25.0f) * FPS_ANIMATION_FACTOR;
                 }
                 VectorCopy(Temp_Pos, o->Position);
@@ -8870,7 +8870,7 @@ void MoveParticles()
             break;
             case BITMAP_DAMAGE1:
             {
-                o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
+                o->Scale *= powf(1.2f, FPS_ANIMATION_FACTOR);
                 VectorScale(o->Light, 0.8f, o->Light);
             }
             break;
@@ -8878,11 +8878,11 @@ void MoveParticles()
             {
                 if (o->SubType == 1)
                 {
-                    o->Scale *= pow(0.8f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(0.8f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 0)
                 {
-                    o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
+                    o->Scale *= powf(1.2f, FPS_ANIMATION_FACTOR);
                 }
                 if (o->Scale > 6.0f)
                 {
@@ -8903,7 +8903,7 @@ void MoveParticles()
             break;
             case BITMAP_DAMAGE2:
             {
-                o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
+                o->Scale *= powf(1.2f, FPS_ANIMATION_FACTOR);
                 VectorScale(o->Light, 0.55f, o->Light);
             }
             break;

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -2205,7 +2205,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     Vector(0.f, -100.f, 0.f, p1);
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(p1, Matrix, p2);
-                    VectorAdd(o->Position, p2, o->Position);
+                    VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
 
                     o->Position[0] += (-8.0f + (float)(rand() % 16)) * FPS_ANIMATION_FACTOR;
                     o->Position[1] += (-8.0f + (float)(rand() % 16)) * FPS_ANIMATION_FACTOR;
@@ -2260,7 +2260,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     Vector(o->Velocity[0] * 10.0f, o->Velocity[1] * 10.0f, o->Velocity[2] * 10.0f + 100.0f, p1);
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(p1, Matrix, p2);
-                    VectorAdd(o->Position, p2, o->Position);
+                    VectorAddScaled(o->Position, p2, o->Position, FPS_ANIMATION_FACTOR);
 
                     o->Gravity = 3.5f;
                 }
@@ -3945,7 +3945,7 @@ void MoveParticles()
                         o->Velocity[1] += ((float)(rand() % 8 - 4) * 0.05f) * FPS_ANIMATION_FACTOR;
                         o->Velocity[2] -= ((float)(rand() % 8) * 0.05f) * FPS_ANIMATION_FACTOR;
                     }
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 }
                 Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
                 if (o->Position[2] < Height)
@@ -4893,7 +4893,7 @@ void MoveParticles()
                 }
                 break;
                 case 10:
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Light[0] = (float)(o->LifeTime) / 10.f;
@@ -5190,7 +5190,7 @@ void MoveParticles()
                         o->Alpha += FPS_ANIMATION_FACTOR * (float)(rand() % 20) * 0.005f;
                     }
 
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Scale += ((float)(rand() % 10) * 0.01f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 8)
@@ -5205,7 +5205,7 @@ void MoveParticles()
                         o->Alpha += FPS_ANIMATION_FACTOR * (float)(rand() % 20) * 0.005f;
                     }
 
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Scale += ((float)(rand() % 10) * 0.01f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 9)
@@ -5712,7 +5712,7 @@ void MoveParticles()
                     break;
                 case 52:
                 {
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
                     o->Light[0] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
                     o->Light[1] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
@@ -6559,7 +6559,7 @@ void MoveParticles()
                 //o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 //o->Gravity -= 1.5f;
                 VectorScale(o->Velocity, 0.95f, o->Velocity);
-                VectorAdd(o->Position, o->Velocity, o->Position);
+                VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 break;
             case BITMAP_SPARK:
                 Luminosity = (float)(o->LifeTime) / 16.f;
@@ -6604,7 +6604,7 @@ void MoveParticles()
                     o->Gravity = -o->Gravity * 0.6f;
                     o->LifeTime -= 4;
                 }
-                VectorAdd(o->Position, o->Velocity, o->Position);
+                VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 if (o->SubType == 5 || o->SubType == 6)
                 {
                     vec3_t p;
@@ -6654,7 +6654,7 @@ void MoveParticles()
 
                     vec3_t p;
                     VectorSubtract(o->Target->Position, o->Target->StartPosition, p);
-                    VectorAdd(o->Position, p, o->Position);
+                    VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
                     break;
                 case 5:
                     o->Scale *= pow(0.9f, FPS_ANIMATION_FACTOR);
@@ -7011,7 +7011,7 @@ void MoveParticles()
                         o->Gravity = -o->Gravity * 0.6f;
                         o->LifeTime -= 4;
                     }
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 }
                 break;
                 }
@@ -7065,7 +7065,7 @@ void MoveParticles()
                 Vector(Luminosity, Luminosity, Luminosity, o->Light);
                 o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
                 //o->Angle[0] += (4.f) * FPS_ANIMATION_FACTOR;
-                VectorAdd(o->Position, o->Velocity, o->Position);
+                VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 VectorScale(o->Velocity, 0.9f, o->Velocity);
 
                 if (o->SubType == 6)
@@ -7086,7 +7086,7 @@ void MoveParticles()
                     o->Rotation -= (12.f) * FPS_ANIMATION_FACTOR;
 
                     o->Velocity[2] -= ((float)(rand() % 8) * 0.05f) * FPS_ANIMATION_FACTOR;
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
                     o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
@@ -7115,7 +7115,7 @@ void MoveParticles()
                     o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
 
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 5)
                 {
@@ -7464,7 +7464,7 @@ void MoveParticles()
                 else
                     o->Scale -= 0.01f * FPS_ANIMATION_FACTOR;
 
-                VectorAdd(o->Position, o->Velocity, o->Position);
+                VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 break;
 
             case BITMAP_DS_EFFECT:
@@ -7516,7 +7516,7 @@ void MoveParticles()
             {
                 if (o->SubType == 0)
                 {
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
                     vec3_t vTemp;
                     VectorSubtract(o->Position, o->StartPosition, vTemp);
@@ -7556,7 +7556,7 @@ void MoveParticles()
             case BITMAP_CLOUD:
                 if (o->SubType == 6)
                 {
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
@@ -7603,7 +7603,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 10)
                 {
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->TurningForce[0] = 1.5f;
 
                     vec3_t vTemp;
@@ -7631,7 +7631,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 11)
                 {
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->TurningForce[0] = 1.5f;
 
                     vec3_t vTemp;
@@ -7651,7 +7651,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 14)
                 {
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
@@ -7671,7 +7671,7 @@ void MoveParticles()
                         o->Live = false;
                     }
 
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
                     vec3_t vTemp;
                     VectorSubtract(o->Position, o->StartPosition, vTemp);
@@ -7712,7 +7712,7 @@ void MoveParticles()
                         o->Live = false;
                     }
 
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
                     vec3_t vTemp;
                     VectorSubtract(o->Position, o->StartPosition, vTemp);
@@ -7749,7 +7749,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
                     vec3_t vTemp;
                     VectorSubtract(o->Position, o->StartPosition, vTemp);
@@ -8223,7 +8223,7 @@ void MoveParticles()
                 }
                 break;
             case BITMAP_ADV_SMOKE:
-                VectorAdd(o->Position, o->Velocity, o->Position);
+                VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 o->Light[0] = (float)(o->LifeTime) / 10.f;
@@ -8253,7 +8253,7 @@ void MoveParticles()
                 }
                 break;
             case BITMAP_ADV_SMOKE + 1:
-                VectorAdd(o->Position, o->Velocity, o->Position);
+                VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                 o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
@@ -8622,7 +8622,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 11)
                 {
-                    VectorAdd(o->Position, o->Velocity, o->Position);
+                    VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -4792,7 +4792,7 @@ void MoveParticles()
                 switch (o->SubType)
                 {
                 case 1:
-                    if (o->LifeTime == 10)
+                    if ((int)o->LifeTime == 10)
                     {
                         o->Velocity[1] += (32 * 0.2f) * FPS_ANIMATION_FACTOR;
                         o->Scale -= 0.15f * FPS_ANIMATION_FACTOR;
@@ -4803,7 +4803,7 @@ void MoveParticles()
                     o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
                     break;
                 case 5:
-                    if (o->LifeTime == 10)
+                    if ((int)o->LifeTime == 10)
                     {
                         o->Velocity[1] += (32 * 0.2f) * FPS_ANIMATION_FACTOR;
                         o->Scale *= pow(0.8f, FPS_ANIMATION_FACTOR);
@@ -6897,7 +6897,7 @@ void MoveParticles()
                 break;
                 case 25:
                 {
-                    if (o->LifeTime == 19)
+                    if ((int)o->LifeTime == 19)
                     {
                         o->Velocity[0] -= (1.f) * FPS_ANIMATION_FACTOR;
                         o->Velocity[1] -= (1.f) * FPS_ANIMATION_FACTOR;
@@ -7255,7 +7255,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 1)
                 {
-                    if (o->LifeTime == 69)
+                    if ((int)o->LifeTime == 69)
                     {
                         o->Velocity[0] -= (1.f) * FPS_ANIMATION_FACTOR;
                         o->Velocity[1] -= (1.f) * FPS_ANIMATION_FACTOR;

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -4232,7 +4232,6 @@ void MoveParticles()
                         o->LifeTime = 19.9f;
                         for (int j = 0; j < 18; j++)
                         {
-                            if (!rand_fps_check(1)) continue;
                             Vector(0.f, 200.f, 0.f, p);
                             Vector(0.f, 0.f, j * 20.f, Angle);
                             AngleMatrix(Angle, Matrix);

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -96,9 +96,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 40 + rand() % 3;
                 }
-                o->Position[0] += (float)(rand() % 50 - 25);
-                o->Position[1] += (float)(rand() % 50 - 25);
-                o->Position[2] += (float)(rand() % 200 - 100) + 250.0f;
+                o->Position[0] += ((float)(rand() % 50 - 25));
+                o->Position[1] += ((float)(rand() % 50 - 25));
+                o->Position[2] += ((float)(rand() % 200 - 100) + 250.0f);
 
                 if (o->SubType == 4)
                 {
@@ -111,7 +111,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
 
                     o->Position[0] = Position[0] + (float)(rand() % 80 - 40);
 #endif //PJH_NEW_SERVER_SELECT_MAP
-                    o->Position[2] -= 100.f;
+                    o->Position[2] -= (100.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 5)
                 {
@@ -123,7 +123,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale = (float)(rand() % 10 + 20) * 0.01f;
                     o->Gravity = (float)(rand() % 10 + 20) * 0.05f;
 #endif //PJH_NEW_SERVER_SELECT_MAP
-                    o->Position[2] -= 100.f;
+                    o->Position[2] -= (100.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 6)
                 {
@@ -131,7 +131,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale = (float)(rand() % 5 + 20) * 0.1f;
 
                     //o->Position[0] = Position[0] + (float)(rand()%80 - 40);
-                    o->Position[2] -= 200.f;
+                    o->Position[2] -= (200.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 7)
                 {
@@ -139,7 +139,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale = (float)(rand() % 10 + 20) * 0.01f;
                     o->Gravity = (float)(rand() % 20 + 80) * 0.1f;
 
-                    o->Position[2] -= 100.f;
+                    o->Position[2] -= (100.f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
 
@@ -260,7 +260,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 o->Scale = 1.8f;
                 o->Angle[0] = 30.f;
                 Vector((float)(rand() % 4 + 6) * 0.1f, (float)(rand() % 4 + 6) * 0.1f, (float)(rand() % 4 + 6) * 0.1f, o->Light);
-                o->Position[2] += 260.f;
+                o->Position[2] += (260.f) * FPS_ANIMATION_FACTOR;
                 //CreateEffect(BITMAP_LIGHTNING+1,o->Position,o->Angle,o->Light);
                 //for(i=0;i<5;i++)
                 //	CreateParticle(BITMAP_SMOKE,o->Position,o->Angle,o->Light,3);
@@ -284,9 +284,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 }
                 else if (o->SubType == 1)
                 {
-                    o->Position[0] += (rand() % 10 - 5) * 0.2f;
-                    o->Position[1] += (rand() % 10 - 5) * 0.2f;
-                    o->Position[2] += (rand() % 10 - 5) * 0.2f;
+                    o->Position[0] += ((rand() % 10 - 5) * 0.2f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((rand() % 10 - 5) * 0.2f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((rand() % 10 - 5) * 0.2f) * FPS_ANIMATION_FACTOR;
                     o->LifeTime = (rand() % 28 + 4);
                     Vector(0.f, 0.f, 0.f, o->Velocity);
                     o->Scale = (float)(rand() % 5 + 50) * 0.016f;
@@ -546,9 +546,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 }
                 else if (o->SubType == 8)
                 {
-                    o->Position[0] += (float)(rand() % 20 - 10);
-                    o->Position[1] += (float)(rand() % 20 - 10);
-                    o->Position[2] += (float)(rand() % 20 - 10);
+                    o->Position[0] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
                     o->LifeTime = 32;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 5 + 5) / 5.0f;
@@ -589,13 +589,13 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale = -(float)(rand() % 20) / 100.0f + o->Scale;
                     o->Rotation = (float)(rand() % 360) - 180.0f;
                     o->StartPosition[0] = o->Position[0];
-                    o->Position[0] += ((float)(rand() % 2) / 2.0f - 0.0f) * o->Scale;
+                    o->Position[0] += (((float)(rand() % 2) / 2.0f - 0.0f) * o->Scale) * FPS_ANIMATION_FACTOR;
                     o->Gravity = ((float)(rand() % 100) / 100.0f + 1.8f) * o->Scale;
                     float fTemp = 0.0f;
                     if (rand() % 10 >= 3)
                         fTemp = ((float)(rand() % 20) / 10.0f - 1.0f) * o->Scale;
                     Vector(0.0f, fTemp, 0.0f, o->Velocity);
-                    o->Position[1] += o->Position[0] - o->StartPosition[0];
+                    o->Position[1] += (o->Position[0] - o->StartPosition[0]) * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 1:
@@ -658,7 +658,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale += -(float)(rand() % 20) / 100.0f * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360) - 180.0f;
                     o->StartPosition[0] = o->Position[0];
-                    o->Position[0] += ((float)(rand() % 2) / 2.0f - 0.0f) * o->Scale;
+                    o->Position[0] += (((float)(rand() % 2) / 2.0f - 0.0f) * o->Scale) * FPS_ANIMATION_FACTOR;
                     o->Gravity = ((float)(rand() % 100) / 100.0f + 1.8f) * o->Scale + 2.0f;
                     float fTemp = 0.0f;
                     if (rand() % 10 >= 3)
@@ -666,7 +666,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         fTemp = ((float)(rand() % 20) / 10.0f - 1.0f) * o->Scale;
                     }
                     Vector(0.0f, fTemp * 2.0f, 0.0f, o->Velocity);
-                    o->Position[1] += o->Position[0] - o->StartPosition[0];
+                    o->Position[1] += (o->Position[0] - o->StartPosition[0]) * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 10:
@@ -702,9 +702,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 o->Scale = (rand() % 6 + 8) * 0.1f;
                 if (o->Type == BITMAP_RAIN_CIRCLE + 1 || o->SubType == 1)
                 {
-                    o->Position[0] += (rand() % 10 - 5) * 1.f;
-                    o->Position[1] += (rand() % 10 - 5) * 1.f;
-                    o->Position[2] += (rand() % 10 - 5) * 1.f;
+                    o->Position[0] += ((rand() % 10 - 5) * 1.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((rand() % 10 - 5) * 1.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((rand() % 10 - 5) * 1.f) * FPS_ANIMATION_FACTOR;
                 }
                 if (o->SubType == 1)
                 {
@@ -822,7 +822,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Angle[0] = (float)(rand() % 360);
                     o->Rotation = (float)((int)WorldTime % 360);
                     o->Gravity = (float)(rand() % 10 + 40) * 0.04f;
-                    o->Position[1] += 10.f;
+                    o->Position[1] += (10.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
@@ -873,7 +873,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     Vector(0.f, (float)(rand() % 2 + 60) * 0.1f, 0.f, p1);
                     VectorRotate(p1, Matrix, o->TurningForce);
 
-                    o->TurningForce[2] += 4.0f;
+                    o->TurningForce[2] += (4.0f) * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)((int)WorldTime % 360);
                     o->Alpha = 1.0f;
                 }
@@ -889,7 +889,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     Vector(0.f, (float)(rand() % 2 + 60) * 0.1f, 0.f, p1);
                     VectorRotate(p1, Matrix, o->TurningForce);
 
-                    o->TurningForce[2] += 2.0f;
+                    o->TurningForce[2] += (2.0f) * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)((int)WorldTime % 360);
                     o->Alpha = 1.0f;
 
@@ -909,7 +909,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     Vector(0.f, (float)(rand() % 2 + 60) * 0.1f, 0.f, p1);
                     VectorRotate(p1, Matrix, o->TurningForce);
 
-                    o->TurningForce[2] += 2.0f;
+                    o->TurningForce[2] += (2.0f) * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)((int)WorldTime % 360);
                     o->Alpha = 1.0f;
 
@@ -938,7 +938,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale = (float)(rand() % 64 + 64) * 0.01f;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 32 + 60) * 0.1f;
-                    o->Position[2] -= 45.00f;
+                    o->Position[2] -= (45.00f) * FPS_ANIMATION_FACTOR;
                     o->TexType = BITMAP_POUNDING_BALL;
                     break;
                 }
@@ -953,9 +953,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 40;
                     o->Scale = (float)(rand() % 20 + 250) * 0.01f;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += (float)(rand() % 20 - 10);
-                    o->Position[1] += (float)(rand() % 20 - 10);
-                    o->Position[2] -= 20.f;
+                    o->Position[0] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (20.f) * FPS_ANIMATION_FACTOR;
                     o->Gravity = (float)(rand() % 10 + 5) * 0.1f;
                 }
                 else if (o->SubType == 1)
@@ -963,7 +963,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 12;
                     o->Scale += (float)(rand() % 30) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[2] += 30.0f;
+                    o->Position[2] += (30.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 3)
                 {
@@ -972,9 +972,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 50;
                     o->Scale = Scale + (float)(rand() % 10 + 10) * 0.01f;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += (float)(rand() % 20 - 10);
-                    o->Position[1] += (float)(rand() % 20 - 10);
-                    o->Position[2] -= 20.f;
+                    o->Position[0] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (20.f) * FPS_ANIMATION_FACTOR;
                     o->Gravity = (float)(rand() % 10 + 5) * 0.1f;
                 }
                 else if (o->SubType == 4)
@@ -984,9 +984,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 4;
                     o->Scale = Scale + (float)(rand() % 10 + 10) * 0.01f;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += (float)(rand() % 20 - 10);
-                    o->Position[1] += (float)(rand() % 20 - 10);
-                    o->Position[2] -= 20.f;
+                    o->Position[0] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (20.f) * FPS_ANIMATION_FACTOR;
                     o->Gravity = (float)(rand() % 10 + 5) * 0.1f;
                 }
                 else if (o->SubType == 5)
@@ -996,9 +996,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 50;
                     o->Scale = Scale + (float)(rand() % 10 + 10) * 0.01f;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += (float)(rand() % 20 - 10);
-                    o->Position[1] += (float)(rand() % 20 - 10);
-                    o->Position[2] -= 20.f;
+                    o->Position[0] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (20.f) * FPS_ANIMATION_FACTOR;
                     o->Gravity = (float)(rand() % 10 + 5) * 0.1f;
                 }
                 else if (o->SubType == 6)	// ¡Ý
@@ -1018,7 +1018,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Velocity[0] = (float)(rand() % 20 - 10) * 0.1f;
                     o->Velocity[1] = (float)(rand() % 20 - 10) * 0.1f;
                     //o->Velocity[2] = (float)(rand()%20-10)*0.2f;
-                    o->Position[2] += 80.0f;
+                    o->Position[2] += (80.0f) * FPS_ANIMATION_FACTOR;
                     o->Gravity = 0;
                     o->Alpha = 0.5f;
                 }
@@ -1028,7 +1028,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Velocity[0] = (float)(rand() % 20 - 10) * 0.1f;
                     o->Velocity[1] = (float)(rand() % 20 - 10) * 0.1f;
                     //o->Velocity[2] = (float)(rand()%20-10)*0.2f;
-                    o->Position[2] += 80.0f;
+                    o->Position[2] += (80.0f) * FPS_ANIMATION_FACTOR;
                     o->Gravity = 0;
                     o->Alpha = 0.5f;
                 }
@@ -1048,9 +1048,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 }
                 else if (o->SubType == 10)	// BITMAP_FIRE_CURSEDLICH o->SubType == 1°ú ºñ½Á.
                 {
-                    o->Position[0] += (rand() % 10 - 5) * 0.2f;
-                    o->Position[1] += (rand() % 10 - 5) * 0.2f;
-                    o->Position[2] += (rand() % 10 - 5) * 0.2f;
+                    o->Position[0] += ((rand() % 10 - 5) * 0.2f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((rand() % 10 - 5) * 0.2f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((rand() % 10 - 5) * 0.2f) * FPS_ANIMATION_FACTOR;
                     o->LifeTime = (rand() % 28 + 4);
                     Vector(0.f, 0.f, 0.f, o->Velocity);
                     o->Scale = (float)(rand() % 5 + 70) * 0.016f;
@@ -1066,9 +1066,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 30;
                     o->Scale = Scale;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += (float)(rand() % 20 - 10);
-                    o->Position[1] += (float)(rand() % 20 - 10);
-                    o->Position[2] += (float)(rand() % 20 - 10);
+                    o->Position[0] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
                     o->Gravity = -1.5f;
                 }
             }
@@ -1080,17 +1080,17 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = rand() % 10 + 140;
                     o->Gravity = rand() % 10 + 5.0f;
                     o->Scale = (rand() % 20 + 20.f) / 100.f * Scale;
-                    o->Position[0] += (float)(rand() % 100 - 50);
-                    o->Position[1] += (float)(rand() % 100 - 50);
+                    o->Position[0] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
                     o->Scale = 0.1f;
                     o->StartPosition[0] = o->Scale;
                     o->LifeTime = rand() % 10 + 20;
-                    o->Position[0] += (float)(rand() % 50 - 25);
-                    o->Position[1] += (float)(rand() % 50 - 25);
-                    o->Position[2] += (float)(rand() % 50 - 25);
+                    o->Position[0] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
 
                     o->Gravity = 1.0f;
 
@@ -1112,25 +1112,25 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 50 + rand() % 10;
                     o->Scale = (float)(rand() % 32 + 140) * 0.01f;
-                    o->Position[0] += (float)(rand() % 120 - 60);
-                    o->Position[1] += (float)(rand() % 100 - 50);
-                    o->Position[2] += (float)(rand() % 100);
+                    o->Position[0] += ((float)(rand() % 120 - 60)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 100)) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
                     o->LifeTime = 20 + rand() % 10;
                     o->Scale = (float)(rand() % 32 + 50) * 0.01f;
-                    o->Position[0] += (float)(rand() % 80 - 40);
-                    o->Position[1] += (float)(rand() % 80 - 40);
-                    o->Position[2] += (float)(rand() % 80);
+                    o->Position[0] += ((float)(rand() % 80 - 40)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 80 - 40)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 80)) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
                     o->LifeTime = 60 + rand() % 10;
                     o->Scale = (float)(rand() % 32 + 50) * 0.02f;
-                    o->Position[0] += (float)(rand() % 40 - 20);
-                    o->Position[1] += (float)(rand() % 40 - 20);
-                    o->Position[2] += (float)(rand() % 40);
+                    o->Position[0] += ((float)(rand() % 40 - 20)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 40 - 20)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 40)) * FPS_ANIMATION_FACTOR;
                 }
                 o->Angle[0] = (float)(rand() % 360);
                 o->Angle[2] = (float)(rand() % 360);
@@ -1171,8 +1171,8 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     if (o->SubType == 37)
                     {
                         VectorCopy(o->Light, o->TurningForce);
-                        o->Position[2] -= 15.0f * o->TurningForce[2];
-                        o->Position[1] -= 15.0f * o->TurningForce[1];
+                        o->Position[2] -= (15.0f * o->TurningForce[2]) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] -= (15.0f * o->TurningForce[1]) * FPS_ANIMATION_FACTOR;
                         Vector(1.0f, 1.0f, 1.0f, o->Light);
                     }
                     else
@@ -1250,9 +1250,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 11:
                 case 14:
                     o->LifeTime = 50;
-                    o->Position[0] += (float)(rand() % 64 - 32);
-                    o->Position[1] += (float)(rand() % 64 - 32);
-                    o->Position[2] += (float)(rand() % 64 + 32);
+                    o->Position[0] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 64 + 32)) * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 90 - 45);
                     o->Angle[2] = (float)(rand() % 360);
                     o->Rotation = (float)(rand() % 360);
@@ -1269,9 +1269,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 1:
                     o->LifeTime = 50;
                     o->Scale = (float)(rand() % 32 + 80) * 0.01f;
-                    o->Position[0] += (float)(rand() % 64 - 32);
-                    o->Position[1] += (float)(rand() % 64 - 32);
-                    o->Position[2] += (float)(rand() % 64 + 32);
+                    o->Position[0] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 64 + 32)) * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 90 - 45);
                     o->Angle[2] = (float)(rand() % 360);
                     Vector(0.f, -(float)(rand() % 8 + 40), 0.f, o->Velocity);
@@ -1298,9 +1298,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 30;
                     o->Gravity = (float)(rand() % 1000);
                     o->Scale = (float)(rand() % 20 + 180) * 0.01f;
-                    o->Position[0] += (float)(rand() % 200 - 100) * Scale;
-                    o->Position[1] += (float)(rand() % 200 - 100) * Scale;
-                    o->Position[2] += (float)(rand() % 20 + 20);
+                    o->Position[0] += ((float)(rand() % 200 - 100) * Scale) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 200 - 100) * Scale) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 20 + 20)) * FPS_ANIMATION_FACTOR;
                     o->Rotation = o->Position[2];
                     Vector(0.f, 0.f, 0.f, o->Velocity);
                     break;
@@ -1389,8 +1389,8 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Gravity = 15.0f;
                     o->Rotation = (float)(rand() % 360);
                     o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]) + 15;
-                    o->Position[0] += (float)sinf(WorldTime) * 5.0f;
-                    o->Position[1] += (float)sinf(WorldTime) * 5.0f;
+                    o->Position[0] += ((float)sinf(WorldTime) * 5.0f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)sinf(WorldTime) * 5.0f) * FPS_ANIMATION_FACTOR;
                     break;
                 case 31:
                     o->LifeTime = 15;
@@ -1402,9 +1402,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 50;
                     o->Scale = (float)(rand() % 32 + 80) * 0.01f;
-                    o->Position[0] += (float)(rand() % 64 - 32);
-                    o->Position[1] += (float)(rand() % 64 - 32);
-                    o->Position[2] += (float)(rand() % 64 + 32);
+                    o->Position[0] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 64 + 32)) * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 90 - 45);
                     o->Angle[2] = (float)(rand() % 360);
                     Vector(0.f, -(float)(rand() % 8 + 40), 0.f, o->Velocity);
@@ -1414,9 +1414,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 50;
                     o->Scale = (float)(rand() % 32 + 80) * 0.01f;
-                    o->Position[0] += (float)(rand() % 64 - 32);
-                    o->Position[1] += (float)(rand() % 64 - 32);
-                    o->Position[2] += (float)(rand() % 64 + 32);
+                    o->Position[0] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 64 + 32)) * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 90 - 45);
                     o->Angle[2] = (float)(rand() % 360);
                     Vector(0.f, -(float)(rand() % 8 + 40), 0.f, o->Velocity);
@@ -1436,9 +1436,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 60;
                     o->Scale += (float)(rand() % 10) / 2.0f * FPS_ANIMATION_FACTOR;
-                    o->Position[0] += (float)(rand() % 500) - 250.0f;
-                    o->Position[1] += (float)(rand() % 700) - 350.0f;
-                    o->Position[2] += (float)(rand() % 100) + 150.0f;
+                    o->Position[0] += ((float)(rand() % 500) - 250.0f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 700) - 350.0f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 100) + 150.0f) * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 50) - 25.0f;
                     Vector(0.1f, 0.2f, 0.3f, o->Light);
@@ -1449,9 +1449,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->TexType = BITMAP_LIGHT + 2;
                     o->LifeTime = 15;
                     o->Scale += (float)(rand() % 10) / 20.0f * FPS_ANIMATION_FACTOR;
-                    o->Position[0] += (float)(rand() % 40) - 20.0f;
-                    o->Position[1] += (float)(rand() % 40) - 20.0f;
-                    o->Position[2] += (float)(rand() % 40) - 20.0f;
+                    o->Position[0] += ((float)(rand() % 40) - 20.0f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 40) - 20.0f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 40) - 20.0f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 46:
@@ -1541,9 +1541,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 58:
                     o->LifeTime = 50;
                     o->Scale = (float)(rand() % 32 + 80) * 0.01f;
-                    o->Position[0] += (float)(rand() % 64 - 32);
-                    o->Position[1] += (float)(rand() % 64 - 32);
-                    o->Position[2] += (float)(rand() % 64 + 32);
+                    o->Position[0] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 64 + 32)) * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 90 - 45);
                     o->Angle[2] = (float)(rand() % 360);
                     Vector(0.f, -(float)(rand() % 8 + 40), 0.f, o->Velocity);
@@ -1564,8 +1564,8 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     //	Vector(0.9f,0.4f,0.1f,o->Light);
                     //	o->Scale = (float)(rand()%32+80)*0.01f;
                     o->Scale = o->Scale;
-                    o->Position[0] += (float)(rand() % 64 - 32);
-                    o->Position[1] += (float)(rand() % 64 - 32);
+                    o->Position[0] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 64 - 32)) * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 90 - 45);
                     o->Angle[2] = (float)(rand() % 360);
                     Vector(0.f, -(float)(rand() % 8), 0.f, o->Velocity);
@@ -1658,8 +1658,8 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
             case BITMAP_SMOKE + 1:
             case BITMAP_SMOKE + 4:
                 o->LifeTime = 32;
-                o->Position[0] += (float)(rand() % 16 - 8);
-                o->Position[1] += (float)(rand() % 16 - 8);
+                o->Position[0] += ((float)(rand() % 16 - 8)) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += ((float)(rand() % 16 - 8)) * FPS_ANIMATION_FACTOR;
 
                 if (o->Type == BITMAP_SMOKE + 4)
                 {
@@ -1689,13 +1689,13 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 40;
                     Vector(0.f, 0.0f, 0.0f, o->Velocity);
-                    o->Position[2] += (float)(rand() % 16 - 8);
+                    o->Position[2] += ((float)(rand() % 16 - 8)) * FPS_ANIMATION_FACTOR;
                 }
                 else if (SubType == 6)
                 {
                     o->LifeTime = 40;
                     Vector(0.f, 0.0f, 0.0f, o->Velocity);
-                    o->Position[2] += (float)(rand() % 16 - 8);
+                    o->Position[2] += ((float)(rand() % 16 - 8)) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_SMOKE + 2:
@@ -1738,9 +1738,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 60;
                     o->Scale *= (float)(rand() % 64 + 64) * 0.02f;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += (float)(rand() % 250 - 125);
-                    o->Position[1] += (float)(rand() % 250 - 125);
-                    o->Position[2] -= (float)(rand() % 45);
+                    o->Position[0] += ((float)(rand() % 250 - 125)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 250 - 125)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= ((float)(rand() % 45)) * FPS_ANIMATION_FACTOR;
                     o->Gravity = (float)(rand() % 100 - 50) * 0.1f;
                     Vector(1.0f, 1.0f, 1.0f, o->Light);
                     break;
@@ -1749,9 +1749,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 30;
                     o->Scale *= (float)(rand() % 64 + 64) * 0.02f;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += (float)(rand() % 250 - 125);
-                    o->Position[1] += (float)(rand() % 250 - 125);
-                    o->Position[2] -= (float)(rand() % 45);
+                    o->Position[0] += ((float)(rand() % 250 - 125)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 250 - 125)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= ((float)(rand() % 45)) * FPS_ANIMATION_FACTOR;
                     o->Gravity = (float)(rand() % 100 - 50) * 0.1f;
                     Vector(1.0f, 1.0f, 1.0f, o->Light);
                     break;
@@ -1804,9 +1804,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 }
                 else if (o->SubType == 4)
                 {
-                    o->Position[0] += (float)(rand() % 20 - 10) * 2.f;
-                    o->Position[1] += (float)(rand() % 20 - 10) * 2.f;
-                    o->Position[2] += (float)(rand() % 20 - 10) * 2.f;
+                    o->Position[0] += ((float)(rand() % 20 - 10) * 2.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20 - 10) * 2.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 20 - 10) * 2.f) * FPS_ANIMATION_FACTOR;
 
                     o->Scale = o->Scale + ((float)(rand() % 20 - 10) * (o->Scale * 0.03f));
                     o->LifeTime = 45;
@@ -1988,7 +1988,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 else if (o->SubType == 2)
                 {
                     o->LifeTime = 19;
-                    o->Position[1] += -30.0f + (float)(rand() % 60);
+                    o->Position[1] += (-30.0f + (float)(rand() % 60)) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 3)
                 {
@@ -2159,9 +2159,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     break;
                 case 7:
                     o->Alpha = 1.0f;
-                    o->Position[1] += -30.0f + (float)(rand() % 60);
-                    o->Position[2] += -30.0f + (float)(rand() % 60);
-                    o->Position[3] += -30.0f + (float)(rand() % 60);
+                    o->Position[1] += (-30.0f + (float)(rand() % 60)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (-30.0f + (float)(rand() % 60)) * FPS_ANIMATION_FACTOR;
+                    o->Position[3] += (-30.0f + (float)(rand() % 60)) * FPS_ANIMATION_FACTOR;
                     o->LifeTime = 30;
                     o->Gravity = 1.3f;
                     o->Scale = (float)(rand() % 5) / 10.0f + 1.0f;
@@ -2207,9 +2207,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     VectorRotate(p1, Matrix, p2);
                     VectorAdd(o->Position, p2, o->Position);
 
-                    o->Position[0] += -8.0f + (float)(rand() % 16);
-                    o->Position[1] += -8.0f + (float)(rand() % 16);
-                    o->Position[2] += 150.0f;
+                    o->Position[0] += (-8.0f + (float)(rand() % 16)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (-8.0f + (float)(rand() % 16)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (150.0f) * FPS_ANIMATION_FACTOR;
 
                     o->Velocity[0] = -1.0f + (float)(rand() % 20) / 10.f;
                     o->Velocity[1] = -1.0f + (float)(rand() % 20) / 10.f;
@@ -2440,9 +2440,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 16;
                     o->Scale = Scale + (float)(rand() % 10 - 5) * 0.03f;
-                    o->Position[0] += (float)(rand() % 10 - 5);
-                    o->Position[1] += (float)(rand() % 10 - 5);
-                    o->Position[2] += (float)(rand() % 10 - 5);
+                    o->Position[0] += ((float)(rand() % 10 - 5)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 10 - 5)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 10 - 5)) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
@@ -2532,8 +2532,8 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = rand() % 10 + 10;
                     o->Scale += (rand() % 10) * 0.02f * FPS_ANIMATION_FACTOR;
-                    o->Position[0] += (float)(rand() % 10 - 5);
-                    o->Position[1] += (float)(rand() % 10 - 5);
+                    o->Position[0] += ((float)(rand() % 10 - 5)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 10 - 5)) * FPS_ANIMATION_FACTOR;
                     o->Gravity = -(float)(rand() % 10) * 0.3f;
                 }
                 else if (o->SubType == 6)
@@ -2558,9 +2558,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale = 0.1f;//(float)(rand()%5)/6.0f+0.5f;
                     o->StartPosition[0] = o->Scale;
                     o->LifeTime = rand() % 10 + 20;
-                    o->Position[0] += (float)(rand() % 50 - 25);
-                    o->Position[1] += (float)(rand() % 50 - 25);
-                    o->Position[2] += (float)(rand() % 50 - 25);
+                    o->Position[0] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
 
                     o->Gravity = 1.0f;
 
@@ -2702,9 +2702,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 if (o->SubType == 0)
                 {
                     o->Alpha = 1.0f;
-                    o->Position[0] += -5.0f + (float)(rand() % 10);
-                    o->Position[1] += -5.0f + (float)(rand() % 10);
-                    o->Position[2] += -5.0f + (float)(rand() % 10);
+                    o->Position[0] += (-5.0f + (float)(rand() % 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (-5.0f + (float)(rand() % 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (-5.0f + (float)(rand() % 10)) * FPS_ANIMATION_FACTOR;
                     o->LifeTime = 30;
                     o->Gravity = 1.3f;
                     o->Scale += (float)(rand() % 3) / 10.0f * FPS_ANIMATION_FACTOR;
@@ -2715,9 +2715,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = rand() % 3 + 10;
                     o->Scale = 0.3f;
 
-                    o->Position[0] += (float)(rand() % 50 - 25);
-                    o->Position[1] += (float)(rand() % 50 - 25);
-                    o->Position[2] += (float)(rand() % 50 - 25);
+                    o->Position[0] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 50 - 25)) * FPS_ANIMATION_FACTOR;
                     o->Rotation = rand() % 20 - 10;
                 }
                 break;
@@ -2725,9 +2725,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 o->Alpha = 1.0f;
 
                 {
-                    o->Position[0] += -5.0f + (float)(rand() % 10);
-                    o->Position[1] += -5.0f + (float)(rand() % 10);
-                    o->Position[2] += -5.0f + (float)(rand() % 10);
+                    o->Position[0] += (-5.0f + (float)(rand() % 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (-5.0f + (float)(rand() % 10)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (-5.0f + (float)(rand() % 10)) * FPS_ANIMATION_FACTOR;
                 }
                 o->LifeTime = 30;
                 o->Gravity = 10.0f;
@@ -2813,9 +2813,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 30;
                     o->Gravity = (float)(rand() % 1000);
 
-                    o->Position[0] += (float)(rand() % 500 - 250);//*Scale;
-                    o->Position[1] += (float)(rand() % 500 - 250);//*Scale;
-                    o->Position[2] += (float)(rand() % 20 + 20);
+                    o->Position[0] += ((float)(rand() % 500 - 250);//*Scale) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 500 - 250);//*Scale) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 20 + 20)) * FPS_ANIMATION_FACTOR;
 
                     o->StartPosition[1] = (rand() % 100) / 100.f;
                     o->StartPosition[2] = o->Position[2];
@@ -2841,9 +2841,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->Gravity = (float)(rand() % 1000);
                         o->Alpha = 0.1f;
 
-                        o->Position[0] += (float)(rand() % 500 - 250);
-                        o->Position[1] += (float)(rand() % 500 - 250);
-                        o->Position[2] += (float)(rand() % 20 - 20);
+                        o->Position[0] += ((float)(rand() % 500 - 250)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 500 - 250)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 20 - 20)) * FPS_ANIMATION_FACTOR;
 
                         o->StartPosition[1] = (rand() % 100) / 100.f;
                         o->StartPosition[2] = o->Position[2];
@@ -2858,9 +2858,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->Gravity = (float)(rand() % 1000);
                         o->Alpha = 0.1f;
 
-                        o->Position[0] += (float)(rand() % 500 - 250);
-                        o->Position[1] += (float)(rand() % 500 - 250);
-                        o->Position[2] += (float)(rand() % 20 - 20);
+                        o->Position[0] += ((float)(rand() % 500 - 250)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 500 - 250)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 20 - 20)) * FPS_ANIMATION_FACTOR;
 
                         o->StartPosition[1] = (rand() % 100) / 100.f;
                         o->StartPosition[2] = o->Position[2];
@@ -2873,9 +2873,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     {
                         Vector(0.0f, 0.0f, 0.0f, o->Light);
                         o->LifeTime = 500;
-                        o->Position[0] += (float)(rand() % 400 - 200);
-                        o->Position[1] += (float)(rand() % 400 - 200);
-                        o->Position[2] += (float)(rand() % 400 - 200);
+                        o->Position[0] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
                         VectorCopy(o->Position, o->StartPosition);
                         o->Scale = (float)(rand() % 15 + 10) / 15.0f + Scale;
                         float fTemp = (float)(rand() % 10 + 5) * 0.12f;
@@ -2886,9 +2886,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     else if (o->SubType == 11)
                     {
                         o->LifeTime = 500;
-                        o->Position[0] += (float)(rand() % 400 - 200);
-                        o->Position[1] += (float)(rand() % 400 - 200);
-                        o->Position[2] += (float)(rand() % 400 - 200);
+                        o->Position[0] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
                         VectorCopy(o->Position, o->StartPosition);
                         o->Scale = (float)(rand() % 15 + 15) / 30.0f + Scale;
                         float fTemp = (float)(rand() % 10 + 5) * 0.12f;
@@ -2901,9 +2901,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->LifeTime = 30;
                         o->Gravity = (float)(rand() % 1000);
 
-                        o->Position[0] += (float)(rand() % 500 - 250);//*Scale;
-                        o->Position[1] += (float)(rand() % 500 - 250);//*Scale;
-                        o->Position[2] += (float)(rand() % 20 + 20);
+                        o->Position[0] += ((float)(rand() % 500 - 250) * FPS_ANIMATION_FACTOR);//*Scale);
+                        o->Position[1] += ((float)(rand() % 500 - 250) * FPS_ANIMATION_FACTOR);//*Scale);
+                        o->Position[2] += ((float)(rand() % 20 + 20)) * FPS_ANIMATION_FACTOR;
 
                         o->StartPosition[1] = (rand() % 100) / 100.f;
                         o->StartPosition[2] = o->Position[2];
@@ -2932,9 +2932,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     {
                         o->LifeTime = 500;
 
-                        o->Position[0] += (float)(rand() % 400 - 200);
-                        o->Position[1] += (float)(rand() % 400 - 200);
-                        o->Position[2] += (float)(rand() % 400 - 200);
+                        o->Position[0] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
                         VectorCopy(o->Position, o->StartPosition);
 
                         o->Rotation = rand() % 360;
@@ -2957,9 +2957,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
 
                         o->LifeTime = 500;
 
-                        o->Position[0] += (float)(rand() % 400 - 200);
-                        o->Position[1] += (float)(rand() % 400 - 200);
-                        o->Position[2] += (float)(rand() % 400 - 200);
+                        o->Position[0] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
                         VectorCopy(o->Position, o->StartPosition);
 
                         o->Rotation = rand() % 360;
@@ -2976,9 +2976,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->TexType = BITMAP_EVENT_CLOUD;
                         o->LifeTime = 500;
 
-                        o->Position[0] += (float)(rand() % 900 - 450);
-                        o->Position[1] += (float)(rand() % 900 - 450);
-                        o->Position[2] += (float)(rand() % 20 + 50);
+                        o->Position[0] += ((float)(rand() % 900 - 450)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 900 - 450)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 20 + 50)) * FPS_ANIMATION_FACTOR;
                         VectorCopy(o->Position, o->StartPosition);
 
                         o->Rotation = rand() % 360;
@@ -3005,7 +3005,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->Gravity = (float)(rand() % 1000);
 
                         VectorCopy(Position, o->Position);
-                        o->Position[2] += (float)(rand() % 80);
+                        o->Position[2] += ((float)(rand() % 80)) * FPS_ANIMATION_FACTOR;
                         o->Rotation = rand() % 360;
 
                         o->StartPosition[0] = (rand() % 200 - 10) / 10.0f;
@@ -3026,9 +3026,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->Light[2] = 0.f;
                         o->Gravity = (float)(rand() % 1000);
 
-                        o->Position[0] += (float)(rand() % 500 - 250);//*Scale;
-                        o->Position[1] += (float)(rand() % 500 - 250);//*Scale;
-                        o->Position[2] += (float)(rand() % 20 + 20);
+                        o->Position[0] += ((float)(rand() % 500 - 250) * FPS_ANIMATION_FACTOR);//*Scale)
+                        o->Position[1] += ((float)(rand() % 500 - 250) * FPS_ANIMATION_FACTOR);//*Scale)
+                        o->Position[2] += ((float)(rand() % 20 + 20)) * FPS_ANIMATION_FACTOR;
                         o->Rotation = rand() % 360;
 
                         o->StartPosition[1] = (rand() % 100) / 100.f;
@@ -3044,9 +3044,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->Gravity = (float)(rand() % 1000);
                         o->Alpha = 0.1f;
 
-                        o->Position[0] += (float)(rand() % 500 - 250);
-                        o->Position[1] += (float)(rand() % 500 - 250);
-                        o->Position[2] += (float)(rand() % 20 - 20);
+                        o->Position[0] += ((float)(rand() % 500 - 250)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 500 - 250)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 20 - 20)) * FPS_ANIMATION_FACTOR;
 
                         o->StartPosition[1] = (rand() % 100) / 100.f;
                         o->StartPosition[2] = o->Position[2];
@@ -3061,9 +3061,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->Gravity = (float)(rand() % 1000);
                         o->Alpha = 0.6f;
 
-                        o->Position[0] += (float)(rand() % 200 - 100);
-                        o->Position[1] += (float)(rand() % 200 - 100);
-                        o->Position[2] += (float)(rand() % 20 - 20);
+                        o->Position[0] += ((float)(rand() % 200 - 100)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 200 - 100)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 20 - 20)) * FPS_ANIMATION_FACTOR;
 
                         o->StartPosition[1] = (rand() % 100) / 100.f;
                         o->StartPosition[2] = o->Position[2];
@@ -3078,9 +3078,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->Gravity = (float)(rand() % 1000);
                         o->Alpha = 0.1f;
 
-                        o->Position[0] += (float)(rand() % 20 - 10);
-                        o->Position[1] += (float)(rand() % 20 - 10);
-                        o->Position[2] += (float)(rand() % 20 - 20);
+                        o->Position[0] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 20 - 10)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 20 - 20)) * FPS_ANIMATION_FACTOR;
 
                         o->Scale = (((float)(rand() % 20 + 50) * 0.003f) * o->Scale);
                         Vector(0.f, 0.f, 0.f, o->TurningForce);
@@ -3099,9 +3099,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->Gravity = (float)(rand() % 1000);
                         o->Alpha = 0.1f;
 
-                        o->Position[0] += (float)(rand() % 6 - 3);
-                        o->Position[1] += (float)(rand() % 6 - 3);
-                        o->Position[2] += (float)(rand() % 6 - 3);
+                        o->Position[0] += ((float)(rand() % 6 - 3)) * FPS_ANIMATION_FACTOR;
+                        o->Position[1] += ((float)(rand() % 6 - 3)) * FPS_ANIMATION_FACTOR;
+                        o->Position[2] += ((float)(rand() % 6 - 3)) * FPS_ANIMATION_FACTOR;
 
                         o->Scale = 0;//(((float)(rand()%20+20)*0.001f) * o->Scale);
                         Vector(0.f, 0.f, 0.f, o->TurningForce);
@@ -3120,9 +3120,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                         o->LifeTime = 30;
                         o->Gravity = (float)(rand() % 1000);
 
-                        o->Position[0] += (float)(rand() % 500 - 250);//*Scale;
-                        o->Position[1] += (float)(rand() % 500 - 250);//*Scale;
-                        o->Position[2] += (float)(rand() % 20 + 20);
+                        o->Position[0] += ((float)(rand() % 500 - 250)) * FPS_ANIMATION_FACTOR;//*Scale)
+                        o->Position[1] += ((float)(rand() % 500 - 250)) * FPS_ANIMATION_FACTOR;//*Scale)
+                        o->Position[2] += ((float)(rand() % 20 + 20)) * FPS_ANIMATION_FACTOR;
 
                         o->StartPosition[1] = (rand() % 100) / 100.f;
                         o->StartPosition[2] = o->Position[2];
@@ -3137,9 +3137,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 o->LifeTime = rand() % 5 + 60;
                 o->Scale = (float)(rand() % 30 + 30) * 0.02f + Scale / 3.f;
 
-                o->Position[0] += (float)(rand() % 4 - 2) * 0.25f;
-                o->Position[1] += (float)(rand() % 4 - 2) * 0.25f;
-                o->Position[2] += (float)(rand() % 10 - 5);
+                o->Position[0] += ((float)(rand() % 4 - 2) * 0.25f) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += ((float)(rand() % 4 - 2) * 0.25f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += ((float)(rand() % 10 - 5)) * FPS_ANIMATION_FACTOR;
 
                 o->Gravity = (float)(rand() % 2 + 10) * 0.5f;
             }
@@ -3151,10 +3151,10 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 if (o->SubType == 0)
                 {
                     o->LifeTime = 500;
-                    o->Position[0] += (float)(rand() % 400 - 200);
+                    o->Position[0] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
 
-                    o->Position[1] += (float)(rand() % 400 - 200);
-                    o->Position[2] += (float)(rand() % 400 - 200);
+                    o->Position[1] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 400 - 200)) * FPS_ANIMATION_FACTOR;
                     VectorCopy(o->Position, o->StartPosition);
                     o->Scale = (float)(rand() % 15 + 15) / 30.0f + Scale;
                     float fTemp = (float)(rand() % 10 + 5) * 0.08f;
@@ -3353,9 +3353,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->Scale = Scale + (float)(rand() % 30) / 100.f;
                     o->LifeTime = 15;
-                    o->Position[0] += (float)(rand() % 10) / 10.f - 0.5f;
-                    o->Position[1] += (float)(rand() % 10) / 10.f - 0.5f;
-                    o->Position[2] += (float)(rand() % 10) / 10.f - 0.5f;
+                    o->Position[0] += ((float)(rand() % 10) / 10.f - 0.5f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 10) / 10.f - 0.5f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 10) / 10.f - 0.5f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 5)
                     o->LifeTime = 20;
@@ -3432,14 +3432,14 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 20;
                     o->Rotation = (float)(rand() % 360);
                     o->Scale = 1.f;
-                    o->Position[2] += 50.f;
+                    o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
                     o->LifeTime = 20;
                     o->Rotation = (float)(rand() % 360);
                     o->Scale = 0.5f;
-                    o->Position[2] += 50.f;
+                    o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                     o->Velocity[2] = (float)((rand() % 5 + 10));
                 }
                 else if (o->SubType == 3)
@@ -3506,9 +3506,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
             case BITMAP_PLUS:
                 o->LifeTime = 20;
                 o->Scale = Scale;
-                o->Position[0] += rand() % 30 - 15.f;
-                o->Position[1] += rand() % 30 - 15.f;
-                o->Position[2] += 240.f;
+                o->Position[0] += (rand() % 30 - 15.f) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 30 - 15.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (240.f) * FPS_ANIMATION_FACTOR;
                 break;
 
             case BITMAP_WATERFALL_2:
@@ -3541,9 +3541,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     Vector(0.4f, 0.4f, 0.4f, o->Light);
                 }
 
-                o->Position[0] += rand() % 20 - 10.f;
-                o->Position[1] += rand() % 20 - 10.f;
-                o->Position[2] += rand() % 40 - 20.f;
+                o->Position[0] += (rand() % 20 - 10.f) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 20 - 10.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
 
                 if (o->SubType == 1)
                 {
@@ -3560,9 +3560,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale = (rand() % 3 + 3) * 0.18f;
                     o->Velocity[2] = 2.0f;
 
-                    o->Position[0] += rand() % 20 - 10.f;
-                    o->Position[1] += rand() % 20 - 10.f;
-                    o->Position[2] += rand() % 40 - 20.f;
+                    o->Position[0] += (rand() % 20 - 10.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 20 - 10.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
                 }
                 if (o->SubType == 4)
                 {
@@ -3578,9 +3578,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Velocity[0] = -(rand() % 2 + 2);
                     o->Velocity[1] = -(rand() % 2 + 2);
                     o->Velocity[2] = (rand() % 2 + 1);
-                    o->Position[0] += rand() % 60 - 30.f;
-                    o->Position[1] += rand() % 60 - 30.f;
-                    o->Position[2] += rand() % 10;
+                    o->Position[0] += (rand() % 60 - 30.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 60 - 30.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 10) * FPS_ANIMATION_FACTOR;
                     break;
                 }
                 if (o->SubType == 11)
@@ -3618,8 +3618,8 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Velocity[2] = -1.0f;
                     o->Scale *= (rand() % 10 + 15) * 0.02f;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += rand() % 40 - 20.f;
-                    o->Position[2] += rand() % 25 - 10.f;
+                    o->Position[0] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 25 - 10.f) * FPS_ANIMATION_FACTOR;
                     break;
                 }
                 else if (o->SubType == 12)
@@ -3628,9 +3628,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = (rand() % 2 - 1) + 5;
                     float fIntervalScale = Scale * 0.3f;
                     o->Scale += ((float((rand() % 20) - 10) / 2.0f) * ((fIntervalScale / 2.f)) * FPS_ANIMATION_FACTOR);
-                    o->Position[0] += (float)(rand() % 20) - 10.f;
-                    o->Position[1] += (float)(rand() % 20) - 10.f;
-                    o->Position[2] += (float)(rand() % 20) - 10.f;
+                    o->Position[0] += ((float)(rand() % 20) - 10.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 20) - 10.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 20) - 10.f) * FPS_ANIMATION_FACTOR;
 
                     break;
                 }
@@ -3660,9 +3660,9 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Gravity = ((rand() % 100) / 100.f) * 2.f;
                     o->Scale = (rand() % 10 + 10) * 0.02f + Scale;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += rand() % 40 - 20.f;
-                    o->Position[1] += rand() % 40 - 20.f;
-                    o->Position[2] -= 50.f;
+                    o->Position[0] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (50.f) * FPS_ANIMATION_FACTOR;
                     break;
                 }
                 else if (o->SubType == 7)
@@ -3671,8 +3671,8 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Velocity[2] = (rand() % 4) * 0.1f + 0.8f;
                     o->Scale *= (rand() % 10 + 15) * 0.02f;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += rand() % 18 - 9.f;
-                    o->Position[2] += rand() % 18 - 9.f;
+                    o->Position[0] += (rand() % 18 - 9.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (rand() % 18 - 9.f) * FPS_ANIMATION_FACTOR;
                     break;
                 }
                 else if (o->SubType == 8)
@@ -3732,14 +3732,14 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Gravity = ((rand() % 100) / 100.f) * 2.f;
                     o->Scale = (rand() % 10 + 10) * 0.02f + Scale;
                     o->Rotation = (float)(rand() % 360);
-                    o->Position[0] += rand() % 40 - 20.f;
-                    o->Position[1] += rand() % 40 - 20.f;
-                    o->Position[2] -= 50.f;
+                    o->Position[0] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (50.f) * FPS_ANIMATION_FACTOR;
                     break;
                 }
-                o->Position[0] += rand() % 40 - 20.f;
-                o->Position[1] += rand() % 40 - 20.f;
-                o->Position[2] += rand() % 20 - 10.f;
+                o->Position[0] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 40 - 20.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (rand() % 20 - 10.f) * FPS_ANIMATION_FACTOR;
                 break;
             case BITMAP_SHOCK_WAVE:
                 if (o->SubType == 3)
@@ -3840,7 +3840,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
             {
                 o->LifeTime = 15;
                 o->Scale = Scale * 0.9f + (rand() % 2 + 2) * 0.1f;
-                o->Position[2] += 80.0f + rand() % 20;
+                o->Position[2] += (80.0f + rand() % 20) * FPS_ANIMATION_FACTOR;
             }
             break;
             }
@@ -3935,15 +3935,15 @@ void MoveParticles()
                 {
                     if (o->SubType == 0)
                     {
-                        o->Velocity[0] += (float)(rand() % 32 - 16) * 0.1f;
-                        o->Velocity[1] += (float)(rand() % 32 - 16) * 0.1f;
-                        o->Velocity[2] += (float)(rand() % 32 - 16) * 0.1f;
+                        o->Velocity[0] += ((float)(rand() % 32 - 16) * 0.1f) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[1] += ((float)(rand() % 32 - 16) * 0.1f) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[2] += ((float)(rand() % 32 - 16) * 0.1f) * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->SubType == 1)
                     {
-                        o->Velocity[0] += (float)(rand() % 8 - 4) * 0.05f;
-                        o->Velocity[1] += (float)(rand() % 8 - 4) * 0.05f;
-                        o->Velocity[2] -= (float)(rand() % 8) * 0.05f;
+                        o->Velocity[0] += ((float)(rand() % 8 - 4) * 0.05f) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[1] += ((float)(rand() % 8 - 4) * 0.05f) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[2] -= ((float)(rand() % 8) * 0.05f) * FPS_ANIMATION_FACTOR;
                     }
                     VectorAdd(o->Position, o->Velocity, o->Position);
                 }
@@ -3954,26 +3954,26 @@ void MoveParticles()
                     Vector(0.f, 0.f, 0.f, o->Velocity);
                     o->Frame = 1;
                 }
-                o->Rotation += rand() % 16;
+                o->Rotation += (rand() % 16) * FPS_ANIMATION_FACTOR;
                 break;
             case BITMAP_FLARE_BLUE:
                 if (o->SubType == 0)
                 {
                     o->Scale = 0.2f;//sin( WorldTime*0.001f )*0.2f+0.35f;
 
-                    o->Velocity[2] += 0.4f;
-                    o->Velocity[2] = min(8.f, o->Velocity[2]);
+                    o->Velocity[2] += (0.4f) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[2] = min(8.f * FPS_ANIMATION_FACTOR, o->Velocity[2]);
 
                     if (o->LifeTime < 5)
                     {
-                        o->Light[0] /= 1.2f;
-                        o->Light[1] /= 1.2f;
-                        o->Light[2] /= 1.2f;
+                        o->Light[0] *= 0.98f + (0.02f * 1 - FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= 0.98f + (0.02f * 1 - FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= 0.98f + (0.02f * 1 - FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->SubType == 1)
                 {
-                    o->Light[0] /= 1.1f;
+                    o->Light[0] *= 0.99f + (0.01f * 1 - FPS_ANIMATION_FACTOR);
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
                     o->Scale += 1.5f * FPS_ANIMATION_FACTOR;
@@ -4000,7 +4000,7 @@ void MoveParticles()
                     if (o->SubType == 1)
                     {
                         o->Scale += FPS_ANIMATION_FACTOR * 0.19f;
-                        o->Position[2] += 5.00f;
+                        o->Position[2] += (5.00f) * FPS_ANIMATION_FACTOR;
                     }
                     else
                         o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
@@ -4024,18 +4024,18 @@ void MoveParticles()
                 }
                 else if (o->SubType == 5)
                 {
-                    o->TurningForce[2] -= o->Gravity;
+                    o->TurningForce[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
-                    o->Position[0] += o->TurningForce[0];
-                    o->Position[1] += o->TurningForce[1];
-                    o->Position[2] += o->TurningForce[2];
+                    o->Position[0] += (o->TurningForce[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->TurningForce[1]) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (o->TurningForce[2]) * FPS_ANIMATION_FACTOR;
 
-                    o->Angle[0] += 0.5f * o->LifeTime;
-                    o->Angle[1] += 0.5f * o->LifeTime;
+                    o->Angle[0] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                    o->Angle[1] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     if (o->LifeTime < 20)
                     {
@@ -4049,25 +4049,25 @@ void MoveParticles()
                     VectorSubtract(o->Position, o->StartPosition, o->Position);
                     VectorCopy(o->Target->Position, o->StartPosition);
                     VectorAdd(o->Position, o->StartPosition, o->Position);
-                    o->Velocity[0] += 0.05f;
-                    o->Velocity[1] += 0.05f;
+                    o->Velocity[0] += (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[1] += (0.05f) * FPS_ANIMATION_FACTOR;
 
-                    o->Rotation += 1.0f;
+                    o->Rotation += (1.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 6)
                 {
-                    o->TurningForce[2] -= o->Gravity;
+                    o->TurningForce[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
-                    o->Position[0] += o->TurningForce[0];
-                    o->Position[1] += o->TurningForce[1];
-                    o->Position[2] += o->TurningForce[2];
+                    o->Position[0] += (o->TurningForce[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->TurningForce[1]) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (o->TurningForce[2]) * FPS_ANIMATION_FACTOR;
 
-                    o->Angle[0] += 0.5f * o->LifeTime;
-                    o->Angle[1] += 0.5f * o->LifeTime;
+                    o->Angle[0] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                    o->Angle[1] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     if (o->LifeTime < 20)
                     {
@@ -4081,26 +4081,26 @@ void MoveParticles()
                         o->Live = false;
                     }
 
-                    o->Velocity[0] += 0.05f;
-                    o->Velocity[1] += 0.05f;
+                    o->Velocity[0] += (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[1] += (0.05f) * FPS_ANIMATION_FACTOR;
 
-                    o->Rotation += 2.0f;
+                    o->Rotation += (2.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 7)
                 {
-                    o->TurningForce[2] -= o->Gravity;
+                    o->TurningForce[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
 
-                    o->Position[0] += o->TurningForce[0];
-                    o->Position[1] += o->TurningForce[1];
-                    o->Position[2] += o->TurningForce[2];
+                    o->Position[0] += (o->TurningForce[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->TurningForce[1]) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (o->TurningForce[2]) * FPS_ANIMATION_FACTOR;
 
-                    o->Angle[0] += 0.5f * o->LifeTime;
-                    o->Angle[1] += 0.5f * o->LifeTime;
+                    o->Angle[0] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
+                    o->Angle[1] += (0.5f * o->LifeTime) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     o->TexType = BITMAP_LIGHT;
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     if (o->LifeTime < 20)
                     {
@@ -4114,23 +4114,23 @@ void MoveParticles()
                         o->Live = false;
                     }
 
-                    o->Velocity[0] += 0.05f;
-                    o->Velocity[1] += 0.05f;
+                    o->Velocity[0] += (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[1] += (0.05f) * FPS_ANIMATION_FACTOR;
 
-                    o->Rotation += 2.0f;
+                    o->Rotation += (2.0f) * FPS_ANIMATION_FACTOR;
 
                     Luminosity = (float)(o->LifeTime) / 8.f * 0.02f;
-                    o->Light[0] += Luminosity;
-                    o->Light[1] += Luminosity;
-                    o->Light[2] += Luminosity;
+                    o->Light[0] += (Luminosity) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] += (Luminosity) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] += (Luminosity) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
                     Luminosity = (float)(o->LifeTime) / 8.f * 0.02f;
-                    o->Light[0] += Luminosity;
-                    o->Light[1] += Luminosity;
-                    o->Light[2] += Luminosity;
-                    o->Gravity += 0.2f;
+                    o->Light[0] += (Luminosity) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] += (Luminosity) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] += (Luminosity) * FPS_ANIMATION_FACTOR;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.1f * FPS_ANIMATION_FACTOR;
                 }
@@ -4138,9 +4138,9 @@ void MoveParticles()
             case BITMAP_GM_AURORA:
             {
                 Luminosity = (float)(o->LifeTime) / 8.f * 0.04f;
-                o->Light[0] -= Luminosity;
-                o->Light[1] -= Luminosity;
-                o->Light[2] -= Luminosity;
+                o->Light[0] -= (Luminosity) * FPS_ANIMATION_FACTOR;
+                o->Light[1] -= (Luminosity) * FPS_ANIMATION_FACTOR;
+                o->Light[2] -= (Luminosity) * FPS_ANIMATION_FACTOR;
             }
             break;
             case BITMAP_MAGIC + 1:
@@ -4156,23 +4156,23 @@ void MoveParticles()
                 {
                 case 0:
                     o->Frame++;
-                    o->Position[0] += (float)(rand() % 20 - 10) * 2.5f * o->Scale;
-                    o->Position[1] += (float)(rand() % 20 - 10) * 2.5f * o->Scale;
-                    o->Position[2] += (float)(rand() % 20 + 10) * 2.5f * o->Scale;
+                    o->Position[0] += (float)(rand() % 20 - 10) * 2.5f * o->Scale * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (float)(rand() % 20 - 10) * 2.5f * o->Scale * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (float)(rand() % 20 + 10) * 2.5f * o->Scale * FPS_ANIMATION_FACTOR;
                     break;
 
                 case 1:
                     o->Frame++;
-                    o->Position[0] += (float)(rand() % 30 - 15) * 1.f * o->Scale;
-                    o->Position[1] += (float)(rand() % 30 - 15) * 1.f * o->Scale;
-                    o->Position[2] += (float)(rand() % 20 + 10) * 0.3f * o->Scale;
+                    o->Position[0] += (float)(rand() % 30 - 15) * 1.f * o->Scale * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (float)(rand() % 30 - 15) * 1.f * o->Scale * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (float)(rand() % 20 + 10) * 0.3f * o->Scale * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.002f;
                     break;
 
                 case 2:
                     o->Position[0];// += (float)(rand()%30-15)*1.f*o->Scale;
                     o->Position[1];// += (float)(rand()%30-15)*1.f*o->Scale;
-                    o->Position[2] += (float)(rand() % 20 + 10) * 0.3f;
+                    o->Position[2] += (float)(rand() % 20 + 10) * 0.3f * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                     break;
 
@@ -4185,7 +4185,7 @@ void MoveParticles()
                 case 4:
                     o->Position[0];// += (float)(rand()%30-15)*1.f*o->Scale;
                     o->Position[1];// += (float)(rand()%30-15)*1.f*o->Scale;
-                    o->Position[2] += (float)(rand() % 20 + 10) * 0.3f;
+                    o->Position[2] += (float)(rand() % 20 + 10) * 0.3f * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                     if (o->Position[2] > 350)
                     {
@@ -4195,9 +4195,9 @@ void MoveParticles()
                     break;
                 case 5:
                     o->Frame++;
-                    o->Position[0] += (float)(rand() % 20 - 10) * 2.5f * o->Scale;
-                    o->Position[1] += (float)(rand() % 20 - 10) * 2.5f * o->Scale;
-                    o->Position[2] += (float)(rand() % 20 + 10) * 2.5f * o->Scale;
+                    o->Position[0] += (float)(rand() % 20 - 10) * 2.5f * o->Scale * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (float)(rand() % 20 - 10) * 2.5f * o->Scale * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (float)(rand() % 20 + 10) * 2.5f * o->Scale * FPS_ANIMATION_FACTOR;
                     if (o->Position[2] > 550)
                         o->Live = false;
                     break;
@@ -4209,9 +4209,9 @@ void MoveParticles()
                 o->Frame = (20 - o->LifeTime) / 2;
                 if (o->SubType == 2)
                 {
-                    int Life = 0;
+                    float Life = 0;
                     if (o->LifeTime > 10)
-                        Life = o->LifeTime - 10;
+                        Life = (o->LifeTime - 10) * FPS_ANIMATION_FACTOR;
                     else
                         Life = 1;
                     o->Frame = (20 - Life) / 2;
@@ -4293,7 +4293,7 @@ void MoveParticles()
                     o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                     Vector(Luminosity * 0.5f, Luminosity * 1.f, Luminosity * 0.8f, o->Light);
                     VectorCopy(o->Target->Position, o->Position);
-                    o->Position[2] += 80.f;
+                    o->Position[2] += 80.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_LIGHTNING:
@@ -4309,7 +4309,7 @@ void MoveParticles()
                 o->Gravity = 0.0f;
                 Luminosity = (float)(o->LifeTime) / 24.f;
                 o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
-                o->Rotation += 5;
+                o->Rotation += (5) * FPS_ANIMATION_FACTOR;
                 o->Frame = (23 - o->LifeTime) / 6;
                 break;
             case BITMAP_FIRE_CURSEDLICH:
@@ -4357,11 +4357,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -4381,7 +4381,7 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                     if (o->SubType == 9)
                     {
                         o->Rotation = 0.0f;
@@ -4392,11 +4392,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 15)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -4416,17 +4416,17 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 6)
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -4445,20 +4445,20 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[0] += o->Velocity[0];
-                    o->Position[1] += o->Velocity[1];
+                    o->Position[0] += (o->Velocity[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 7)
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -4484,11 +4484,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 5)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -4517,7 +4517,7 @@ void MoveParticles()
                     VectorCopy(o->Target->Position, o->StartPosition);
                     VectorAdd(o->Position, o->Target->Position, o->Position);
 
-                    o->Rotation += 5.0f;
+                    o->Rotation += (5.0f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_LEAF_TOTEMGOLEM:
@@ -4529,7 +4529,7 @@ void MoveParticles()
                 {
                     Vector(0, 0, 0, o->Velocity);
                     o->Position[2] = Height;
-                    o->Alpha -= 0.05f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
                     Vector(o->Alpha, o->Alpha, o->Alpha, o->Light);
                 }
                 else
@@ -4545,7 +4545,7 @@ void MoveParticles()
                 {
                 case    0:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += 0.004f * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -4556,17 +4556,17 @@ void MoveParticles()
                 case    5:
                 case    6:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 5;
+                    o->Rotation += (5) * FPS_ANIMATION_FACTOR;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case    7:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Frame = (15 - o->LifeTime) / 6;
                     o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
@@ -4576,22 +4576,22 @@ void MoveParticles()
                 break;
                 case    8:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale *= 0.95f;
-                    o->Rotation += 5;
+                    o->Rotation += (5) * FPS_ANIMATION_FACTOR;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case    9:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Position[0] = o->Target->Position[0] + o->StartPosition[0];
                     o->Position[1] = o->Target->Position[1] + o->StartPosition[1];
                     o->Position[2] = o->Target->Position[2] + o->StartPosition[2];
-                    o->Gravity += ((rand() % 60) + 60) / 100;
+                    o->Gravity += (((rand() % 60) + 60) / 100) * FPS_ANIMATION_FACTOR;
                     o->Scale -= o->Gravity * FPS_ANIMATION_FACTOR / 90.f;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -4599,7 +4599,7 @@ void MoveParticles()
                 break;
                 case    11:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     if (o->LifeTime > 12)
                     {
@@ -4612,7 +4612,7 @@ void MoveParticles()
                 break;
                 case	10:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale *= 0.95f;
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -4621,9 +4621,9 @@ void MoveParticles()
                 break;
                 case    12:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Rotation += (float)(rand() % 10 + 10.f);
+                    o->Rotation += ((float)(rand() % 10 + 10.f)) * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -4632,9 +4632,9 @@ void MoveParticles()
                 break;
                 case    13:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Rotation += (float)(rand() % 10 + 10.f);
+                    o->Rotation += ((float)(rand() % 10 + 10.f)) * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -4643,7 +4643,7 @@ void MoveParticles()
                 break;
                 case 14:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
@@ -4658,7 +4658,7 @@ void MoveParticles()
                 break;
                 case 15:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.1f;
@@ -4680,7 +4680,7 @@ void MoveParticles()
                 }break;
                 case 18:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Velocity, 0.98f, o->Velocity);
@@ -4691,7 +4691,7 @@ void MoveParticles()
                 break;
                 default:
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Velocity, 0.98f, o->Velocity);
@@ -4716,13 +4716,13 @@ void MoveParticles()
                     //					o->Gravity += 0.02f;
                     //					o->Scale += o->Gravity;
                     //     				VectorScale(o->Velocity,1.05f,o->Velocity);
-                    //					o->Position[2] += o->Gravity*20.f;
+                    //					o->Position[2] += (o->Gravity*20.f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) * 0.2f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Gravity += 0.02f;
+                    o->Gravity += (0.02f) * FPS_ANIMATION_FACTOR;
                     o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Velocity, 1.05f, o->Velocity);
                     o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
@@ -4743,16 +4743,16 @@ void MoveParticles()
                 {
                     //					Luminosity = (float)(o->LifeTime)*0.2f;
                     //					Vector(o->TurningForce[0]*Luminosity,o->TurningForce[1]*Luminosity,o->TurningForce[2]*Luminosity,o->Light);
-                    o->Position[0] += (float)(cos(o->Angle[2]) * 20.0f);
-                    o->Position[1] += (float)(sin(o->Angle[2]) * 20.0f);
+                    o->Position[0] += ((float)(cos(o->Angle[2]) * 20.0f)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(sin(o->Angle[2]) * 20.0f)) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 1;
+                    o->Rotation += (1) * FPS_ANIMATION_FACTOR;
                     //o->Scale += FPS_ANIMATION_FACTOR * 0.003f;
                 }
                 else if (o->SubType == 6)
                 {
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 4;
+                    o->Rotation += (4) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 7)
                 {
@@ -4770,7 +4770,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 0)
                 {
-                    o->Gravity += 0.02f;
+                    o->Gravity += (0.02f) * FPS_ANIMATION_FACTOR;
                     o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Velocity, 1.05f, o->Velocity);
                     o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
@@ -4786,24 +4786,24 @@ void MoveParticles()
                 case 1:
                     if (o->LifeTime == 10)
                     {
-                        o->Velocity[1] += 32 * 0.2f;
+                        o->Velocity[1] += (32 * 0.2f) * FPS_ANIMATION_FACTOR;
                         o->Scale -= 0.15f * FPS_ANIMATION_FACTOR;
                     }
                     o->Rotation = (float)(rand() % 360);
-                    o->Light[0] -= 0.05f;
-                    o->Light[1] -= 0.05f;
-                    o->Light[2] -= 0.05f;
+                    o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
                     break;
                 case 5:
                     if (o->LifeTime == 10)
                     {
-                        o->Velocity[1] += 32 * 0.2f;
+                        o->Velocity[1] += (32 * 0.2f) * FPS_ANIMATION_FACTOR;
                         o->Scale *= 0.8f;
                     }
                     o->Rotation = (float)(rand() % 360);
-                    o->Light[0] -= 0.05f;
-                    o->Light[1] -= 0.05f;
-                    o->Light[2] -= 0.05f;
+                    o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
                     break;
                 case 2:
                     if (o->LifeTime < 10)
@@ -4813,9 +4813,9 @@ void MoveParticles()
                         //                        o->Light[2] /= (15-o->LifeTime);
                     }
                     o->Rotation = (float)(rand() % 360);
-                    o->Light[0] -= 0.05f;
-                    o->Light[1] -= 0.05f;
-                    o->Light[2] -= 0.05f;
+                    o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
                     break;
 
                 case 3:
@@ -4823,22 +4823,22 @@ void MoveParticles()
                     break;
 
                 case 4:
-                    o->Position[0] += o->Target->Position[0] - o->StartPosition[0];
-                    o->Position[1] += o->Target->Position[1] - o->StartPosition[1];
+                    o->Position[0] += (o->Target->Position[0] - o->StartPosition[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->Target->Position[1] - o->StartPosition[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Target->Position[2] - o->StartPosition[2] + o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorCopy(o->Target->Position, o->StartPosition);
-                    o->Gravity += 0.1f;
+                    o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
-                    o->Light[0] -= 0.05f;
-                    o->Light[1] -= 0.05f;
-                    o->Light[2] -= 0.05f;
+                    o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
                     break;
                 case 8:
                 {
                     if (o->StartPosition[0] < o->Position[0])
-                        o->Rotation += 2.0f;
+                        o->Rotation += (2.0f) * FPS_ANIMATION_FACTOR;
                     else
-                        o->Rotation -= 2.0f;
+                        o->Rotation -= (2.0f) * FPS_ANIMATION_FACTOR;
 
                     o->Position[2] += (o->Gravity / 2.f) * FPS_ANIMATION_FACTOR;
                     o->Scale -= o->Gravity * FPS_ANIMATION_FACTOR / 95.f;
@@ -4853,9 +4853,9 @@ void MoveParticles()
                 case 7:
                 {
                     if (o->StartPosition[0] < o->Position[0])
-                        o->Rotation += 2.0f;
+                        o->Rotation += (2.0f) * FPS_ANIMATION_FACTOR;
                     else
-                        o->Rotation -= 2.0f;
+                        o->Rotation -= (2.0f) * FPS_ANIMATION_FACTOR;
 
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= o->Gravity * FPS_ANIMATION_FACTOR / 95.f;
@@ -4870,9 +4870,9 @@ void MoveParticles()
                 case 9:
                 {
                     if (o->StartPosition[0] < o->Position[0])
-                        o->Rotation += 0.5f;
+                        o->Rotation += (0.5f) * FPS_ANIMATION_FACTOR;
                     else
-                        o->Rotation -= 0.5f;
+                        o->Rotation -= (0.5f) * FPS_ANIMATION_FACTOR;
 
                     o->Position[2] += o->Gravity * 1.2f * FPS_ANIMATION_FACTOR;
                     o->Scale -= o->Gravity * FPS_ANIMATION_FACTOR / 98.f;
@@ -4891,7 +4891,7 @@ void MoveParticles()
                     o->Light[0] = (float)(o->LifeTime) / 10.f;
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
-                    o->Velocity[2] += 0.3f;
+                    o->Velocity[2] += (0.3f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.07f;
                     break;
                 case 11:
@@ -4936,7 +4936,7 @@ void MoveParticles()
                 break;
             case BITMAP_ENERGY:
             {
-                o->Rotation += o->Gravity;
+                o->Rotation += (o->Gravity) * FPS_ANIMATION_FACTOR;
 
                 if (o->SubType == 1)
                 {
@@ -4945,9 +4945,9 @@ void MoveParticles()
                 }
                 else if (o->SubType == 2)
                 {
-                    o->Light[0] -= 0.01f;
-                    o->Light[1] -= 0.01f;
-                    o->Light[2] -= 0.01f;
+                    o->Light[0] -= (0.01f) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] -= (0.01f) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] -= (0.01f) * FPS_ANIMATION_FACTOR;
                 }
                 // ChainLighting
                 else if (o->SubType == 3 || o->SubType == 4 || o->SubType == 5)
@@ -4969,7 +4969,7 @@ void MoveParticles()
                     else if (o->SubType == 5)
                     {
                         VectorCopy(o->Target->Position, o->Position);
-                        o->Position[2] += 80.f;
+                        o->Position[2] += (80.f) * FPS_ANIMATION_FACTOR;
                     }
 
                     o->Light[0] /= 1.01f;
@@ -4987,9 +4987,9 @@ void MoveParticles()
                 {
                     o->Scale -= 0.05f * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] -= 0.01f;
-                    o->Light[1] -= 0.01f;
-                    o->Light[2] -= 0.01f;
+                    o->Light[0] -= (0.01f) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] -= (0.01f) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] -= (0.01f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_FLARE:  //
@@ -5024,10 +5024,10 @@ void MoveParticles()
                     float count = (o->Velocity[0] + o->LifeTime) * 0.1f;
                     o->Position[0] = o->StartPosition[0] + sinf(count) * 40.f;
                     o->Position[1] = o->StartPosition[1] - cosf(count) * 40.f;
-                    o->Position[2] -= o->Gravity;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
 
-                    o->StartPosition[0] += 2.5f;
+                    o->StartPosition[0] += (2.5f) * FPS_ANIMATION_FACTOR;
                 }
 
                 if (o->SubType == 4)
@@ -5067,7 +5067,7 @@ void MoveParticles()
                             o->Position[0] = o->StartPosition[0] + sinf(count) * 110.f;
                             o->Position[1] = o->StartPosition[1] - cosf(count) * 110.f;
                         }
-                        o->Position[2] += (o->Gravity + 0.1f);
+                        o->Position[2] += ((o->Gravity + 0.1f)) * FPS_ANIMATION_FACTOR;
 
                         o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
                         if (o->LifeTime <= 35)
@@ -5103,7 +5103,7 @@ void MoveParticles()
                     o->Gravity -= 0.01f * FPS_ANIMATION_FACTOR;
                     o->Position[2] -= o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.03f * FPS_ANIMATION_FACTOR;
-                    o->Alpha -= 0.05f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
                 }
                 else if (o->SubType == 1 || o->SubType == 2)
                 {
@@ -5142,11 +5142,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 3) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 3) * 0.1f;
                     }
                     else
                     {
@@ -5174,12 +5174,12 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                         VectorScale(o->Light, 0.9f, o->Light);
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (float)(rand() % 20) * 0.005f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (float)(rand() % 20) * 0.005f;
                     }
 
                     VectorAdd(o->Position, o->Velocity, o->Position);
@@ -5189,12 +5189,12 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                         VectorScale(o->Light, 0.9f, o->Light);
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (float)(rand() % 20) * 0.005f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (float)(rand() % 20) * 0.005f;
                     }
 
                     VectorAdd(o->Position, o->Velocity, o->Position);
@@ -5227,7 +5227,7 @@ void MoveParticles()
                     o->Gravity -= 0.01f * FPS_ANIMATION_FACTOR;
                     o->Position[2] -= o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.03f * FPS_ANIMATION_FACTOR;
-                    o->Alpha -= 0.05f * FPS_ANIMATION_FACTOR;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
                 }
             }
             break;
@@ -5262,7 +5262,7 @@ void MoveParticles()
                 }
 
                 o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                o->Alpha -= 0.05f * FPS_ANIMATION_FACTOR;
+                o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
                 o->Light[0] /= 1.02f;
                 o->Light[1] /= 1.02f;
                 o->Light[2] /= 1.02f;
@@ -5283,18 +5283,18 @@ void MoveParticles()
                     {
                         o->Gravity += (0.1f * o->Scale) * FPS_ANIMATION_FACTOR;
                         o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                        o->Position[1] += o->Gravity;
+                        o->Position[1] += (o->Gravity) * FPS_ANIMATION_FACTOR;
                         o->Scale -= 0.08f * FPS_ANIMATION_FACTOR;
                     }
                     else
                         VectorAdd(o->Target->Position, o->StartPosition, o->Position);
-                    o->Rotation += 0.01f;
+                    o->Rotation += (0.01f) * FPS_ANIMATION_FACTOR;
                     break;
                 case 37:
-                    o->Position[2] -= o->TurningForce[2] * 0.8f;
-                    o->Position[1] -= o->TurningForce[1] * 0.8f;
+                    o->Position[2] -= (o->TurningForce[2] * 0.8f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] -= (o->TurningForce[1] * 0.8f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
-                    o->Rotation += 0.01f;
+                    o->Rotation += (0.01f) * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.03f;
                     o->Light[1] /= 1.03f;
                     o->Light[2] /= 1.03f;
@@ -5310,7 +5310,7 @@ void MoveParticles()
                     Vector(Luminosity * 0.4f, Luminosity * 0.4f, Luminosity, o->Light);
                     VectorScale(o->Velocity, 0.001f, o->Velocity);
                     o->Scale += (0.01f * 2) * FPS_ANIMATION_FACTOR;
-                    o->Position[2] += o->Scale;
+                    o->Position[2] += (o->Scale) * FPS_ANIMATION_FACTOR;
                     break;
                 case 32:
                     Luminosity = (float)(o->LifeTime) / 8.f;
@@ -5321,7 +5321,7 @@ void MoveParticles()
                 case 23:
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 0.1f, Luminosity, Luminosity * 0.6f, o->Light);
-                    o->Gravity += 0.2f;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
@@ -5337,22 +5337,22 @@ void MoveParticles()
                     Vector(Luminosity * o->TurningForce[0], Luminosity * o->TurningForce[1], Luminosity * o->TurningForce[2], o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Position[2] -= 1.f;
+                    o->Position[2] -= (1.f) * FPS_ANIMATION_FACTOR;
                     break;
                 case 17:
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Luminosity = (Luminosity > 1.0f ? 1.0f - Luminosity : Luminosity);
                     Vector(Luminosity * o->TurningForce[0], Luminosity * o->TurningForce[1], Luminosity * o->TurningForce[2], o->Light);
-                    o->Gravity += 0.2f;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 15:
                     Luminosity = (float)(o->LifeTime) / 40.f;
                     Vector(Luminosity * 0.5f, Luminosity * 0.5f, Luminosity * 0.5f, o->Light);
-                    o->Gravity += (rand() % 20) / 500.f;
-                    o->Position[0] += (rand() % 100 - 20) / 100.f;
-                    o->Position[1] += (rand() % 100 - 20) / 100.f;
+                    o->Gravity += ((rand() % 20) / 500.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += ((rand() % 100 - 20) / 100.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((rand() % 100 - 20) / 100.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += (rand() % 10) * FPS_ANIMATION_FACTOR / 1000.f;
                     o->Rotation = o->Scale;
@@ -5366,16 +5366,16 @@ void MoveParticles()
                 case 2:
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Gravity -= 0.1f;
-                    o->Position[0] -= o->Gravity * 0.2f;
+                    o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] -= (o->Gravity * 0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     break;
                 case 16:
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Gravity -= 0.1f;
-                    o->Position[0] -= o->Gravity * 0.2f;
+                    o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] -= (o->Gravity * 0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     break;
@@ -5397,15 +5397,15 @@ void MoveParticles()
                 case 4:
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 120.f / 255.f, Luminosity * 100.7f / 255.f, Luminosity * 80.f / 255.f, o->Light);
-                    o->Gravity += 0.2f;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 5:
                     Luminosity = (float)(o->LifeTime) / 10.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Gravity -= 0.1f;
-                    o->Position[0] -= o->Gravity * (0.2f * (rand() % 2 + 1));
+                    o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] -= (o->Gravity * (0.2f * (rand() % 2 + 1))) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     break;
@@ -5421,9 +5421,9 @@ void MoveParticles()
                     Luminosity = 1.0f;
 
                     o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
-                    o->Gravity += 1.0f;
-                    o->Velocity[1] -= 0.1f;
-                    o->Position[2] -= o->Gravity;
+                    o->Gravity += (1.0f) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[1] -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime < 5)
                     {
                         Luminosity = (float)(o->LifeTime) / 8.f;
@@ -5432,7 +5432,7 @@ void MoveParticles()
                     Vector(Luminosity * 0.725f, Luminosity * 0.572f, Luminosity * 0.333f, o->Light);
                     break;
                 case 8:
-                    o->Gravity += 0.02f;
+                    o->Gravity += (0.02f) * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime > 5)
                     {
                         o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
@@ -5452,7 +5452,7 @@ void MoveParticles()
                 case 9:
                     Luminosity = (float)(o->LifeTime) / 10.f;
                     Vector(Luminosity * 250.f / 255.f, Luminosity * 156.7f / 255.f, 0.f, o->Light);
-                    o->Gravity += 0.5f;
+                    o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                     break;
@@ -5464,9 +5464,9 @@ void MoveParticles()
                 case 19:
                     Luminosity = (float)(o->LifeTime) / 40.f;
                     Vector(Luminosity * 0.5f, Luminosity * 0.5f, Luminosity * 0.5f, o->Light);
-                    o->Gravity += (rand() % 20) / 500.f;
-                    o->Position[0] += (rand() % 100 - 20) / 100.f;
-                    o->Position[1] += (rand() % 100 - 20) / 100.f;
+                    o->Gravity += ((rand() % 20) / 500.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += ((rand() % 100 - 20) / 100.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((rand() % 100 - 20) / 100.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += (rand() % 10) * FPS_ANIMATION_FACTOR / 1000.f;
                     o->Rotation = o->Scale;
@@ -5474,9 +5474,9 @@ void MoveParticles()
                 case 20:
                     Luminosity = (float)(o->LifeTime) / 40.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Gravity += (rand() % 20) / 500.f;
-                    o->Position[0] += (rand() % 100 - 20) / 100.f;
-                    o->Position[1] += (rand() % 100 - 20) / 100.f;
+                    o->Gravity += ((rand() % 20) / 500.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += ((rand() % 100 - 20) / 100.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((rand() % 100 - 20) / 100.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += (rand() % 10) * FPS_ANIMATION_FACTOR / 1000.f;
                     o->Rotation = o->Scale;
@@ -5484,23 +5484,23 @@ void MoveParticles()
                 case 21:
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Gravity -= 0.1f;
-                    o->Position[0] -= o->Gravity * 0.2f;
+                    o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] -= (o->Gravity * 0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     break;
                 case 22:
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * 0.9f, Luminosity * 0.5f, Luminosity * 0.5f, o->Light);
-                    o->Gravity -= 0.1f;
-                    o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
+                    o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->Gravity * sinf(WorldTime) * 0.05f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     break;
                 case 24:
                     Luminosity = (float)(o->LifeTime) / 32.f;
                     Vector(Luminosity * 0.2f, Luminosity * 0.5f, Luminosity * 0.35f, o->Light);
-                    o->Gravity += 0.1f;
+                    o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
@@ -5569,7 +5569,7 @@ void MoveParticles()
                     Vector(Luminosity * 0.5f, Luminosity * 1.f, Luminosity * 0.8f, o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Gravity += 0.2f;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 break;
@@ -5577,7 +5577,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 127.f / 255.f, Luminosity * 255.f / 255.f,
                         Luminosity * 200.f / 255.f, o->Light);
-                    o->Gravity += 0.2f;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
@@ -5604,8 +5604,8 @@ void MoveParticles()
                         o->Light[2] /= 1.07f;
                     }
                     o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
-                    o->Position[2] += 0.8f;
-                    o->Rotation += o->Gravity / 50.0f;
+                    o->Position[2] += (0.8f) * FPS_ANIMATION_FACTOR;
+                    o->Rotation += (o->Gravity / 50.0f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 45:
@@ -5624,8 +5624,8 @@ void MoveParticles()
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
 
-                    o->Gravity -= 0.05f;
-                    o->Position[2] += (o->Scale + o->Gravity) * 1.5f;
+                    o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((o->Scale + o->Gravity) * 1.5f) * FPS_ANIMATION_FACTOR;
                     o->Scale += o->Scale * FPS_ANIMATION_FACTOR / 100.0f;
                 }
                 break;
@@ -5671,18 +5671,18 @@ void MoveParticles()
 
                     VectorScale(o->Velocity, 0.001f, o->Velocity);
                     o->Scale += (rand() % 15 + 4) * (0.001f) * FPS_ANIMATION_FACTOR;
-                    o->Position[2] += o->Scale * 6.0f;
-                    o->Rotation += (rand() % 10 + 10) * 0.1f * o->Angle[0];
+                    o->Position[2] += (o->Scale * 6.0f) * FPS_ANIMATION_FACTOR;
+                    o->Rotation += ((rand() % 10 + 10) * 0.1f * o->Angle[0]) * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 50:
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     else if (o->Alpha < 0.5f)
                     {
-                        o->Alpha += (rand() % 3 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 3 + 2) * 0.1f;
                     }
                     else
                     {
@@ -5726,14 +5726,14 @@ void MoveParticles()
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
 
-                    o->Gravity -= 0.05f;
-                    o->Position[2] += (o->Scale + o->Gravity) * 1.5f;
+                    o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((o->Scale + o->Gravity) * 1.5f) * FPS_ANIMATION_FACTOR;
                     o->Scale += o->Scale * FPS_ANIMATION_FACTOR / 100.0f;
                 }
                 break;
                 case 55:
                 {
-                    o->Gravity += 0.1f;
+                    o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
 
@@ -5751,7 +5751,7 @@ void MoveParticles()
                 case 57:
                     Luminosity = (float)(o->LifeTime) / 32.f;
                     Vector(Luminosity * 0.5f, Luminosity * 0.1f, Luminosity * 0.8f, o->Light);
-                    o->Gravity += 0.1f;
+                    o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
@@ -5766,8 +5766,8 @@ void MoveParticles()
                 {
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * 0.4f, Luminosity * 0.4f, Luminosity * 0.4f, o->Light);
-                    o->Gravity -= 0.1f;
-                    o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
+                    o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->Gravity * sinf(WorldTime) * 0.05f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                 }
@@ -5775,7 +5775,7 @@ void MoveParticles()
                 case 61:
                 {
                     Luminosity = (float)(o->LifeTime) / 8.f;
-                    o->Gravity += 0.2f;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                 }
@@ -5795,7 +5795,7 @@ void MoveParticles()
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.5f;
-                    o->Velocity[1] += 1.5f;
+                    o->Velocity[1] += (1.5f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 64:
@@ -5805,17 +5805,17 @@ void MoveParticles()
 
                     MovePosition(o->Position, o->Angle, o->Velocity);
 
-                    o->Rotation += 0.05f;//(rand()%100)/100.f;
+                    o->Rotation += 0.05f * FPS_ANIMATION_FACTOR;//(rand()%100)/100.f) ;
 
-                    o->Gravity -= 0.1f;
-                    o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
+                    o->Gravity -= (0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->Gravity * sinf(WorldTime) * 0.05f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     o->Scale += (float)(rand() % 15 + 15) * 0.01f * FPS_ANIMATION_FACTOR;
 
                     if (16 > o->LifeTime)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                 }
                 break;
@@ -5823,8 +5823,8 @@ void MoveParticles()
                 {
                     Luminosity = (float)(o->LifeTime) / 40.f;
                     Vector(Luminosity * 0.4f, Luminosity * 0.4f, Luminosity * 0.4f, o->Light);
-                    o->Gravity -= 0.05f;
-                    o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
+                    o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->Gravity * sinf(WorldTime) * 0.05f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 break;
@@ -5837,15 +5837,15 @@ void MoveParticles()
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
 
-                    o->Gravity -= 0.05f;
-                    o->Position[0] += o->TurningForce[0] * (o->Scale + o->Gravity) * 1.0f;
-                    o->Position[1] += o->TurningForce[1] * (o->Scale + o->Gravity) * 1.0f;
+                    o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->TurningForce[0] * (o->Scale + o->Gravity) * 1.0f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->TurningForce[1] * (o->Scale + o->Gravity) * 1.0f) * FPS_ANIMATION_FACTOR;
                     o->Scale += o->Scale * FPS_ANIMATION_FACTOR / 100.0f;
                 }
                 break;
                 case 67:
                 {
-                    o->Alpha -= 0.01f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.01f;
 
                     if (o->Alpha < 0.1f)
                     {
@@ -5856,22 +5856,22 @@ void MoveParticles()
                     o->Light[2] *= o->Alpha;
 
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Rotation += 0.01f;
+                    o->Rotation += (0.01f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 68:
                 {
                     Luminosity = (float)(o->LifeTime) / 40.f;
                     Vector(Luminosity * 0.4f, Luminosity * 0.4f, Luminosity * 0.4f, o->Light);
-                    o->Velocity[0] += (0.03f * o->Velocity[0]);
-                    o->Velocity[1] += (0.03f * o->Velocity[1]);
-                    o->Velocity[2] += (0.03f * o->Velocity[2]);
+                    o->Velocity[0] += ((0.03f * o->Velocity[0])) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[1] += ((0.03f * o->Velocity[1])) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[2] += ((0.03f * o->Velocity[2])) * FPS_ANIMATION_FACTOR;
 
                     MovePosition(o->Position, o->Angle, o->Velocity);
 
                     if (30 > o->LifeTime)
                     {
-                        o->Alpha -= 0.02f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.02f;
                     }
                 }
                 break;
@@ -5879,8 +5879,8 @@ void MoveParticles()
                 case 69:
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * o->Angle[0], Luminosity * o->Angle[1], Luminosity * o->Angle[2], o->Light);
-                    o->Gravity -= 0.04f;
-                    o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
+                    o->Gravity -= (0.04f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->Gravity * sinf(WorldTime) * 0.05f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     break;
@@ -5895,40 +5895,40 @@ void MoveParticles()
                 VectorRotate(o->StartPosition, Matrix, Position);
                 VectorCopy(o->Target->Position, TargetPosition);
                 VectorAdd(TargetPosition, Position, o->Position);
-                o->Angle[1] += 5.f;
+                o->Angle[1] += (5.f) * FPS_ANIMATION_FACTOR;
                 o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                 break;
             case BITMAP_SMOKE + 3:
                 switch (o->SubType)
                 {
                 case 0:
-                    if (o->TurningForce[0] > 0.1f) o->TurningForce[0] -= 0.015f;
-                    if (o->TurningForce[1] > 0.1f) o->TurningForce[0] -= 0.005f;
-                    //o->TurningForce[1] -= 0.001f;
+                    if (o->TurningForce[0] > 0.1f) o->TurningForce[0] -= (0.015f) * FPS_ANIMATION_FACTOR;
+                    if (o->TurningForce[1] > 0.1f) o->TurningForce[0] -= (0.005f) * FPS_ANIMATION_FACTOR;
+                    //o->TurningForce[1] -= (0.001f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 55.f;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
-                    o->Gravity += 0.2f;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
-                    o->Rotation += o->Angle[0];
+                    o->Rotation += (o->Angle[0]) * FPS_ANIMATION_FACTOR;
                     break;
                 case 1:
                     Luminosity = (float)(o->LifeTime) / 55.f;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
-                    o->Gravity += 0.1f;
+                    o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
-                    o->Rotation += o->Angle[0];
+                    o->Rotation += (o->Angle[0]) * FPS_ANIMATION_FACTOR;
                     break;
                 case 2:
-                    if (o->TurningForce[1] > 0.1f) o->TurningForce[1] -= 0.005f;
-                    if (o->TurningForce[2] > 0.1f) o->TurningForce[2] -= 0.015f;
+                    if (o->TurningForce[1] > 0.1f) o->TurningForce[1] -= (0.005f) * FPS_ANIMATION_FACTOR;
+                    if (o->TurningForce[2] > 0.1f) o->TurningForce[2] -= (0.015f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 55.f;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
-                    o->Gravity += 0.2f;
+                    o->Gravity += (0.2f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
-                    o->Rotation += o->Angle[0];
+                    o->Rotation += (o->Angle[0]) * FPS_ANIMATION_FACTOR;
                     break;
                 case 3:
                     if (o->Light[0] <= 0.05f)
@@ -5937,7 +5937,7 @@ void MoveParticles()
                     o->Light[1] /= 1.012f;
                     o->Light[2] /= 1.012f;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
-                    o->Rotation += o->Gravity / 2.0f;
+                    o->Rotation += (o->Gravity / 2.0f) * FPS_ANIMATION_FACTOR;
 
                     if (o->Gravity <= 0.0f)
                         o->Gravity = -o->Gravity;
@@ -5950,7 +5950,7 @@ void MoveParticles()
                     o->Light[1] /= 1.012f;
                     o->Light[2] /= 1.012f;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
-                    o->Rotation += o->Gravity / 2.0f;
+                    o->Rotation += (o->Gravity / 2.0f) * FPS_ANIMATION_FACTOR;
 
                     if (o->Gravity <= 0.0f)
                         o->Gravity = -o->Gravity;
@@ -5965,11 +5965,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     else if (o->Alpha < 0.7f)
                     {
-                        o->Alpha += (rand() % 5 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 5 + 2) * 0.1f;
                     }
                     else
                     {
@@ -5995,11 +5995,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 5 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 5 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6029,11 +6029,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     else if (o->Alpha < 0.7f)
                     {
-                        o->Alpha += (rand() % 5 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 5 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6052,10 +6052,10 @@ void MoveParticles()
                 else if (o->SubType == 4)
                 {
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 0.8f;
+                    o->Rotation += (0.8f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
 
-                    o->Alpha -= 0.01f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.01f;
 
                     if (o->Alpha < 0.1f)
                     {
@@ -6074,7 +6074,7 @@ void MoveParticles()
                 {
                 case 0:
                 {
-                    o->Alpha -= 0.15f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.15f;
 
                     if (o->Alpha < 0.1f)
                     {
@@ -6093,11 +6093,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 15)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6117,7 +6117,7 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                     if (o->SubType == 6)
                     {
                         o->Rotation = 0.0f;
@@ -6128,11 +6128,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 20)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6152,17 +6152,17 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6181,20 +6181,20 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[0] += o->Velocity[0];
-                    o->Position[1] += o->Velocity[1];
+                    o->Position[0] += (o->Velocity[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 10)
                 {
                     if (o->LifeTime < 15)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6214,17 +6214,17 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 3)
                 {
                     if (o->LifeTime < 15)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6244,17 +6244,17 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 4)
                 {
                     if (o->LifeTime < 5)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6283,17 +6283,17 @@ void MoveParticles()
                     VectorCopy(o->Target->Position, o->StartPosition);
                     VectorAdd(o->Position, o->Target->Position, o->Position);
 
-                    o->Rotation += 5.0f;
+                    o->Rotation += (5.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 5)
                 {
                     if (o->LifeTime < 15)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6313,7 +6313,7 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_FIRE_HIK3:
@@ -6322,11 +6322,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6346,7 +6346,7 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                     if (o->SubType == 6)
                     {
                         o->Rotation = 0.0f;
@@ -6357,11 +6357,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 15)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6381,17 +6381,17 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6410,20 +6410,20 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[0] += o->Velocity[0];
-                    o->Position[1] += o->Velocity[1];
+                    o->Position[0] += (o->Velocity[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 3)
                 {
                     if (o->LifeTime < 10)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6443,17 +6443,17 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 4)
                 {
                     if (o->LifeTime < 15)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6472,18 +6472,18 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += (o->Gravity);//*((float)o->LifeTime/39.0f));
-                    o->Rotation += 3.0f;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;//*((float)o->LifeTime/39.0f)));
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 5)
                 {
                     if (o->LifeTime < 4)
                     {
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -6512,7 +6512,7 @@ void MoveParticles()
                     VectorCopy(o->Target->Position, o->StartPosition);
                     VectorAdd(o->Position, o->Target->Position, o->Position);
 
-                    o->Rotation += 5.0f;
+                    o->Rotation += (5.0f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_LIGHT + 1:
@@ -6539,9 +6539,9 @@ void MoveParticles()
                 }
                 else
                 {
-                    o->Position[2] -= o->Gravity;
-                    o->Position[1] -= 1.f;
-                    o->Gravity += 1.f;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] -= (1.f) * FPS_ANIMATION_FACTOR;
+                    o->Gravity += (1.f) * FPS_ANIMATION_FACTOR;
                     o->Scale *= 0.95f;
                 }
                 break;
@@ -6569,11 +6569,11 @@ void MoveParticles()
                 o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 if (o->SubType == 5)
                 {
-                    o->Gravity -= 0.3f;
+                    o->Gravity -= (0.3f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 6)
                 {
-                    o->Gravity -= 0.3f;
+                    o->Gravity -= (0.3f) * FPS_ANIMATION_FACTOR;
                     Vector(0.9f, 0.9f, 0.9f, o->Light);
                 }
                 else if (o->SubType == 8 || o->SubType == 10)
@@ -6583,11 +6583,11 @@ void MoveParticles()
                     o->Light[2] /= 1.02f;
                 }
                 if (o->SubType == 7)
-                    o->Gravity -= 0.6f;
+                    o->Gravity -= (0.6f) * FPS_ANIMATION_FACTOR;
                 else if (o->SubType == 9)
-                    o->Gravity -= 0.4f;
+                    o->Gravity -= (0.4f) * FPS_ANIMATION_FACTOR;
                 else
-                    o->Gravity -= 2.f;
+                    o->Gravity -= (2.f) * FPS_ANIMATION_FACTOR;
 
                 Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
                 if (o->Position[2] < Height)
@@ -6657,9 +6657,9 @@ void MoveParticles()
                 case 6:
                 {
                     if (o->LifeTime <= 0) o->Live = false;
-                    o->Position[2] -= o->Gravity;
-                    o->Position[1] -= 1.f;
-                    o->Gravity += 0.1f;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] -= (1.f) * FPS_ANIMATION_FACTOR;
+                    o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
                     float fLight = (float)(rand() % 10) / 100.0f + 0.7f;
                     Vector(o->Light[0], fLight, o->Light[2], o->Light);
                 }
@@ -6667,9 +6667,9 @@ void MoveParticles()
                 case 7:
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
-                    o->Position[2] -= o->Gravity;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     float fLight = (float)(rand() % 50) / 100.0f + 0.2f;
                     Vector(0.0f, fLight, 0.0f, o->Light);
                 }
@@ -6682,8 +6682,8 @@ void MoveParticles()
                 break;
                 case 9:
                 {
-                    o->Velocity[0] -= 1.2f;
-                    o->Velocity[2] -= 1.0f;
+                    o->Velocity[0] -= (1.2f) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[2] -= (1.0f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.08f;
                     if (o->LifeTime <= 0)
                         o->Live = false;
@@ -6697,7 +6697,7 @@ void MoveParticles()
                     o->Light[1] /= 1.08f;
                     o->Light[2] /= 1.08f;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.03f;
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 break;
@@ -6708,7 +6708,7 @@ void MoveParticles()
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 break;
@@ -6717,7 +6717,7 @@ void MoveParticles()
                     float fLight = rand() % 2;
                     Vector(fLight - 0.6f, fLight - 0.6f, fLight - 0.8f, o->Light);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 break;
@@ -6727,7 +6727,7 @@ void MoveParticles()
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 break;
@@ -6736,7 +6736,7 @@ void MoveParticles()
                     o->Light[0] /= 1.05f;
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 break;
@@ -6751,7 +6751,7 @@ void MoveParticles()
                     if (o->Frame == 77)
                     {
                         o->Gravity *= 1.03f;
-                        o->Position[2] -= o->Gravity;
+                        o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->Frame == 88)
                     {
@@ -6766,10 +6766,10 @@ void MoveParticles()
                     else if (o->Frame == 99)
                     {
                         o->Gravity *= 1.2f;
-                        o->Position[2] -= o->Gravity;
+                        o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Alpha -= 0.007f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.007f;
                     if (o->Alpha <= 0.0f)
                         o->Live = false;
                 }
@@ -6786,8 +6786,8 @@ void MoveParticles()
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
 
-                    o->Position[0] += sinf(WorldTime * o->Rotation) * o->Gravity * 0.3f;
-                    //o->Position[1] += sinf(WorldTime*o->Rotation)*o->Gravity*0.3f;
+                    o->Position[0] += (sinf(WorldTime * o->Rotation) * o->Gravity * 0.3f) * FPS_ANIMATION_FACTOR;
+                    //o->Position[1] += (sinf(WorldTime*o->Rotation)*o->Gravity*0.3f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 break;
@@ -6797,7 +6797,7 @@ void MoveParticles()
                         o->Live = false;
 
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Gravity += 0.1f;
+                    o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -6813,8 +6813,8 @@ void MoveParticles()
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
 
-                    o->Position[2] += (o->Gravity * 0.5f);
-                    o->Gravity -= 1.5f;
+                    o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
+                    o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
                     Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
                     if (o->Position[2] < Height + 3.f)
@@ -6841,8 +6841,8 @@ void MoveParticles()
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
 
-                    o->Position[2] += (o->Gravity * 0.5f);
-                    o->Gravity -= 1.5f;
+                    o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
+                    o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
                     Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
                     if (o->Position[2] < Height + 3.f)
@@ -6864,7 +6864,7 @@ void MoveParticles()
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
-                    o->Alpha -= 0.0001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.0001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 break;
@@ -6878,7 +6878,7 @@ void MoveParticles()
 
                     if (o->LifeTime <= 10)
                     {
-                        o->Alpha -= 0.05f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
                         o->Light[0] *= o->Alpha;
                         o->Light[1] *= o->Alpha;
                         o->Light[2] *= o->Alpha;
@@ -6891,16 +6891,16 @@ void MoveParticles()
                 {
                     if (o->LifeTime == 19)
                     {
-                        o->Velocity[0] -= 1.f;
-                        o->Velocity[1] -= 1.f;
-                        o->Velocity[2] -= 1.f;
+                        o->Velocity[0] -= (1.f) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[1] -= (1.f) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[2] -= (1.f) * FPS_ANIMATION_FACTOR;
                     }
 
                     o->Light[0] /= 1.05f;
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
                     o->Scale = sinf(o->LifeTime * (Q_PI / 40.f));
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 break;
@@ -6938,8 +6938,8 @@ void MoveParticles()
                     if (o->Light[0] <= 0.03f)
                         o->Live = false;
 
-                    o->Position[2] += (o->Gravity * 0.5f);
-                    o->Gravity -= 1.5f;
+                    o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
+                    o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
                     Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
                     if (o->Position[2] < Height + 3.f)
@@ -6961,8 +6961,8 @@ void MoveParticles()
                     if (o->Light[0] <= 0.03f)
                         o->Live = false;
 
-                    o->Position[2] += (o->Gravity * 0.5f);
-                    o->Gravity -= 1.5f;
+                    o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
+                    o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
                     Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
                     if (o->Position[2] < Height + 3.f)
@@ -6977,8 +6977,8 @@ void MoveParticles()
                 {
                     if (o->LifeTime <= 45)
                     {
-                        o->Velocity[0] += sinf(Q_PI / 180.0f * float(rand() % 360));
-                        o->Velocity[1] += cosf(Q_PI / 180.0f * float(rand() % 360));
+                        o->Velocity[0] += (sinf(Q_PI / 180.0f * float(rand() % 360))) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[1] += (cosf(Q_PI / 180.0f * float(rand() % 360))) * FPS_ANIMATION_FACTOR;
                     }
 
                     o->Light[0] /= 1.05f;
@@ -6994,7 +6994,7 @@ void MoveParticles()
                 case 31:
                 {
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Gravity -= 2.f;
+                    o->Gravity -= (2.f) * FPS_ANIMATION_FACTOR;
 
                     Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
                     if (o->Position[2] < Height)
@@ -7020,9 +7020,9 @@ void MoveParticles()
                     {
                         vec3_t vPos;
                         VectorCopy(o->Position, vPos);
-                        vPos[0] += (float)(rand() % 100 - 50);
-                        vPos[1] += (float)(rand() % 100 - 50);
-                        vPos[2] += (float)(rand() % 100 - 50);
+                        vPos[0] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
+                        vPos[1] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
+                        vPos[2] += ((float)(rand() % 100 - 50)) * FPS_ANIMATION_FACTOR;
                         CreateBomb(vPos, true);
                     }
                 }
@@ -7056,14 +7056,14 @@ void MoveParticles()
                 Luminosity = (float)(o->LifeTime) / 32.f;
                 Vector(Luminosity, Luminosity, Luminosity, o->Light);
                 o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
-                //o->Angle[0] += 4.f;
+                //o->Angle[0] += (4.f) * FPS_ANIMATION_FACTOR;
                 VectorAdd(o->Position, o->Velocity, o->Position);
                 VectorScale(o->Velocity, 0.9f, o->Velocity);
 
                 if (o->SubType == 6)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Position[2] += 4.0f;
+                    o->Position[2] += (4.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                     if (o->SubType != 5)
@@ -7075,9 +7075,9 @@ void MoveParticles()
             case BITMAP_SHINY:
                 if (o->SubType == 2)
                 {
-                    o->Rotation -= 12.f;
+                    o->Rotation -= (12.f) * FPS_ANIMATION_FACTOR;
 
-                    o->Velocity[2] -= (float)(rand() % 8) * 0.05f;
+                    o->Velocity[2] -= ((float)(rand() % 8) * 0.05f) * FPS_ANIMATION_FACTOR;
                     VectorAdd(o->Position, o->Velocity, o->Position);
 
                     o->Light[0] /= 1.05f;
@@ -7092,26 +7092,26 @@ void MoveParticles()
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 else if (o->SubType == 4)
                 {
-                    o->Rotation += 20.f;
-                    o->Position[2] += (o->Gravity * 0.5f);
+                    o->Rotation += (20.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.02f;
                     o->Light[1] /= 1.02f;
                     o->Light[2] /= 1.02f;
 
-                    o->Gravity -= 1.5f;
+                    o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
 
                     VectorAdd(o->Position, o->Velocity, o->Position);
                 }
                 else if (o->SubType == 5)
                 {
-                    o->Rotation += 10.f;
+                    o->Rotation += (10.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.02f;
@@ -7147,8 +7147,8 @@ void MoveParticles()
                         o->Velocity[1] /= 1.04f;
                         o->Velocity[2] /= 1.04f;
 
-                        o->Position[2] -= (o->Gravity * 0.1f);
-                        o->Gravity += 0.5f;
+                        o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
+                        o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 7)
@@ -7182,8 +7182,8 @@ void MoveParticles()
                         o->Velocity[1] /= 1.04f;
                         o->Velocity[2] /= 1.04f;
 
-                        o->Position[2] -= (o->Gravity * 0.1f);
-                        o->Gravity += 0.5f;
+                        o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
+                        o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 9)
@@ -7213,8 +7213,8 @@ void MoveParticles()
                         o->Velocity[1] /= 1.04f;
                         o->Velocity[2] /= 1.04f;
 
-                        o->Position[2] -= (o->Gravity * 0.1f);
-                        o->Gravity += 0.5f;
+                        o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
+                        o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
 
                         if (rand() % 5 == 0)
                         {
@@ -7232,7 +7232,7 @@ void MoveParticles()
                     if (o->SubType == 1)
                     {
                         o->Scale *= 0.75f;
-                        o->Rotation -= 12.f;
+                        o->Rotation -= (12.f) * FPS_ANIMATION_FACTOR;
                     }
                 }
                 break;
@@ -7242,16 +7242,16 @@ void MoveParticles()
                 {
                     o->Rotation = (float)(rand() % 360);
                     o->Scale = sinf(o->LifeTime * (Q_PI / 180.f));
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
                 else if (o->SubType == 1)
                 {
                     if (o->LifeTime == 69)
                     {
-                        o->Velocity[0] -= 1.f;
-                        o->Velocity[1] -= 1.f;
-                        o->Velocity[2] -= 1.f;
+                        o->Velocity[0] -= (1.f) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[1] -= (1.f) * FPS_ANIMATION_FACTOR;
+                        o->Velocity[2] -= (1.f) * FPS_ANIMATION_FACTOR;
                     }
 
                     o->Light[0] /= 1.01f;
@@ -7259,7 +7259,7 @@ void MoveParticles()
                     o->Light[2] /= 1.01f;
 
                     //o->Scale = sinf(o->LifeTime*(Q_PI/240.f));
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     //o->Rotation = (float)(rand()%360);
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -7270,11 +7270,11 @@ void MoveParticles()
                 if (o->SubType == 0)
                 {
                     o->Scale = sinf(o->LifeTime * (Q_PI / 180.f));
-                    o->Alpha -= 0.002f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.002f;
                     if (o->Alpha <= 0.0f) o->Live = false;
 
-                    o->Position[2] += (o->Gravity * 0.5f);
-                    o->Gravity -= 1.5f;
+                    o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
+                    o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
 
                     o->Rotation = (float)(rand() % 360);
 
@@ -7292,9 +7292,9 @@ void MoveParticles()
                 if (o->SubType == 99)
                 {
                     VectorCopy(o->Target->Position, o->Position);
-                    o->Position[2] += 50.f;
+                    o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
                     //                    o->Scale *= 0.75f;
-                    o->Rotation -= 1.f;
+                    o->Rotation -= (1.f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
@@ -7311,7 +7311,7 @@ void MoveParticles()
                         //Vector(Luminosity*0.6f,Luminosity*0.8f,Luminosity,o->Light);
                         if (o->SubType >= 2) {
                             o->Scale *= 0.75f;
-                            o->Rotation -= 12.f;
+                            o->Rotation -= (12.f) * FPS_ANIMATION_FACTOR;
                         }
                         HandPosition(o);
                     }
@@ -7331,7 +7331,7 @@ void MoveParticles()
                 else if (o->SubType == 1)
                 {
                     o->Scale = sinf(o->Gravity * (Q_PI / 180.f)) * 3.f + 1.5f;
-                    o->Gravity += (15 - o->LifeTime) * 6.f;
+                    o->Gravity += ((15 - o->LifeTime) * 6.f) * FPS_ANIMATION_FACTOR;
                     if (o->Gravity > 90.f)
                     {
                         o->Gravity = 90.f;
@@ -7352,28 +7352,28 @@ void MoveParticles()
             case BITMAP_SHINY + 6:
                 if (o->SubType == 0)
                 {
-                    o->Rotation += 5.f;
+                    o->Rotation += (5.f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f)
                         o->Live = false;
-                    o->Position[2] -= o->Gravity;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     float fLight = (float)(rand() % 10) / 100.0f - 0.05f;
-                    o->Light[0] += fLight;
-                    o->Light[1] += fLight;
-                    o->Light[2] += fLight;
+                    o->Light[0] += (fLight) * FPS_ANIMATION_FACTOR;
+                    o->Light[1] += (fLight) * FPS_ANIMATION_FACTOR;
+                    o->Light[2] += (fLight) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
-                    o->Rotation -= 5.f;
+                    o->Rotation -= (5.f) * FPS_ANIMATION_FACTOR;
                 }
 
                 break;
             case BITMAP_PIN_LIGHT:
             {
                 o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
-                o->Alpha -= 0.001f;
+                o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                 if (o->Alpha <= 0.0f)
                     o->Live = false;
                 if (o->SubType == 1)
@@ -7386,12 +7386,12 @@ void MoveParticles()
                 }
                 else
                 {
-                    o->Position[2] -= o->Gravity;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                 }
                 float fLight = (float)(rand() % 10) / 100.0f - 0.05f;
-                o->Light[0] += fLight;
-                o->Light[1] += fLight;
-                o->Light[2] += fLight;
+                o->Light[0] += (fLight) * FPS_ANIMATION_FACTOR;
+                o->Light[1] += (fLight) * FPS_ANIMATION_FACTOR;
+                o->Light[2] += (fLight) * FPS_ANIMATION_FACTOR;
             }
             break;
             case BITMAP_ORORA:
@@ -7406,27 +7406,27 @@ void MoveParticles()
                 case 0:
                     fScale = 0.01f;
                     fLight = 1.05f;
-                    o->Rotation += 5.f;
+                    o->Rotation += (5.f) * FPS_ANIMATION_FACTOR;
                     pModel->TransformByObjectBone(vPos, o->Target, 37);
                     break;
                 case 1:
                     fScale = 0.01f;
                     fLight = 1.05f;
-                    o->Rotation -= 5.f;
+                    o->Rotation -= (5.f) * FPS_ANIMATION_FACTOR;
                     pModel->TransformByObjectBone(vPos, o->Target, 28);
                     break;
                 case 2:
                     fScale = 0.04f;
                     //						fLight = 1.12f;
                     fLight = 1.33f;
-                    o->Rotation += 20.f;
+                    o->Rotation += (20.f) * FPS_ANIMATION_FACTOR;
                     pModel->TransformByObjectBone(vPos, o->Target, 37);
                     break;
                 case 3:
                     fScale = 0.04f;
                     //						fLight = 1.12f;
                     fLight = 1.33f;
-                    o->Rotation -= 20.f;
+                    o->Rotation -= (20.f) * FPS_ANIMATION_FACTOR;
                     pModel->TransformByObjectBone(vPos, o->Target, 28);
                     break;
                 }
@@ -7443,14 +7443,14 @@ void MoveParticles()
             break;
             case BITMAP_SNOW_EFFECT_1:
             case BITMAP_SNOW_EFFECT_2:
-                o->Rotation += 20.f;
-                o->Position[2] += (o->Gravity * 0.5f);
+                o->Rotation += (20.f) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
 
                 o->Light[0] /= 1.02f;
                 o->Light[1] /= 1.02f;
                 o->Light[2] /= 1.02f;
 
-                o->Gravity -= 1.5f;
+                o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
                 if (o->LifeTime < 10)
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                 else
@@ -7460,7 +7460,7 @@ void MoveParticles()
                 break;
 
             case BITMAP_DS_EFFECT:
-                o->Rotation += 10.f;
+                o->Rotation += (10.f) * FPS_ANIMATION_FACTOR;
 
                 if (o->Target != NULL)
                 {
@@ -7471,10 +7471,10 @@ void MoveParticles()
                 }
                 break;
             case BITMAP_FIRECRACKER:
-                o->Velocity[2] -= .5f;
+                o->Velocity[2] -= (.5f) * FPS_ANIMATION_FACTOR;
                 break;
             case BITMAP_SWORD_FORCE:
-                o->Gravity += 0.01f;
+                o->Gravity += (0.01f) * FPS_ANIMATION_FACTOR;
                 o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                 Luminosity = (float)(o->LifeTime) / 10.f;
                 Vector(Luminosity, Luminosity, Luminosity, o->Light);
@@ -7516,9 +7516,9 @@ void MoveParticles()
 
                     float fSin = sinf(WorldTime * 0.001f);
                     if (fSin > 0.f)
-                        o->Rotation += 0.2f + (rand() % 4 * 0.1f);
+                        o->Rotation += (0.2f + (rand() % 4 * 0.1f)) * FPS_ANIMATION_FACTOR;
                     else
-                        o->Rotation -= 0.2f + (rand() % 4 * 0.1f);
+                        o->Rotation -= (0.2f + (rand() % 4 * 0.1f)) * FPS_ANIMATION_FACTOR;
 
                     if (fTemp <= 20.f)
                     {
@@ -7551,15 +7551,15 @@ void MoveParticles()
                     VectorAdd(o->Position, o->Velocity, o->Position);
                     o->Velocity[0] *= 0.95f;
                     o->Velocity[1] *= 0.95f;
-                    o->Velocity[2] += 0.6f;
-                    o->Position[0] += (float)(rand() % 4 - 2);
-                    o->Position[1] += (float)(rand() % 4 - 2);
-                    o->Position[2] += (float)(rand() % 4 - 2) * 0.8f;
+                    o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 4 - 2) * 0.8f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Light[0] = (float)(o->LifeTime) / 50.f;
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
-                    o->Rotation += 1.f + rand() % 2;
+                    o->Rotation += (1.f + rand() % 2) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 8)
                 {
@@ -7568,13 +7568,13 @@ void MoveParticles()
                     }
                     else if (o->LifeTime > 150) {
                         if (o->Alpha < 1.0f)
-                            o->Alpha += 0.04;
-                        o->Position[2] += 1.f;
+                            o->Alpha += FPS_ANIMATION_FACTOR * 0.04;
+                        o->Position[2] += (1.f) * FPS_ANIMATION_FACTOR;
                     }
                     else {
                         if (o->Alpha > 0.1f)
-                            o->Alpha -= 0.025f;
-                        o->Position[2] -= 0.5f;
+                            o->Alpha -= FPS_ANIMATION_FACTOR * 0.025f;
+                        o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 9)
@@ -7584,13 +7584,13 @@ void MoveParticles()
                     }
                     else if (o->LifeTime > 150) {
                         if (o->Alpha < 1.0f)
-                            o->Alpha += 0.04;
-                        o->Position[2] += 1.f;
+                            o->Alpha += FPS_ANIMATION_FACTOR * 0.04;
+                        o->Position[2] += (1.f) * FPS_ANIMATION_FACTOR;
                     }
                     else {
                         if (o->Alpha > 0.1f)
-                            o->Alpha -= 0.025f;
-                        o->Position[2] -= 0.5f;
+                            o->Alpha -= FPS_ANIMATION_FACTOR * 0.025f;
+                        o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 10)
@@ -7604,9 +7604,9 @@ void MoveParticles()
 
                     if (fTemp <= 300.0f)
                     {
-                        o->Light[0] += 0.01f;
-                        o->Light[1] += 0.01f;
-                        o->Light[2] += 0.01f;
+                        o->Light[0] += (0.01f) * FPS_ANIMATION_FACTOR;
+                        o->Light[1] += (0.01f) * FPS_ANIMATION_FACTOR;
+                        o->Light[2] += (0.01f) * FPS_ANIMATION_FACTOR;
                         if (o->Light[0] >= 0.15f)
                             Vector(0.15f, 0.15f, 0.15f, o->Light);
                     }
@@ -7630,7 +7630,7 @@ void MoveParticles()
                     VectorSubtract(o->Position, o->StartPosition, vTemp);
                     float fTemp = VectorLength(vTemp);
 
-                    o->Rotation += 0.5f + rand() % 2;
+                    o->Rotation += (0.5f + rand() % 2) * FPS_ANIMATION_FACTOR;
 
                     if (fTemp > 500.0f)
                     {
@@ -7639,22 +7639,22 @@ void MoveParticles()
                 }
                 else if (o->SubType == 13)
                 {
-                    o->Rotation += o->Gravity * 1.5f;
+                    o->Rotation += (o->Gravity * 1.5f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 14)
                 {
                     VectorAdd(o->Position, o->Velocity, o->Position);
                     o->Velocity[0] *= 0.95f;
                     o->Velocity[1] *= 0.95f;
-                    o->Velocity[2] += 0.6f;
-                    o->Position[0] += (float)(rand() % 4 - 2);
-                    o->Position[1] += (float)(rand() % 4 - 2);
-                    o->Position[2] += (float)(rand() % 4 - 2) * 0.8f;
+                    o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += ((float)(rand() % 4 - 2) * 0.8f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Light[0] = (float)(o->LifeTime) / 50.f;
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
-                    o->Rotation += 1.f + rand() % 2;
+                    o->Rotation += (1.f + rand() % 2) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 15)
                 {
@@ -7669,7 +7669,7 @@ void MoveParticles()
                     VectorSubtract(o->Position, o->StartPosition, vTemp);
                     float fTemp = VectorLength(vTemp);
 
-                    o->Rotation += 0.5f + rand() % 2;
+                    o->Rotation += (0.5f + rand() % 2) * FPS_ANIMATION_FACTOR;
 
                     if (fTemp <= 50.f)
                     {
@@ -7710,13 +7710,13 @@ void MoveParticles()
                     VectorSubtract(o->Position, o->StartPosition, vTemp);
                     float fTemp = VectorLength(vTemp);
 
-                    o->Rotation += 0.5f + rand() % 2;
+                    o->Rotation += (0.5f + rand() % 2) * FPS_ANIMATION_FACTOR;
 
                     if (fTemp <= 50.0f)
                     {
-                        o->Light[0] += 0.01f;
-                        o->Light[1] += 0.01f;
-                        o->Light[2] += 0.01f;
+                        o->Light[0] += (0.01f) * FPS_ANIMATION_FACTOR;
+                        o->Light[1] += (0.01f) * FPS_ANIMATION_FACTOR;
+                        o->Light[2] += (0.01f) * FPS_ANIMATION_FACTOR;
                         if (o->Light[0] >= 0.2f)
                             Vector(0.2f, 0.2f, 0.2f, o->Light);
                     }
@@ -7747,7 +7747,7 @@ void MoveParticles()
                     VectorSubtract(o->Position, o->StartPosition, vTemp);
                     float fTemp = VectorLength(vTemp);
 
-                    o->Rotation += 0.08f + rand() % 2 * 0.15f;
+                    o->Rotation += (0.08f + rand() % 2 * 0.15f) * FPS_ANIMATION_FACTOR;
 
                     if (o->LifeTime >= 400.f)
                     {
@@ -7780,21 +7780,21 @@ void MoveParticles()
                     Luminosity = 1.0f;
                     if (o->LifeTime > 90)
                     {
-                        o->Light[0] += 0.002f;
-                        o->Light[1] += 0.002f;
-                        o->Light[2] += 0.0017f;
+                        o->Light[0] += (0.002f) * FPS_ANIMATION_FACTOR;
+                        o->Light[1] += (0.002f) * FPS_ANIMATION_FACTOR;
+                        o->Light[2] += (0.0017f) * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->LifeTime < 30)
                     {
-                        o->Light[0] -= 0.004f;
-                        o->Light[1] -= 0.004f;
-                        o->Light[2] -= 0.0033f;
+                        o->Light[0] -= (0.004f) * FPS_ANIMATION_FACTOR;
+                        o->Light[1] -= (0.004f) * FPS_ANIMATION_FACTOR;
+                        o->Light[2] -= (0.0033f) * FPS_ANIMATION_FACTOR;
                     }
                     if (o->Scale > 0) o->Scale -= FPS_ANIMATION_FACTOR * 0.001f;
-                    if (o->TurningForce[1] > 0) o->TurningForce[1] -= 0.5f;
+                    if (o->TurningForce[1] > 0) o->TurningForce[1] -= (0.5f) * FPS_ANIMATION_FACTOR;
                     o->Position[0] = o->Target->Position[0] + o->StartPosition[0] + cosf((WorldTime + o->Rotation) * o->TurningForce[0]) * o->TurningForce[1];
                     o->Position[1] = o->Target->Position[1] + o->StartPosition[1] + sinf((WorldTime + o->Rotation) * o->TurningForce[0]) * o->TurningForce[1];
-                    o->Position[2] += (rand() % 10) / 10.0f;
+                    o->Position[2] += ((rand() % 10) / 10.0f) * FPS_ANIMATION_FACTOR;
 
                     if (o->LifeTime <= 0)
                     {
@@ -7807,19 +7807,19 @@ void MoveParticles()
                     Luminosity = 1.0f;
                     if (o->LifeTime > 30)
                     {
-                        o->Light[0] += 0.01f;
-                        o->Light[1] += 0.01f;
-                        o->Light[2] += 0.01f;
+                        o->Light[0] += (0.01f) * FPS_ANIMATION_FACTOR;
+                        o->Light[1] += (0.01f) * FPS_ANIMATION_FACTOR;
+                        o->Light[2] += (0.01f) * FPS_ANIMATION_FACTOR;
                         o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     }
                     else
                     {
-                        o->Light[0] -= 0.01f;
-                        o->Light[1] -= 0.01f;
-                        o->Light[2] -= 0.01f;
+                        o->Light[0] -= (0.01f) * FPS_ANIMATION_FACTOR;
+                        o->Light[1] -= (0.01f) * FPS_ANIMATION_FACTOR;
+                        o->Light[2] -= (0.01f) * FPS_ANIMATION_FACTOR;
                     }
-                    //o->Position[0] -= 4.0f+(rand()%100)*0.1f;
-                    o->Position[1] += 8.0f + (rand() % 200) * 0.1f;
+                    //o->Position[0] -= (4.0f+(rand()%100)*0.1f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (8.0f + (rand() % 200) * 0.1f) * FPS_ANIMATION_FACTOR;
                     //o->Position[2] = o->StartPosition[2] + sinf((WorldTime+o->Gravity)/5000.0f)*20.0f;
 
                     if (o->LifeTime <= 0)
@@ -7835,13 +7835,13 @@ void MoveParticles()
                     }
                     else if (o->LifeTime > 150) {
                         if (o->Alpha < 1.0f)
-                            o->Alpha += 0.04;
-                        o->Position[2] += 1.f;
+                            o->Alpha += FPS_ANIMATION_FACTOR * 0.04;
+                        o->Position[2] += (1.f) * FPS_ANIMATION_FACTOR;
                     }
                     else {
                         if (o->Alpha > 0.1f)
-                            o->Alpha -= 0.025f;
-                        o->Position[2] -= 0.5f;
+                            o->Alpha -= FPS_ANIMATION_FACTOR * 0.025f;
+                        o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 21)
@@ -7851,13 +7851,13 @@ void MoveParticles()
                     }
                     else if (o->LifeTime > 50) {
                         if (o->Alpha < 1.0f)
-                            o->Alpha += 0.04;
-                        o->Position[2] += 2.f;
+                            o->Alpha += FPS_ANIMATION_FACTOR * 0.04;
+                        o->Position[2] += (2.f) * FPS_ANIMATION_FACTOR;
                     }
                     else {
                         if (o->Alpha > 0.1f)
-                            o->Alpha -= 0.005f;
-                        o->Position[2] -= 1.0f;
+                            o->Alpha -= FPS_ANIMATION_FACTOR * 0.005f;
+                        o->Position[2] -= (1.0f) * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 22)
@@ -7868,15 +7868,15 @@ void MoveParticles()
                     else if (o->LifeTime > 40)
                     {
                         if (o->Alpha < 1.0f)
-                            o->Alpha += 0.1f;
-                        o->Position[2] += 0.5f;
+                            o->Alpha += FPS_ANIMATION_FACTOR * 0.1f;
+                        o->Position[2] += (0.5f) * FPS_ANIMATION_FACTOR;
                     }
                     else {
                         if (o->Alpha > 0.0f)
-                            o->Alpha -= 0.025f;
+                            o->Alpha -= FPS_ANIMATION_FACTOR * 0.025f;
                         else
                             o->Live = false;
-                        o->Position[2] -= 0.5f;
+                        o->Position[2] -= (0.5f) * FPS_ANIMATION_FACTOR;
                     }
 
                     o->Scale += FPS_ANIMATION_FACTOR * 0.001f;
@@ -7889,8 +7889,8 @@ void MoveParticles()
                     else if (o->LifeTime > 40)
                     {
                         if (o->Alpha < 1.0f)
-                            o->Alpha += 0.2f;
-                        //o->Position[2] += 0.5f;
+                            o->Alpha += FPS_ANIMATION_FACTOR * 0.2f;
+                        //o->Position[2] += (0.5f) * FPS_ANIMATION_FACTOR;
 
                         o->Scale += FPS_ANIMATION_FACTOR * 0.003f;
                     }
@@ -7900,14 +7900,14 @@ void MoveParticles()
                         o->Velocity[1] *= 0.7f;
 
                         if (o->Alpha > 0.0f)
-                            o->Alpha -= (rand() % 10 * 0.01f);
+                            o->Alpha -= FPS_ANIMATION_FACTOR * (rand() % 10 * 0.01f);
                         else
                             o->Live = false;
-                        o->Position[2] += 0.2f;
+                        o->Position[2] += (0.2f) * FPS_ANIMATION_FACTOR;
 
                         //o->Scale += FPS_ANIMATION_FACTOR * 0.0005f;
                     }
-                    o->Rotation += o->TurningForce[0] * 5.0f;;
+                    o->Rotation += (o->TurningForce[0] * 5.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
@@ -7947,7 +7947,7 @@ void MoveParticles()
                     if (o->SubType == 7)
                     {
                         fScale = sinf(WorldTime + o->LifeTime) * 5.f + 10.f;
-                        o->Position[2] += fScale;
+                        o->Position[2] += (fScale) * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
@@ -7957,7 +7957,7 @@ void MoveParticles()
                         VectorAdd(vRandom, g_vParticleWind, vRandom);
                         VectorScale(vRandom, fScale, vRandom);
                         VectorAdd(o->Position, vRandom, o->Position);
-                        o->Position[2] += 5.f * fScale;
+                        o->Position[2] += (5.f * fScale) * FPS_ANIMATION_FACTOR;
                     }
                     if (0 == o->SubType || o->SubType == 8)
                     {
@@ -7966,7 +7966,7 @@ void MoveParticles()
                     else if (o->SubType == 7)
                     {
                         //                        o->Scale = sin ( o->Gravity+WorldTime*0.001f )*0.2f+0.5f;
-                        o->Rotation += 30.f;
+                        o->Rotation += (30.f) * FPS_ANIMATION_FACTOR;
                     }
                     else if (1 == o->SubType)
                     {
@@ -8020,7 +8020,7 @@ void MoveParticles()
                     vRandom[2] = 0.f;
                     VectorScale(vRandom, fScale, vRandom);
                     VectorAdd(o->Position, vRandom, o->Position);
-                    o->Position[2] += 5.f * fScale;
+                    o->Position[2] += (5.f * fScale) * FPS_ANIMATION_FACTOR;
                     o->Scale *= 0.95f;
 
                     //                    Vector(o->Scale,o->Scale,o->Scale,o->Light);
@@ -8047,12 +8047,12 @@ void MoveParticles()
                 {
                     VectorScale(o->Light, 0.9f, o->Light);
                     o->Scale *= 0.85f;
-                    o->Gravity += 5.f;
+                    o->Gravity += (5.f) * FPS_ANIMATION_FACTOR;
 
                     VectorCopy(o->Target->Position, o->Position);
 
-                    o->Position[0] += 2.f;
-                    o->Position[1] -= 2.f;
+                    o->Position[0] += (2.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] -= (2.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 4)
@@ -8071,7 +8071,7 @@ void MoveParticles()
                         o->Live = false;
                     }
 
-                    o->Gravity += (rand() % 40 + 60) / 100.f * 9.5f;
+                    o->Gravity += ((rand() % 40 + 60) / 100.f * 9.5f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 400 + 400) / 10000.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
@@ -8102,7 +8102,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 10)
                 {
-                    o->Rotation -= 10;
+                    o->Rotation -= (10) * FPS_ANIMATION_FACTOR;
                     if (o->Target != NULL)
                     {
                         if (o->Target->CurrentAction != PLAYER_SANTA_2)
@@ -8125,7 +8125,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 13)
                 {
-                    o->Position[1] -= o->Gravity;
+                    o->Position[1] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.001f;
                 }
@@ -8136,20 +8136,20 @@ void MoveParticles()
                 }
                 else if (o->SubType == 15)
                 {
-                    o->StartPosition[2] += (rand() % 10 + 5) * 0.01f;
+                    o->StartPosition[2] += ((rand() % 10 + 5) * 0.01f) * FPS_ANIMATION_FACTOR;
                     o->Position[0] = o->StartPosition[0] + sinf(o->StartPosition[2]) * o->Gravity * 2;
                     o->Position[1] = o->StartPosition[1] + cosf(o->StartPosition[2]) * o->Gravity * 2;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->LifeTime > 20)
                     {
-                        o->Alpha += 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * 0.1f;
                         if (o->Alpha > 1.0f) o->Alpha = 1.0f;
                     }
                     else
                     {
                         o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
-                        o->Alpha -= 0.1f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                         if (o->Alpha > 1.0f) o->Alpha = 1.0f;
                     }
                     o->Light[0] = o->TurningForce[0] * o->Alpha;
@@ -8160,7 +8160,7 @@ void MoveParticles()
             case BITMAP_POUNDING_BALL:
                 if (o->SubType == 0 && o->SubType == 1)
                 {
-                    o->Gravity += 0.004f;
+                    o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
 
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -8187,11 +8187,11 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 15)
                     {
-                        o->Alpha -= 0.2f;
+                        o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                     }
                     else if (o->Alpha < 1.0f)
                     {
-                        o->Alpha += (rand() % 2 + 2) * 0.1f;
+                        o->Alpha += FPS_ANIMATION_FACTOR * (rand() % 2 + 2) * 0.1f;
                     }
                     else
                     {
@@ -8211,7 +8211,7 @@ void MoveParticles()
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += (3.0f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_ADV_SMOKE:
@@ -8223,24 +8223,24 @@ void MoveParticles()
                 o->Light[2] = o->Light[0];
                 if (o->SubType == 0)
                 {
-                    o->Velocity[2] += 0.3f;
+                    o->Velocity[2] += (0.3f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.07f;
                 }
                 else if (o->SubType == 2)
                 {
-                    o->Velocity[2] += 0.3f;
+                    o->Velocity[2] += (0.3f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.07f;
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Velocity[1] += 0.1f;
+                    o->Velocity[1] += (0.1f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Alpha -= 0.2f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.2f;
                 }
 
                 else
                 {
-                    o->Velocity[2] += 0.3f;
+                    o->Velocity[2] += (0.3f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                 }
                 break;
@@ -8248,10 +8248,10 @@ void MoveParticles()
                 VectorAdd(o->Position, o->Velocity, o->Position);
                 o->Velocity[0] *= 0.95f;
                 o->Velocity[1] *= 0.95f;
-                o->Velocity[2] += 0.6f;
-                o->Position[0] += (float)(rand() % 4 - 2);
-                o->Position[1] += (float)(rand() % 4 - 2);
-                o->Position[2] += (float)(rand() % 4 - 2) * 0.8f;
+                o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
+                o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += ((float)(rand() % 4 - 2) * 0.8f) * FPS_ANIMATION_FACTOR;
                 o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                 if (o->SubType == 2)
                 {
@@ -8265,7 +8265,7 @@ void MoveParticles()
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
                 }
-                o->Rotation += 1.f + rand() % 2;
+                o->Rotation += (1.f + rand() % 2) * FPS_ANIMATION_FACTOR;
                 break;
 
             case BITMAP_TRUE_FIRE:
@@ -8290,9 +8290,9 @@ void MoveParticles()
 
                         float length = VectorLength(Direction);
                         o->Scale -=  FPS_ANIMATION_FACTOR * (length * 0.003f);
-                        o->Light[0] -= (length * 0.08f);
-                        o->Light[1] -= (length * 0.08f);
-                        o->Light[2] -= (length * 0.08f);
+                        o->Light[0] -= ((length * 0.08f)) * FPS_ANIMATION_FACTOR;
+                        o->Light[1] -= ((length * 0.08f)) * FPS_ANIMATION_FACTOR;
+                        o->Light[2] -= ((length * 0.08f)) * FPS_ANIMATION_FACTOR;
                     }
                 }
 
@@ -8314,7 +8314,7 @@ void MoveParticles()
                 if (o->SubType == 7)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.1f;
-                    o->Position[2] += 2.0f;
+                    o->Position[2] += (2.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
@@ -8326,9 +8326,9 @@ void MoveParticles()
                 o->Velocity[1] *= 0.95f;
 
                 if (o->Type == 6)
-                    o->Position[2] += 2.0f;
+                    o->Position[2] += (2.0f) * FPS_ANIMATION_FACTOR;
                 else
-                    o->Position[2] += 1.f;
+                    o->Position[2] += (1.f) * FPS_ANIMATION_FACTOR;
 
                 o->Light[0] = (float)(o->LifeTime) / 25.f;
                 o->Light[1] = o->Light[0];
@@ -8336,7 +8336,7 @@ void MoveParticles()
                 break;
 
             case BITMAP_HOLE:
-                o->Rotation += 5.f;
+                o->Rotation += (5.f) * FPS_ANIMATION_FACTOR;
                 if (o->LifeTime < 20)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.08f;
@@ -8368,7 +8368,7 @@ void MoveParticles()
                     o->Light[1] *= 1.1f;
                     o->Light[2] *= 1.1f;
                 }
-                o->Velocity[2] += 0.1f;
+                o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
 
                 if (o->SubType == 1)
                 {
@@ -8378,7 +8378,7 @@ void MoveParticles()
                     }
                     o->Rotation++;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
-                    o->Velocity[2] -= 0.4f;
+                    o->Velocity[2] -= (0.4f) * FPS_ANIMATION_FACTOR;
                 }
                 break;
 
@@ -8386,47 +8386,47 @@ void MoveParticles()
                 if (o->SubType == 0)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
-                    o->Velocity[2] += 0.1f;
+                    o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
-                    o->Position[0] += rand() % 10 - 5.f;
-                    o->Position[1] += rand() % 10 - 5.f;
+                    o->Position[0] += (rand() % 10 - 5.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 10 - 5.f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
                     if (o->Scale < 1.0f)
                         o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
-                    o->Position[0] += rand() % 10 - 5.f;
-                    o->Position[1] += rand() % 10 - 5.f;
-                    o->Velocity[2] -= 1.0f;
+                    o->Position[0] += (rand() % 10 - 5.f) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (rand() % 10 - 5.f) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[2] -= (1.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 3)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
-                    o->Rotation += 4.f;
-                    o->Velocity[2] += 0.1f;
+                    o->Rotation += (4.f) * FPS_ANIMATION_FACTOR;
+                    o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 4)
                 {
-                    o->Position[0] += (float)(cos(o->Angle[2]) * 20.0f);
-                    o->Position[1] += (float)(sin(o->Angle[2]) * 20.0f);
+                    o->Position[0] += ((float)(cos(o->Angle[2]) * 20.0f)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(sin(o->Angle[2]) * 20.0f)) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 1;
+                    o->Rotation += (1) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 5)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
-                    o->Velocity[2] += 0.1f;
+                    o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 7)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
-                    o->Rotation += 1;
-                    o->Position[0] += o->Velocity[0];
-                    o->Position[1] += o->Velocity[1];
-                    o->Position[2] += o->Velocity[2];
+                    o->Rotation += (1) * FPS_ANIMATION_FACTOR;
+                    o->Position[0] += (o->Velocity[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (o->Velocity[2]) * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8435,7 +8435,7 @@ void MoveParticles()
                 else if (o->SubType == 8)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Velocity[2] -= 0.6f;
+                    o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8445,7 +8445,7 @@ void MoveParticles()
                 else if (o->SubType == 9)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
-                    o->Velocity[2] += 0.1f;
+                    o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
                 }
 
                 if (o->LifeTime < 8)
@@ -8464,9 +8464,9 @@ void MoveParticles()
 
             case BITMAP_PLUS:
                 o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
-                o->Position[0] += rand() % 2 - 1;
-                o->Position[1] += rand() % 2 - 1;
-                o->Position[2] += 2.f;
+                o->Position[0] += (rand() % 2 - 1) * FPS_ANIMATION_FACTOR;
+                o->Position[1] += (rand() % 2 - 1) * FPS_ANIMATION_FACTOR;
+                o->Position[2] += (2.f) * FPS_ANIMATION_FACTOR;
 
                 o->Light[0] = o->LifeTime / 20.f;
                 o->Light[1] = o->LifeTime / 20.f;
@@ -8477,10 +8477,10 @@ void MoveParticles()
                 if (o->SubType == 5)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
-                    o->Velocity[2] += 0.1f;
+                    o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
 
-                    o->Position[0] += o->Velocity[0];
-                    o->Position[1] += o->Velocity[1];
+                    o->Position[0] += (o->Velocity[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR + o->Velocity[2];
 
                     o->Light[0] /= 1.1f;
@@ -8492,7 +8492,7 @@ void MoveParticles()
                 o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                 o->Velocity[0] = (rand() % 20 - 10) * 0.1f;
                 o->Velocity[1] = (rand() % 20 - 10) * 0.1f;
-                o->Velocity[2] += 0.1f;
+                o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
                 if (o->LifeTime < 10)
                 {
                     o->Light[0] /= 1.1f;
@@ -8509,23 +8509,23 @@ void MoveParticles()
                 if (o->SubType == 3)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.038f;
-                    o->Velocity[2] -= 0.02f;
+                    o->Velocity[2] -= (0.02f) * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.02f;
                     o->Light[1] /= 1.02f;
                     o->Light[2] /= 1.02f;
                 }
                 if (o->SubType == 4)
                 {
-                    o->Rotation -= 1.1f;
+                    o->Rotation -= (1.1f) * FPS_ANIMATION_FACTOR;
                 }
                 if (o->SubType == 6)
                 {
-                    o->Gravity += (rand() % 5 + 1.5f * (o->LifeTime / 5.0f));
+                    o->Gravity += ((rand() % 5 + 1.5f * (o->LifeTime / 5.0f))) * FPS_ANIMATION_FACTOR;
 
-                    o->Velocity[0] += 1;
+                    o->Velocity[0] += (1) * FPS_ANIMATION_FACTOR;
 
-                    o->Velocity[0] -= 100 * (20.0f / o->LifeTime);
-                    o->Rotation += 50.f;
+                    o->Velocity[0] -= (100 * (20.0f / o->LifeTime)) * FPS_ANIMATION_FACTOR;
+                    o->Rotation += (50.f) * FPS_ANIMATION_FACTOR;
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(o->Velocity, Matrix, TargetPosition);
                     VectorAdd(o->StartPosition, TargetPosition, o->Position);
@@ -8545,10 +8545,10 @@ void MoveParticles()
             case BITMAP_WATERFALL_4:
                 if (o->SubType == 2)
                 {
-                    o->Position[0] += (float)(cos(o->Angle[2]) * 20.0f);
-                    o->Position[1] += (float)(sin(o->Angle[2]) * 20.0f);
+                    o->Position[0] += ((float)(cos(o->Angle[2]) * 20.0f)) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += ((float)(sin(o->Angle[2]) * 20.0f)) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 1;
+                    o->Rotation += (1) * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -8557,7 +8557,7 @@ void MoveParticles()
                 else if (o->SubType == 3)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
-                    o->Velocity[2] -= 0.05f;
+                    o->Velocity[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
                     o->Light[0] *= 0.97f;
                     o->Light[1] *= 0.97f;
                     o->Light[2] *= 0.97f;
@@ -8565,8 +8565,8 @@ void MoveParticles()
                 }
                 else if (o->SubType == 5)
                 {
-                    o->Position[2] -= o->Gravity;
-                    o->Gravity -= 0.05f;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+                    o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -8575,9 +8575,9 @@ void MoveParticles()
                 else if (o->SubType == 6)
                 {
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Gravity += 0.05f;
+                    o->Gravity += (0.05f) * FPS_ANIMATION_FACTOR;
 
-                    o->Alpha -= 0.01f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.01f;
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8586,7 +8586,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 7)
                 {
-                    o->Velocity[2] += 0.01f;
+                    o->Velocity[2] += (0.01f) * FPS_ANIMATION_FACTOR;
                     o->Light[0] *= 0.97f;
                     o->Light[1] *= 0.97f;
                     o->Light[2] *= 0.97f;
@@ -8595,7 +8595,7 @@ void MoveParticles()
                 else if (o->SubType == 8)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Velocity[2] -= 0.6f;
+                    o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -8603,10 +8603,10 @@ void MoveParticles()
                 }
                 else if (o->SubType == 10)
                 {
-                    o->Position[0] += o->Velocity[0];
-                    o->Position[1] += o->Velocity[1];
-                    o->Position[2] -= o->Gravity;
-                    o->Gravity -= 0.05f;
+                    o->Position[0] += (o->Velocity[0]) * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+                    o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -8623,7 +8623,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 12)
                 {
-                    o->Rotation += ((int)WorldTime % 360) * 0.01f;
+                    o->Rotation += (((int)WorldTime % 360) * 0.01f) * FPS_ANIMATION_FACTOR;
                     o->Scale *= 0.92f;
                     Vector(o->Light[0] *= 0.92f, o->Light[1] *= 0.92f, o->Light[2] *= 0.92f, o->Light);
                     o->Alpha *= 0.8f;
@@ -8632,7 +8632,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 13)
                 {
-                    o->Position[2] -= o->Gravity;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.001f;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8643,17 +8643,17 @@ void MoveParticles()
                 else if (o->SubType == 14)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Velocity[2] -= 0.6f;
+                    o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
                 }
                 else if (o->SubType == 15)
                 {
-                    o->Position[2] -= o->Gravity;
-                    o->Gravity -= 0.05f;
+                    o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
+                    o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
-                    //o->Velocity[2] -= 0.05f;
+                    //o->Velocity[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8664,7 +8664,7 @@ void MoveParticles()
                 else if (o->SubType == 16)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
-                    o->Velocity[2] -= 0.1f;
+                    o->Velocity[2] -= (0.1f) * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime < 8)
                     {
                         o->Light[0] /= 1.2f;
@@ -8681,7 +8681,7 @@ void MoveParticles()
                 }
 #endif	// ASG_ADD_MAP_KARUTAN
                 o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
-                o->Velocity[2] -= 2.5f;
+                o->Velocity[2] -= (2.5f) * FPS_ANIMATION_FACTOR;
                 o->Light[0] /= 1.1f;
                 o->Light[1] /= 1.1f;
                 o->Light[2] /= 1.1f;
@@ -8705,13 +8705,13 @@ void MoveParticles()
                 }
                 if (o->SubType == 4)
                 {
-                    o->Alpha -= 0.001f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                     o->Light[0] /= 1.01f;
                     o->Light[1] /= 1.03f;
                     o->Light[2] /= 1.03f;
                     o->Scale += (o->Gravity * 0.015f) * FPS_ANIMATION_FACTOR;
-                    o->Gravity += 2.4f;
+                    o->Gravity += (2.4f) * FPS_ANIMATION_FACTOR;
                 }
             }
             break;
@@ -8787,8 +8787,8 @@ void MoveParticles()
                 if (o->Scale > 0) o->Scale -= FPS_ANIMATION_FACTOR * 0.1f;
                 else o->Scale = 0;
 
-                o->Rotation += 1.0f;
-                o->Alpha -= 0.05f;
+                o->Rotation += (1.0f) * FPS_ANIMATION_FACTOR;
+                o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
                 if (o->Target != NULL)
                 {
                     o->Position[0] = o->Target->Position[0] - o->StartPosition[0];
@@ -8800,7 +8800,7 @@ void MoveParticles()
             case BITMAP_AG_ADDITION_EFFECT:
             {
                 if (o->LifeTime < 10)
-                    o->Alpha -= 0.1f;
+                    o->Alpha -= FPS_ANIMATION_FACTOR * 0.1f;
                 else
                     o->Alpha = 0.7f;
 
@@ -8817,17 +8817,17 @@ void MoveParticles()
                 if (o->SubType == 0)
                 {
                     o->Scale *= 1.05f;
-                    Temp_Pos[2] -= 10.0f;
+                    Temp_Pos[2] -= (10.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
                     o->Scale *= 1.02f;
-                    Temp_Pos[2] += 10.0f;
+                    Temp_Pos[2] += (10.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
                     o->Scale *= 1.03f;
-                    Temp_Pos[2] += 25.0f;
+                    Temp_Pos[2] += (25.0f) * FPS_ANIMATION_FACTOR;
                 }
                 VectorCopy(Temp_Pos, o->Position);
 
@@ -8977,7 +8977,7 @@ void RenderParticles(BYTE byRenderOneMore)
                 for (int i = 0; i < 3; ++i)
                 {
                     RenderSprite(o->Type, vPos, Width, Height, o->Light, o->Rotation);
-                    vPos[2] -= 10.f;
+                    vPos[2] -= 10.f * FPS_ANIMATION_FACTOR;
                 }
             }
             break;
@@ -9241,7 +9241,7 @@ void RenderParticles(BYTE byRenderOneMore)
             {
                 vec3_t vPos;
                 VectorCopy(o->Position, vPos);
-                vPos[2] += 31.0f * o->Scale;
+                vPos[2] += (31.0f * o->Scale) * FPS_ANIMATION_FACTOR;
                 RenderSprite(o->TexType, vPos, Width * 0.9f, Height * 1.1f, o->Light, o->Rotation);
             }
             break;

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -3856,12 +3856,14 @@ void MoveParticles()
     {
         g_vParticleWindVelo[i] += (rand() % 2001 - 1000) * (0.001f * 0.6f);
         g_vParticleWindVelo[i] = max(-.6f, min(g_vParticleWindVelo[i], .6f));
+        g_vParticleWindVelo[i] *= FPS_ANIMATION_FACTOR;
     }
 
     for (int i = 0; i < 2; ++i)
     {
         g_vParticleWind[i] += g_vParticleWindVelo[i];
         g_vParticleWind[i] = max(-1.7f, min(g_vParticleWind[i], 1.7f));
+        g_vParticleWind[i] *= FPS_ANIMATION_FACTOR;
     }
 
     int count = 0;
@@ -3873,8 +3875,12 @@ void MoveParticles()
         if (o->Live)
         {
             count++;
-            o->LifeTime--;
-            if (o->LifeTime <= 0) o->Live = false;
+            o->LifeTime -= FPS_ANIMATION_FACTOR;
+            if (o->LifeTime <= 0)
+            {
+                o->Live = false;
+            }
+
             vec3_t Position;
             vec3_t TargetPosition;
             vec3_t Light;
@@ -3883,7 +3889,9 @@ void MoveParticles()
             float Matrix[3][4];
 
             if (o->bEnableMove)
+            {
                 MovePosition(o->Position, o->Angle, o->Velocity);
+            }
 
             switch (o->Type)
             {
@@ -3918,7 +3926,7 @@ void MoveParticles()
                         o->Light[2] /= 1.16f;
                     }
                 }
-                o->Position[2] += o->Gravity;
+                o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 break;
             case BITMAP_FLOWER01:
             case BITMAP_FLOWER01 + 1:
@@ -3977,7 +3985,7 @@ void MoveParticles()
                     float count = (o->Velocity[0] + o->LifeTime) * 0.05f;
                     o->Position[0] = o->StartPosition[0] + sinf(count) * (105.f + o->Scale * -250);
                     o->Position[1] = o->StartPosition[1] - cosf(count) * (105.f + o->Scale * -250);
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     o->Scale -= 0.0008f;
                 }
@@ -4003,8 +4011,9 @@ void MoveParticles()
             case BITMAP_LIGHT + 2:
                 if (o->SubType == 3)
                 {
-                    o->Gravity += 0.2f;
-                    //o->Position[2] += o->Gravity;
+                    o->Gravity += 0.2f * FPS_ANIMATION_FACTOR;
+
+                    //o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.03f;
 
                     if (o->Scale < 0 || !o->Target->Live)
@@ -4122,7 +4131,7 @@ void MoveParticles()
                     o->Light[1] += Luminosity;
                     o->Light[2] += Luminosity;
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.1f;
                 }
                 break;
@@ -4169,9 +4178,9 @@ void MoveParticles()
 
                 case 3:
                     o->Frame++;
-                    o->Position[0] += (float)(rand() % 20 - 10) * 2.5f * o->Gravity;
-                    o->Position[1] += (float)(rand() % 20 - 10) * 2.5f * o->Gravity;
-                    o->Position[2] += (float)(rand() % 20 + 10) * 2.5f * o->Gravity;
+                    o->Position[0] += (float)(rand() % 20 - 10) * 2.5f * o->Gravity * FPS_ANIMATION_FACTOR;
+                    o->Position[1] += (float)(rand() % 20 - 10) * 2.5f * o->Gravity * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += (float)(rand() % 20 + 10) * 2.5f * o->Gravity * FPS_ANIMATION_FACTOR;
                     break;
                 case 4:
                     o->Position[0];// += (float)(rand()%30-15)*1.f*o->Scale;
@@ -4309,12 +4318,12 @@ void MoveParticles()
                 {
                     o->Scale -= (rand() % 20 + 10) * 0.001f;
                     Luminosity -= 0.05f;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
                     o->Scale -= (rand() % 5 + 15) * 0.0016f;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
 
                     if (o->Scale < 0 || !o->Target->Live)
                         o->Live = false;
@@ -4326,13 +4335,13 @@ void MoveParticles()
                 {
                     o->Scale -= (rand() % 20 + 10) * 0.004f;
                     Luminosity -= 0.05f;
-                    o->Position[2] += o->Gravity * 25.f;
+                    o->Position[2] += o->Gravity * 25.f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 3)
                 {
                     o->Scale -= 0.03f;//(rand()%20+10)*0.001f;
                     Luminosity -= 0.05f;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
 
                     if (o->Scale < 0)
                         o->Live = false;
@@ -4371,12 +4380,12 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                     if (o->SubType == 9)
                     {
                         o->Rotation = 0.0f;
-                        o->Position[2] += o->Gravity * 1.2f;
+                        o->Position[2] += o->Gravity * 1.2f * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 5)
@@ -4406,7 +4415,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 6)
@@ -4438,7 +4447,7 @@ void MoveParticles()
                     }
                     o->Position[0] += o->Velocity[0];
                     o->Position[1] += o->Velocity[1];
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 7)
@@ -4468,7 +4477,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 8)
@@ -4513,7 +4522,7 @@ void MoveParticles()
                 break;
             case BITMAP_LEAF_TOTEMGOLEM:
             {
-                o->Velocity[2] += o->Gravity;
+                o->Velocity[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                 Height = RequestTerrainHeight(o->Position[0], o->Position[1]) + 20;
                 if (o->Position[2] <= Height)
@@ -4540,7 +4549,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale -= 0.04f;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case	17:
@@ -4552,7 +4561,7 @@ void MoveParticles()
                     o->Scale -= 0.04f;
                     o->Rotation += 5;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case    7:
@@ -4562,7 +4571,7 @@ void MoveParticles()
                     o->Frame = (15 - o->LifeTime) / 6;
                     o->Scale -= 0.04f;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case    8:
@@ -4572,7 +4581,7 @@ void MoveParticles()
                     o->Scale *= 0.95f;
                     o->Rotation += 5;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case    9:
@@ -4585,7 +4594,7 @@ void MoveParticles()
                     o->Gravity += ((rand() % 60) + 60) / 100;
                     o->Scale -= o->Gravity / 90.f;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case    11:
@@ -4598,7 +4607,7 @@ void MoveParticles()
                     }
                     o->Scale += 0.04f;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case	10:
@@ -4607,7 +4616,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale *= 0.95f;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case    12:
@@ -4618,7 +4627,7 @@ void MoveParticles()
                     o->Scale -= 0.04f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case    13:
@@ -4629,14 +4638,14 @@ void MoveParticles()
                     o->Scale -= 0.04f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 14:
                 {
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Rotation += o->Gravity;
+                    o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.03f;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -4644,7 +4653,7 @@ void MoveParticles()
                     if (o->Light[2] <= 0.05f || o->Scale <= 0.0f)
                         o->Live = false;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 15:
@@ -4658,7 +4667,7 @@ void MoveParticles()
                     if (o->Light[2] <= 0.05f || o->Scale <= 0.0f)
                         o->Live = false;
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 16:
@@ -4676,7 +4685,7 @@ void MoveParticles()
                     o->Scale += o->Gravity;
                     VectorScale(o->Velocity, 0.98f, o->Velocity);
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Light, 0.95f, o->Light);
                 }
                 break;
@@ -4687,7 +4696,7 @@ void MoveParticles()
                     o->Scale += o->Gravity;
                     VectorScale(o->Velocity, 0.98f, o->Velocity);
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 }
@@ -4698,7 +4707,7 @@ void MoveParticles()
                     //					o->Gravity += 0.02f;
                     //					o->Scale += o->Gravity;
                     VectorScale(o->Velocity, 1.05f, o->Velocity);
-                    o->Position[2] += o->Gravity * 20.f;
+                    o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) * 0.2f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                 }
@@ -4716,7 +4725,7 @@ void MoveParticles()
                     o->Gravity += 0.02f;
                     o->Scale += o->Gravity;
                     VectorScale(o->Velocity, 1.05f, o->Velocity);
-                    o->Position[2] += o->Gravity * 20.f;
+                    o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) * 0.2f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                 }
@@ -4727,7 +4736,7 @@ void MoveParticles()
                     float count = (o->Velocity[0] + o->LifeTime) * 0.1f;
                     o->Position[0] = o->StartPosition[0] + sinf(count) * 120.f;
                     o->Position[1] = o->StartPosition[1] - cosf(count) * 120.f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.002f;
                 }
                 else if (o->SubType == 5)
@@ -4736,13 +4745,13 @@ void MoveParticles()
                     //					Vector(o->TurningForce[0]*Luminosity,o->TurningForce[1]*Luminosity,o->TurningForce[2]*Luminosity,o->Light);
                     o->Position[0] += (float)(cos(o->Angle[2]) * 20.0f);
                     o->Position[1] += (float)(sin(o->Angle[2]) * 20.0f);
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 1;
                     //o->Scale += 0.003f;
                 }
                 else if (o->SubType == 6)
                 {
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 4;
                 }
                 else if (o->SubType == 7)
@@ -4754,7 +4763,7 @@ void MoveParticles()
                 else if (o->SubType == 8 || o->SubType == 9)
                 {
                     o->Scale += 0.13f;
-                    o->Rotation += o->Gravity;
+                    o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.13f;
                     o->Light[1] /= 1.13f;
                     o->Light[2] /= 1.13f;
@@ -4764,7 +4773,7 @@ void MoveParticles()
                     o->Gravity += 0.02f;
                     o->Scale += o->Gravity;
                     VectorScale(o->Velocity, 1.05f, o->Velocity);
-                    o->Position[2] += o->Gravity * 20.f;
+                    o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) * 0.2f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                 }
@@ -4816,7 +4825,7 @@ void MoveParticles()
                 case 4:
                     o->Position[0] += o->Target->Position[0] - o->StartPosition[0];
                     o->Position[1] += o->Target->Position[1] - o->StartPosition[1];
-                    o->Position[2] += o->Target->Position[2] - o->StartPosition[2] + o->Gravity;
+                    o->Position[2] += o->Target->Position[2] - o->StartPosition[2] + o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorCopy(o->Target->Position, o->StartPosition);
                     o->Gravity += 0.1f;
                     o->Rotation = (float)(rand() % 360);
@@ -4831,7 +4840,7 @@ void MoveParticles()
                     else
                         o->Rotation -= 2.0f;
 
-                    o->Position[2] += o->Gravity / 2.f;
+                    o->Position[2] += (o->Gravity / 2.f) * FPS_ANIMATION_FACTOR;
                     o->Scale -= o->Gravity / 95.f;
                     if (o->Scale <= 0.0f)
                         o->Live = false;
@@ -4848,7 +4857,7 @@ void MoveParticles()
                     else
                         o->Rotation -= 2.0f;
 
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= o->Gravity / 95.f;
                     if (o->Scale <= 0.0f)
                         o->Live = false;
@@ -4865,7 +4874,7 @@ void MoveParticles()
                     else
                         o->Rotation -= 0.5f;
 
-                    o->Position[2] += o->Gravity * 1.2f;
+                    o->Position[2] += o->Gravity * 1.2f * FPS_ANIMATION_FACTOR;
                     o->Scale -= o->Gravity / 98.f;
                     if (o->Scale <= 0.0f)
                         o->Live = false;
@@ -4999,7 +5008,7 @@ void MoveParticles()
                         o->Position[0] = o->StartPosition[0] + sinf(count) * 40.f;
                         o->Position[1] = o->StartPosition[1] - cosf(count) * 40.f;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     o->Scale -= 0.002f;
                 }
@@ -5007,7 +5016,7 @@ void MoveParticles()
                 {
                     o->Position[0] = o->StartPosition[0];
                     o->Position[1] = o->StartPosition[1];
-                    o->Position[2] += o->Gravity * ((60 - o->LifeTime) / 10);
+                    o->Position[2] += o->Gravity * ((60 - o->LifeTime) / 10) * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.002f;
                 }
                 else if (o->SubType == 5)
@@ -5026,7 +5035,7 @@ void MoveParticles()
                     float count = (o->Velocity[0] + o->LifeTime) * 0.1f;
                     o->Position[0] = o->StartPosition[0] + sinf(count) * 40.f;
                     o->Position[1] = o->StartPosition[1] - cosf(count) * 40.f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.004f;
 
                     if (o->LifeTime <= 30)
@@ -5156,7 +5165,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorSubtract(o->Position, o->StartPosition, o->Position);
                     VectorCopy(o->Target->Position, o->StartPosition);
                     VectorAdd(o->Position, o->StartPosition, o->Position);
@@ -5203,7 +5212,7 @@ void MoveParticles()
                 else if (o->SubType == 10)
                 {
                     o->Scale -= (rand() % 5 + 15) * 0.0016f;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
 
                     if (o->Scale < 0 || !o->Target->Live)
                         o->Live = false;
@@ -5229,7 +5238,7 @@ void MoveParticles()
                     float _Angle = (o->Velocity[0] + o->LifeTime) * 0.1f;
                     o->Position[0] = o->StartPosition[0] + sinf(_Angle) * 35.f;
                     o->Position[1] = o->StartPosition[1] - cosf(_Angle) * 35.f;
-                    o->Position[2] += o->Gravity * 0.1f;
+                    o->Position[2] += o->Gravity * 0.1f * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.001f;
                 }
 #ifdef PJH_ADD_PANDA_PET
@@ -5252,7 +5261,7 @@ void MoveParticles()
                     o->Scale -= 0.026f;
                 }
 
-                o->Position[2] += o->Gravity;
+                o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 o->Alpha -= 0.05f;
                 o->Light[0] /= 1.02f;
                 o->Light[1] /= 1.02f;
@@ -5266,14 +5275,14 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
                     break;
                 case 36:
                     if (o->LifeTime < 23)
                     {
                         o->Gravity += (0.1f * o->Scale);
-                        o->Position[2] += o->Gravity;
+                        o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                         o->Position[1] += o->Gravity;
                         o->Scale -= 0.08f;
                     }
@@ -5313,7 +5322,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 0.1f, Luminosity, Luminosity * 0.6f, o->Light);
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
                     break;
                 case 3:
@@ -5335,7 +5344,7 @@ void MoveParticles()
                     Luminosity = (Luminosity > 1.0f ? 1.0f - Luminosity : Luminosity);
                     Vector(Luminosity * o->TurningForce[0], Luminosity * o->TurningForce[1], Luminosity * o->TurningForce[2], o->Light);
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
                     break;
                 case 15:
@@ -5344,7 +5353,7 @@ void MoveParticles()
                     o->Gravity += (rand() % 20) / 500.f;
                     o->Position[0] += (rand() % 100 - 20) / 100.f;
                     o->Position[1] += (rand() % 100 - 20) / 100.f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += (rand() % 10) / 1000.f;
                     o->Rotation = o->Scale;
                     break;
@@ -5359,7 +5368,7 @@ void MoveParticles()
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Gravity -= 0.1f;
                     o->Position[0] -= o->Gravity * 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.01f;
                     break;
                 case 16:
@@ -5367,7 +5376,7 @@ void MoveParticles()
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Gravity -= 0.1f;
                     o->Position[0] -= o->Gravity * 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.01f;
                     break;
                 case 12:
@@ -5389,7 +5398,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 120.f / 255.f, Luminosity * 100.7f / 255.f, Luminosity * 80.f / 255.f, o->Light);
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
                     break;
                 case 5:
@@ -5397,7 +5406,7 @@ void MoveParticles()
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Gravity -= 0.1f;
                     o->Position[0] -= o->Gravity * (0.2f * (rand() % 2 + 1));
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.01f;
                     break;
                 case 6:
@@ -5427,7 +5436,7 @@ void MoveParticles()
                     if (o->LifeTime > 5)
                     {
                         o->Scale += o->Gravity;
-                        o->Position[2] += o->Gravity * 20.f;
+                        o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
 
                         VectorScale(o->Velocity, 1.05f, o->Velocity);
                         Luminosity = (float)(o->LifeTime) / 24.f;
@@ -5444,7 +5453,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 10.f;
                     Vector(Luminosity * 250.f / 255.f, Luminosity * 156.7f / 255.f, 0.f, o->Light);
                     o->Gravity += 0.5f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.1f;
                     break;
                 case 10:
@@ -5458,7 +5467,7 @@ void MoveParticles()
                     o->Gravity += (rand() % 20) / 500.f;
                     o->Position[0] += (rand() % 100 - 20) / 100.f;
                     o->Position[1] += (rand() % 100 - 20) / 100.f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += (rand() % 10) / 1000.f;
                     o->Rotation = o->Scale;
                     break;
@@ -5468,7 +5477,7 @@ void MoveParticles()
                     o->Gravity += (rand() % 20) / 500.f;
                     o->Position[0] += (rand() % 100 - 20) / 100.f;
                     o->Position[1] += (rand() % 100 - 20) / 100.f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += (rand() % 10) / 1000.f;
                     o->Rotation = o->Scale;
                     break;
@@ -5477,7 +5486,7 @@ void MoveParticles()
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Gravity -= 0.1f;
                     o->Position[0] -= o->Gravity * 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.01f;
                     break;
                 case 22:
@@ -5485,14 +5494,14 @@ void MoveParticles()
                     Vector(Luminosity * 0.9f, Luminosity * 0.5f, Luminosity * 0.5f, o->Light);
                     o->Gravity -= 0.1f;
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.04f;
                     break;
                 case 24:
                     Luminosity = (float)(o->LifeTime) / 32.f;
                     Vector(Luminosity * 0.2f, Luminosity * 0.5f, Luminosity * 0.35f, o->Light);
                     o->Gravity += 0.1f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
                     break;
                 case 25:
@@ -5522,20 +5531,20 @@ void MoveParticles()
                     o->Scale -= 0.05f;
                     break;
                 case 28:
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime >= 9) o->Scale -= 0.4f;
                     else o->Scale *= 1.2f;
                     Vector(o->Light[0] * 0.92f, o->Light[1] * 0.92f, o->Light[2] * 0.92f, o->Light);
                     break;
                 case 29:
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime >= 9) o->Scale -= 0.4f;
                     else o->Scale *= 1.2f;
                     Vector(1.0f, 1.0f, 1.0f, o->Light);
                     break;
                 case 30:
                     o->Scale += 0.15f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     Vector(1.0f, 3.0f, 1.0f, o->Light);
                     break;
                 case 31:
@@ -5561,7 +5570,7 @@ void MoveParticles()
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
                     o->Scale += 0.05f;
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 42:
@@ -5569,7 +5578,7 @@ void MoveParticles()
                     Vector(Luminosity * 127.f / 255.f, Luminosity * 255.f / 255.f,
                         Luminosity * 200.f / 255.f, o->Light);
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
                     break;
                 case 43:
@@ -5686,7 +5695,7 @@ void MoveParticles()
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Scale += 0.02f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     break;
                 case 51:
                     Luminosity = (float)(o->LifeTime) / 20.f;
@@ -5725,7 +5734,7 @@ void MoveParticles()
                 case 55:
                 {
                     o->Gravity += 0.1f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
 
                     o->Light[0] /= 1.08f;
@@ -5743,7 +5752,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 32.f;
                     Vector(Luminosity * 0.5f, Luminosity * 0.1f, Luminosity * 0.8f, o->Light);
                     o->Gravity += 0.1f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
                     break;
                 case 58:
@@ -5759,7 +5768,7 @@ void MoveParticles()
                     Vector(Luminosity * 0.4f, Luminosity * 0.4f, Luminosity * 0.4f, o->Light);
                     o->Gravity -= 0.1f;
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.04f;
                 }
                 break;
@@ -5767,7 +5776,7 @@ void MoveParticles()
                 {
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.05f;
                 }
                 break;
@@ -5800,7 +5809,7 @@ void MoveParticles()
 
                     o->Gravity -= 0.1f;
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     o->Scale += (float)(rand() % 15 + 15) * 0.01f;
 
@@ -5816,7 +5825,7 @@ void MoveParticles()
                     Vector(Luminosity * 0.4f, Luminosity * 0.4f, Luminosity * 0.4f, o->Light);
                     o->Gravity -= 0.05f;
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 66:
@@ -5872,7 +5881,7 @@ void MoveParticles()
                     Vector(Luminosity * o->Angle[0], Luminosity * o->Angle[1], Luminosity * o->Angle[2], o->Light);
                     o->Gravity -= 0.04f;
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.04f;
                     break;
 #endif	// ASG_ADD_MAP_KARUTAN
@@ -5899,7 +5908,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 55.f;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.03f;
                     o->Rotation += o->Angle[0];
                     break;
@@ -5907,7 +5916,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 55.f;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Gravity += 0.1f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.03f;
                     o->Rotation += o->Angle[0];
                     break;
@@ -5917,7 +5926,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 55.f;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Gravity += 0.2f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += 0.03f;
                     o->Rotation += o->Angle[0];
                     break;
@@ -5932,7 +5941,7 @@ void MoveParticles()
 
                     if (o->Gravity <= 0.0f)
                         o->Gravity = -o->Gravity;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     break;
                 case 4:
                     if (o->Light[0] <= 0.05f)
@@ -5945,7 +5954,7 @@ void MoveParticles()
 
                     if (o->Gravity <= 0.0f)
                         o->Gravity = -o->Gravity;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     break;
                 }
                 break;
@@ -5974,7 +5983,7 @@ void MoveParticles()
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Scale += (rand() % 3 + 6) * 0.01f;//0.07f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     if (o->SubType == 5)
                     {
                         VectorSubtract(o->Position, o->StartPosition, o->Position);
@@ -6011,7 +6020,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorSubtract(o->Position, o->StartPosition, o->Position);
                     VectorCopy(o->Target->Position, o->StartPosition);
                     VectorAdd(o->Position, o->StartPosition, o->Position);
@@ -6038,11 +6047,11 @@ void MoveParticles()
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Scale += (rand() % 3 + 6) * 0.01f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 4)
                 {
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 0.8f;
                     o->Scale += 0.01f;
 
@@ -6107,12 +6116,12 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                     if (o->SubType == 6)
                     {
                         o->Rotation = 0.0f;
-                        o->Position[2] += o->Gravity * 1.2f;
+                        o->Position[2] += o->Gravity * 1.2f * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 1)
@@ -6142,7 +6151,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 2)
@@ -6174,7 +6183,7 @@ void MoveParticles()
                     }
                     o->Position[0] += o->Velocity[0];
                     o->Position[1] += o->Velocity[1];
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 10)
@@ -6204,7 +6213,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 3)
@@ -6234,7 +6243,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 4)
@@ -6303,7 +6312,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 break;
@@ -6336,12 +6345,12 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                     if (o->SubType == 6)
                     {
                         o->Rotation = 0.0f;
-                        o->Position[2] += o->Gravity * 1.2f;
+                        o->Position[2] += o->Gravity * 1.2f * FPS_ANIMATION_FACTOR;
                     }
                 }
                 else if (o->SubType == 1)
@@ -6371,7 +6380,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 2)
@@ -6403,7 +6412,7 @@ void MoveParticles()
                     }
                     o->Position[0] += o->Velocity[0];
                     o->Position[1] += o->Velocity[1];
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 3)
@@ -6433,7 +6442,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 else if (o->SubType == 4)
@@ -6539,7 +6548,7 @@ void MoveParticles()
             case BITMAP_BLOOD:
             case BITMAP_BLOOD + 1:
                 o->Frame = (12 - o->LifeTime) / 3;
-                //o->Position[2] += o->Gravity;
+                //o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 //o->Gravity -= 1.5f;
                 VectorScale(o->Velocity, 0.95f, o->Velocity);
                 VectorAdd(o->Position, o->Velocity, o->Position);
@@ -6557,7 +6566,7 @@ void MoveParticles()
                 else
                     if (o->SubType != 8)
                         Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                o->Position[2] += o->Gravity;
+                o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 if (o->SubType == 5)
                 {
                     o->Gravity -= 0.3f;
@@ -6752,7 +6761,7 @@ void MoveParticles()
                             o->Gravity = 0.1f;
                             o->Frame = 99;
                         }
-                        o->Position[2] += o->Gravity;
+                        o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->Frame == 99)
                     {
@@ -6779,7 +6788,7 @@ void MoveParticles()
 
                     o->Position[0] += sinf(WorldTime * o->Rotation) * o->Gravity * 0.3f;
                     //o->Position[1] += sinf(WorldTime*o->Rotation)*o->Gravity*0.3f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 19:
@@ -6787,7 +6796,7 @@ void MoveParticles()
                     if (o->LifeTime <= 0)
                         o->Live = false;
 
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Gravity += 0.1f;
 
                     o->Light[0] /= 1.1f;
@@ -6984,7 +6993,7 @@ void MoveParticles()
                 break;
                 case 31:
                 {
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Gravity -= 2.f;
 
                     Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
@@ -7007,7 +7016,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 1)
                 {
-                    if (o->LifeTime % 3 == 0)
+                    if ((int)o->LifeTime % 3 == 0)
                     {
                         vec3_t vPos;
                         VectorCopy(o->Position, vPos);
@@ -7103,7 +7112,7 @@ void MoveParticles()
                 else if (o->SubType == 5)
                 {
                     o->Rotation += 10.f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.02f;
                     o->Light[1] /= 1.02f;
@@ -7274,7 +7283,7 @@ void MoveParticles()
                     {
                         o->Position[2] = Height + 3.f;
                         o->Gravity = -o->Gravity * 0.3f;
-                        o->LifeTime -= 2;
+                        o->LifeTime -= 2 * FPS_ANIMATION_FACTOR;
                     }
                 }
             }
@@ -7293,7 +7302,7 @@ void MoveParticles()
                     {
                         VectorCopy(o->Target->Angle, o->Angle);
                         o->Scale -= 0.06f;
-                        o->Position[2] += o->Gravity * 10.f;
+                        o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
@@ -7477,7 +7486,7 @@ void MoveParticles()
                 }
                 else
                 {
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     if (o->Position[2] >= 500.f)
                     {
@@ -8044,7 +8053,7 @@ void MoveParticles()
 
                     o->Position[0] += 2.f;
                     o->Position[1] -= 2.f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 4)
                 {
@@ -8064,7 +8073,7 @@ void MoveParticles()
 
                     o->Gravity += (rand() % 40 + 60) / 100.f * 9.5f;
                     o->Scale -= (rand() % 400 + 400) / 10000.f;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.35f;
                     o->Light[1] /= 1.35f;
@@ -8104,7 +8113,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 11)
                 {
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.0005f;
                 }
                 else if (o->SubType == 12)
@@ -8117,7 +8126,7 @@ void MoveParticles()
                 else if (o->SubType == 13)
                 {
                     o->Position[1] -= o->Gravity;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.001f;
                 }
                 else if (o->SubType == 14)
@@ -8130,7 +8139,7 @@ void MoveParticles()
                     o->StartPosition[2] += (rand() % 10 + 5) * 0.01f;
                     o->Position[0] = o->StartPosition[0] + sinf(o->StartPosition[2]) * o->Gravity * 2;
                     o->Position[1] = o->StartPosition[1] + cosf(o->StartPosition[2]) * o->Gravity * 2;
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale -= 0.001f;
                     if (o->LifeTime > 20)
                     {
@@ -8155,7 +8164,7 @@ void MoveParticles()
                     o->Scale -= 0.02f;
 
                     o->Frame = (23 - o->LifeTime) / 6;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
 
                     if (o->SubType == 1)
                     {
@@ -8169,7 +8178,7 @@ void MoveParticles()
                     VectorCopy(o->Target->Angle, o->Angle);
 
                     o->Scale -= 0.06f;
-                    o->Position[2] += o->Gravity * 10.f;
+                    o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                     o->Light[0] = o->LifeTime / 10.f;
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
@@ -8201,7 +8210,7 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 3.0f;
                 }
                 break;
@@ -8264,7 +8273,7 @@ void MoveParticles()
                 if ((o->SubType == 1 || o->SubType == 2) && o->Target != NULL)
                 {
                     if (o->Target->CurrentAction == 1)
-                        o->LifeTime -= 2;
+                        o->LifeTime -= 2 * FPS_ANIMATION_FACTOR;
                 }
 
                 if (o->SubType >= 3 && o->SubType < 5 && o->Target != NULL)
@@ -8403,7 +8412,7 @@ void MoveParticles()
                 {
                     o->Position[0] += (float)(cos(o->Angle[2]) * 20.0f);
                     o->Position[1] += (float)(sin(o->Angle[2]) * 20.0f);
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 1;
                 }
                 else if (o->SubType == 5)
@@ -8472,7 +8481,7 @@ void MoveParticles()
 
                     o->Position[0] += o->Velocity[0];
                     o->Position[1] += o->Velocity[1];
-                    o->Position[2] += o->Gravity + o->Velocity[2];
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR + o->Velocity[2];
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8538,7 +8547,7 @@ void MoveParticles()
                 {
                     o->Position[0] += (float)(cos(o->Angle[2]) * 20.0f);
                     o->Position[1] += (float)(sin(o->Angle[2]) * 20.0f);
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 1;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8565,7 +8574,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 6)
                 {
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Gravity += 0.05f;
 
                     o->Alpha -= 0.01f;

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -4933,12 +4933,12 @@ void MoveParticles()
                     if (o->SubType == 2)
                     {
                         Vector(0.03f, 0.03f, 0.03f, Light);
-                        VectorSubtract(o->Light, Light, o->Light);
+                        VectorSubtractScaled(o->Light, Light, o->Light, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
                         Vector(0.05f, 0.05f, 0.05f, Light);
-                        VectorSubtract(o->Light, Light, o->Light);
+                        VectorSubtractScaled(o->Light, Light, o->Light, FPS_ANIMATION_FACTOR);
                     }
                 }
                 break;

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -16,6 +16,7 @@
 #include "WSClient.h"
 #include "GMCrywolf1st.h"
 #include "MapManager.h"
+#include "NewUISystem.h"
 
 vec3_t g_vParticleWind = { 0.0f, 0.0f, 0.0f };
 vec3_t g_vParticleWindVelo = { 0.0f, 0.0f, 0.0f };
@@ -41,6 +42,11 @@ void HandPosition(PARTICLE* o)
 
 int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType, float Scale, OBJECT* Owner)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return false;
+    }
+
     for (int i = 0; i < MAX_PARTICLES; i++)
     {
         PARTICLE* o = &Particles[i];
@@ -3852,6 +3858,11 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
 
 void MoveParticles()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < 2; ++i)
     {
         g_vParticleWindVelo[i] += (rand() % 2001 - 1000) * (0.001f * 0.6f);
@@ -8904,6 +8915,11 @@ void MoveParticles()
 
 void RenderParticles(BYTE byRenderOneMore)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_PARTICLES; i++)
     {
         PARTICLE* o = &Particles[i];

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -600,7 +600,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 break;
                 case 1:
                     o->LifeTime = 15;
-                    o->Scale += (float)(rand() % 32 + 32) * 0.01f;
+                    o->Scale += (float)(rand() % 32 + 32) * 0.01f * FPS_ANIMATION_FACTOR;
                     Vector(0.f, (float)(rand() % 4 + 4) * 0.15f, 0.f, o->Velocity);
                     break;
                 case 5:
@@ -612,7 +612,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     float Luminosity;
 
                     o->LifeTime = 10;
-                    o->Scale += (float)(rand() % 32 + 32) * 0.01f;
+                    o->Scale += (float)(rand() % 32 + 32) * 0.01f * FPS_ANIMATION_FACTOR;
 
                     float inter = Light[0] * (rand() % 80) / 100.0f;
                     Vector(0.f, inter, 0.f, o->Velocity);
@@ -632,7 +632,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     float Luminosity;
 
                     o->LifeTime = 10;
-                    o->Scale += (float)(rand() % 32 + 32) * 0.01f;
+                    o->Scale += (float)(rand() % 32 + 32) * 0.01f * FPS_ANIMATION_FACTOR;
                     Vector(0.f, 0.f, 0.f, o->Velocity);
 
                     Luminosity = (float)sinf(WorldTime * 0.002f) * 0.3f + 0.7f;
@@ -644,7 +644,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     float Luminosity;
 
                     o->LifeTime = 5;
-                    o->Scale += (float)(rand() % 32 + 32) * 0.01f;
+                    o->Scale += (float)(rand() % 32 + 32) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Gravity = 10.f;
                     VectorCopy(o->Target->Position, o->StartPosition);
 
@@ -655,7 +655,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 9:
                 {
                     o->LifeTime = 40;
-                    o->Scale = -(float)(rand() % 20) / 100.0f + o->Scale;
+                    o->Scale += -(float)(rand() % 20) / 100.0f * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360) - 180.0f;
                     o->StartPosition[0] = o->Position[0];
                     o->Position[0] += ((float)(rand() % 2) / 2.0f - 0.0f) * o->Scale;
@@ -810,7 +810,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 if (o->SubType == 0)
                 {
                     o->LifeTime = 16;
-                    o->Scale += (float)(rand() % 32 + 48) * 0.01f;
+                    o->Scale += (float)(rand() % 32 + 48) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 360);
                     o->Rotation = (float)((int)WorldTime % 360);
                 }
@@ -818,7 +818,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->TexType = BITMAP_SMOKE;
                     o->LifeTime = 20;
-                    o->Scale += (float)(rand() % 10 + 10) * 0.01f;
+                    o->Scale += (float)(rand() % 10 + 10) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 360);
                     o->Rotation = (float)((int)WorldTime % 360);
                     o->Gravity = (float)(rand() % 10 + 40) * 0.04f;
@@ -827,7 +827,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 else if (o->SubType == 2)
                 {
                     o->LifeTime = 10;
-                    o->Scale -= (float)(rand() % 40 + 48) * 0.008f;
+                    o->Scale -= (float)(rand() % 40 + 48) * 0.008f * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 360);
                     o->Rotation = (float)((int)WorldTime % 360);
                     o->Gravity = 0.0f;
@@ -835,7 +835,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 else if (o->SubType == 3)
                 {
                     o->LifeTime = 20;
-                    o->Scale += (float)(rand() % 32 + 48) * 0.008f;
+                    o->Scale += (float)(rand() % 32 + 48) * 0.008f * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 360);
                     o->Rotation = (float)((int)WorldTime % 360);
                     VectorCopy(o->Target->Position, o->StartPosition);
@@ -843,7 +843,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 else if (o->SubType == 4)
                 {
                     o->LifeTime = 16;
-                    o->Scale += (float)(rand() % 32 + 48) * 0.01f;
+                    o->Scale += (float)(rand() % 32 + 48) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Angle[0] = (float)(rand() % 360);
                     o->Rotation = (float)((int)WorldTime % 360);
                 }
@@ -865,7 +865,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Velocity[2] = 0;
 
                     o->LifeTime = 21;
-                    o->Scale = (float)(rand() % 4 + 8) * 0.01f;
+                    o->Scale = (float)(rand() % 4 + 8) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Gravity = (float)(rand() % 1 + 4) * 0.1f;
 
                     o->Angle[2] = (float)(rand() % 360);
@@ -920,7 +920,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 break;
             case BITMAP_MAGIC + 1:
                 o->LifeTime = 10;
-                o->Scale += (float)(rand() % 32 + 48) * 0.001f;
+                o->Scale += (float)(rand() % 32 + 48) * 0.001f * FPS_ANIMATION_FACTOR;
                 o->Angle[0] = (float)(rand() % 360);
                 o->Rotation = (float)((int)WorldTime % 360);
                 break;
@@ -961,7 +961,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 else if (o->SubType == 1)
                 {
                     o->LifeTime = 12;
-                    o->Scale += (float)(rand() % 30) * 0.01f;
+                    o->Scale += (float)(rand() % 30) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
                     o->Position[2] += 30.0f;
                 }
@@ -1039,7 +1039,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = 40;
                     o->Alpha = 0.5f;
                     float fIntervalScale = Scale * 0.1f;
-                    o->Scale += ((float((rand() % 20) - 10) / 2.0f) * ((fIntervalScale / 2.f)));
+                    o->Scale += ((float((rand() % 20) - 10) / 2.0f) * ((fIntervalScale / 2.f))) * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
                     o->Velocity[0] = (float)(rand() % 20 - 10) * 0.03f;
                     o->Velocity[1] = (float)(rand() % 20 - 10) * 0.03f;
@@ -1334,13 +1334,13 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     break;
                 case 21:
                     o->LifeTime = 80;
-                    o->Scale = o->Scale * (float)(rand() % 64 + 64) * 0.005f;
+                    o->Scale *= (float)(rand() % 64 + 64) * 0.005f;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 32 + 60) * 0.1f;
                     break;
                 case 22:
                     o->LifeTime = 60;
-                    o->Scale = o->Scale * (float)(rand() % 64 + 64) * 0.005f;
+                    o->Scale *= (float)(rand() % 64 + 64) * 0.005f;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 32 + 60) * 0.1f;
                     break;
@@ -1435,7 +1435,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 44:
                 {
                     o->LifeTime = 60;
-                    o->Scale += (float)(rand() % 10) / 2.0f;
+                    o->Scale += (float)(rand() % 10) / 2.0f * FPS_ANIMATION_FACTOR;
                     o->Position[0] += (float)(rand() % 500) - 250.0f;
                     o->Position[1] += (float)(rand() % 700) - 350.0f;
                     o->Position[2] += (float)(rand() % 100) + 150.0f;
@@ -1448,7 +1448,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->TexType = BITMAP_LIGHT + 2;
                     o->LifeTime = 15;
-                    o->Scale += (float)(rand() % 10) / 20.0f;
+                    o->Scale += (float)(rand() % 10) / 20.0f * FPS_ANIMATION_FACTOR;
                     o->Position[0] += (float)(rand() % 40) - 20.0f;
                     o->Position[1] += (float)(rand() % 40) - 20.0f;
                     o->Position[2] += (float)(rand() % 40) - 20.0f;
@@ -1458,7 +1458,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     //o->TexType = BITMAP_CLOUD;
                     o->LifeTime = 60 + (int)(o->Scale * 10.0f);
-                    o->Scale += (float)(rand() % 50) * 0.01f;
+                    o->Scale += (float)(rand() % 50) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 30 + 50) * 0.05f;
                 }
@@ -1467,7 +1467,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->TexType = BITMAP_MAGIC + 1;
                     o->LifeTime = 5;
-                    o->Scale += (float)(rand() % 50) * 0.01f;
+                    o->Scale += (float)(rand() % 50) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
                 }
                 break;
@@ -1525,7 +1525,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     //o->TexType = BITMAP_CLOUD;
                     o->LifeTime = (int)(o->Scale * 8.0f);
-                    o->Scale += (float)(rand() % 50) * 0.01f;
+                    o->Scale += (float)(rand() % 50) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 30 + 50) * 0.05f;
                 }
@@ -1553,7 +1553,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     Vector(0.4f, 0.4f, 0.4f, o->Light);
                     o->LifeTime = 60;
-                    o->Scale = o->Scale * (float)(rand() % 64 + 64) * 0.005f;
+                    o->Scale *= (float)(rand() % 64 + 64) * 0.005f;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 32 + 60) * 0.1f;
                 }
@@ -1583,7 +1583,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 64:
                 {
                     o->LifeTime = 30;
-                    o->Scale = o->Scale * 0.3f;
+                    o->Scale *= 0.3f;
 
                     o->Velocity[0] = 0.0f;
                     o->Velocity[1] = 10.0f;
@@ -1599,7 +1599,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 65:
                 {
                     o->LifeTime = 45;
-                    o->Scale = o->Scale * (float)(rand() % 64 + 64) * 0.005f;
+                    o->Scale *= (float)(rand() % 64 + 64) * 0.005f;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 10 + 18) * 0.1f;
                 }
@@ -1608,7 +1608,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     //o->TexType = BITMAP_CLOUD;
                     o->LifeTime = (int)(o->Scale * 30.0f);
-                    o->Scale += (float)(rand() % 50) * 0.01f;
+                    o->Scale += (float)(rand() % 50) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 30 + 50) * 0.01f;
                     int iAngle = rand() % 360;
@@ -1627,7 +1627,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 68:
                 {
                     o->LifeTime = 45;
-                    o->Scale = o->Scale * (float)(rand() % 64 + 64) * 0.005f;
+                    o->Scale *= (float)(rand() % 64 + 64) * 0.005f;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 10 + 18) * 0.1f;
                     o->Alpha = 1.0f;
@@ -1647,7 +1647,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
 #ifdef ASG_ADD_MAP_KARUTAN
                 case 69:
                     o->LifeTime = 60;
-                    o->Scale = o->Scale * (float)(rand() % 64 + 64) * 0.005f;
+                    o->Scale *= (float)(rand() % 64 + 64) * 0.005f;
                     o->Rotation = (float)(rand() % 360);
                     o->Gravity = (float)(rand() % 16 + 30) * 0.1f;
                     VectorCopy(Light, o->Angle);
@@ -1736,7 +1736,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 3:
                     o->TexType = BITMAP_CLUD64;
                     o->LifeTime = 60;
-                    o->Scale = o->Scale * (float)(rand() % 64 + 64) * 0.02f;
+                    o->Scale *= (float)(rand() % 64 + 64) * 0.02f;
                     o->Rotation = (float)(rand() % 360);
                     o->Position[0] += (float)(rand() % 250 - 125);
                     o->Position[1] += (float)(rand() % 250 - 125);
@@ -1747,7 +1747,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 4:
                     o->TexType = BITMAP_WATERFALL_3;
                     o->LifeTime = 30;
-                    o->Scale = o->Scale * (float)(rand() % 64 + 64) * 0.02f;
+                    o->Scale *= (float)(rand() % 64 + 64) * 0.02f;
                     o->Rotation = (float)(rand() % 360);
                     o->Position[0] += (float)(rand() % 250 - 125);
                     o->Position[1] += (float)(rand() % 250 - 125);
@@ -2107,7 +2107,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
 
                     if (o->SubType == 7)
                     {
-                        o->Scale += Scale;
+                        o->Scale += Scale * FPS_ANIMATION_FACTOR;
                     }
                 }
                 break;
@@ -2215,7 +2215,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Velocity[1] = -1.0f + (float)(rand() % 20) / 10.f;
                     o->Velocity[2] = -(float)(rand() % 3) - 3.0f;
                     o->LifeTime = 40;
-                    o->Scale = -(float)(rand() % 15) / 10.0f + Scale;
+                    o->Scale += -(float)(rand() % 15) / 10.0f * FPS_ANIMATION_FACTOR;
                     break;
                 case 14:
                     if (rand() % 2 == 0)
@@ -2268,7 +2268,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 case 17:
                 {
                     o->LifeTime = 200;
-                    o->Scale += (float)(rand() % 3) * 0.1f;
+                    o->Scale += (float)(rand() % 3) * 0.1f * FPS_ANIMATION_FACTOR;
                     o->Gravity = (float)(rand() % 5) * 0.3f + 2.0f;
                     o->Rotation = (float)(rand() % 20) * 0.0001f + 0.002f;
                     o->Alpha = (float)(rand() % 10) * 0.1f + 0.5f;
@@ -2531,7 +2531,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 else if (o->SubType == 5)
                 {
                     o->LifeTime = rand() % 10 + 10;
-                    o->Scale = Scale + (rand() % 10) * 0.02f;
+                    o->Scale += (rand() % 10) * 0.02f * FPS_ANIMATION_FACTOR;
                     o->Position[0] += (float)(rand() % 10 - 5);
                     o->Position[1] += (float)(rand() % 10 - 5);
                     o->Gravity = -(float)(rand() % 10) * 0.3f;
@@ -2707,7 +2707,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Position[2] += -5.0f + (float)(rand() % 10);
                     o->LifeTime = 30;
                     o->Gravity = 1.3f;
-                    o->Scale += (float)(rand() % 3) / 10.0f;
+                    o->Scale += (float)(rand() % 3) / 10.0f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
@@ -2731,7 +2731,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 }
                 o->LifeTime = 30;
                 o->Gravity = 10.0f;
-                o->Scale += (float)(rand() % 5) / 10.0f;
+                o->Scale += (float)((rand() % 5) / 10.0f) * FPS_ANIMATION_FACTOR;
                 if (o->SubType == 2)
                 {
                     o->Gravity = -5.0f;
@@ -3490,7 +3490,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 30;
                     o->Velocity[2] = rand() % 3 + 1;
-                    o->Scale = (rand() % 5 + 5) * 0.05f + Scale;
+                    o->Scale += (rand() % 5 + 5) * 0.05f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 9)
                 {
@@ -3616,7 +3616,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 60;
                     o->Velocity[2] = -1.0f;
-                    o->Scale = o->Scale * (rand() % 10 + 15) * 0.02f;
+                    o->Scale *= (rand() % 10 + 15) * 0.02f;
                     o->Rotation = (float)(rand() % 360);
                     o->Position[0] += rand() % 40 - 20.f;
                     o->Position[2] += rand() % 25 - 10.f;
@@ -3627,7 +3627,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Rotation = (float)(rand() % 360);
                     o->LifeTime = (rand() % 2 - 1) + 5;
                     float fIntervalScale = Scale * 0.3f;
-                    o->Scale += ((float((rand() % 20) - 10) / 2.0f) * ((fIntervalScale / 2.f)));
+                    o->Scale += ((float((rand() % 20) - 10) / 2.0f) * ((fIntervalScale / 2.f)) * FPS_ANIMATION_FACTOR);
                     o->Position[0] += (float)(rand() % 20) - 10.f;
                     o->Position[1] += (float)(rand() % 20) - 10.f;
                     o->Position[2] += (float)(rand() % 20) - 10.f;
@@ -3669,7 +3669,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 {
                     o->LifeTime = 60;
                     o->Velocity[2] = (rand() % 4) * 0.1f + 0.8f;
-                    o->Scale = o->Scale * (rand() % 10 + 15) * 0.02f;
+                    o->Scale *= (rand() % 10 + 15) * 0.02f;
                     o->Rotation = (float)(rand() % 360);
                     o->Position[0] += rand() % 18 - 9.f;
                     o->Position[2] += rand() % 18 - 9.f;
@@ -3976,7 +3976,7 @@ void MoveParticles()
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
-                    o->Scale += 1.5f;
+                    o->Scale += 1.5f * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_FLARE + 1:
@@ -3987,7 +3987,7 @@ void MoveParticles()
                     o->Position[1] = o->StartPosition[1] - cosf(count) * (105.f + o->Scale * -250);
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
-                    o->Scale -= 0.0008f;
+                    o->Scale -= 0.0008f * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_BLUE_BLUR:
@@ -3999,11 +3999,11 @@ void MoveParticles()
                     Vector(Luminosity * 1.f, Luminosity * 1.f, Luminosity * 1.f, o->Light);
                     if (o->SubType == 1)
                     {
-                        o->Scale += 0.19f;
+                        o->Scale += FPS_ANIMATION_FACTOR * 0.19f;
                         o->Position[2] += 5.00f;
                     }
                     else
-                        o->Scale += 0.05f;
+                        o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
 
                     break;
                 }
@@ -4014,7 +4014,7 @@ void MoveParticles()
                     o->Gravity += 0.2f * FPS_ANIMATION_FACTOR;
 
                     //o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.03f;
+                    o->Scale -= 0.03f * FPS_ANIMATION_FACTOR;
 
                     if (o->Scale < 0 || !o->Target->Live)
                         o->Live = false;
@@ -4032,7 +4032,7 @@ void MoveParticles()
 
                     o->Angle[0] += 0.5f * o->LifeTime;
                     o->Angle[1] += 0.5f * o->LifeTime;
-                    o->Scale += 0.04f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     if (o->LifeTime < 10)
                     {
                         o->Alpha -= 0.1f;
@@ -4064,7 +4064,7 @@ void MoveParticles()
 
                     o->Angle[0] += 0.5f * o->LifeTime;
                     o->Angle[1] += 0.5f * o->LifeTime;
-                    o->Scale += 0.04f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     if (o->LifeTime < 10)
                     {
                         o->Alpha -= 0.1f;
@@ -4096,7 +4096,7 @@ void MoveParticles()
 
                     o->Angle[0] += 0.5f * o->LifeTime;
                     o->Angle[1] += 0.5f * o->LifeTime;
-                    o->Scale += 0.04f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     o->TexType = BITMAP_LIGHT;
                     if (o->LifeTime < 10)
                     {
@@ -4132,7 +4132,7 @@ void MoveParticles()
                     o->Light[2] += Luminosity;
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.1f;
+                    o->Scale -= 0.1f * FPS_ANIMATION_FACTOR;
                 }
                 break;
             case BITMAP_GM_AURORA:
@@ -4148,7 +4148,7 @@ void MoveParticles()
                 o->Light[0] *= 0.9f;
                 o->Light[1] *= 0.9f;
                 o->Light[2] *= 0.9f;
-                o->Scale += 0.1f;
+                o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
             }
             break;
             case BITMAP_BUBBLE:
@@ -4166,14 +4166,14 @@ void MoveParticles()
                     o->Position[0] += (float)(rand() % 30 - 15) * 1.f * o->Scale;
                     o->Position[1] += (float)(rand() % 30 - 15) * 1.f * o->Scale;
                     o->Position[2] += (float)(rand() % 20 + 10) * 0.3f * o->Scale;
-                    o->Scale += 0.002f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.002f;
                     break;
 
                 case 2:
                     o->Position[0];// += (float)(rand()%30-15)*1.f*o->Scale;
                     o->Position[1];// += (float)(rand()%30-15)*1.f*o->Scale;
                     o->Position[2] += (float)(rand() % 20 + 10) * 0.3f;
-                    o->Scale += 0.005f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                     break;
 
                 case 3:
@@ -4186,7 +4186,7 @@ void MoveParticles()
                     o->Position[0];// += (float)(rand()%30-15)*1.f*o->Scale;
                     o->Position[1];// += (float)(rand()%30-15)*1.f*o->Scale;
                     o->Position[2] += (float)(rand() % 20 + 10) * 0.3f;
-                    o->Scale += 0.005f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                     if (o->Position[2] > 350)
                     {
                         o->Position[2] = 350;
@@ -4290,7 +4290,7 @@ void MoveParticles()
                 AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
                 if (o->SubType == 2)
                 {
-                    o->Scale += 0.1f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                     Vector(Luminosity * 0.5f, Luminosity * 1.f, Luminosity * 0.8f, o->Light);
                     VectorCopy(o->Target->Position, o->Position);
                     o->Position[2] += 80.f;
@@ -4308,7 +4308,7 @@ void MoveParticles()
             case BITMAP_CHROME_ENERGY2:
                 o->Gravity = 0.0f;
                 Luminosity = (float)(o->LifeTime) / 24.f;
-                o->Scale -= 0.04f;
+                o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                 o->Rotation += 5;
                 o->Frame = (23 - o->LifeTime) / 6;
                 break;
@@ -4316,13 +4316,13 @@ void MoveParticles()
             case BITMAP_FIRE_HIK2_MONO:
                 if (o->SubType == 0)
                 {
-                    o->Scale -= (rand() % 20 + 10) * 0.001f;
-                    Luminosity -= 0.05f;
+                    o->Scale -= (rand() % 20 + 10) * 0.001f * FPS_ANIMATION_FACTOR;
+                    Luminosity -= 0.05f * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
-                    o->Scale -= (rand() % 5 + 15) * 0.0016f;
+                    o->Scale -= (rand() % 5 + 15) * 0.0016f * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
 
                     if (o->Scale < 0 || !o->Target->Live)
@@ -4333,14 +4333,14 @@ void MoveParticles()
                 }
                 else if (o->SubType == 2)
                 {
-                    o->Scale -= (rand() % 20 + 10) * 0.004f;
-                    Luminosity -= 0.05f;
+                    o->Scale -= (rand() % 20 + 10) * 0.004f * FPS_ANIMATION_FACTOR;
+                    Luminosity -= 0.05f * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * 25.f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Scale -= 0.03f;//(rand()%20+10)*0.001f;
-                    Luminosity -= 0.05f;
+                    o->Scale -= 0.03f * FPS_ANIMATION_FACTOR;//(rand()%20+10)*0.001f;
+                    Luminosity -= 0.05f * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
 
                     if (o->Scale < 0)
@@ -4374,7 +4374,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 6) * 0.01f;
+                        o->Scale -= (rand() % 3 + 6) * 0.01f * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
@@ -4409,7 +4409,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 2 + 5) * 0.01f;
+                        o->Scale -= (rand() % 2 + 5) * 0.01f * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
@@ -4439,7 +4439,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 6) * 0.01f;
+                        o->Scale -= (rand() % 3 + 6) * 0.01f * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
@@ -4471,14 +4471,14 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 3) * 0.01f;
+                        o->Scale -= (rand() % 3 + 3) * 0.01f * FPS_ANIMATION_FACTOR;
                     }
                     else
                     {
                         o->Live = false;
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Rotation += 3.0f;
+                    o->Rotation += 3.0f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 8)
                 {
@@ -4500,10 +4500,10 @@ void MoveParticles()
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
 
-                    o->Scale += (rand() % 3 + 8) * 0.01f;
+                    o->Scale += (rand() % 3 + 8) * 0.01f * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime < 3)
                     {
-                        o->Scale += (10 - o->LifeTime) * 0.02f;
+                        o->Scale += (10 - o->LifeTime) * 0.02f * FPS_ANIMATION_FACTOR;
                     }
 
                     AngleMatrix(o->Angle, Matrix);
@@ -4534,7 +4534,7 @@ void MoveParticles()
                 }
                 else
                 {
-                    o->Scale += 0.01f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                 }
             }
             break;
@@ -4547,7 +4547,7 @@ void MoveParticles()
                 {
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale -= 0.04f;
+                    o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
@@ -4558,7 +4558,7 @@ void MoveParticles()
                 {
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale -= 0.04f;
+                    o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     o->Rotation += 5;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -4569,7 +4569,7 @@ void MoveParticles()
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Frame = (15 - o->LifeTime) / 6;
-                    o->Scale -= 0.04f;
+                    o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
@@ -4592,7 +4592,7 @@ void MoveParticles()
                     o->Position[1] = o->Target->Position[1] + o->StartPosition[1];
                     o->Position[2] = o->Target->Position[2] + o->StartPosition[2];
                     o->Gravity += ((rand() % 60) + 60) / 100;
-                    o->Scale -= o->Gravity / 90.f;
+                    o->Scale -= o->Gravity * FPS_ANIMATION_FACTOR / 90.f;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
@@ -4605,7 +4605,7 @@ void MoveParticles()
                     {
                         o->Frame = (24 - o->LifeTime) / 3;
                     }
-                    o->Scale += 0.04f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
@@ -4624,7 +4624,7 @@ void MoveParticles()
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Rotation += (float)(rand() % 10 + 10.f);
-                    o->Scale -= 0.04f;
+                    o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -4635,7 +4635,7 @@ void MoveParticles()
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Rotation += (float)(rand() % 10 + 10.f);
-                    o->Scale -= 0.04f;
+                    o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -4646,7 +4646,7 @@ void MoveParticles()
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.03f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -4660,7 +4660,7 @@ void MoveParticles()
                 {
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale -= 0.04f;
+                    o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -4682,7 +4682,7 @@ void MoveParticles()
                 {
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale += o->Gravity;
+                    o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Velocity, 0.98f, o->Velocity);
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -4693,7 +4693,7 @@ void MoveParticles()
                 {
                     o->Gravity += 0.004f;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale += o->Gravity;
+                    o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Velocity, 0.98f, o->Velocity);
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -4723,7 +4723,7 @@ void MoveParticles()
                 else if (o->SubType == 3)
                 {
                     o->Gravity += 0.02f;
-                    o->Scale += o->Gravity;
+                    o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Velocity, 1.05f, o->Velocity);
                     o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) * 0.2f;
@@ -4737,7 +4737,7 @@ void MoveParticles()
                     o->Position[0] = o->StartPosition[0] + sinf(count) * 120.f;
                     o->Position[1] = o->StartPosition[1] - cosf(count) * 120.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.002f;
+                    o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 5)
                 {
@@ -4747,7 +4747,7 @@ void MoveParticles()
                     o->Position[1] += (float)(sin(o->Angle[2]) * 20.0f);
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 1;
-                    //o->Scale += 0.003f;
+                    //o->Scale += FPS_ANIMATION_FACTOR * 0.003f;
                 }
                 else if (o->SubType == 6)
                 {
@@ -4762,7 +4762,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 8 || o->SubType == 9)
                 {
-                    o->Scale += 0.13f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.13f;
                     o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Light[0] /= 1.13f;
                     o->Light[1] /= 1.13f;
@@ -4771,7 +4771,7 @@ void MoveParticles()
                 else if (o->SubType == 0)
                 {
                     o->Gravity += 0.02f;
-                    o->Scale += o->Gravity;
+                    o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                     VectorScale(o->Velocity, 1.05f, o->Velocity);
                     o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) * 0.2f;
@@ -4787,7 +4787,7 @@ void MoveParticles()
                     if (o->LifeTime == 10)
                     {
                         o->Velocity[1] += 32 * 0.2f;
-                        o->Scale -= 0.15f;
+                        o->Scale -= 0.15f * FPS_ANIMATION_FACTOR;
                     }
                     o->Rotation = (float)(rand() % 360);
                     o->Light[0] -= 0.05f;
@@ -4841,7 +4841,7 @@ void MoveParticles()
                         o->Rotation -= 2.0f;
 
                     o->Position[2] += (o->Gravity / 2.f) * FPS_ANIMATION_FACTOR;
-                    o->Scale -= o->Gravity / 95.f;
+                    o->Scale -= o->Gravity * FPS_ANIMATION_FACTOR / 95.f;
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
@@ -4858,7 +4858,7 @@ void MoveParticles()
                         o->Rotation -= 2.0f;
 
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= o->Gravity / 95.f;
+                    o->Scale -= o->Gravity * FPS_ANIMATION_FACTOR / 95.f;
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
@@ -4875,7 +4875,7 @@ void MoveParticles()
                         o->Rotation -= 0.5f;
 
                     o->Position[2] += o->Gravity * 1.2f * FPS_ANIMATION_FACTOR;
-                    o->Scale -= o->Gravity / 98.f;
+                    o->Scale -= o->Gravity * FPS_ANIMATION_FACTOR / 98.f;
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
@@ -4892,7 +4892,7 @@ void MoveParticles()
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
                     o->Velocity[2] += 0.3f;
-                    o->Scale += 0.07f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.07f;
                     break;
                 case 11:
                     o->Light[0] /= 1.008f;
@@ -4910,11 +4910,11 @@ void MoveParticles()
                 if (o->LifeTime <= 0) o->Live = false;
                 if (o->SubType == 1)
                 {
-                    o->Scale += o->Gravity;
+                    o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 else
                 {
-                    o->Scale += 0.03f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                 }
                 if (M34CryWolf1st::IsCyrWolf1st() == true)
                 {
@@ -4941,7 +4941,7 @@ void MoveParticles()
                 if (o->SubType == 1)
                 {
                     o->Light[1] = o->Light[2] = o->Light[0] = o->LifeTime / 15.f;
-                    o->Scale += 0.1f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                 }
                 else if (o->SubType == 2)
                 {
@@ -4985,7 +4985,7 @@ void MoveParticles()
             case BITMAP_MAGIC:
                 if (o->SubType == 0)
                 {
-                    o->Scale -= 0.05f;
+                    o->Scale -= 0.05f * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] -= 0.01f;
                     o->Light[1] -= 0.01f;
@@ -5010,14 +5010,14 @@ void MoveParticles()
                     }
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
-                    o->Scale -= 0.002f;
+                    o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
                     o->Position[0] = o->StartPosition[0];
                     o->Position[1] = o->StartPosition[1];
                     o->Position[2] += o->Gravity * ((60 - o->LifeTime) / 10) * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.002f;
+                    o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 5)
                 {
@@ -5025,7 +5025,7 @@ void MoveParticles()
                     o->Position[0] = o->StartPosition[0] + sinf(count) * 40.f;
                     o->Position[1] = o->StartPosition[1] - cosf(count) * 40.f;
                     o->Position[2] -= o->Gravity;
-                    o->Scale -= 0.002f;
+                    o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
 
                     o->StartPosition[0] += 2.5f;
                 }
@@ -5036,7 +5036,7 @@ void MoveParticles()
                     o->Position[0] = o->StartPosition[0] + sinf(count) * 40.f;
                     o->Position[1] = o->StartPosition[1] - cosf(count) * 40.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.004f;
+                    o->Scale -= 0.004f * FPS_ANIMATION_FACTOR;
 
                     if (o->LifeTime <= 30)
                     {
@@ -5056,7 +5056,7 @@ void MoveParticles()
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
-                    o->Scale += 1.5f;
+                    o->Scale += 1.5f * FPS_ANIMATION_FACTOR;
                 }
                 else
                     if (o->SubType == 12)
@@ -5069,7 +5069,7 @@ void MoveParticles()
                         }
                         o->Position[2] += (o->Gravity + 0.1f);
 
-                        o->Scale -= 0.002f;
+                        o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
                         if (o->LifeTime <= 35)
                         {
                             o->Light[0] /= 1.1f;
@@ -5100,14 +5100,14 @@ void MoveParticles()
                 {
                     Luminosity = (float)(o->LifeTime) / 10.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Gravity -= 0.01f;
-                    o->Position[2] -= o->Gravity;
-                    o->Scale -= 0.03f;
+                    o->Gravity -= 0.01f * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= o->Gravity * FPS_ANIMATION_FACTOR;
+                    o->Scale -= 0.03f * FPS_ANIMATION_FACTOR;
                     o->Alpha -= 0.05f;
                 }
                 else if (o->SubType == 1 || o->SubType == 2)
                 {
-                    o->Scale += 0.5f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.5f;
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -5118,7 +5118,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Scale += 0.08f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -5129,7 +5129,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 5)
                 {
-                    o->Scale += 0.08f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
 
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -5159,7 +5159,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 5 + 55) * 0.001f;
+                        o->Scale -= (rand() % 5 + 55) * 0.001f * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->Scale < 0.1f)
                     {
@@ -5183,7 +5183,7 @@ void MoveParticles()
                     }
 
                     VectorAdd(o->Position, o->Velocity, o->Position);
-                    o->Scale += ((float)(rand() % 10) * 0.01f);
+                    o->Scale += ((float)(rand() % 10) * 0.01f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 8)
                 {
@@ -5198,7 +5198,7 @@ void MoveParticles()
                     }
 
                     VectorAdd(o->Position, o->Velocity, o->Position);
-                    o->Scale += ((float)(rand() % 10) * 0.01f);
+                    o->Scale += ((float)(rand() % 10) * 0.01f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 9)
                 {
@@ -5211,7 +5211,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 10)
                 {
-                    o->Scale -= (rand() % 5 + 15) * 0.0016f;
+                    o->Scale -= (rand() % 5 + 15) * 0.0016f * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
 
                     if (o->Scale < 0 || !o->Target->Live)
@@ -5224,10 +5224,10 @@ void MoveParticles()
                 {
                     Luminosity = (float)(o->LifeTime) / 10.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Gravity -= 0.01f;
-                    o->Position[2] -= o->Gravity;
-                    o->Scale -= 0.03f;
-                    o->Alpha -= 0.05f;
+                    o->Gravity -= 0.01f * FPS_ANIMATION_FACTOR;
+                    o->Position[2] -= o->Gravity * FPS_ANIMATION_FACTOR;
+                    o->Scale -= 0.03f * FPS_ANIMATION_FACTOR;
+                    o->Alpha -= 0.05f * FPS_ANIMATION_FACTOR;
                 }
             }
             break;
@@ -5239,7 +5239,7 @@ void MoveParticles()
                     o->Position[0] = o->StartPosition[0] + sinf(_Angle) * 35.f;
                     o->Position[1] = o->StartPosition[1] - cosf(_Angle) * 35.f;
                     o->Position[2] += o->Gravity * 0.1f * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.001f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.001f;
                 }
 #ifdef PJH_ADD_PANDA_PET
                 else if (o->SubType == 1)
@@ -5254,15 +5254,15 @@ void MoveParticles()
             {
                 if (o->SubType == 0 || o->SubType == 1)
                 {
-                    o->Scale -= 0.013f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.013f;
                 }
                 else if (o->SubType == 2)
                 {
-                    o->Scale -= 0.026f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.026f;
                 }
 
                 o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                o->Alpha -= 0.05f;
+                o->Alpha -= 0.05f * FPS_ANIMATION_FACTOR;
                 o->Light[0] /= 1.02f;
                 o->Light[1] /= 1.02f;
                 o->Light[2] /= 1.02f;
@@ -5274,17 +5274,17 @@ void MoveParticles()
                 case 0:
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Gravity += 0.2f;
+                    o->Gravity += 0.2f * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 36:
                     if (o->LifeTime < 23)
                     {
-                        o->Gravity += (0.1f * o->Scale);
+                        o->Gravity += (0.1f * o->Scale) * FPS_ANIMATION_FACTOR;
                         o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                         o->Position[1] += o->Gravity;
-                        o->Scale -= 0.08f;
+                        o->Scale -= 0.08f * FPS_ANIMATION_FACTOR;
                     }
                     else
                         VectorAdd(o->Target->Position, o->StartPosition, o->Position);
@@ -5293,14 +5293,14 @@ void MoveParticles()
                 case 37:
                     o->Position[2] -= o->TurningForce[2] * 0.8f;
                     o->Position[1] -= o->TurningForce[1] * 0.8f;
-                    o->Scale += 0.08f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
                     o->Rotation += 0.01f;
                     o->Light[0] /= 1.03f;
                     o->Light[1] /= 1.03f;
                     o->Light[2] /= 1.03f;
                     break;
                 case 38:
-                    o->Scale += 0.09f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     o->Light[0] /= 1.04f;
                     o->Light[1] /= 1.04f;
                     o->Light[2] /= 1.04f;
@@ -5309,34 +5309,34 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 0.4f, Luminosity * 0.4f, Luminosity, o->Light);
                     VectorScale(o->Velocity, 0.001f, o->Velocity);
-                    o->Scale += (0.01f * 2);
+                    o->Scale += (0.01f * 2) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Scale;
                     break;
                 case 32:
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 0.8f, Luminosity * 0.8f, Luminosity, o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.1f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                     break;
                 case 23:
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 0.1f, Luminosity, Luminosity * 0.6f, o->Light);
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 3:
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 0.8f, Luminosity * 0.8f, Luminosity, o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.1f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                     break;
                 case 11:
                 case 14:
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * o->TurningForce[0], Luminosity * o->TurningForce[1], Luminosity * o->TurningForce[2], o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Position[2] -= 1.f;
                     break;
                 case 17:
@@ -5345,7 +5345,7 @@ void MoveParticles()
                     Vector(Luminosity * o->TurningForce[0], Luminosity * o->TurningForce[1], Luminosity * o->TurningForce[2], o->Light);
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 15:
                     Luminosity = (float)(o->LifeTime) / 40.f;
@@ -5354,14 +5354,14 @@ void MoveParticles()
                     o->Position[0] += (rand() % 100 - 20) / 100.f;
                     o->Position[1] += (rand() % 100 - 20) / 100.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += (rand() % 10) / 1000.f;
+                    o->Scale += (rand() % 10) * FPS_ANIMATION_FACTOR / 1000.f;
                     o->Rotation = o->Scale;
                     break;
                 case 1:
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * 0.5f, Luminosity * 1.f, Luminosity * 0.8f, o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 2:
                     Luminosity = (float)(o->LifeTime) / 50.f;
@@ -5369,7 +5369,7 @@ void MoveParticles()
                     o->Gravity -= 0.1f;
                     o->Position[0] -= o->Gravity * 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     break;
                 case 16:
                     Luminosity = (float)(o->LifeTime) / 50.f;
@@ -5377,29 +5377,29 @@ void MoveParticles()
                     o->Gravity -= 0.1f;
                     o->Position[0] -= o->Gravity * 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     break;
                 case 12:
                     Luminosity = (float)(o->LifeTime) / 40.f;
                     Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 13:
                     Luminosity = (float)(o->LifeTime) / 20.f;
                     Vector(Luminosity * 1.f, Luminosity * 0.5f, Luminosity * 0.1f, o->Light);
-                    o->Scale += 0.09f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     break;
                 case 18:
                     Luminosity = (float)(o->LifeTime) / 20.f;
                     Vector(Luminosity * 1.f, Luminosity * 1.f, Luminosity * 1.f, o->Light);
-                    o->Scale += 0.09f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     break;
                 case 4:
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     Vector(Luminosity * 120.f / 255.f, Luminosity * 100.7f / 255.f, Luminosity * 80.f / 255.f, o->Light);
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 5:
                     Luminosity = (float)(o->LifeTime) / 10.f;
@@ -5407,7 +5407,7 @@ void MoveParticles()
                     o->Gravity -= 0.1f;
                     o->Position[0] -= o->Gravity * (0.2f * (rand() % 2 + 1));
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     break;
                 case 6:
                     Luminosity = 0.6f;
@@ -5420,14 +5420,14 @@ void MoveParticles()
                 case 7:
                     Luminosity = 1.0f;
 
-                    o->Scale += 0.03f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                     o->Gravity += 1.0f;
                     o->Velocity[1] -= 0.1f;
                     o->Position[2] -= o->Gravity;
                     if (o->LifeTime < 5)
                     {
                         Luminosity = (float)(o->LifeTime) / 8.f;
-                        o->Scale -= 0.1f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * 0.1f;
                     }
                     Vector(Luminosity * 0.725f, Luminosity * 0.572f, Luminosity * 0.333f, o->Light);
                     break;
@@ -5435,7 +5435,7 @@ void MoveParticles()
                     o->Gravity += 0.02f;
                     if (o->LifeTime > 5)
                     {
-                        o->Scale += o->Gravity;
+                        o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                         o->Position[2] += o->Gravity * 20.f * FPS_ANIMATION_FACTOR;
 
                         VectorScale(o->Velocity, 1.05f, o->Velocity);
@@ -5454,12 +5454,12 @@ void MoveParticles()
                     Vector(Luminosity * 250.f / 255.f, Luminosity * 156.7f / 255.f, 0.f, o->Light);
                     o->Gravity += 0.5f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.1f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                     break;
                 case 10:
                     Luminosity = (float)(o->LifeTime) / 16.f;
                     Vector(Luminosity * 1.f, Luminosity * 0.1f, Luminosity * 0.1f, o->Light);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 19:
                     Luminosity = (float)(o->LifeTime) / 40.f;
@@ -5468,7 +5468,7 @@ void MoveParticles()
                     o->Position[0] += (rand() % 100 - 20) / 100.f;
                     o->Position[1] += (rand() % 100 - 20) / 100.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += (rand() % 10) / 1000.f;
+                    o->Scale += (rand() % 10) * FPS_ANIMATION_FACTOR / 1000.f;
                     o->Rotation = o->Scale;
                     break;
                 case 20:
@@ -5478,7 +5478,7 @@ void MoveParticles()
                     o->Position[0] += (rand() % 100 - 20) / 100.f;
                     o->Position[1] += (rand() % 100 - 20) / 100.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += (rand() % 10) / 1000.f;
+                    o->Scale += (rand() % 10) * FPS_ANIMATION_FACTOR / 1000.f;
                     o->Rotation = o->Scale;
                     break;
                 case 21:
@@ -5487,7 +5487,7 @@ void MoveParticles()
                     o->Gravity -= 0.1f;
                     o->Position[0] -= o->Gravity * 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     break;
                 case 22:
                     Luminosity = (float)(o->LifeTime) / 50.f;
@@ -5495,60 +5495,60 @@ void MoveParticles()
                     o->Gravity -= 0.1f;
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.04f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     break;
                 case 24:
                     Luminosity = (float)(o->LifeTime) / 32.f;
                     Vector(Luminosity * 0.2f, Luminosity * 0.5f, Luminosity * 0.35f, o->Light);
                     o->Gravity += 0.1f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 25:
                     Luminosity = (float)(o->LifeTime) / 20.f;
                     Vector(Luminosity * 1.f, Luminosity * 1.f, Luminosity * 1.f, o->Light);
-                    o->Scale += 0.09f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     break;
                 case 35:
                     o->Light[0] /= 1.04f;
                     o->Light[1] /= 1.04f;
                     o->Light[2] /= 1.04f;
-                    o->Scale += 0.06f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
                     break;
                 case 34:
                     o->Light[0] /= 1.04f;
                     o->Light[1] /= 1.04f;
                     o->Light[2] /= 1.04f;
-                    o->Scale += 0.06f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
                     break;
                 case 26:
                     Luminosity = (float)(o->LifeTime) / 20.f;
                     Vector(o->Light[0] * Luminosity * 1.f, o->Light[1] * Luminosity * 1.f, o->Light[2] * Luminosity * 1.f, o->Light);
-                    o->Scale += 0.15f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.15f;
                     break;
                 case 27:
                     Vector(o->Light[0] * 0.92f, o->Light[1] * 0.92f, o->Light[2] * 0.92f, o->Light);
-                    o->Scale -= 0.05f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 28:
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    if (o->LifeTime >= 9) o->Scale -= 0.4f;
+                    if (o->LifeTime >= 9) o->Scale -= FPS_ANIMATION_FACTOR* 0.4f;
                     else o->Scale *= 1.2f;
                     Vector(o->Light[0] * 0.92f, o->Light[1] * 0.92f, o->Light[2] * 0.92f, o->Light);
                     break;
                 case 29:
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    if (o->LifeTime >= 9) o->Scale -= 0.4f;
+                    if (o->LifeTime >= 9) o->Scale -= FPS_ANIMATION_FACTOR * 0.4f;
                     else o->Scale *= 1.2f;
                     Vector(1.0f, 1.0f, 1.0f, o->Light);
                     break;
                 case 30:
-                    o->Scale += 0.15f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.15f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     Vector(1.0f, 3.0f, 1.0f, o->Light);
                     break;
                 case 31:
-                    o->Scale -= 0.05f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -5560,7 +5560,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * 0.5f, Luminosity * 0.5f, Luminosity * 1.0f, o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                 }
                 break;
                 case 41:
@@ -5568,7 +5568,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * 0.5f, Luminosity * 1.f, Luminosity * 0.8f, o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
@@ -5579,14 +5579,14 @@ void MoveParticles()
                         Luminosity * 200.f / 255.f, o->Light);
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 43:
                 {
                     o->Light[0] /= 1.02f;
                     o->Light[1] /= 1.02f;
                     o->Light[2] /= 1.02f;
-                    o->Scale += 0.08f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
                 }
                 break;
                 case 44:
@@ -5603,7 +5603,7 @@ void MoveParticles()
                         o->Light[1] /= 1.07f;
                         o->Light[2] /= 1.07f;
                     }
-                    o->Scale += 0.02f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
                     o->Position[2] += 0.8f;
                     o->Rotation += o->Gravity / 50.0f;
                 }
@@ -5626,7 +5626,7 @@ void MoveParticles()
 
                     o->Gravity -= 0.05f;
                     o->Position[2] += (o->Scale + o->Gravity) * 1.5f;
-                    o->Scale += o->Scale / 100.0f;
+                    o->Scale += o->Scale * FPS_ANIMATION_FACTOR / 100.0f;
                 }
                 break;
                 case 47:
@@ -5638,18 +5638,18 @@ void MoveParticles()
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
 
-                    o->Scale += 1.0f;
+                    o->Scale += 1.0f * FPS_ANIMATION_FACTOR;
                 }
                 break;
                 case 59:
                     Luminosity = (float)(o->LifeTime) / 40.f;
                     Vector(Luminosity * 0.9f, Luminosity * 0.9f, Luminosity * 0.9f, o->Light);
-                    o->Scale += 0.09f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     break;
                 case 48:
                     Luminosity = (float)(o->LifeTime) / 40.f;
                     Vector(Luminosity * 0.4f, Luminosity * 0.4f, Luminosity * 0.4f, o->Light);
-                    o->Scale += 0.09f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     break;
                 case 49:
                 {
@@ -5670,7 +5670,7 @@ void MoveParticles()
                         o->LifeTime = 0;
 
                     VectorScale(o->Velocity, 0.001f, o->Velocity);
-                    o->Scale += (rand() % 15 + 4) * (0.001f);
+                    o->Scale += (rand() % 15 + 4) * (0.001f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Scale * 6.0f;
                     o->Rotation += (rand() % 10 + 10) * 0.1f * o->Angle[0];
                 }
@@ -5694,18 +5694,18 @@ void MoveParticles()
                     }
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
-                    o->Scale += 0.02f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     break;
                 case 51:
                     Luminosity = (float)(o->LifeTime) / 20.f;
                     VectorScale(o->TurningForce, Luminosity, o->Light);
-                    o->Scale += 0.09f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     break;
                 case 52:
                 {
                     VectorAdd(o->Position, o->Velocity, o->Position);
-                    o->Scale += 0.06f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
                     o->Light[0] /= 1.07f;
                     o->Light[1] /= 1.07f;
                     o->Light[2] /= 1.07f;
@@ -5715,7 +5715,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * 1.f, Luminosity * 1.f, Luminosity * 1.f, o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 54:
                 {
@@ -5728,14 +5728,14 @@ void MoveParticles()
 
                     o->Gravity -= 0.05f;
                     o->Position[2] += (o->Scale + o->Gravity) * 1.5f;
-                    o->Scale += o->Scale / 100.0f;
+                    o->Scale += o->Scale * FPS_ANIMATION_FACTOR / 100.0f;
                 }
                 break;
                 case 55:
                 {
                     o->Gravity += 0.1f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
 
                     o->Light[0] /= 1.08f;
                     o->Light[1] /= 1.08f;
@@ -5746,21 +5746,21 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * 0.5f, Luminosity * 0.1f, Luminosity * 0.8f, o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 57:
                     Luminosity = (float)(o->LifeTime) / 32.f;
                     Vector(Luminosity * 0.5f, Luminosity * 0.1f, Luminosity * 0.8f, o->Light);
                     o->Gravity += 0.1f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 58:
                     Luminosity = (float)(o->LifeTime) / 50.f;
                     Vector(Luminosity * o->StartPosition[0], Luminosity * o->StartPosition[1],
                         Luminosity * o->StartPosition[2], o->Light);
                     VectorScale(o->Velocity, 0.4f, o->Velocity);
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     break;
                 case 60:
                 {
@@ -5769,7 +5769,7 @@ void MoveParticles()
                     o->Gravity -= 0.1f;
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.04f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                 }
                 break;
                 case 61:
@@ -5777,7 +5777,7 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 8.f;
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                 }
                 break;
                 case 62:
@@ -5786,7 +5786,7 @@ void MoveParticles()
                     //Vector(Luminosity*0.9f,Luminosity*0.4f,Luminosity*0.1f,o->Light);
                     Vector(Luminosity * 0.9f, Luminosity * 0.9f, Luminosity * 0.9f, o->Light);
                     VectorScale(o->Velocity, 0.001f, o->Velocity);
-                    o->Scale += 0.03f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                 }
                 break;
                 case 63:
@@ -5794,7 +5794,7 @@ void MoveParticles()
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
-                    o->Scale += 0.5f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.5f;
                     o->Velocity[1] += 1.5f;
                 }
                 break;
@@ -5811,7 +5811,7 @@ void MoveParticles()
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
-                    o->Scale += (float)(rand() % 15 + 15) * 0.01f;
+                    o->Scale += (float)(rand() % 15 + 15) * 0.01f * FPS_ANIMATION_FACTOR;
 
                     if (16 > o->LifeTime)
                     {
@@ -5840,7 +5840,7 @@ void MoveParticles()
                     o->Gravity -= 0.05f;
                     o->Position[0] += o->TurningForce[0] * (o->Scale + o->Gravity) * 1.0f;
                     o->Position[1] += o->TurningForce[1] * (o->Scale + o->Gravity) * 1.0f;
-                    o->Scale += o->Scale / 100.0f;
+                    o->Scale += o->Scale * FPS_ANIMATION_FACTOR / 100.0f;
                 }
                 break;
                 case 67:
@@ -5855,7 +5855,7 @@ void MoveParticles()
                     o->Light[1] *= o->Alpha;
                     o->Light[2] *= o->Alpha;
 
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Rotation += 0.01f;
                 }
                 break;
@@ -5882,7 +5882,7 @@ void MoveParticles()
                     o->Gravity -= 0.04f;
                     o->Position[0] += o->Gravity * sinf(WorldTime) * 0.05f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.04f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.04f;
                     break;
 #endif	// ASG_ADD_MAP_KARUTAN
                 }
@@ -5896,7 +5896,7 @@ void MoveParticles()
                 VectorCopy(o->Target->Position, TargetPosition);
                 VectorAdd(TargetPosition, Position, o->Position);
                 o->Angle[1] += 5.f;
-                o->Scale -= 0.01f;
+                o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                 break;
             case BITMAP_SMOKE + 3:
                 switch (o->SubType)
@@ -5909,7 +5909,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.03f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                     o->Rotation += o->Angle[0];
                     break;
                 case 1:
@@ -5917,7 +5917,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Gravity += 0.1f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.03f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                     o->Rotation += o->Angle[0];
                     break;
                 case 2:
@@ -5927,7 +5927,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     o->Gravity += 0.2f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale += 0.03f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                     o->Rotation += o->Angle[0];
                     break;
                 case 3:
@@ -5936,7 +5936,7 @@ void MoveParticles()
                     o->Light[0] /= 1.012f;
                     o->Light[1] /= 1.012f;
                     o->Light[2] /= 1.012f;
-                    o->Scale += 0.01f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Rotation += o->Gravity / 2.0f;
 
                     if (o->Gravity <= 0.0f)
@@ -5949,7 +5949,7 @@ void MoveParticles()
                     o->Light[0] /= 1.012f;
                     o->Light[1] /= 1.012f;
                     o->Light[2] /= 1.012f;
-                    o->Scale += 0.01f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Rotation += o->Gravity / 2.0f;
 
                     if (o->Gravity <= 0.0f)
@@ -5982,7 +5982,7 @@ void MoveParticles()
                     }
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
-                    o->Scale += (rand() % 3 + 6) * 0.01f;//0.07f;
+                    o->Scale += (rand() % 3 + 6) * 0.01f * FPS_ANIMATION_FACTOR;//0.07f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     if (o->SubType == 5)
                     {
@@ -6014,7 +6014,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 10 + 10) * 0.001f;//0.07f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 10 + 10) * 0.001f;//0.07f;
                     }
                     else
                     {
@@ -6046,14 +6046,14 @@ void MoveParticles()
                     }
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
-                    o->Scale += (rand() % 3 + 6) * 0.01f;
+                    o->Scale += (rand() % 3 + 6) * 0.01f * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 4)
                 {
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += 0.8f;
-                    o->Scale += 0.01f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
 
                     o->Alpha -= 0.01f;
 
@@ -6110,7 +6110,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 5) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 5) * 0.01f;
                     }
                     else
                     {
@@ -6145,7 +6145,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 2 + 4) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 2 + 4) * 0.01f;
                     }
                     else
                     {
@@ -6175,7 +6175,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 7) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 7) * 0.01f;
                     }
                     else
                     {
@@ -6207,7 +6207,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 5) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 5) * 0.01f;
                     }
                     else
                     {
@@ -6237,7 +6237,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 2) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 2) * 0.01f;
                     }
                     else
                     {
@@ -6266,10 +6266,10 @@ void MoveParticles()
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
 
-                    o->Scale += (rand() % 3 + 8) * 0.01f;
+                    o->Scale += (rand() % 3 + 8) * 0.01f * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime < 3)
                     {
-                        o->Scale += (10 - o->LifeTime) * 0.02f;
+                        o->Scale += (10 - o->LifeTime) * 0.02f * FPS_ANIMATION_FACTOR;
                     }
 
                     AngleMatrix(o->Angle, Matrix);
@@ -6306,7 +6306,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 5) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 5) * 0.01f;
                     }
                     else
                     {
@@ -6339,7 +6339,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 7) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 7) * 0.01f;
                     }
                     else
                     {
@@ -6374,7 +6374,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 2 + 6) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 2 + 6) * 0.01f;
                     }
                     else
                     {
@@ -6404,7 +6404,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 7) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 7) * 0.01f;
                     }
                     else
                     {
@@ -6436,7 +6436,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 7) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 7) * 0.01f;
                     }
                     else
                     {
@@ -6466,7 +6466,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 4 + 5) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 4 + 5) * 0.01f;
                     }
                     else
                     {
@@ -6495,10 +6495,10 @@ void MoveParticles()
                     Luminosity = o->Alpha;
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
 
-                    o->Scale += (rand() % 3 + 8) * 0.01f;
+                    o->Scale += (rand() % 3 + 8) * 0.01f * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime < 3)
                     {
-                        o->Scale += (10 - o->LifeTime) * 0.02f;
+                        o->Scale += (10 - o->LifeTime) * 0.02f * FPS_ANIMATION_FACTOR;
                     }
 
                     AngleMatrix(o->Angle, Matrix);
@@ -6609,11 +6609,11 @@ void MoveParticles()
                 switch (o->SubType)
                 {
                 case 0:
-                    o->Scale -= 0.5f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.5f;
                     if (o->Scale < 0.2f) o->Live = false;
                     break;
                 case 1:
-                    o->Scale -= 2.f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 2.f;
                     if (o->Scale < 0.2f) o->Live = false;
                     break;
                 case 2:
@@ -6624,7 +6624,7 @@ void MoveParticles()
                     o->Light[1] = o->LifeTime / 5.f;
                     o->Light[2] = o->LifeTime / 5.f;
 
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     VectorAdd(o->StartPosition, o->Velocity, o->Position);
                     VectorCopy(o->Position, o->StartPosition);
                     break;
@@ -6639,7 +6639,7 @@ void MoveParticles()
                     o->Light[1] = o->LifeTime / 5.f;
                     o->Light[2] = o->LifeTime / 5.f;
 
-                    o->Scale += 0.08f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
 
                     VectorAdd(o->StartPosition, o->Velocity, o->Position);
                     VectorCopy(o->Position, o->StartPosition);
@@ -6666,7 +6666,7 @@ void MoveParticles()
                 break;
                 case 7:
                 {
-                    o->Scale -= 0.02f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
                     o->Alpha -= 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                     o->Position[2] -= o->Gravity;
@@ -6676,7 +6676,7 @@ void MoveParticles()
                 break;
                 case 8:
                 {
-                    o->Scale -= 0.5f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.5f;
                     if (o->Scale < 0.2f) o->Live = false;
                 }
                 break;
@@ -6684,7 +6684,7 @@ void MoveParticles()
                 {
                     o->Velocity[0] -= 1.2f;
                     o->Velocity[2] -= 1.0f;
-                    o->Scale -= 0.08f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.08f;
                     if (o->LifeTime <= 0)
                         o->Live = false;
                     if (o->Scale < 0.2f)
@@ -6696,7 +6696,7 @@ void MoveParticles()
                     o->Light[0] /= 1.08f;
                     o->Light[1] /= 1.08f;
                     o->Light[2] /= 1.08f;
-                    o->Scale -= 0.03f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.03f;
                     o->Alpha -= 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -6707,7 +6707,7 @@ void MoveParticles()
                     o->Light[0] /= 1.05f;
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
-                    o->Scale -= 0.04f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
                     o->Alpha -= 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -6716,7 +6716,7 @@ void MoveParticles()
                 {
                     float fLight = rand() % 2;
                     Vector(fLight - 0.6f, fLight - 0.6f, fLight - 0.8f, o->Light);
-                    o->Scale -= 0.04f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
                     o->Alpha -= 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -6726,7 +6726,7 @@ void MoveParticles()
                     o->Light[0] /= 1.05f;
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     o->Alpha -= 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -6863,7 +6863,7 @@ void MoveParticles()
                     o->Light[0] /= 1.05f;
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
-                    o->Scale -= 0.02f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
                     o->Alpha -= 0.0001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -6884,7 +6884,7 @@ void MoveParticles()
                         o->Light[2] *= o->Alpha;
                     }
 
-                    o->Scale -= 0.02f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
                 }
                 break;
                 case 25:
@@ -6913,7 +6913,7 @@ void MoveParticles()
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
 
-                    o->Scale -= 0.05f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     VectorAdd(o->StartPosition, o->Velocity, o->Position);
                     VectorCopy(o->Position, o->StartPosition);
                 }
@@ -6985,7 +6985,7 @@ void MoveParticles()
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
 
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
 
                     o->LifeTime -= 1;
                     if (o->LifeTime <= 0) o->Live = false;
@@ -7055,14 +7055,14 @@ void MoveParticles()
             case BITMAP_SMOKE + 4:
                 Luminosity = (float)(o->LifeTime) / 32.f;
                 Vector(Luminosity, Luminosity, Luminosity, o->Light);
-                o->Scale += 0.08f;
+                o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
                 //o->Angle[0] += 4.f;
                 VectorAdd(o->Position, o->Velocity, o->Position);
                 VectorScale(o->Velocity, 0.9f, o->Velocity);
 
                 if (o->SubType == 6)
                 {
-                    o->Scale -= 0.05f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     o->Position[2] += 4.0f;
                 }
                 else
@@ -7091,7 +7091,7 @@ void MoveParticles()
                     o->Light[0] /= 1.05f;
                     o->Light[1] /= 1.05f;
                     o->Light[2] /= 1.05f;
-                    o->Scale -= 0.04f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
                     o->Alpha -= 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -7105,7 +7105,7 @@ void MoveParticles()
                     o->Light[2] /= 1.02f;
 
                     o->Gravity -= 1.5f;
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
 
                     VectorAdd(o->Position, o->Velocity, o->Position);
                 }
@@ -7118,7 +7118,7 @@ void MoveParticles()
                     o->Light[1] /= 1.02f;
                     o->Light[2] /= 1.02f;
 
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                 }
                 else if (o->SubType == 6)
                 {
@@ -7301,7 +7301,7 @@ void MoveParticles()
                     if (o->SubType == 5)
                     {
                         VectorCopy(o->Target->Angle, o->Angle);
-                        o->Scale -= 0.06f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * 0.06f;
                         o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                     }
                     else
@@ -7353,7 +7353,7 @@ void MoveParticles()
                 if (o->SubType == 0)
                 {
                     o->Rotation += 5.f;
-                    o->Scale -= 0.02f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
                     o->Alpha -= 0.001f;
                     if (o->Alpha <= 0.0f)
                         o->Live = false;
@@ -7365,14 +7365,14 @@ void MoveParticles()
                 }
                 else if (o->SubType == 1)
                 {
-                    o->Scale -= 0.01f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     o->Rotation -= 5.f;
                 }
 
                 break;
             case BITMAP_PIN_LIGHT:
             {
-                o->Scale -= 0.02f;
+                o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
                 o->Alpha -= 0.001f;
                 if (o->Alpha <= 0.0f)
                     o->Live = false;
@@ -7432,7 +7432,7 @@ void MoveParticles()
                 }
 
                 VectorCopy(vPos, o->Position);
-                o->Scale += fScale;
+                o->Scale += fScale * FPS_ANIMATION_FACTOR;
                 if (o->Scale >= 0.8f)
                 {
                     o->Light[0] /= fLight;
@@ -7452,9 +7452,9 @@ void MoveParticles()
 
                 o->Gravity -= 1.5f;
                 if (o->LifeTime < 10)
-                    o->Scale += 0.01f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                 else
-                    o->Scale -= 0.01f;
+                    o->Scale -= 0.01f * FPS_ANIMATION_FACTOR;
 
                 VectorAdd(o->Position, o->Velocity, o->Position);
                 break;
@@ -7475,7 +7475,7 @@ void MoveParticles()
                 break;
             case BITMAP_SWORD_FORCE:
                 o->Gravity += 0.01f;
-                o->Scale += o->Gravity;
+                o->Scale += o->Gravity * FPS_ANIMATION_FACTOR;
                 Luminosity = (float)(o->LifeTime) / 10.f;
                 Vector(Luminosity, Luminosity, Luminosity, o->Light);
                 break;
@@ -7494,7 +7494,7 @@ void MoveParticles()
                     }
                     if (o->LifeTime >= 20.f)
                     {
-                        o->Scale -= 0.02f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
                         if (o->Scale <= 0.02f)
                         {
                             o->Live = false;
@@ -7555,7 +7555,7 @@ void MoveParticles()
                     o->Position[0] += (float)(rand() % 4 - 2);
                     o->Position[1] += (float)(rand() % 4 - 2);
                     o->Position[2] += (float)(rand() % 4 - 2) * 0.8f;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Light[0] = (float)(o->LifeTime) / 50.f;
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
@@ -7650,7 +7650,7 @@ void MoveParticles()
                     o->Position[0] += (float)(rand() % 4 - 2);
                     o->Position[1] += (float)(rand() % 4 - 2);
                     o->Position[2] += (float)(rand() % 4 - 2) * 0.8f;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Light[0] = (float)(o->LifeTime) / 50.f;
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
@@ -7790,7 +7790,7 @@ void MoveParticles()
                         o->Light[1] -= 0.004f;
                         o->Light[2] -= 0.0033f;
                     }
-                    if (o->Scale > 0) o->Scale -= 0.001f;
+                    if (o->Scale > 0) o->Scale -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->TurningForce[1] > 0) o->TurningForce[1] -= 0.5f;
                     o->Position[0] = o->Target->Position[0] + o->StartPosition[0] + cosf((WorldTime + o->Rotation) * o->TurningForce[0]) * o->TurningForce[1];
                     o->Position[1] = o->Target->Position[1] + o->StartPosition[1] + sinf((WorldTime + o->Rotation) * o->TurningForce[0]) * o->TurningForce[1];
@@ -7810,7 +7810,7 @@ void MoveParticles()
                         o->Light[0] += 0.01f;
                         o->Light[1] += 0.01f;
                         o->Light[2] += 0.01f;
-                        o->Scale += 0.01f;
+                        o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     }
                     else
                     {
@@ -7879,7 +7879,7 @@ void MoveParticles()
                         o->Position[2] -= 0.5f;
                     }
 
-                    o->Scale += 0.001f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.001f;
                 }
                 else if (o->SubType == 23)
                 {
@@ -7892,7 +7892,7 @@ void MoveParticles()
                             o->Alpha += 0.2f;
                         //o->Position[2] += 0.5f;
 
-                        o->Scale += 0.003f;
+                        o->Scale += FPS_ANIMATION_FACTOR * 0.003f;
                     }
                     else
                     {
@@ -7905,7 +7905,7 @@ void MoveParticles()
                             o->Live = false;
                         o->Position[2] += 0.2f;
 
-                        //o->Scale += 0.0005f;
+                        //o->Scale += FPS_ANIMATION_FACTOR * 0.0005f;
                     }
                     o->Rotation += o->TurningForce[0] * 5.0f;;
                 }
@@ -7961,7 +7961,7 @@ void MoveParticles()
                     }
                     if (0 == o->SubType || o->SubType == 8)
                     {
-                        o->Scale -= 0.05f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     }
                     else if (o->SubType == 7)
                     {
@@ -8072,7 +8072,7 @@ void MoveParticles()
                     }
 
                     o->Gravity += (rand() % 40 + 60) / 100.f * 9.5f;
-                    o->Scale -= (rand() % 400 + 400) / 10000.f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 400 + 400) / 10000.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] /= 1.35f;
@@ -8081,7 +8081,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 9)
                 {
-                    o->Scale -= 0.011f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.011f;
                     if (!o->Live)
                         o->LifeTime = 0;
                     if (o->Scale <= 0.0f)
@@ -8114,20 +8114,20 @@ void MoveParticles()
                 else if (o->SubType == 11)
                 {
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.0005f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.0005f;
                 }
                 else if (o->SubType == 12)
                 {
                     if (o->LifeTime > 80)
-                        o->Scale += 0.02f;
+                        o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
                     else
-                        o->Scale -= 0.005f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                 }
                 else if (o->SubType == 13)
                 {
                     o->Position[1] -= o->Gravity;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.001f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.001f;
                 }
                 else if (o->SubType == 14)
                 {
@@ -8140,7 +8140,7 @@ void MoveParticles()
                     o->Position[0] = o->StartPosition[0] + sinf(o->StartPosition[2]) * o->Gravity * 2;
                     o->Position[1] = o->StartPosition[1] + cosf(o->StartPosition[2]) * o->Gravity * 2;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Scale -= 0.001f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->LifeTime > 20)
                     {
                         o->Alpha += 0.1f;
@@ -8148,7 +8148,7 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Scale -= 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                         o->Alpha -= 0.1f;
                         if (o->Alpha > 1.0f) o->Alpha = 1.0f;
                     }
@@ -8161,7 +8161,7 @@ void MoveParticles()
                 if (o->SubType == 0 && o->SubType == 1)
                 {
                     o->Gravity += 0.004f;
-                    o->Scale -= 0.02f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
 
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -8177,7 +8177,7 @@ void MoveParticles()
                 {
                     VectorCopy(o->Target->Angle, o->Angle);
 
-                    o->Scale -= 0.06f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.06f;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                     o->Light[0] = o->LifeTime / 10.f;
                     o->Light[1] = o->Light[0];
@@ -8204,7 +8204,7 @@ void MoveParticles()
                     Vector(o->TurningForce[0] * Luminosity, o->TurningForce[1] * Luminosity, o->TurningForce[2] * Luminosity, o->Light);
                     if (o->Scale > 0)
                     {
-                        o->Scale -= (rand() % 3 + 5) * 0.01f;
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 3 + 5) * 0.01f;
                     }
                     else
                     {
@@ -8224,24 +8224,24 @@ void MoveParticles()
                 if (o->SubType == 0)
                 {
                     o->Velocity[2] += 0.3f;
-                    o->Scale += 0.07f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.07f;
                 }
                 else if (o->SubType == 2)
                 {
                     o->Velocity[2] += 0.3f;
-                    o->Scale += 0.07f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.07f;
                 }
                 else if (o->SubType == 3)
                 {
                     o->Velocity[1] += 0.1f;
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Alpha -= 0.2f;
                 }
 
                 else
                 {
                     o->Velocity[2] += 0.3f;
-                    o->Scale += 0.09f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                 }
                 break;
             case BITMAP_ADV_SMOKE + 1:
@@ -8252,7 +8252,7 @@ void MoveParticles()
                 o->Position[0] += (float)(rand() % 4 - 2);
                 o->Position[1] += (float)(rand() % 4 - 2);
                 o->Position[2] += (float)(rand() % 4 - 2) * 0.8f;
-                o->Scale += 0.05f;
+                o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                 if (o->SubType == 2)
                 {
                     o->Light[0] = (float)(o->LifeTime) / 25.f * 2 - 1.f;
@@ -8289,7 +8289,7 @@ void MoveParticles()
                         VectorSubtract(o->Position, TargetPosition, Direction);
 
                         float length = VectorLength(Direction);
-                        o->Scale -= (length * 0.003f);
+                        o->Scale -=  FPS_ANIMATION_FACTOR * (length * 0.003f);
                         o->Light[0] -= (length * 0.08f);
                         o->Light[1] -= (length * 0.08f);
                         o->Light[2] -= (length * 0.08f);
@@ -8313,11 +8313,11 @@ void MoveParticles()
 
                 if (o->SubType == 7)
                 {
-                    o->Scale -= 0.1f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.1f;
                     o->Position[2] += 2.0f;
                 }
                 else
-                    o->Scale -= 0.02f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
 
                 if (o->Scale < 0)
                     o->Scale = 0.f;
@@ -8339,7 +8339,7 @@ void MoveParticles()
                 o->Rotation += 5.f;
                 if (o->LifeTime < 20)
                 {
-                    o->Scale -= 0.08f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.08f;
                     if (o->LifeTime < 10)
                     {
                         o->Light[0] /= 1.3f;
@@ -8355,7 +8355,7 @@ void MoveParticles()
                 }
                 break;
             case BITMAP_WATERFALL_1:
-                o->Scale -= 0.005f;
+                o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                 if (o->LifeTime < 5)
                 {
                     o->Light[0] /= 1.2f;
@@ -8377,7 +8377,7 @@ void MoveParticles()
                         Vector(0.5f, 0.5f, 0.5f, o->Light);
                     }
                     o->Rotation++;
-                    o->Scale += 0.01f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Velocity[2] -= 0.4f;
                 }
                 break;
@@ -8385,26 +8385,26 @@ void MoveParticles()
             case BITMAP_WATERFALL_5:
                 if (o->SubType == 0)
                 {
-                    o->Scale -= 0.005f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                     o->Velocity[2] += 0.1f;
                 }
                 else if (o->SubType == 1)
                 {
-                    o->Scale += 0.1f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                     o->Position[0] += rand() % 10 - 5.f;
                     o->Position[1] += rand() % 10 - 5.f;
                 }
                 else if (o->SubType == 2)
                 {
                     if (o->Scale < 1.0f)
-                        o->Scale += 0.1f;
+                        o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
                     o->Position[0] += rand() % 10 - 5.f;
                     o->Position[1] += rand() % 10 - 5.f;
                     o->Velocity[2] -= 1.0f;
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Scale -= 0.005f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                     o->Rotation += 4.f;
                     o->Velocity[2] += 0.1f;
                 }
@@ -8417,12 +8417,12 @@ void MoveParticles()
                 }
                 else if (o->SubType == 5)
                 {
-                    o->Scale -= 0.005f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                     o->Velocity[2] += 0.1f;
                 }
                 else if (o->SubType == 7)
                 {
-                    o->Scale -= 0.005f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                     o->Rotation += 1;
                     o->Position[0] += o->Velocity[0];
                     o->Position[1] += o->Velocity[1];
@@ -8434,7 +8434,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 8)
                 {
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= 0.6f;
 
                     o->Light[0] /= 1.1f;
@@ -8444,7 +8444,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 9)
                 {
-                    o->Scale -= 0.005f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                     o->Velocity[2] += 0.1f;
                 }
 
@@ -8463,7 +8463,7 @@ void MoveParticles()
                 break;
 
             case BITMAP_PLUS:
-                o->Scale -= 0.01f;
+                o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                 o->Position[0] += rand() % 2 - 1;
                 o->Position[1] += rand() % 2 - 1;
                 o->Position[2] += 2.f;
@@ -8476,7 +8476,7 @@ void MoveParticles()
             case BITMAP_WATERFALL_2:
                 if (o->SubType == 5)
                 {
-                    o->Scale += 0.03f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                     o->Velocity[2] += 0.1f;
 
                     o->Position[0] += o->Velocity[0];
@@ -8489,7 +8489,7 @@ void MoveParticles()
                     break;
                 }
 
-                o->Scale += 0.03f;
+                o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
                 o->Velocity[0] = (rand() % 20 - 10) * 0.1f;
                 o->Velocity[1] = (rand() % 20 - 10) * 0.1f;
                 o->Velocity[2] += 0.1f;
@@ -8508,7 +8508,7 @@ void MoveParticles()
                 }
                 if (o->SubType == 3)
                 {
-                    o->Scale -= 0.038f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.038f;
                     o->Velocity[2] -= 0.02f;
                     o->Light[0] /= 1.02f;
                     o->Light[1] /= 1.02f;
@@ -8529,7 +8529,7 @@ void MoveParticles()
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(o->Velocity, Matrix, TargetPosition);
                     VectorAdd(o->StartPosition, TargetPosition, o->Position);
-                    o->Scale += (1.0 / o->LifeTime) * 2.0f;
+                    o->Scale += (1.0 / o->LifeTime) * 2.0f * FPS_ANIMATION_FACTOR;
 
                     o->Light[0] *= 0.8f;
                     o->Light[1] *= 0.77f;
@@ -8556,7 +8556,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Scale += 0.005f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                     o->Velocity[2] -= 0.05f;
                     o->Light[0] *= 0.97f;
                     o->Light[1] *= 0.97f;
@@ -8594,7 +8594,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 8)
                 {
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= 0.6f;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8615,7 +8615,7 @@ void MoveParticles()
                 else if (o->SubType == 11)
                 {
                     VectorAdd(o->Position, o->Velocity, o->Position);
-                    o->Scale += 0.01f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -8633,7 +8633,7 @@ void MoveParticles()
                 else if (o->SubType == 13)
                 {
                     o->Position[2] -= o->Gravity;
-                    o->Scale += 0.001f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.001f;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
                     o->Light[2] /= 1.1f;
@@ -8642,7 +8642,7 @@ void MoveParticles()
                 }
                 else if (o->SubType == 14)
                 {
-                    o->Scale += 0.05f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= 0.6f;
                     o->Light[0] /= 1.1f;
                     o->Light[1] /= 1.1f;
@@ -8652,7 +8652,7 @@ void MoveParticles()
                 {
                     o->Position[2] -= o->Gravity;
                     o->Gravity -= 0.05f;
-                    o->Scale -= 0.05f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     //o->Velocity[2] -= 0.05f;
 
                     o->Light[0] /= 1.1f;
@@ -8663,7 +8663,7 @@ void MoveParticles()
 #ifdef ASG_ADD_MAP_KARUTAN
                 else if (o->SubType == 16)
                 {
-                    o->Scale -= 0.005f;
+                    o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                     o->Velocity[2] -= 0.1f;
                     if (o->LifeTime < 8)
                     {
@@ -8680,7 +8680,7 @@ void MoveParticles()
                     break;
                 }
 #endif	// ASG_ADD_MAP_KARUTAN
-                o->Scale += 0.005f;
+                o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                 o->Velocity[2] -= 2.5f;
                 o->Light[0] /= 1.1f;
                 o->Light[1] /= 1.1f;
@@ -8694,14 +8694,14 @@ void MoveParticles()
                     o->Light[0] /= 1.8f;
                     o->Light[1] /= 1.8f;
                     o->Light[2] /= 1.8f;
-                    o->Scale += 0.3f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.3f;
                 }
                 else if (o->SubType == 0)
                 {
                     o->Light[0] /= 1.5f;
                     o->Light[1] /= 1.5f;
                     o->Light[2] /= 1.5f;
-                    o->Scale += 0.8f;
+                    o->Scale += FPS_ANIMATION_FACTOR * 0.8f;
                 }
                 if (o->SubType == 4)
                 {
@@ -8710,7 +8710,7 @@ void MoveParticles()
                     o->Light[0] /= 1.01f;
                     o->Light[1] /= 1.03f;
                     o->Light[2] /= 1.03f;
-                    o->Scale += (o->Gravity * 0.015f);
+                    o->Scale += (o->Gravity * 0.015f) * FPS_ANIMATION_FACTOR;
                     o->Gravity += 2.4f;
                 }
             }
@@ -8721,7 +8721,7 @@ void MoveParticles()
                 o->Light[1] /= 1.1f;
                 o->Light[2] /= 1.1f;
 
-                o->Scale += 0.02f;
+                o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
 
                 if (o->SubType == 0)
                 {
@@ -8784,7 +8784,7 @@ void MoveParticles()
             break;
             case BITMAP_CHROME2:
             {
-                if (o->Scale > 0) o->Scale -= 0.1f;
+                if (o->Scale > 0) o->Scale -= FPS_ANIMATION_FACTOR * 0.1f;
                 else o->Scale = 0;
 
                 o->Rotation += 1.0f;

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -1484,7 +1484,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->LifeTime = rand() % 50 + 100;
                     o->Rotation = (float)(rand() % 360);
                     o->Scale = Scale * 0.4f;
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                         o->Angle[0] = 1.0f;
                     else
                         o->Angle[0] = -1.0f;
@@ -2148,7 +2148,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     VectorRotate(p, Matrix, o->Velocity);
                     break;
                 case 6:
-                    if (rand() % 50 == 0)
+                    if (rand_fps_check(50))
                     {
                         o->LifeTime = 50;
                         o->Gravity = 1.0f + (float)(rand() % 20) / 5.f;
@@ -2218,7 +2218,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     o->Scale += -(float)(rand() % 15) / 10.0f * FPS_ANIMATION_FACTOR;
                     break;
                 case 14:
-                    if (rand() % 2 == 0)
+                    if (rand_fps_check(2))
                     {
                         o->Alpha = 1.0f;
                         o->Velocity[0] = -4.0f + (float)(rand() % 4);
@@ -2229,7 +2229,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                     }
                     break;
                 case 15:
-                    if (rand() % 3 == 0)
+                    if (rand_fps_check(3))
                     {
                         o->Alpha = 1.0f;
                         o->LifeTime = 35;
@@ -3105,7 +3105,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
 
                         o->Scale = 0;//(((float)(rand()%20+20)*0.001f) * o->Scale);
                         Vector(0.f, 0.f, 0.f, o->TurningForce);
-                        o->TurningForce[0] = (rand() % 2 == 0 ? 1.0f : -1.0f);
+                        o->TurningForce[0] = (rand_fps_check(2) ? 1.0f : -1.0f);
 
                         float fAngle = o->Angle[2] + 90 + (rand() % 40) - 20;
                         vec3_t vAngle, vDirection;
@@ -3478,7 +3478,7 @@ int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int Su
                 }
                 else if (o->SubType == 7)
                 {
-                    o->TexType = rand() % 2 == 0 ? BITMAP_WATERFALL_4 : BITMAP_WATERFALL_5;
+                    o->TexType = rand_fps_check(2) ? BITMAP_WATERFALL_4 : BITMAP_WATERFALL_5;
                     o->LifeTime = 30;
                     o->Rotation = (float)(rand() % 360);
                     o->Scale = (float)(rand() % 50) * 0.05f + Scale;
@@ -3900,30 +3900,30 @@ void MoveParticles()
                 {
                     if (o->SubType == 2)
                     {
-                        o->Light[0] /= 1.03f;
-                        o->Light[1] /= 1.03f;
-                        o->Light[2] /= 1.03f;
+                        o->Light[0] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] *= 1.16f;
-                        o->Light[1] *= 1.16f;
-                        o->Light[2] *= 1.16f;
+                        o->Light[0] *= pow(1.16f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.16f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.16f, FPS_ANIMATION_FACTOR);
                     }
                 }
                 else
                 {
                     if (o->SubType == 2)
                     {
-                        o->Light[0] /= 1.03f;
-                        o->Light[1] /= 1.03f;
-                        o->Light[2] /= 1.03f;
+                        o->Light[0] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] /= 1.16f;
-                        o->Light[1] /= 1.16f;
-                        o->Light[2] /= 1.16f;
+                        o->Light[0] *= pow(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.16f), FPS_ANIMATION_FACTOR);
                     }
                 }
                 o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
@@ -3974,8 +3974,8 @@ void MoveParticles()
                 else if (o->SubType == 1)
                 {
                     o->Light[0] *= 0.99f + (0.01f * 1 - FPS_ANIMATION_FACTOR);
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     o->Scale += 1.5f * FPS_ANIMATION_FACTOR;
                 }
                 break;
@@ -4039,8 +4039,8 @@ void MoveParticles()
                     }
                     if (o->LifeTime < 20)
                     {
-                        o->TurningForce[0] *= 0.6f;
-                        o->TurningForce[1] *= 0.6f;
+                        o->TurningForce[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
                     }
                     Vector(o->Alpha * 1.0f, o->Alpha * 0.0f, o->Alpha * 0.6f, o->Light);
 
@@ -4071,8 +4071,8 @@ void MoveParticles()
                     }
                     if (o->LifeTime < 20)
                     {
-                        o->TurningForce[0] *= 0.6f;
-                        o->TurningForce[1] *= 0.6f;
+                        o->TurningForce[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
                     }
                     Vector(o->Alpha * 1.0f, o->Alpha * 1.0f, o->Alpha * 1.0f, o->Light);
 
@@ -4104,8 +4104,8 @@ void MoveParticles()
                     }
                     if (o->LifeTime < 20)
                     {
-                        o->TurningForce[0] *= 0.6f;
-                        o->TurningForce[1] *= 0.6f;
+                        o->TurningForce[0] *= pow(0.6f, FPS_ANIMATION_FACTOR);
+                        o->TurningForce[1] *= pow(0.6f, FPS_ANIMATION_FACTOR);
                     }
                     Vector(o->Alpha * o->Light[0], o->Alpha * o->Light[1], o->Alpha * o->Light[2], o->Light);
 
@@ -4145,9 +4145,9 @@ void MoveParticles()
             break;
             case BITMAP_MAGIC + 1:
             {
-                o->Light[0] *= 0.9f;
-                o->Light[1] *= 0.9f;
-                o->Light[2] *= 0.9f;
+                o->Light[0] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(0.9f, FPS_ANIMATION_FACTOR);
                 o->Scale += FPS_ANIMATION_FACTOR * 0.1f;
             }
             break;
@@ -4216,10 +4216,12 @@ void MoveParticles()
                         Life = 1;
                     o->Frame = (20 - Life) / 2;
                     vec3_t  p, Angle;
-                    if (o->LifeTime == 20)
+                    if ((int)o->LifeTime == 20)
                     {
+                        o->LifeTime = 19.9f;
                         for (int j = 0; j < 18; j++)
                         {
+                            if (!rand_fps_check(1)) continue;
                             Vector(0.f, 200.f, 0.f, p);
                             Vector(0.f, 0.f, j * 20.f, Angle);
                             AngleMatrix(Angle, Matrix);
@@ -4235,8 +4237,9 @@ void MoveParticles()
                         }
                     }
                     else
-                        if (o->LifeTime == 10)
+                        if ((int)o->LifeTime == 10)
                         {
+                            o->LifeTime = 9.9f;
                             for (int j = 0; j < 18; j++)
                             {
                                 Vector(0.f, 400.f, 0.f, p);
@@ -4252,8 +4255,9 @@ void MoveParticles()
                             }
                         }
                         else
-                            if (o->LifeTime == 1)
+                            if ((int)o->LifeTime == 1)
                             {
+                                o->LifeTime = 0.99f;
                                 for (int j = 0; j < 18; j++)
                                 {
                                     Vector(0.f, 600.f, 0.f, p);
@@ -4578,7 +4582,7 @@ void MoveParticles()
                 {
                     o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale *= 0.95f;
+                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Rotation += (5) * FPS_ANIMATION_FACTOR;
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
@@ -4614,7 +4618,7 @@ void MoveParticles()
                 {
                     o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
-                    o->Scale *= 0.95f;
+                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Frame = (23 - o->LifeTime) / 6;
                     o->Position[2] += o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 }
@@ -4647,9 +4651,9 @@ void MoveParticles()
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.03f;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     if (o->Light[2] <= 0.05f || o->Scale <= 0.0f)
                         o->Live = false;
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -4661,9 +4665,9 @@ void MoveParticles()
                     o->Gravity += (0.004f) * FPS_ANIMATION_FACTOR;
                     Luminosity = (float)(o->LifeTime) / 24.f;
                     o->Scale -= 0.04f * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     if (o->Light[2] <= 0.05f || o->Scale <= 0.0f)
                         o->Live = false;
                     o->Frame = (23 - o->LifeTime) / 6;
@@ -4673,10 +4677,10 @@ void MoveParticles()
                 case 16:
                 {
                     o->Frame = (3 - o->LifeTime);
-                    o->Light[0] /= 1.7f;
-                    o->Light[1] /= 1.7f;
-                    o->Light[2] /= 1.7f;
-                    o->Scale *= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.7f), FPS_ANIMATION_FACTOR);
+                    o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
                 }break;
                 case 18:
                 {
@@ -4764,9 +4768,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.13f;
                     o->Rotation += o->Gravity * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.13f;
-                    o->Light[1] /= 1.13f;
-                    o->Light[2] /= 1.13f;
+                    o->Light[0] *= pow(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.13f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 0)
                 {
@@ -4779,7 +4783,11 @@ void MoveParticles()
                 }
                 break;
             case BITMAP_FLAME:
-                if (o->LifeTime <= 0) o->Live = false;
+                if (o->LifeTime <= 0)
+                {
+                    o->Live = false;
+                    break;
+                }
 
                 switch (o->SubType)
                 {
@@ -4798,7 +4806,7 @@ void MoveParticles()
                     if (o->LifeTime == 10)
                     {
                         o->Velocity[1] += (32 * 0.2f) * FPS_ANIMATION_FACTOR;
-                        o->Scale *= 0.8f;
+                        o->Scale *= pow(0.8f, FPS_ANIMATION_FACTOR);
                     }
                     o->Rotation = (float)(rand() % 360);
                     o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
@@ -4808,9 +4816,9 @@ void MoveParticles()
                 case 2:
                     if (o->LifeTime < 10)
                     {
-                        //                        o->Light[0] /= (15-o->LifeTime);
-                        //                        o->Light[1] /= (15-o->LifeTime);
-                        //                        o->Light[2] /= (15-o->LifeTime);
+                        //                        o->Light[0] *= pow(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
+                        //                        o->Light[1] *= pow(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
+                        //                        o->Light[2] *= pow(1.0f / ((15-o->LifeTime)), FPS_ANIMATION_FACTOR);
                     }
                     o->Rotation = (float)(rand() % 360);
                     o->Light[0] -= (0.05f) * FPS_ANIMATION_FACTOR;
@@ -4845,9 +4853,9 @@ void MoveParticles()
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
-                    o->Light[0] /= 1.007f;
-                    o->Light[1] /= 1.007f;
-                    o->Light[2] /= 1.007f;
+                    o->Light[0] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 7:
@@ -4862,9 +4870,9 @@ void MoveParticles()
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
-                    o->Light[0] /= 1.007f;
-                    o->Light[1] /= 1.007f;
-                    o->Light[2] /= 1.007f;
+                    o->Light[0] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.007f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 9:
@@ -4879,15 +4887,15 @@ void MoveParticles()
                     if (o->Scale <= 0.0f)
                         o->Live = false;
 
-                    o->Light[0] /= 1.008f;
-                    o->Light[1] /= 1.008f;
-                    o->Light[2] /= 1.008f;
+                    o->Light[0] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 10:
                     VectorAdd(o->Position, o->Velocity, o->Position);
-                    o->Velocity[0] *= 0.95f;
-                    o->Velocity[1] *= 0.95f;
+                    o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Light[0] = (float)(o->LifeTime) / 10.f;
                     o->Light[1] = o->Light[0];
                     o->Light[2] = o->Light[0];
@@ -4895,9 +4903,9 @@ void MoveParticles()
                     o->Scale += FPS_ANIMATION_FACTOR * 0.07f;
                     break;
                 case 11:
-                    o->Light[0] /= 1.008f;
-                    o->Light[1] /= 1.008f;
-                    o->Light[2] /= 1.008f;
+                    o->Light[0] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.008f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 break;
@@ -4972,9 +4980,9 @@ void MoveParticles()
                         o->Position[2] += (80.f) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Light[0] /= 1.01f;
-                    o->Light[1] /= 1.01f;
-                    o->Light[2] /= 1.01f;
+                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 7)
                 {
@@ -5040,22 +5048,22 @@ void MoveParticles()
 
                     if (o->LifeTime <= 30)
                     {
-                        o->Light[0] /= 1.1f;
-                        o->Light[1] /= 1.1f;
-                        o->Light[2] /= 1.1f;
+                        o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->LifeTime <= 20)
                 {
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 11)
                 {
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     o->Scale += 1.5f * FPS_ANIMATION_FACTOR;
                 }
                 else
@@ -5072,9 +5080,9 @@ void MoveParticles()
                         o->Scale -= 0.002f * FPS_ANIMATION_FACTOR;
                         if (o->LifeTime <= 35)
                         {
-                            o->Light[0] /= 1.1f;
-                            o->Light[1] /= 1.1f;
-                            o->Light[2] /= 1.1f;
+                            o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                            o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                            o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                         }
                     }
                 if (o->SubType == 0)
@@ -5109,9 +5117,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.5f;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -5120,9 +5128,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -5131,9 +5139,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -5202,12 +5210,12 @@ void MoveParticles()
                 }
                 else if (o->SubType == 9)
                 {
-                    o->Scale *= 0.98f + ((float)(rand() % 20 - 10) * 0.002f);
+                    o->Scale *= pow(0.98f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
 
-                    o->Light[0] *= 0.95f + ((float)(rand() % 20 - 10) * 0.002f);
-                    o->Light[1] *= 0.95f + ((float)(rand() % 20 - 10) * 0.002f);
-                    o->Light[2] *= 0.95f + ((float)(rand() % 20 - 10) * 0.002f);
-                    o->Alpha *= 0.95f + ((float)(rand() % 20 - 10) * 0.002f);
+                    o->Light[0] *= pow(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
+                    o->Alpha *= pow(0.95f + ((float)(rand() % 20 - 10) * 0.002f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 10)
                 {
@@ -5263,9 +5271,9 @@ void MoveParticles()
 
                 o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
-                o->Light[0] /= 1.02f;
-                o->Light[1] /= 1.02f;
-                o->Light[2] /= 1.02f;
+                o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
             }
             break;
             case BITMAP_SMOKE:
@@ -5295,15 +5303,15 @@ void MoveParticles()
                     o->Position[1] -= (o->TurningForce[1] * 0.8f) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
                     o->Rotation += (0.01f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.03f;
-                    o->Light[1] /= 1.03f;
-                    o->Light[2] /= 1.03f;
+                    o->Light[0] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     break;
                 case 38:
                     o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
-                    o->Light[0] /= 1.04f;
-                    o->Light[1] /= 1.04f;
-                    o->Light[2] /= 1.04f;
+                    o->Light[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
                     break;
                 case 33:
                     Luminosity = (float)(o->LifeTime) / 8.f;
@@ -5510,15 +5518,15 @@ void MoveParticles()
                     o->Scale += FPS_ANIMATION_FACTOR * 0.09f;
                     break;
                 case 35:
-                    o->Light[0] /= 1.04f;
-                    o->Light[1] /= 1.04f;
-                    o->Light[2] /= 1.04f;
+                    o->Light[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
                     break;
                 case 34:
-                    o->Light[0] /= 1.04f;
-                    o->Light[1] /= 1.04f;
-                    o->Light[2] /= 1.04f;
+                    o->Light[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
                     break;
                 case 26:
@@ -5533,13 +5541,13 @@ void MoveParticles()
                 case 28:
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime >= 9) o->Scale -= FPS_ANIMATION_FACTOR* 0.4f;
-                    else o->Scale *= 1.2f;
+                    else o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
                     Vector(o->Light[0] * 0.92f, o->Light[1] * 0.92f, o->Light[2] * 0.92f, o->Light);
                     break;
                 case 29:
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime >= 9) o->Scale -= FPS_ANIMATION_FACTOR * 0.4f;
-                    else o->Scale *= 1.2f;
+                    else o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
                     Vector(1.0f, 1.0f, 1.0f, o->Light);
                     break;
                 case 30:
@@ -5549,9 +5557,9 @@ void MoveParticles()
                     break;
                 case 31:
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     if (o->Scale <= 0.0f && o->Light[2] <= 0.0f)
                         o->Live = false;
                     break;
@@ -5583,9 +5591,9 @@ void MoveParticles()
                     break;
                 case 43:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.08f;
                 }
                 break;
@@ -5593,15 +5601,15 @@ void MoveParticles()
                 {
                     if (o->LifeTime >= 30)
                     {
-                        o->Light[0] *= 1.07f;
-                        o->Light[1] *= 1.07f;
-                        o->Light[2] *= 1.07f;
+                        o->Light[0] *= pow(1.07f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.07f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.07f, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] /= 1.07f;
-                        o->Light[1] /= 1.07f;
-                        o->Light[2] /= 1.07f;
+                        o->Light[0] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
                     }
                     o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
                     o->Position[2] += (0.8f) * FPS_ANIMATION_FACTOR;
@@ -5610,16 +5618,16 @@ void MoveParticles()
                 break;
                 case 45:
                 {
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 46:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
@@ -5631,9 +5639,9 @@ void MoveParticles()
                 break;
                 case 47:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
@@ -5655,15 +5663,15 @@ void MoveParticles()
                 {
                     if (o->LifeTime < 100)
                     {
-                        o->Light[0] *= 0.97f;
-                        o->Light[1] *= 0.97f;
-                        o->Light[2] *= 0.97f;
+                        o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] *= 1.03f;
-                        o->Light[1] *= 1.03f;
-                        o->Light[2] *= 1.03f;
+                        o->Light[0] *= pow(1.03f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.03f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.03f, FPS_ANIMATION_FACTOR);
                     }
 
                     if (o->Light[0] <= 0.01f)
@@ -5706,9 +5714,9 @@ void MoveParticles()
                 {
                     VectorAdd(o->Position, o->Velocity, o->Position);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.06f;
-                    o->Light[0] /= 1.07f;
-                    o->Light[1] /= 1.07f;
-                    o->Light[2] /= 1.07f;
+                    o->Light[0] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.07f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 53:
@@ -5719,9 +5727,9 @@ void MoveParticles()
                     break;
                 case 54:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
@@ -5737,9 +5745,9 @@ void MoveParticles()
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
 
-                    o->Light[0] /= 1.08f;
-                    o->Light[1] /= 1.08f;
-                    o->Light[2] /= 1.08f;
+                    o->Light[0] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 56:
@@ -5791,9 +5799,9 @@ void MoveParticles()
                 break;
                 case 63:
                 {
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.5f;
                     o->Velocity[1] += (1.5f) * FPS_ANIMATION_FACTOR;
                 }
@@ -5830,9 +5838,9 @@ void MoveParticles()
                 break;
                 case 66:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->LifeTime = 0;
@@ -5851,9 +5859,9 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Light[0] *= o->Alpha;
-                    o->Light[1] *= o->Alpha;
-                    o->Light[2] *= o->Alpha;
+                    o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
 
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Rotation += (0.01f) * FPS_ANIMATION_FACTOR;
@@ -5933,9 +5941,9 @@ void MoveParticles()
                 case 3:
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
-                    o->Light[0] /= 1.012f;
-                    o->Light[1] /= 1.012f;
-                    o->Light[2] /= 1.012f;
+                    o->Light[0] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Rotation += (o->Gravity / 2.0f) * FPS_ANIMATION_FACTOR;
 
@@ -5946,9 +5954,9 @@ void MoveParticles()
                 case 4:
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
-                    o->Light[0] /= 1.012f;
-                    o->Light[1] /= 1.012f;
-                    o->Light[2] /= 1.012f;
+                    o->Light[0] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.012f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
                     o->Rotation += (o->Gravity / 2.0f) * FPS_ANIMATION_FACTOR;
 
@@ -6061,9 +6069,9 @@ void MoveParticles()
                     {
                         o->Live = false;
                     }
-                    o->Light[0] *= o->Alpha;
-                    o->Light[1] *= o->Alpha;
-                    o->Light[2] *= o->Alpha;
+                    o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
                 }
                 break;
             case BITMAP_LIGHTNING_MEGA1:
@@ -6518,21 +6526,21 @@ void MoveParticles()
             case BITMAP_LIGHT + 1:
                 if (o->SubType == 2)
                 {
-                    o->Scale *= 0.92f;
+                    o->Scale *= pow(0.92f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Scale *= 1.3f;
-                    o->Light[0] *= 0.9f;
-                    o->Light[1] *= 0.9f;
-                    o->Light[2] *= 0.9f;
+                    o->Scale *= pow(1.3f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(0.9f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 5)
                 {
                     o->LifeTime = 5;
-                    o->Light[0] *= 0.7f;
-                    o->Light[1] *= 0.7f;
-                    o->Light[2] *= 0.7f;
+                    o->Light[0] *= pow(0.7f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(0.7f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(0.7f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 4)
                 {
@@ -6542,7 +6550,7 @@ void MoveParticles()
                     o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Position[1] -= (1.f) * FPS_ANIMATION_FACTOR;
                     o->Gravity += (1.f) * FPS_ANIMATION_FACTOR;
-                    o->Scale *= 0.95f;
+                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 }
                 break;
             case BITMAP_BLOOD:
@@ -6578,9 +6586,9 @@ void MoveParticles()
                 }
                 else if (o->SubType == 8 || o->SubType == 10)
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                 }
                 if (o->SubType == 7)
                     o->Gravity -= (0.6f) * FPS_ANIMATION_FACTOR;
@@ -6629,7 +6637,7 @@ void MoveParticles()
                     VectorCopy(o->Position, o->StartPosition);
                     break;
                 case 3:
-                    o->Scale *= 0.8f;
+                    o->Scale *= pow(0.8f, FPS_ANIMATION_FACTOR);
                     break;
                 case 4:
                     if (o->LifeTime <= 0) o->Live = false;
@@ -6649,10 +6657,10 @@ void MoveParticles()
                     VectorAdd(o->Position, p, o->Position);
                     break;
                 case 5:
-                    o->Scale *= 0.9f;
-                    o->Light[0] /= 1.03f;
-                    o->Light[1] /= 1.03f;
-                    o->Light[2] /= 1.03f;
+                    o->Scale *= pow(0.9f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     break;
                 case 6:
                 {
@@ -6693,9 +6701,9 @@ void MoveParticles()
                 break;
                 case 10:
                 {
-                    o->Light[0] /= 1.08f;
-                    o->Light[1] /= 1.08f;
-                    o->Light[2] /= 1.08f;
+                    o->Light[0] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.08f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.03f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6704,9 +6712,9 @@ void MoveParticles()
                 case 13:
                 case 11:
                 {
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6723,9 +6731,9 @@ void MoveParticles()
                 break;
                 case 14:
                 {
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6733,9 +6741,9 @@ void MoveParticles()
                 break;
                 case 15:
                 {
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
                 }
@@ -6750,12 +6758,12 @@ void MoveParticles()
 
                     if (o->Frame == 77)
                     {
-                        o->Gravity *= 1.03f;
+                        o->Gravity *= pow(1.03f, FPS_ANIMATION_FACTOR);
                         o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     }
                     else if (o->Frame == 88)
                     {
-                        o->Gravity /= 1.2f;
+                        o->Gravity *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                         if (o->Gravity <= 0.1f)
                         {
                             o->Gravity = 0.1f;
@@ -6765,7 +6773,7 @@ void MoveParticles()
                     }
                     else if (o->Frame == 99)
                     {
-                        o->Gravity *= 1.2f;
+                        o->Gravity *= pow(1.2f, FPS_ANIMATION_FACTOR);
                         o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     }
 
@@ -6778,9 +6786,9 @@ void MoveParticles()
                 {
                     if (o->Position[2] >= o->StartPosition[2] + 350.0f)
                     {
-                        o->Light[0] /= 1.05f;
-                        o->Light[1] /= 1.05f;
-                        o->Light[2] /= 1.05f;
+                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     }
 
                     if (o->Light[0] <= 0.05f)
@@ -6799,16 +6807,16 @@ void MoveParticles()
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Gravity += (0.1f) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 20:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -6827,16 +6835,16 @@ void MoveParticles()
                 break;
                 case 21:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 22:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.05f)
                         o->Live = false;
@@ -6860,9 +6868,9 @@ void MoveParticles()
                         VectorScale(o->Velocity, -1, o->Velocity);
                         o->Rotation = 1;
                     }
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.0001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6879,9 +6887,9 @@ void MoveParticles()
                     if (o->LifeTime <= 10)
                     {
                         o->Alpha -= FPS_ANIMATION_FACTOR * 0.05f;
-                        o->Light[0] *= o->Alpha;
-                        o->Light[1] *= o->Alpha;
-                        o->Light[2] *= o->Alpha;
+                        o->Light[0] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(o->Alpha, FPS_ANIMATION_FACTOR);
                     }
 
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.02f;
@@ -6896,9 +6904,9 @@ void MoveParticles()
                         o->Velocity[2] -= (1.f) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale = sinf(o->LifeTime * (Q_PI / 40.f));
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -6909,9 +6917,9 @@ void MoveParticles()
                     if (o->LifeTime <= 0)
                         o->Live = false;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     VectorAdd(o->StartPosition, o->Velocity, o->Position);
@@ -6920,20 +6928,20 @@ void MoveParticles()
                 break;
                 case 27:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
-                    o->Scale /= 1.03f;
+                    o->Scale *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                 }
                 break;
                 case 28:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
-                    o->Scale /= 1.01f;
+                    o->Scale *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.03f)
                         o->Live = false;
@@ -6952,11 +6960,11 @@ void MoveParticles()
                 break;
                 case 29:
                 {
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
-                    o->Scale /= 1.01f;
+                    o->Scale *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] <= 0.03f)
                         o->Live = false;
@@ -6981,9 +6989,9 @@ void MoveParticles()
                         o->Velocity[1] += (cosf(Q_PI / 180.0f * float(rand() % 360))) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
 
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
 
@@ -7080,17 +7088,17 @@ void MoveParticles()
                     o->Velocity[2] -= ((float)(rand() % 8) * 0.05f) * FPS_ANIMATION_FACTOR;
                     VectorAdd(o->Position, o->Velocity, o->Position);
 
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
 
                     CreateSprite(BITMAP_LIGHT, o->Position, o->Scale / 1.5f, o->Light, NULL);
                 }
                 else if (o->SubType == 3)
                 {
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.04f;
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
@@ -7100,9 +7108,9 @@ void MoveParticles()
                     o->Rotation += (20.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
@@ -7114,25 +7122,25 @@ void MoveParticles()
                     o->Rotation += (10.f) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.01f;
                 }
                 else if (o->SubType == 6)
                 {
-                    o->Light[0] /= 1.01f;
-                    o->Light[1] /= 1.01f;
-                    o->Light[2] /= 1.01f;
+                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] < 0.2f)
                     {
                         o->Live = false;
                     }
 
-                    o->StartPosition[0] /= 1.01f;
-                    if (o->LifeTime < 60 && rand() % 2 == 0)
+                    o->StartPosition[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    if (o->LifeTime < 60 && rand_fps_check(2))
                     {
                         o->Scale = 0;
                     }
@@ -7143,9 +7151,9 @@ void MoveParticles()
 
                     if (o->LifeTime < 60)
                     {
-                        o->Velocity[0] /= 1.04f;
-                        o->Velocity[1] /= 1.04f;
-                        o->Velocity[2] /= 1.04f;
+                        o->Velocity[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
 
                         o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
                         o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
@@ -7157,17 +7165,17 @@ void MoveParticles()
                 }
                 else if (o->SubType == 8)
                 {
-                    o->Light[0] /= 1.01f;
-                    o->Light[1] /= 1.01f;
-                    o->Light[2] /= 1.01f;
+                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] < 0.2f)
                     {
                         o->Live = false;
                     }
 
-                    o->StartPosition[0] /= 1.01f;
-                    if (o->LifeTime < 60 && rand() % 2 == 0)
+                    o->StartPosition[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    if (o->LifeTime < 60 && rand_fps_check(2))
                     {
                         o->Scale = 0;
                     }
@@ -7178,9 +7186,9 @@ void MoveParticles()
 
                     if (o->LifeTime < 60)
                     {
-                        o->Velocity[0] /= 1.04f;
-                        o->Velocity[1] /= 1.04f;
-                        o->Velocity[2] /= 1.04f;
+                        o->Velocity[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
 
                         o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
                         o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
@@ -7188,17 +7196,17 @@ void MoveParticles()
                 }
                 else if (o->SubType == 9)
                 {
-                    o->Light[0] /= 1.01f;
-                    o->Light[1] /= 1.01f;
-                    o->Light[2] /= 1.01f;
+                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     if (o->Light[0] < 0.2f)
                     {
                         o->Live = false;
                     }
 
-                    o->StartPosition[0] /= 1.01f;
-                    if (o->LifeTime < 60 && rand() % 2 == 0)
+                    o->StartPosition[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    if (o->LifeTime < 60 && rand_fps_check(2))
                     {
                         o->Scale = 0;
                     }
@@ -7209,14 +7217,14 @@ void MoveParticles()
 
                     if (o->LifeTime < 60)
                     {
-                        o->Velocity[0] /= 1.04f;
-                        o->Velocity[1] /= 1.04f;
-                        o->Velocity[2] /= 1.04f;
+                        o->Velocity[0] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[1] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
+                        o->Velocity[2] *= pow(1.0f / (1.04f), FPS_ANIMATION_FACTOR);
 
                         o->Position[2] -= ((o->Gravity * 0.1f)) * FPS_ANIMATION_FACTOR;
                         o->Gravity += (0.5f) * FPS_ANIMATION_FACTOR;
 
-                        if (rand() % 5 == 0)
+                        if (rand_fps_check(5))
                         {
                             Position[0] = o->Position[0] + rand() % 40 - 20;
                             Position[1] = o->Position[1] + rand() % 40 - 20;
@@ -7231,7 +7239,7 @@ void MoveParticles()
                     o->Scale = sinf(o->LifeTime * 10.f * (Q_PI / 180.f));
                     if (o->SubType == 1)
                     {
-                        o->Scale *= 0.75f;
+                        o->Scale *= pow(0.75f, FPS_ANIMATION_FACTOR);
                         o->Rotation -= (12.f) * FPS_ANIMATION_FACTOR;
                     }
                 }
@@ -7254,9 +7262,9 @@ void MoveParticles()
                         o->Velocity[2] -= (1.f) * FPS_ANIMATION_FACTOR;
                     }
 
-                    o->Light[0] /= 1.01f;
-                    o->Light[1] /= 1.01f;
-                    o->Light[2] /= 1.01f;
+                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
 
                     //o->Scale = sinf(o->LifeTime*(Q_PI/240.f));
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
@@ -7293,7 +7301,7 @@ void MoveParticles()
                 {
                     VectorCopy(o->Target->Position, o->Position);
                     o->Position[2] += (50.f) * FPS_ANIMATION_FACTOR;
-                    //                    o->Scale *= 0.75f;
+                    //                    o->Scale *= pow(0.75f, FPS_ANIMATION_FACTOR);
                     o->Rotation -= (1.f) * FPS_ANIMATION_FACTOR;
                 }
                 else
@@ -7310,7 +7318,7 @@ void MoveParticles()
                         //Luminosity = (float)(o->LifeTime)/36.f;
                         //Vector(Luminosity*0.6f,Luminosity*0.8f,Luminosity,o->Light);
                         if (o->SubType >= 2) {
-                            o->Scale *= 0.75f;
+                            o->Scale *= pow(0.75f, FPS_ANIMATION_FACTOR);
                             o->Rotation -= (12.f) * FPS_ANIMATION_FACTOR;
                         }
                         HandPosition(o);
@@ -7338,14 +7346,14 @@ void MoveParticles()
                     }
                     if (o->LifeTime < 6)
                     {
-                        o->Light[0] *= 0.5f;
-                        o->Light[1] *= 0.5f;
-                        o->Light[2] *= 0.5f;
+                        o->Light[0] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(0.5f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(0.5f, FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->SubType == 2)
                 {
-                    o->Scale *= 1.1f;
+                    o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
                     VectorScale(o->Light, 0.9f, o->Light);
                 }
                 break;
@@ -7435,9 +7443,9 @@ void MoveParticles()
                 o->Scale += fScale * FPS_ANIMATION_FACTOR;
                 if (o->Scale >= 0.8f)
                 {
-                    o->Light[0] /= fLight;
-                    o->Light[1] /= fLight;
-                    o->Light[2] /= fLight;
+                    o->Light[0] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (fLight), FPS_ANIMATION_FACTOR);
                 }
             }
             break;
@@ -7446,9 +7454,9 @@ void MoveParticles()
                 o->Rotation += (20.f) * FPS_ANIMATION_FACTOR;
                 o->Position[2] += ((o->Gravity * 0.5f)) * FPS_ANIMATION_FACTOR;
 
-                o->Light[0] /= 1.02f;
-                o->Light[1] /= 1.02f;
-                o->Light[2] /= 1.02f;
+                o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                 o->Gravity -= (1.5f) * FPS_ANIMATION_FACTOR;
                 if (o->LifeTime < 10)
@@ -7533,9 +7541,9 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Light[0] /= 1.02f;
-                        o->Light[1] /= 1.02f;
-                        o->Light[2] /= 1.02f;
+                        o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                     }
 
                     if (fTemp > 500.0f)
@@ -7549,8 +7557,8 @@ void MoveParticles()
                 if (o->SubType == 6)
                 {
                     VectorAdd(o->Position, o->Velocity, o->Position);
-                    o->Velocity[0] *= 0.95f;
-                    o->Velocity[1] *= 0.95f;
+                    o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
                     o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
                     o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
@@ -7612,9 +7620,9 @@ void MoveParticles()
                     }
                     else if (fTemp > 300.0f && fTemp <= 500.0f)
                     {
-                        o->Light[0] /= 1.05f;
-                        o->Light[1] /= 1.05f;
-                        o->Light[2] /= 1.05f;
+                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
@@ -7644,8 +7652,8 @@ void MoveParticles()
                 else if (o->SubType == 14)
                 {
                     VectorAdd(o->Position, o->Velocity, o->Position);
-                    o->Velocity[0] *= 0.95f;
-                    o->Velocity[1] *= 0.95f;
+                    o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
                     o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
                     o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
@@ -7684,9 +7692,9 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Light[0] /= 1.02f;
-                        o->Light[1] /= 1.02f;
-                        o->Light[2] /= 1.02f;
+                        o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                         if (o->Light[0] < 0.001f)
                             o->Live = false;
@@ -7722,9 +7730,9 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Light[0] /= 1.05f;
-                        o->Light[1] /= 1.05f;
-                        o->Light[2] /= 1.05f;
+                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
 
                         if (o->Light[0] < 0.001f)
                             o->Live = false;
@@ -7762,9 +7770,9 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Light[0] /= 1.02f;
-                        o->Light[1] /= 1.02f;
-                        o->Light[2] /= 1.02f;
+                        o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
 
                         if (o->Light[0] < 0.015f)
                             o->Live = false;
@@ -7896,8 +7904,8 @@ void MoveParticles()
                     }
                     else
                     {
-                        o->Velocity[0] *= 0.7f;
-                        o->Velocity[1] *= 0.7f;
+                        o->Velocity[0] *= pow(0.7f, FPS_ANIMATION_FACTOR);
+                        o->Velocity[1] *= pow(0.7f, FPS_ANIMATION_FACTOR);
 
                         if (o->Alpha > 0.0f)
                             o->Alpha -= FPS_ANIMATION_FACTOR * (rand() % 10 * 0.01f);
@@ -7970,23 +7978,23 @@ void MoveParticles()
                     }
                     else if (1 == o->SubType)
                     {
-                        o->Scale *= 0.98f;
+                        o->Scale *= pow(0.98f, FPS_ANIMATION_FACTOR);
                     }
                     else if (5 == o->SubType)
                     {
-                        o->Scale *= 0.95f;
+                        o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Scale *= 0.95f;
+                        o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     }
                     if (o->SubType == 7)
                     {
                         if (o->LifeTime < 10)
                         {
-                            o->Light[0] /= 1.2f;
-                            o->Light[1] /= 1.2f;
-                            o->Light[2] /= 1.2f;
+                            o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                            o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                            o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                         }
                     }
                     else
@@ -8021,12 +8029,12 @@ void MoveParticles()
                     VectorScale(vRandom, fScale, vRandom);
                     VectorAdd(o->Position, vRandom, o->Position);
                     o->Position[2] += (5.f * fScale) * FPS_ANIMATION_FACTOR;
-                    o->Scale *= 0.95f;
+                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
 
                     //                    Vector(o->Scale,o->Scale,o->Scale,o->Light);
-                    o->Light[0] *= 0.95f;
-                    o->Light[1] *= 0.95f;
-                    o->Light[2] *= 0.95f;
+                    o->Light[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                     if (o->Scale <= 0.1f)
                     {
                         o->LifeTime = -1;
@@ -8036,17 +8044,17 @@ void MoveParticles()
                 else if (1 == o->SubType)
                 {
                     VectorScale(o->Light, 0.9f, o->Light);
-                    o->Scale *= 0.95f;
+                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 }
                 else if (5 == o->SubType)
                 {
                     VectorScale(o->Light, 0.9f, o->Light);
-                    o->Scale *= 0.95f;
+                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 }
                 else if (3 == o->SubType)
                 {
                     VectorScale(o->Light, 0.9f, o->Light);
-                    o->Scale *= 0.85f;
+                    o->Scale *= pow(0.85f, FPS_ANIMATION_FACTOR);
                     o->Gravity += (5.f) * FPS_ANIMATION_FACTOR;
 
                     VectorCopy(o->Target->Position, o->Position);
@@ -8075,9 +8083,9 @@ void MoveParticles()
                     o->Scale -=  FPS_ANIMATION_FACTOR * (rand() % 400 + 400) / 10000.f;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] /= 1.35f;
-                    o->Light[1] /= 1.35f;
-                    o->Light[2] /= 1.35f;
+                    o->Light[0] *= pow(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.35f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 9)
                 {
@@ -8089,15 +8097,15 @@ void MoveParticles()
 
                     if (o->LifeTime >= 75)
                     {
-                        o->Light[0] *= 1.05f;
-                        o->Light[1] *= 1.05f;
-                        o->Light[2] *= 1.05f;
+                        o->Light[0] *= pow(1.05f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.05f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.05f, FPS_ANIMATION_FACTOR);
                     }
                     else
                     {
-                        o->Light[0] /= 1.05f;
-                        o->Light[1] /= 1.05f;
-                        o->Light[2] /= 1.05f;
+                        o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->SubType == 10)
@@ -8132,7 +8140,7 @@ void MoveParticles()
                 else if (o->SubType == 14)
                 {
                     VectorScale(o->Light, 0.98f, o->Light);
-                    o->Scale *= 0.95f;
+                    o->Scale *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 15)
                 {
@@ -8216,8 +8224,8 @@ void MoveParticles()
                 break;
             case BITMAP_ADV_SMOKE:
                 VectorAdd(o->Position, o->Velocity, o->Position);
-                o->Velocity[0] *= 0.95f;
-                o->Velocity[1] *= 0.95f;
+                o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 o->Light[0] = (float)(o->LifeTime) / 10.f;
                 o->Light[1] = o->Light[0];
                 o->Light[2] = o->Light[0];
@@ -8246,8 +8254,8 @@ void MoveParticles()
                 break;
             case BITMAP_ADV_SMOKE + 1:
                 VectorAdd(o->Position, o->Velocity, o->Position);
-                o->Velocity[0] *= 0.95f;
-                o->Velocity[1] *= 0.95f;
+                o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
                 o->Velocity[2] += (0.6f) * FPS_ANIMATION_FACTOR;
                 o->Position[0] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
                 o->Position[1] += ((float)(rand() % 4 - 2)) * FPS_ANIMATION_FACTOR;
@@ -8322,8 +8330,8 @@ void MoveParticles()
                 if (o->Scale < 0)
                     o->Scale = 0.f;
 
-                o->Velocity[0] *= 0.95f;
-                o->Velocity[1] *= 0.95f;
+                o->Velocity[0] *= pow(0.95f, FPS_ANIMATION_FACTOR);
+                o->Velocity[1] *= pow(0.95f, FPS_ANIMATION_FACTOR);
 
                 if (o->Type == 6)
                     o->Position[2] += (2.0f) * FPS_ANIMATION_FACTOR;
@@ -8342,31 +8350,31 @@ void MoveParticles()
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.08f;
                     if (o->LifeTime < 10)
                     {
-                        o->Light[0] /= 1.3f;
-                        o->Light[1] /= 1.3f;
-                        o->Light[2] /= 1.3f;
+                        o->Light[0] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.3f), FPS_ANIMATION_FACTOR);
                     }
                 }
                 else if (o->LifeTime < 30)
                 {
-                    o->Light[0] *= 1.1f;
-                    o->Light[1] *= 1.1f;
-                    o->Light[2] *= 1.1f;
+                    o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
                 }
                 break;
             case BITMAP_WATERFALL_1:
                 o->Scale -=  FPS_ANIMATION_FACTOR * 0.005f;
                 if (o->LifeTime < 5)
                 {
-                    o->Light[0] /= 1.2f;
-                    o->Light[1] /= 1.2f;
-                    o->Light[2] /= 1.2f;
+                    o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->LifeTime > 20)
                 {
-                    o->Light[0] *= 1.1f;
-                    o->Light[1] *= 1.1f;
-                    o->Light[2] *= 1.1f;
+                    o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
                 }
                 o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
 
@@ -8428,18 +8436,18 @@ void MoveParticles()
                     o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += (o->Velocity[2]) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 8)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 9)
@@ -8450,15 +8458,15 @@ void MoveParticles()
 
                 if (o->LifeTime < 8)
                 {
-                    o->Light[0] /= 1.2f;
-                    o->Light[1] /= 1.2f;
-                    o->Light[2] /= 1.2f;
+                    o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->LifeTime > 20)
                 {
-                    o->Light[0] *= 1.1f;
-                    o->Light[1] *= 1.1f;
-                    o->Light[2] *= 1.1f;
+                    o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
                 }
                 break;
 
@@ -8483,9 +8491,9 @@ void MoveParticles()
                     o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR + o->Velocity[2];
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
 
@@ -8495,24 +8503,24 @@ void MoveParticles()
                 o->Velocity[2] += (0.1f) * FPS_ANIMATION_FACTOR;
                 if (o->LifeTime < 10)
                 {
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
 
                 if (o->SubType == 1)
                 {
-                    o->Light[0] /= 1.05f;
-                    o->Light[1] /= 1.05f;
-                    o->Light[2] /= 1.05f;
+                    o->Light[0] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.05f), FPS_ANIMATION_FACTOR);
                 }
                 if (o->SubType == 3)
                 {
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.038f;
                     o->Velocity[2] -= (0.02f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.02f;
-                    o->Light[1] /= 1.02f;
-                    o->Light[2] /= 1.02f;
+                    o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
                 }
                 if (o->SubType == 4)
                 {
@@ -8531,9 +8539,9 @@ void MoveParticles()
                     VectorAdd(o->StartPosition, TargetPosition, o->Position);
                     o->Scale += (1.0 / o->LifeTime) * 2.0f * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] *= 0.8f;
-                    o->Light[1] *= 0.77f;
-                    o->Light[2] *= 0.77f;
+                    o->Light[0] *= pow(0.8f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(0.77f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(0.77f, FPS_ANIMATION_FACTOR);
 
                     VectorCopy(o->StartPosition, o->Position);
                     o->StartPosition[2] = o->StartPosition[2] + rand() % 5 + 10.0f;
@@ -8549,27 +8557,27 @@ void MoveParticles()
                     o->Position[1] += ((float)(sin(o->Angle[2]) * 20.0f)) * FPS_ANIMATION_FACTOR;
                     o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                     o->Rotation += (1) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 3)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                     o->Velocity[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= 0.97f;
-                    o->Light[1] *= 0.97f;
-                    o->Light[2] *= 0.97f;
+                    o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 5)
                 {
                     o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 6)
@@ -8579,26 +8587,26 @@ void MoveParticles()
 
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.01f;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 7)
                 {
                     o->Velocity[2] += (0.01f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] *= 0.97f;
-                    o->Light[1] *= 0.97f;
-                    o->Light[2] *= 0.97f;
+                    o->Light[0] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(0.97f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(0.97f, FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 8)
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 10)
@@ -8607,26 +8615,28 @@ void MoveParticles()
                     o->Position[1] += (o->Velocity[1]) * FPS_ANIMATION_FACTOR;
                     o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Gravity -= (0.05f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 11)
                 {
                     VectorAdd(o->Position, o->Velocity, o->Position);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.01f;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
                 else if (o->SubType == 12)
                 {
                     o->Rotation += (((int)WorldTime % 360) * 0.01f) * FPS_ANIMATION_FACTOR;
-                    o->Scale *= 0.92f;
-                    Vector(o->Light[0] *= 0.92f, o->Light[1] *= 0.92f, o->Light[2] *= 0.92f, o->Light);
-                    o->Alpha *= 0.8f;
+                    o->Scale *= pow(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Light[0] *= pow(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(0.92f, FPS_ANIMATION_FACTOR);
+                    o->Alpha *= pow(0.8f, FPS_ANIMATION_FACTOR);
 
                     break;
                 }
@@ -8634,9 +8644,9 @@ void MoveParticles()
                 {
                     o->Position[2] -= (o->Gravity) * FPS_ANIMATION_FACTOR;
                     o->Scale += FPS_ANIMATION_FACTOR * 0.001f;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                     break;
                 }
@@ -8644,9 +8654,9 @@ void MoveParticles()
                 {
                     o->Scale += FPS_ANIMATION_FACTOR * 0.05f;
                     o->Velocity[2] -= (0.6f) * FPS_ANIMATION_FACTOR;
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 15)
                 {
@@ -8655,9 +8665,9 @@ void MoveParticles()
                     o->Scale -=  FPS_ANIMATION_FACTOR * 0.05f;
                     //o->Velocity[2] -= (0.05f) * FPS_ANIMATION_FACTOR;
 
-                    o->Light[0] /= 1.1f;
-                    o->Light[1] /= 1.1f;
-                    o->Light[2] /= 1.1f;
+                    o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                     break;
                 }
 #ifdef ASG_ADD_MAP_KARUTAN
@@ -8667,49 +8677,49 @@ void MoveParticles()
                     o->Velocity[2] -= (0.1f) * FPS_ANIMATION_FACTOR;
                     if (o->LifeTime < 8)
                     {
-                        o->Light[0] /= 1.2f;
-                        o->Light[1] /= 1.2f;
-                        o->Light[2] /= 1.2f;
+                        o->Light[0] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.0f / (1.2f), FPS_ANIMATION_FACTOR);
                     }
                     else if (o->LifeTime > 20)
                     {
-                        o->Light[0] *= 1.1f;
-                        o->Light[1] *= 1.1f;
-                        o->Light[2] *= 1.1f;
+                        o->Light[0] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                        o->Light[1] *= pow(1.1f, FPS_ANIMATION_FACTOR);
+                        o->Light[2] *= pow(1.1f, FPS_ANIMATION_FACTOR);
                     }
                     break;
                 }
 #endif	// ASG_ADD_MAP_KARUTAN
                 o->Scale += FPS_ANIMATION_FACTOR * 0.005f;
                 o->Velocity[2] -= (2.5f) * FPS_ANIMATION_FACTOR;
-                o->Light[0] /= 1.1f;
-                o->Light[1] /= 1.1f;
-                o->Light[2] /= 1.1f;
+                o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
                 break;
 
             case BITMAP_SHOCK_WAVE:
             {
                 if (o->SubType == 3)
                 {
-                    o->Light[0] /= 1.8f;
-                    o->Light[1] /= 1.8f;
-                    o->Light[2] /= 1.8f;
+                    o->Light[0] *= pow(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.8f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.3f;
                 }
                 else if (o->SubType == 0)
                 {
-                    o->Light[0] /= 1.5f;
-                    o->Light[1] /= 1.5f;
-                    o->Light[2] /= 1.5f;
+                    o->Light[0] *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.5f), FPS_ANIMATION_FACTOR);
                     o->Scale += FPS_ANIMATION_FACTOR * 0.8f;
                 }
                 if (o->SubType == 4)
                 {
                     o->Alpha -= FPS_ANIMATION_FACTOR * 0.001f;
                     if (o->Alpha <= 0.0f) o->Live = false;
-                    o->Light[0] /= 1.01f;
-                    o->Light[1] /= 1.03f;
-                    o->Light[2] /= 1.03f;
+                    o->Light[0] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
+                    o->Light[1] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
+                    o->Light[2] *= pow(1.0f / (1.03f), FPS_ANIMATION_FACTOR);
                     o->Scale += (o->Gravity * 0.015f) * FPS_ANIMATION_FACTOR;
                     o->Gravity += (2.4f) * FPS_ANIMATION_FACTOR;
                 }
@@ -8717,9 +8727,9 @@ void MoveParticles()
             break;
             case BITMAP_CURSEDTEMPLE_EFFECT_MASKER:
             {
-                o->Light[0] /= 1.1f;
-                o->Light[1] /= 1.1f;
-                o->Light[2] /= 1.1f;
+                o->Light[0] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[1] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
+                o->Light[2] *= pow(1.0f / (1.1f), FPS_ANIMATION_FACTOR);
 
                 o->Scale += FPS_ANIMATION_FACTOR * 0.02f;
 
@@ -8763,7 +8773,7 @@ void MoveParticles()
                     o->Live = false;
                 }
 
-                if (rand() % 10 == 0)
+                if (rand_fps_check(10))
                 {
                     const	float BASERANGE_SHINYSTAR = 70.0f * o->Scale;
                     float	fRand1, fRand2, fRand3;
@@ -8816,17 +8826,17 @@ void MoveParticles()
 
                 if (o->SubType == 0)
                 {
-                    o->Scale *= 1.05f;
+                    o->Scale *= pow(1.05f, FPS_ANIMATION_FACTOR);
                     Temp_Pos[2] -= (10.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 1)
                 {
-                    o->Scale *= 1.02f;
+                    o->Scale *= pow(1.02f, FPS_ANIMATION_FACTOR);
                     Temp_Pos[2] += (10.0f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (o->SubType == 2)
                 {
-                    o->Scale *= 1.03f;
+                    o->Scale *= pow(1.03f, FPS_ANIMATION_FACTOR);
                     Temp_Pos[2] += (25.0f) * FPS_ANIMATION_FACTOR;
                 }
                 VectorCopy(Temp_Pos, o->Position);
@@ -8850,7 +8860,7 @@ void MoveParticles()
             break;
             case BITMAP_DAMAGE1:
             {
-                o->Scale *= 1.2f;
+                o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
                 VectorScale(o->Light, 0.8f, o->Light);
             }
             break;
@@ -8858,11 +8868,11 @@ void MoveParticles()
             {
                 if (o->SubType == 1)
                 {
-                    o->Scale *= 0.8f;
+                    o->Scale *= pow(0.8f, FPS_ANIMATION_FACTOR);
                 }
                 else if (o->SubType == 0)
                 {
-                    o->Scale *= 1.2f;
+                    o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
                 }
                 if (o->Scale > 6.0f)
                 {
@@ -8883,7 +8893,7 @@ void MoveParticles()
             break;
             case BITMAP_DAMAGE2:
             {
-                o->Scale *= 1.2f;
+                o->Scale *= pow(1.2f, FPS_ANIMATION_FACTOR);
                 VectorScale(o->Light, 0.55f, o->Light);
             }
             break;

--- a/Source Main 5.2/source/ZzzEffectPoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectPoint.cpp
@@ -75,7 +75,7 @@ void MovePoints()
         PARTICLE* o = &Points[i];
         if (o->Live)
         {
-            o->LifeTime--;
+            o->LifeTime -= FPS_ANIMATION_FACTOR;
             if (o->LifeTime < 0)
             {
                 if (o->bRepeatedly && o->Position[2] > o->fRepeatedlyHeight)
@@ -85,9 +85,9 @@ void MovePoints()
                 }
                 if (o->bEnableMove)
                 {
-                    o->Position[2] += o->Gravity;
+                    o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
                 }
-                o->Gravity -= 0.3f;
+                o->Gravity -= 0.3f * FPS_ANIMATION_FACTOR;
                 if (o->Gravity <= 0.f)
                     o->Live = false;
                 if (o->Type != -2)

--- a/Source Main 5.2/source/ZzzEffectPoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectPoint.cpp
@@ -13,6 +13,7 @@
 #include "ZzzEffect.h"
 #include "DSPlaySound.h"
 #include "WSClient.h"
+#include "NewUISystem.h"
 
 PARTICLE  Points[MAX_POINTS];
 
@@ -20,6 +21,11 @@ int g_iLatestPoint = -1;
 
 void CreatePoint(vec3_t Position, int Value, vec3_t Color, float scale, bool bMove, bool bRepeatedly)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_POINTS; i++)
     {
         PARTICLE* o = &Points[i];
@@ -43,6 +49,11 @@ void CreatePoint(vec3_t Position, int Value, vec3_t Color, float scale, bool bMo
 
 void RenderPoints(BYTE byRenderOneMore)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     EnableAlphaTest();
     DisableDepthTest();
     for (int i = 0; i < MAX_POINTS; i++)
@@ -70,6 +81,11 @@ void RenderPoints(BYTE byRenderOneMore)
 
 void MovePoints()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_POINTS; i++)
     {
         PARTICLE* o = &Points[i];

--- a/Source Main 5.2/source/ZzzEffectPoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectPoint.cpp
@@ -92,7 +92,7 @@ void MovePoints()
                     o->Live = false;
                 if (o->Type != -2)
                 {
-                    o->Scale -= 5.f;//20.f;
+                    o->Scale -= 5.f * FPS_ANIMATION_FACTOR;//20.f;
                     if (o->Scale < 15.f)
                         o->Scale = 15.f;
                 }

--- a/Source Main 5.2/source/ZzzEffectPointer.cpp
+++ b/Source Main 5.2/source/ZzzEffectPointer.cpp
@@ -65,7 +65,7 @@ void MovePointers()
             switch (o->Type)
             {
             case BITMAP_CURSOR + 5:
-                o->Scale -= 0.05f;
+                o->Scale -= 0.05f * FPS_ANIMATION_FACTOR;
                 if (o->Scale < 0.1f) o->Live = false;
                 break;
             case BITMAP_BLOOD:
@@ -73,7 +73,7 @@ void MovePointers()
             case BITMAP_FOOT:
                 if (o->Type == BITMAP_BLOOD)
                 {
-                    o->Scale += 0.004f;
+                    o->Scale += 0.004f * FPS_ANIMATION_FACTOR;
                 }
                 Vector(0.1f, 0.f, 0.f, o->Light);
                 if (o->LifeTime <= 0) o->Live = false;

--- a/Source Main 5.2/source/ZzzEffectPointer.cpp
+++ b/Source Main 5.2/source/ZzzEffectPointer.cpp
@@ -61,7 +61,7 @@ void MovePointers()
         PARTICLE* o = &Pointers[i];
         if (o->Live)
         {
-            o->LifeTime--;
+            o->LifeTime -= FPS_ANIMATION_FACTOR;
             switch (o->Type)
             {
             case BITMAP_CURSOR + 5:

--- a/Source Main 5.2/source/ZzzInterface.cpp
+++ b/Source Main 5.2/source/ZzzInterface.cpp
@@ -536,14 +536,15 @@ void CreateNotice(char* Text, int Color)
 
 void MoveNotices()
 {
-    if (NoticeTime-- <= 0)
+    NoticeTime -= FPS_ANIMATION_FACTOR;
+    if (NoticeTime <= 0)
     {
         NoticeTime = 300;
         CreateNotice("", 0);
     }
 }
 
-int NoticeInverse = 0;
+float NoticeInverse = 0;
 
 void RenderNotices()
 {
@@ -563,7 +564,7 @@ void RenderNotices()
         if (n->Color == 0)
         {
             g_pRenderText->SetBgColor(0, 0, 0, 128);
-            if (NoticeInverse % 10 < 5)
+            if ((int)NoticeInverse % 10 < 5)
             {
                 g_pRenderText->SetTextColor(255, 200, 80, 128);
             }
@@ -587,7 +588,8 @@ void RenderNotices()
             g_pRenderText->RenderText(320, 300 + i * 13, n->Text, 0, 0, RT3_WRITE_CENTER);
         }
     }
-    NoticeInverse++;
+
+    NoticeInverse += FPS_ANIMATION_FACTOR;
 }
 
 void CutText(const char* Text, char* Text1, char* Text2, int Length)

--- a/Source Main 5.2/source/ZzzInterface.cpp
+++ b/Source Main 5.2/source/ZzzInterface.cpp
@@ -2691,7 +2691,7 @@ void UseSkillRagefighter(CHARACTER* pCha, OBJECT* pObj)
     case AT_SKILL_DEF_UP_OURFORCES:
     {
         SendRequestMagic(iSkill, HeroKey);
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             SetAction(pObj, PLAYER_SKILL_ATT_UP_OURFORCES);
             PlayBuffer(SOUND_RAGESKILL_BUFF_1);
@@ -4522,7 +4522,7 @@ void CheckChatText(char* Text)
 
         if (pItem_rr->Type == ITEM_HELPER + 40 || pItem_rl->Type == ITEM_HELPER + 40)
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 SetAction(o, PLAYER_JACK_1);
                 SendRequestAction(AT_JACK1, ((BYTE)((o->Angle[2] + 22.5f) / 360.f * 8.f + 1.f) % 8));

--- a/Source Main 5.2/source/ZzzLodTerrain.cpp
+++ b/Source Main 5.2/source/ZzzLodTerrain.cpp
@@ -1505,7 +1505,7 @@ void FaceTexture(int Texture, float xf, float yf, bool Water, bool Scale)
         float Water4 = 0.f;
         if (gMapManager.WorldActive == WD_34CRYWOLF_1ST && Texture == 5)
         {
-            if (rand() % 50 == 0)
+            if (rand_fps_check(50))
             {
                 float sx = xf * TERRAIN_SCALE + (float)((rand() % 100 + 1) * 1.0f);
                 float sy = yf * TERRAIN_SCALE + (float)((rand() % 100 + 1) * 1.0f);
@@ -2361,7 +2361,7 @@ void DeleteAllFrustrum()
     return true;
 }*/
 
-extern int RainCurrent;
+extern float RainCurrent;
 extern int EnableEvent;
 
 void InitTerrainLight()

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -541,7 +541,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
             auto* pCloth = (CPhysicsCloth*)o->m_pCloth;
             if (!pCloth[0].Move2(0.005f, 5))
             {
-                CHARACTER* c = &CharactersClient[o->PKKey];
+                CHARACTER* c = &CharactersClient[(int)o->PKKey];
                 DeleteCloth(c, o);
             }
             else
@@ -3281,7 +3281,7 @@ void RenderObjects()
 
     if (Time_Effect > 40)
         Time_Effect = 0;
-    Time_Effect++;
+    Time_Effect += FPS_ANIMATION_FACTOR;
 
     for (int i = 0; i < 16; i++)
     {
@@ -3573,7 +3573,7 @@ void RenderObjects_AfterCharacter()
 
     if (Time_Effect > 40)
         Time_Effect = 0;
-    Time_Effect++;
+    Time_Effect += FPS_ANIMATION_FACTOR;
 
     for (int i = 0; i < 16; i++)
     {
@@ -6336,7 +6336,7 @@ void MoveItems()
         OBJECT* o = &Items[i].Object;
         if (o->Live)
         {
-            o->Position[2] += o->Gravity;
+            o->Position[2] += o->Gravity * FPS_ANIMATION_FACTOR;
             o->Gravity -= 6.f;
             float Height = RequestTerrainHeight(o->Position[0], o->Position[1]) + 30.f;
             if (o->Type >= MODEL_SWORD && o->Type < MODEL_STAFF + MAX_ITEM_INDEX)
@@ -6349,9 +6349,9 @@ void MoveItems()
             else
             {
                 if (o->Type >= MODEL_SHIELD && o->Type < MODEL_SHIELD + MAX_ITEM_INDEX)
-                    o->Angle[1] = -o->Gravity * 10.f;
+                    o->Angle[1] = -o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
                 else
-                    o->Angle[0] = -o->Gravity * 10.f;
+                    o->Angle[0] = -o->Gravity * 10.f * FPS_ANIMATION_FACTOR;
             }
             CreateShiny(o);
         }
@@ -6913,12 +6913,12 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
         glColor3fv(b->BodyLight);
         b->RenderMesh(2, RENDER_TEXTURE, o->Alpha, o->BlendMesh, o->BlendMeshLight, o->BlendMeshTexCoordU, o->BlendMeshTexCoordV, o->HiddenMesh);
         b->RenderMesh(0, RENDER_TEXTURE | RENDER_BRIGHT, o->Alpha, o->BlendMesh, o->BlendMeshLight, o->BlendMeshTexCoordU, o->BlendMeshTexCoordV, o->HiddenMesh);
-        float fU = 0.f;
-        static int s_iTexAni = 0;
-        s_iTexAni++;
+
+        static float s_iTexAni = 0;
+        s_iTexAni += FPS_ANIMATION_FACTOR;
         if (s_iTexAni > 15)
             s_iTexAni = 0;
-        fU = (s_iTexAni / 4) * 0.25f;
+        float fU = ((int)s_iTexAni / 4) * 0.25f;
         Vector(0.9f, 0.6f, 0.3f, b->BodyLight);
         b->RenderMesh(1, RENDER_TEXTURE | RENDER_BRIGHT, o->Alpha, 1, o->BlendMeshLight, fU, o->BlendMeshTexCoordV, o->HiddenMesh);
         Vector(1.f, 1.f, 1.f, b->BodyLight);

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -51,7 +51,7 @@ int          g_iTotalObj = 0;
 OBJECT_BLOCK ObjectBlock[256];
 OBJECT       Boids[MAX_BOIDS];
 OBJECT       Fishs[MAX_FISHS];
-OBJECT       Butterfles[MAX_BUTTERFLES];
+OBJECT       Mounts[MAX_MOUNTS];
 OPERATE      Operates[MAX_OPERATES];
 //int   World = -1;
 float EarthQuake;
@@ -1751,7 +1751,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                                                             vec3_t StartPos, StartRelative;
                                                             vec3_t EndPos, EndRelative;
 
-                                                            float fActionSpeed = o->Velocity;
+                                                            float fActionSpeed = o->Velocity * static_cast<float>(FPS_ANIMATION_FACTOR);
                                                             float fSpeedPerFrame = fActionSpeed / 10.f;
                                                             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
                                                             for (int i = 0; i < 10; i++)
@@ -3242,7 +3242,10 @@ void RenderObjectVisual(OBJECT* o)
 
             if (iTimeCheck >= 7950)
             {
-                Vector(o->Position[0] + rand() % 2048 - 1024, o->Position[1] + rand() % 2048 - 1024, o->Position[2] + 3000 + rand() % 600, Position);
+                Vector(o->Position[0] + (rand() % 2048 - 1024) * FPS_ANIMATION_FACTOR,
+                    o->Position[1] + (rand() % 2048 - 1024) * FPS_ANIMATION_FACTOR,
+                    o->Position[2] + (3000 + rand() % 600) * FPS_ANIMATION_FACTOR,
+                    Position);
                 CreateEffect(MODEL_FIRE, Position, o->Angle, o->Light, 9);
             }
         }

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -9523,7 +9523,7 @@ void RenderPartObjectEffect(OBJECT* o, int Type, vec3_t Light, float Alpha, int 
     {
         if (Level <= 6)
         {
-            Level *= pow(2, FPS_ANIMATION_FACTOR);
+            Level /= 2;
         }
         else
         {

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -6440,11 +6440,11 @@ void RenderItems()
                 VectorCopy(o->Position, vBackup);
                 if (gMapManager.WorldActive == WD_10HEAVEN)
                 {
-                    o->Position[2] += 10.0f * (float)sinf((float)(i * 1237 + WorldTime) * 0.002f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += 10.0f * (float)sinf((float)(i * 1237 + WorldTime) * 0.002f);
                 }
                 else if (gMapManager.WorldActive == WD_39KANTURU_3RD && g_Direction.m_CKanturu.IsMayaScene())
                 {
-                    o->Position[2] += 10.0f * (float)sinf((float)(i * 1237 + WorldTime) * 0.002f) * FPS_ANIMATION_FACTOR;
+                    o->Position[2] += 10.0f * (float)sinf((float)(i * 1237 + WorldTime) * 0.002f);
                 }
                 else if (gMapManager.InHellas() == true)
                 {

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -9921,8 +9921,12 @@ void RenderPartObjectEffect(OBJECT* o, int Type, vec3_t Light, float Alpha, int 
         {
             b->TransformPosition(BoneTransform[22 - i], p, posCenter, true);
             b->TransformPosition(BoneTransform[30 - i], p, Position, true);
-            CreateJoint(BITMAP_JOINT_THUNDER, Position, posCenter, o->Angle, 14, o, Scale);
-            CreateJoint(BITMAP_JOINT_SPIRIT, posCenter, Position, o->Angle, 4, o, Scale + 5);
+            if (rand_fps_check(1))
+            {
+                CreateJoint(BITMAP_JOINT_THUNDER, Position, posCenter, o->Angle, 14, o, Scale);
+                CreateJoint(BITMAP_JOINT_SPIRIT, posCenter, Position, o->Angle, 4, o, Scale + 5);
+            }
+
             CreateSprite(BITMAP_FLARE_BLUE, posCenter, Scale / 28.f, Light, o);
         }
 
@@ -9930,8 +9934,12 @@ void RenderPartObjectEffect(OBJECT* o, int Type, vec3_t Light, float Alpha, int 
         {
             b->TransformPosition(BoneTransform[7 - i], p, posCenter, true);
             b->TransformPosition(BoneTransform[11 + i], p, Position, true);
-            CreateJoint(BITMAP_JOINT_THUNDER, Position, posCenter, o->Angle, 14, o, Scale);
-            CreateJoint(BITMAP_JOINT_SPIRIT, posCenter, Position, o->Angle, 4, o, Scale + 5);
+            if (rand_fps_check(1))
+            {
+                CreateJoint(BITMAP_JOINT_THUNDER, Position, posCenter, o->Angle, 14, o, Scale);
+                CreateJoint(BITMAP_JOINT_SPIRIT, posCenter, Position, o->Angle, 4, o, Scale + 5);
+            }
+
             CreateSprite(BITMAP_FLARE_BLUE, posCenter, Scale / 28.f, Light, o);
         }
     }
@@ -10056,7 +10064,7 @@ void RenderPartObjectEffect(OBJECT* o, int Type, vec3_t Light, float Alpha, int 
         float fLumi = (sinf(WorldTime * 0.004f) + 1.0f) * 0.05f;
         Vector(0.8f + fLumi, 0.8f + fLumi, 0.3f + fLumi, Light);
         CreateSprite(BITMAP_LIGHT, Position, 0.4f, Light, o, 0.5f);
-        if (rand() % 15 >= 8)
+        if (rand_fps_check(2))
         {
             b->TransformPosition(BoneTransform[13], p, Position, true);
             CreateParticle(BITMAP_SHINY, Position, o->Angle, Light, 5, 0.5f);
@@ -10093,28 +10101,32 @@ void RenderPartObjectEffect(OBJECT* o, int Type, vec3_t Light, float Alpha, int 
         {
             b->TransformPosition(BoneTransform[iSparkPos[i]], p, Position, true);
             for (int j = 0; j < iNumParticle; ++j)
-                CreateParticle(BITMAP_CHROME_ENERGY2, Position, o->Angle, Light, 0, 0.1f);
+                if (rand_fps_check(1))
+                    CreateParticle(BITMAP_CHROME_ENERGY2, Position, o->Angle, Light, 0, 0.1f);
         }
 
         for (int i = 6; i < 18; ++i)
         {
             b->TransformPosition(BoneTransform[iSparkPos[i]], p, Position, true);
             for (int j = 0; j < iNumParticle; ++j)
-                CreateParticle(BITMAP_CHROME_ENERGY2, Position, o->Angle, Light, 0, 0.3f);
+                if (rand_fps_check(1))
+                    CreateParticle(BITMAP_CHROME_ENERGY2, Position, o->Angle, Light, 0, 0.3f);
         }
 
         for (int i = 18; i < 30; ++i)
         {
             b->TransformPosition(BoneTransform[iSparkPos[i]], p, Position, true);
             for (int j = 0; j < iNumParticle; ++j)
-                CreateParticle(BITMAP_CHROME_ENERGY2, Position, o->Angle, Light, 0, 0.5f);
+                if (rand_fps_check(1))
+                    CreateParticle(BITMAP_CHROME_ENERGY2, Position, o->Angle, Light, 0, 0.5f);
         }
 
         for (int i = 30; i < 38; ++i)
         {
             b->TransformPosition(BoneTransform[iSparkPos[i]], p, Position, true);
             for (int j = 0; j < iNumParticle; ++j)
-                CreateParticle(BITMAP_CHROME_ENERGY2, Position, o->Angle, Light, 0, 0.7f);
+                if (rand_fps_check(1))
+                    CreateParticle(BITMAP_CHROME_ENERGY2, Position, o->Angle, Light, 0, 0.7f);
         }
     }
     else if (Type == MODEL_WING + 43)

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -4125,7 +4125,7 @@ void MoveObject(OBJECT* o)
         {
         case 22:
             o->HiddenMesh = -2;
-            o->Timer += 0.1f;
+            o->Timer += 0.1f * FPS_ANIMATION_FACTOR;
             if (o->Timer > 10.f)
                 o->Timer = 0.f;
             if (o->Timer > 5.f)

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -684,7 +684,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                     Vector(1.f, 0.5f, 0.5f, vLight);
                     CreateSprite(BITMAP_SHINY + 1, vPos, 1.5f + fLumi / 2.f, vLight, NULL);
 
-                    if (rand() % 5 == 0)
+                    if (rand_fps_check(5))
                     {
                         Vector(0.f, 0.f, 0.f, vRelativePos);
                         b->TransformPosition(BoneTransform[20], vRelativePos, vPos);
@@ -1909,7 +1909,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
 
                     if (o->LifeTime <= 20)
                     {
-                        o->BlendMeshLight *= 0.86f;
+                        o->BlendMeshLight *= pow(0.86f, FPS_ANIMATION_FACTOR);
                     }
                     b->RenderBody(RENDER_TEXTURE, o->Alpha, o->BlendMesh, o->BlendMeshLight, o->BlendMeshTexCoordU, o->BlendMeshTexCoordV, o->HiddenMesh);
                 }
@@ -1920,7 +1920,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                     //Vector(0.7f, 0.2f, 0.9f, b->BodyLight);
                     if (o->LifeTime <= 10)
                     {
-                        o->BlendMeshLight *= 0.8f;
+                        o->BlendMeshLight *= pow(0.8f, FPS_ANIMATION_FACTOR);
                     }
                     b->RenderBody(RENDER_TEXTURE, o->Alpha, o->BlendMesh, o->BlendMeshLight, o->BlendMeshTexCoordU, o->BlendMeshTexCoordV, o->HiddenMesh);
                 }
@@ -2330,7 +2330,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 66, 2.0f, o);
                         }
 
-                        if (rand() % 2 == 0)
+                        if (rand_fps_check(2))
                         {
                             vPos[0] = o->Position[0] + rand() % 80 - 40;
                             vPos[1] = o->Position[1] + rand() % 80 - 40;
@@ -2422,7 +2422,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                     Vector(0.f, 0.f, 0.f, vRelativePos);
                     float fScale = 0.0f;
 
-                    if (o->CurrentAction == 0 && rand() % 5 == 0)
+                    if (o->CurrentAction == 0 && rand_fps_check(5))
                     {
                         Vector(0.f, 0.f, 0.f, vWorldPos);
                         Vector((rand() % 90 + 10) * 0.01f, (rand() % 90 + 10) * 0.01f, (rand() % 90 + 10) * 0.01f, Light);
@@ -2773,7 +2773,7 @@ void RenderObjectVisual(OBJECT* o)
         case MODEL_WATERSPOUT:
             o->BlendMeshLight = 1.f;
             o->BlendMeshTexCoordV = -(int)WorldTime % 1000 * 0.001f;
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Vector((float)(rand() % 32 - 16), -20.f, (float)(rand() % 32 - 16), p);
                 b->TransformPosition(BoneTransform[1], p, Position);
@@ -2810,7 +2810,7 @@ void RenderObjectVisual(OBJECT* o)
             break;
         case 103:		//. Sleddog
             if (b->CurrentAnimationFrame == b->Actions[o->CurrentAction].NumAnimationKeys - 1) {
-                if (rand() % 32 == 0)
+                if (rand_fps_check(32))
                     SetAction(o, 1);
                 else
                     SetAction(o, 0);
@@ -2888,14 +2888,14 @@ void RenderObjectVisual(OBJECT* o)
             {
                 b->TransformPosition(BoneTransform[i], p, Position);
                 CreateSprite(BITMAP_LIGHT, Position, 1.f, Light, o);
-                if (rand() % 32 == 0)
+                if (rand_fps_check(32))
                 {
                     CreateParticle(BITMAP_SHINY, Position, o->Angle, Light);
                     CreateParticle(BITMAP_SHINY, Position, o->Angle, Light, 1);
                 }
             }
             b->TransformPosition(BoneTransform[58], p, Position);
-            if (rand() % 8 == 0)
+            if (rand_fps_check(8))
             {
                 vec3_t Angle;
 
@@ -3006,7 +3006,7 @@ void RenderObjectVisual(OBJECT* o)
 
         case 70:
             o->HiddenMesh = -2;
-            if (rand() % 5 == 0)
+            if (rand_fps_check(5))
                 CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 7, o->Scale);
             break;
 
@@ -3033,7 +3033,7 @@ void RenderObjectVisual(OBJECT* o)
                     Vector(1.f, 1.f, 1.f, Light);
 
                     CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 8, o->Scale);
-                    if (rand() % 3 == 0)
+                    if (rand_fps_check(3))
                     {
                         Position[0] = o->Position[0] + (rand() % 128 - 64);
                         Position[1] = o->Position[1] + (rand() % 128 - 64);
@@ -3052,12 +3052,12 @@ void RenderObjectVisual(OBJECT* o)
         case 2:
             Vector(1.f, 1.f, 1.f, Light);
             Vector(-15.f, 0.f, 0.f, p);
-            if (rand() % 4 == 0)
+            if (rand_fps_check(4))
             {
                 b->TransformPosition(BoneTransform[23], p, Position);
                 CreateParticle(BITMAP_RAIN_CIRCLE + 1, Position, o->Angle, Light);
             }
-            if (rand() % 4 == 0)
+            if (rand_fps_check(4))
             {
                 b->TransformPosition(BoneTransform[31], p, Position);
                 CreateParticle(BITMAP_RAIN_CIRCLE + 1, Position, o->Angle, Light);
@@ -3207,13 +3207,13 @@ void RenderObjectVisual(OBJECT* o)
             break;
         case 37:
             Vector(1.f, 1.f, 1.f, Light);
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 if ((int)((o->Timer++) + 2) % 4 == 0)
                 {
                     CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light);
                     CreateParticle(BITMAP_ADV_SMOKE, o->Position, o->Angle, Light, 0);
                 }
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
                 if ((int)(o->Timer++) % 4 == 0)
                 {
                     CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 6);
@@ -3230,7 +3230,7 @@ void RenderObjectVisual(OBJECT* o)
         switch (o->Type)
         {
         case 84:
-            if (rand() % 5 == 0)
+            if (rand_fps_check(5))
                 CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 10, o->Scale, o);
             break;
         case 90:
@@ -3714,7 +3714,7 @@ void MoveObject(OBJECT* o)
     if (gMapManager.WorldActive == 9)
     {
         if ((int)WorldTime % 4000 < 1000)
-            if (rand() % 100 == 0)
+            if (rand_fps_check(100))
             {
                 float Luminosity = (float)(rand() % 12 + 4) * 0.1f;
                 vec3_t Light;
@@ -3740,7 +3740,7 @@ void MoveObject(OBJECT* o)
         {
             if (o->PriorAnimationFrame > o->AnimationFrame)
             {
-                if (rand() % 10 == 0 && o->CurrentAction != MONSTER01_STOP2)
+                if (rand_fps_check(10) && o->CurrentAction != MONSTER01_STOP2)
                     o->CurrentAction = MONSTER01_STOP2;
                 else
                     o->CurrentAction = MONSTER01_STOP1;
@@ -3769,7 +3769,7 @@ void MoveObject(OBJECT* o)
         switch (o->Type)
         {
         case 8:
-            fSpeed *= 4.0f;
+            fSpeed *= pow(4.0f, FPS_ANIMATION_FACTOR);
             break;
         }
     }
@@ -3780,22 +3780,22 @@ void MoveObject(OBJECT* o)
         {
             if (o->CurrentAction == 0)
             {
-                fSpeed *= 2.2f;
+                fSpeed *= pow(2.2f, FPS_ANIMATION_FACTOR);
             }
             else
             {
-                fSpeed *= 2.0f;
+                fSpeed *= pow(2.0f, FPS_ANIMATION_FACTOR);
             }
 
             if (SEASON3B::GMNewTown::IsCheckMouseIn() == true)
             {
                 if (o->CurrentAction == 0)
                 {
-                    fSpeed *= 2.0f;
+                    fSpeed *= pow(2.0f, FPS_ANIMATION_FACTOR);
                 }
                 else
                 {
-                    fSpeed *= 3.0f;
+                    fSpeed *= pow(3.0f, FPS_ANIMATION_FACTOR);
                 }
             }
         }
@@ -3941,7 +3941,7 @@ void MoveObject(OBJECT* o)
         switch (o->Type)
         {
         case 52:
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
                 CreateEffect(MODEL_DUNGEON_STONE01, o->Position, o->Angle, o->Light);
             //CreateEffect(MODEL_STONE1,o->Position,o->Angle,o->Light);
             o->HiddenMesh = -2;
@@ -4087,7 +4087,7 @@ void MoveObject(OBJECT* o)
             break;
         case 24:
             o->HiddenMesh = -2;
-            if (rand() % 64 == 0)
+            if (rand_fps_check(64))
                 CreateEffect(BITMAP_FLAME, o->Position, o->Angle, o->Light);
             //o->BlendMeshTexCoordV = (int)WorldTime%1000 * 0.001f;
             break;
@@ -4325,7 +4325,7 @@ int MoveHeavenThunder(void)
     float   Luminosity;
     vec3_t  Light;
 
-    if ((rand() % 50) == 0)
+    if (rand_fps_check(50))
     {
         vec3_t  position, Angle;
 
@@ -4344,7 +4344,7 @@ int MoveHeavenThunder(void)
             objectCount = rand() % visibleObject;
         }
 
-        if ((rand() % 5) == 0)
+        if (rand_fps_check(5))
         {
             float Matrix1[3][4];
             float Matrix2[3][4];
@@ -4442,7 +4442,7 @@ void MoveObjectSetting(int& objCount)
             Hero->Object.Position[1] + (float)(rand() % 900 - 300),
             Hero->Object.Position[2] + rand() % 50 + 250.f, Position);
 
-        if ((rand() % 4) == 0)
+        if (rand_fps_check(4))
         {
             CreateParticle(BITMAP_FLARE, Position, Angle, Light, 3, 0.19f, NULL);
         }
@@ -4458,7 +4458,7 @@ void MoveObjectOnEffect(OBJECT* o, int& objCount, int& visObject)
         visObject++;
         if (objCount)
         {
-            if ((rand() % 10) == 0 && o->Type >= 0 && o->Type <= 5)
+            if (rand_fps_check(10) && o->Type >= 0 && o->Type <= 5)
             {
                 Vector(rand() % 10 / 50.f, rand() % 10 / 50.f, rand() % 10 / 50.f, Light);
                 CreateSprite(BITMAP_CLOUD + 1, o->Position, 0.5f, Light, &Hero->Object);
@@ -6440,11 +6440,11 @@ void RenderItems()
                 VectorCopy(o->Position, vBackup);
                 if (gMapManager.WorldActive == WD_10HEAVEN)
                 {
-                    o->Position[2] += 10.0f * (float)sinf((float)(i * 1237 + WorldTime) * 0.002f);
+                    o->Position[2] += 10.0f * (float)sinf((float)(i * 1237 + WorldTime) * 0.002f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (gMapManager.WorldActive == WD_39KANTURU_3RD && g_Direction.m_CKanturu.IsMayaScene())
                 {
-                    o->Position[2] += 10.0f * (float)sinf((float)(i * 1237 + WorldTime) * 0.002f);
+                    o->Position[2] += 10.0f * (float)sinf((float)(i * 1237 + WorldTime) * 0.002f) * FPS_ANIMATION_FACTOR;
                 }
                 else if (gMapManager.InHellas() == true)
                 {
@@ -6705,7 +6705,7 @@ void PartObjectColor(int Type, float Alpha, float Bright, vec3_t Light, bool Ext
             }
         }
     }
-    Bright *= Alpha;
+    Bright *= pow(Alpha, FPS_ANIMATION_FACTOR);
     switch (Color)
     {
     case 0:Vector(Bright * 1.0f, Bright * 0.5f, Bright * 0.0f, Light); break;
@@ -6827,7 +6827,7 @@ void PartObjectColor2(int Type, float Alpha, float Bright, vec3_t Light, bool Ex
             }
         }
     }
-    Bright *= Alpha;
+    Bright *= pow(Alpha, FPS_ANIMATION_FACTOR);
     switch (Color)
     {
     case 0: Vector(Bright * 1.0f * Light[0], Bright * 1.0f * Light[1], Bright * 1.0f * Light[2], Light); break;
@@ -8294,7 +8294,7 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
         VectorCopy(o->Position, b->BodyOrigin);
         b->TransformPosition(o->BoneTransform[20], vRelativePos, vPos, true);
         vPos[2] += 36.f;
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             CreateParticle(BITMAP_TRUE_FIRE, vPos, o->Angle, vLight, 8, 0.5f, o);
         }
@@ -8306,7 +8306,7 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
         Vector(fLumi + 0.5f, fLumi * 0.3f + 0.1f, 0.f, vLight);
         CreateSprite(BITMAP_LIGHT, vPos, 1.0f + fLumi * 0.1f, vLight, o);
 
-        if (rand() % 8 == 0)
+        if (rand_fps_check(8))
         {
             vPos[2] -= 10.0f;
             fLumi = (float)(rand() % 100) * 0.01f;
@@ -8446,7 +8446,7 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
         vec3_t vPos;
 
         Vector(1.f, 0.6f, 0.2f, Light);
-        if (rand() % 100 == 0)
+        if (rand_fps_check(100))
         {
             CreateEffect(MODEL_ARROWSRE06, vPos, o->Angle, Light, 2, o, 0, 0, 0, 0, 1.f);
             CreateEffect(MODEL_ARROWSRE06, vPos, o->Angle, Light, 2, o, 1, 0, 0, 0, 1.f);
@@ -8503,11 +8503,11 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
             Vector(1.f, 1.f, 1.f, vLight);
             CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 20, 1.f);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 4, 2.0f);
-            if (rand() % 6 == 0)
+            if (rand_fps_check(6))
             {
                 CreateParticle(BITMAP_SNOW_EFFECT_1, vPos, o->Angle, vLight, 0, 0.3f);
             }
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 CreateParticle(BITMAP_SNOW_EFFECT_2, vPos, o->Angle, vLight, 0, 0.5f);
             }
@@ -9523,7 +9523,7 @@ void RenderPartObjectEffect(OBJECT* o, int Type, vec3_t Light, float Alpha, int 
     {
         if (Level <= 6)
         {
-            Level *= 2;
+            Level *= pow(2, FPS_ANIMATION_FACTOR);
         }
         else
         {
@@ -9959,12 +9959,12 @@ void RenderPartObjectEffect(OBJECT* o, int Type, vec3_t Light, float Alpha, int 
         }
 
         int iBoneThunder[] = { 11, 21, 29, 63, 81, 89 };
-        if (rand() % 2 == 0)
+        if (rand_fps_check(2))
         {
             for (int i = 0; i < 6; ++i)
             {
                 b->TransformPosition(BoneTransform[iBoneThunder[i]], vRelativePos, vPos, true);
-                if (rand() % 20 == 0)
+                if (rand_fps_check(20))
                 {
                     Vector(0.6f, 0.6f, 0.9f, vLight);
                     CreateEffect(MODEL_FENRIR_THUNDER, vPos, o->Angle, vLight, 1, o);

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -1844,7 +1844,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                 {
                     if (o->CurrentAction == MONSTER01_DIE)
                     {
-                        if (o->LifeTime == 100)
+                        if ((int)o->LifeTime == 100)
                         {
                             o->LifeTime = 90;
                             o->m_bRenderShadow = false;

--- a/Source Main 5.2/source/ZzzObject.h
+++ b/Source Main 5.2/source/ZzzObject.h
@@ -2,7 +2,7 @@
 #define ZZZ_OBJECT_H
 
 extern OBJECT_BLOCK ObjectBlock[256];
-extern OBJECT       Butterfles[];
+extern OBJECT       Mounts[];
 extern OBJECT       Boids[];
 extern OBJECT       Fishs[];
 

--- a/Source Main 5.2/source/ZzzObject.h
+++ b/Source Main 5.2/source/ZzzObject.h
@@ -9,8 +9,8 @@ extern OBJECT       Fishs[];
 extern float EarthQuake;
 extern bool EnableShadow;
 extern float AmbientShadowAngle;
-extern int RainTarget;
-extern int RainCurrent;
+extern float RainTarget;
+extern float RainCurrent;
 
 void CopyShadowAngle(OBJECT* o, BMD* b);
 void CreateShadowAngle();

--- a/Source Main 5.2/source/ZzzOpenglUtil.h
+++ b/Source Main 5.2/source/ZzzOpenglUtil.h
@@ -7,11 +7,12 @@ extern int OpenglWindowHeight;
 extern unsigned int WindowWidth;
 extern unsigned int WindowHeight;
 extern vec3_t CollisionPosition;
-extern float  FPS;
+extern double  FPS;
+extern double  FPS_ANIMATION_FACTOR;
 #if defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)		// 실FPS.(고정 20FPS 상황에서 추정용.)
 extern float g_fFrameEstimate;
 #endif // defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
-extern float  WorldTime;
+extern double  WorldTime;
 extern bool   CameraTopViewEnable;
 extern float  CameraViewNear;
 extern float  CameraViewFar;

--- a/Source Main 5.2/source/ZzzOpenglUtil.h
+++ b/Source Main 5.2/source/ZzzOpenglUtil.h
@@ -9,7 +9,7 @@ extern unsigned int WindowHeight;
 extern vec3_t CollisionPosition;
 extern double  FPS;
 extern double  FPS_AVG;
-extern double  FPS_ANIMATION_FACTOR;
+extern float  FPS_ANIMATION_FACTOR;
 #if defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)		// 실FPS.(고정 20FPS 상황에서 추정용.)
 extern float g_fFrameEstimate;
 #endif // defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)

--- a/Source Main 5.2/source/ZzzOpenglUtil.h
+++ b/Source Main 5.2/source/ZzzOpenglUtil.h
@@ -108,3 +108,4 @@ void InitCollisionDetectLineToFace();
 bool CollisionDetectLineToFace(vec3_t Position, vec3_t Target, int Polygon, float* v1, float* v2, float* v3, float* v4, vec3_t Normal, bool Collision = true);
 bool CollisionDetectLineToOBB(vec3_t p1, vec3_t p2, OBB_t obb);
 void CalcFPS();
+bool rand_fps_check(int reference_frames);

--- a/Source Main 5.2/source/ZzzOpenglUtil.h
+++ b/Source Main 5.2/source/ZzzOpenglUtil.h
@@ -8,6 +8,7 @@ extern unsigned int WindowWidth;
 extern unsigned int WindowHeight;
 extern vec3_t CollisionPosition;
 extern double  FPS;
+extern double  FPS_AVG;
 extern double  FPS_ANIMATION_FACTOR;
 #if defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)		// 실FPS.(고정 20FPS 상황에서 추정용.)
 extern float g_fFrameEstimate;

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -947,7 +947,7 @@ void NewMoveCharacterScene()
     }
     InitTerrainLight();
     MoveObjects();
-    MoveBugs();
+    MoveMounts();
     MoveCharactersClient();
     MoveCharacterClient(&CharacterView);
 
@@ -1112,7 +1112,7 @@ bool NewRenderCharacterScene(HDC hDC)
     if (!CUIMng::Instance().IsCursorOnUI())
         SelectObjects();
 
-    RenderBugs();
+    RenderMount();
     RenderBlurs();
     RenderJoints();
     RenderEffects();
@@ -1236,7 +1236,7 @@ void NewMoveLogInScene()
     {
         InitTerrainLight();
         MoveObjects();
-        MoveBugs();
+        MoveMounts();
         MoveLeaves();
         MoveCharactersClient();
         MoveEffects();
@@ -1350,7 +1350,7 @@ bool NewRenderLogInScene(HDC hDC)
         RenderTerrain(false);
         CameraViewFar = 7000.f;
         RenderCharactersClient();
-        RenderBugs();
+        RenderMount();
         RenderObjects();
         RenderJoints();
         RenderEffects();
@@ -1556,7 +1556,7 @@ bool MoveMainCamera()
 
             vec3_t p1, p2;
             Vector(0.f, 0.f, 0.f, p1);
-            FLOAT Velocity = sqrtf(TERRAIN_SCALE * TERRAIN_SCALE) * 1.25f;
+            FLOAT Velocity = sqrtf(TERRAIN_SCALE * TERRAIN_SCALE) * 1.25f * FPS_ANIMATION_FACTOR;
 
             if (HIBYTE(GetAsyncKeyState(VK_LEFT)) == 128)// || (MouseX<=0 && MouseY>=100))
             {
@@ -1988,11 +1988,11 @@ void MoveMainScene()
 
     MoveBoids();
     MoveFishs();
-    MoveBugs();
     MoveChat();
     UpdatePersonalShopTitleImp();
     MoveHero();
     MoveCharactersClient();
+    MoveMounts();
     ThePetProcess().UpdatePets();
     MovePoints();
     MovePlanes();
@@ -2139,7 +2139,7 @@ bool RenderMainScene()
         RenderItems();
 
     RenderFishs();
-    RenderBugs();
+    RenderMount();
     RenderLeaves();
 
     if (!gMapManager.InChaosCastle())
@@ -2256,7 +2256,7 @@ extern int  GrabScreen;
 
 void MoveCharacter(CHARACTER* c, OBJECT* o);
 
-constexpr int target_fps = 30;
+constexpr int target_fps = 60;
 constexpr int ms_per_frame = 1000 / target_fps;
 
 uint64_t current_tick_count = GetTickCount64();

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -2508,7 +2508,7 @@ void MainScene(HDC hDC)
                 break;
             case WD_3NORIA:
                 PlayBuffer(SOUND_WIND01, NULL, true);
-                if (rand() % 512 == 0)
+                if (rand_fps_check(512))
                     PlayBuffer(SOUND_FOREST01);
                 break;
             case WD_4LOSTTOWER:
@@ -2525,11 +2525,11 @@ void MainScene(HDC hDC)
                 break;
             case WD_10HEAVEN:
                 PlayBuffer(SOUND_HEAVEN01, NULL, true);
-                if ((rand() % 100) == 0)
+                if (rand_fps_check(100))
                 {
                     //                PlayBuffer(SOUND_HEAVEN01);
                 }
-                else if ((rand() % 10) == 0)
+                else if (rand_fps_check(10))
                 {
                     //                PlayBuffer(SOUND_THUNDERS02);
                 }

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -107,7 +107,7 @@ int g_iLengthAuthorityCode = 20;
 
 char* szServerIpAddress = "127.127.127.127";
 //char *szServerIpAddress = "210.181.89.215";
-WORD g_ServerPort = 55900;
+WORD g_ServerPort = 55901;
 
 #ifdef MOVIE_DIRECTSHOW
 int  SceneFlag = MOVIE_SCENE;
@@ -2261,7 +2261,7 @@ float ms_per_frame = 1000.f / target_fps;
 void SetTargetFps(float targetFps)
 {
     target_fps = targetFps;
-    ms_per_frame = 1000 / target_fps;
+    ms_per_frame = 1000.0f / target_fps;
 }
 
 uint64_t current_tick_count = GetTickCount64();
@@ -2271,63 +2271,55 @@ void MainScene(HDC hDC)
 {
     CalcFPS();
 
-    for (float remain = ms_per_frame; remain >= ms_per_frame; remain -= ms_per_frame)
+    g_pNewKeyInput->ScanAsyncKeyState();
+
+    if (SceneFlag == LOG_IN_SCENE || SceneFlag == CHARACTER_SCENE)
     {
-        g_pNewKeyInput->ScanAsyncKeyState();
+        double dDeltaTick = g_pTimer->GetTimeElapsed();
+        dDeltaTick = MIN(dDeltaTick, 200.0 * FPS_ANIMATION_FACTOR);
+        g_pTimer->ResetTimer();
 
-        if (LOG_IN_SCENE == SceneFlag || CHARACTER_SCENE == SceneFlag)
-        {
-            double dDeltaTick = g_pTimer->GetTimeElapsed();
-            dDeltaTick = MIN(dDeltaTick, 200.0);
-            g_pTimer->ResetTimer();
+        CInput::Instance().Update();
+        CUIMng::Instance().Update(dDeltaTick);
+    }
 
-            CInput::Instance().Update();
-            CUIMng::Instance().Update(dDeltaTick);
-        }
+    g_dwMouseUseUIID = 0;
 
-        g_dwMouseUseUIID = 0;
+    switch (SceneFlag)
+    {
+    case LOG_IN_SCENE:
+        NewMoveLogInScene();
+        break;
 
-        switch (SceneFlag)
-        {
-        case LOG_IN_SCENE:
-            NewMoveLogInScene();
-            break;
+    case CHARACTER_SCENE:
+        NewMoveCharacterScene();
+        break;
 
-        case CHARACTER_SCENE:
-            NewMoveCharacterScene();
-            break;
+    case MAIN_SCENE:
+        MoveMainScene();
+        break;
+    }
 
-        case MAIN_SCENE:
-            MoveMainScene();
-            break;
-        }
+    g_PhysicsManager.Move(0.025f * FPS_ANIMATION_FACTOR);
+    MoveNotices();
 
-        for (int iCount = 0; iCount < 5; ++iCount)
-        {
-            g_PhysicsManager.Move(0.005f);
-        }
+    if (PressKey(VK_SNAPSHOT))
+    {
+        if (GrabEnable)
+            GrabEnable = false;
+        else
+            GrabEnable = true;
+    }
 
-        MoveNotices();
-
-        if (PressKey(VK_SNAPSHOT))
-        {
-            if (GrabEnable)
-                GrabEnable = false;
-            else
-                GrabEnable = true;
-        }
-
-        constexpr int NumberOfWaterTextures = 32;
-        constexpr double timePerFrame = 1000 / 25.0;
-        int64_t time_since_last_render = current_tick_count - last_water_change;
-
-        while (time_since_last_render > timePerFrame)
-        {
-            WaterTextureNumber++;
-            WaterTextureNumber %= NumberOfWaterTextures;
-            time_since_last_render -= timePerFrame;
-            last_water_change = current_tick_count;
-        }
+    constexpr int NumberOfWaterTextures = 32;
+    constexpr double timePerFrame = 1000 / REFERENCE_FPS;
+    int64_t time_since_last_render = current_tick_count - last_water_change;
+    while (time_since_last_render > timePerFrame)
+    {
+        WaterTextureNumber++;
+        WaterTextureNumber %= NumberOfWaterTextures;
+        time_since_last_render -= timePerFrame;
+        last_water_change = current_tick_count;
     }
 
     if (Destroy) {
@@ -2338,23 +2330,21 @@ void MainScene(HDC hDC)
 
     Set3DSoundPosition();
 
-    SYSTEMTIME st;
-    GetLocalTime(&st);
-    sprintf(GrabFileName, "Screen(%02d_%02d-%02d_%02d)-%04d.jpg", st.wMonth, st.wDay, st.wHour, st.wMinute, GrabScreen);
-    char Text[256];
-    sprintf(Text, GlobalText[459], GrabFileName);
-    char lpszTemp[64];
-    wsprintf(lpszTemp, " [%s / %s]", g_ServerListManager->GetSelectServerName(), Hero->ID);
-    strcat(Text, lpszTemp);
-    int iCaptureMode = 1;
-
-    if (HIBYTE(GetAsyncKeyState(VK_SHIFT)))
+    const bool addTimeStampToCapture = !HIBYTE(GetAsyncKeyState(VK_SHIFT));
+    char screenshotText[256];
+    if (GrabEnable)
     {
-        iCaptureMode = 1 - iCaptureMode;
-    }
-    if (GrabEnable && iCaptureMode == 1)
-    {
-        g_pChatListBox->AddText("", Text, SEASON3B::TYPE_SYSTEM_MESSAGE);
+        SYSTEMTIME st;
+        GetLocalTime(&st);
+        sprintf(GrabFileName, "Screen(%02d_%02d-%02d_%02d)-%04d.jpg", st.wMonth, st.wDay, st.wHour, st.wMinute, GrabScreen);
+        sprintf(screenshotText, GlobalText[459], GrabFileName);
+        char lpszTemp[64];
+        wsprintf(lpszTemp, " [%s / %s]", g_ServerListManager->GetSelectServerName(), Hero->ID);
+        strcat(screenshotText, lpszTemp);
+        if (addTimeStampToCapture)
+        {
+            g_pChatListBox->AddText("", screenshotText, SEASON3B::TYPE_SYSTEM_MESSAGE);
+        }
     }
 
     if (gMapManager.WorldActive == WD_10HEAVEN)
@@ -2436,10 +2426,11 @@ void MainScene(HDC hDC)
             SaveScreen();
         }
 
-        if (GrabEnable && iCaptureMode == 0)
+        if (GrabEnable && !addTimeStampToCapture)
         {
-            g_pChatListBox->AddText("", Text, SEASON3B::TYPE_SYSTEM_MESSAGE);
+            g_pChatListBox->AddText("", screenshotText, SEASON3B::TYPE_SYSTEM_MESSAGE);
         }
+
         GrabEnable = false;
 
 #ifndef  defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -2248,7 +2248,6 @@ bool RenderMainScene()
     return true;
 }
 
-extern int ChatTime;
 extern int WaterTextureNumber;
 
 int TestTime = 0;
@@ -2256,8 +2255,14 @@ extern int  GrabScreen;
 
 void MoveCharacter(CHARACTER* c, OBJECT* o);
 
-constexpr int target_fps = 60;
-constexpr int ms_per_frame = 1000 / target_fps;
+float target_fps = 60;
+float ms_per_frame = 1000.f / target_fps;
+
+void SetTargetFps(float targetFps)
+{
+    target_fps = targetFps;
+    ms_per_frame = 1000 / target_fps;
+}
 
 uint64_t current_tick_count = GetTickCount64();
 uint64_t last_water_change = GetTickCount64();
@@ -2266,7 +2271,7 @@ void MainScene(HDC hDC)
 {
     CalcFPS();
 
-    for (int32_t remain = ms_per_frame; remain >= ms_per_frame; remain -= ms_per_frame)
+    for (float remain = ms_per_frame; remain >= ms_per_frame; remain -= ms_per_frame)
     {
         g_pNewKeyInput->ScanAsyncKeyState();
 
@@ -2437,7 +2442,7 @@ void MainScene(HDC hDC)
         }
         GrabEnable = false;
 
-#if defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
+#ifndef  defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
         BeginBitmap();
         unicode::t_char szDebugText[128];
         unicode::_sprintf(szDebugText, "FPS : %.1f Connected: %d", FPS_AVG, g_bGameServerConnected);

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -2440,7 +2440,7 @@ void MainScene(HDC hDC)
 #if defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
         BeginBitmap();
         unicode::t_char szDebugText[128];
-        unicode::_sprintf(szDebugText, "FPS : %.1f Connected: %d", FPS, g_bGameServerConnected);
+        unicode::_sprintf(szDebugText, "FPS : %.1f Connected: %d", FPS_AVG, g_bGameServerConnected);
         unicode::t_char szMousePos[128];
         unicode::_sprintf(szMousePos, "MousePos : %d %d %d", MouseX, MouseY, MouseLButtonPush);
         unicode::t_char szCamera3D[128];

--- a/Source Main 5.2/source/ZzzScene.h
+++ b/Source Main 5.2/source/ZzzScene.h
@@ -24,6 +24,7 @@ extern void LoadingScene(HDC hDC);
 extern void Scene(HDC Hdc);
 extern bool CheckName();
 void    StartGame();
+void SetTargetFps(float targetFps);
 
 BOOL	ShowCheckBox(int num, int index, int message = MESSAGE_TRADE_CHECK);
 

--- a/Source Main 5.2/source/_define.h
+++ b/Source Main 5.2/source/_define.h
@@ -120,7 +120,7 @@
 //struct
 #define MAX_BOIDS         40
 #define MAX_FISHS         10
-#define MAX_BUTTERFLES    10
+#define MAX_MOUNTS    10
 //bodypart
 #define BODYPART_HEAD   0
 #define BODYPART_HELM   1

--- a/Source Main 5.2/source/_define.h
+++ b/Source Main 5.2/source/_define.h
@@ -469,7 +469,7 @@ enum struct STORAGE_TYPE
 #define REGIMENT_ATTACK     2
 
 #define MAX_JOINTS 500
-#define MAX_TAILS  50
+#define MAX_TAILS  200
 
 #define RENDER_FACE_ONE 0x01
 #define RENDER_FACE_TWO 0x02

--- a/Source Main 5.2/source/_struct.h
+++ b/Source Main 5.2/source/_struct.h
@@ -470,7 +470,7 @@ typedef struct
     vec3_t Angle;
     vec3_t Light;
     float  Alpha;
-    int    LifeTime;
+    float  LifeTime;
     OBJECT* Target;
     float  Rotation;
     int    Frame;

--- a/Source Main 5.2/source/_struct.h
+++ b/Source Main 5.2/source/_struct.h
@@ -527,14 +527,14 @@ typedef struct
     int			NumTails;
     int			MaxTails;
     vec3_t		Tails[MAX_TAILS][4];
-    int  		LifeTime;
+    float  		LifeTime;
     bool        Collision;
     float		Velocity;
     vec3_t		Direction;
     short       PKKey;
     WORD		Skill;
     BYTE		Weapon;
-    int			MultiUse;
+    float			MultiUse;
     bool        bTileMapping;
     BYTE        m_byReverseUV;
     bool        m_bCreateTails;

--- a/Source Main 5.2/source/_struct.h
+++ b/Source Main 5.2/source/_struct.h
@@ -524,9 +524,6 @@ typedef struct
     OBJECT* Target;
     vec3_t      TargetPosition;
     BYTE        byOnlyOneRender;
-    float		NumTails;
-    int			MaxTails;
-    vec3_t		Tails[MAX_TAILS][4];
     float  		LifeTime;
     bool        Collision;
     float		Velocity;
@@ -537,11 +534,16 @@ typedef struct
     float		MultiUse;
     bool        bTileMapping;
     BYTE        m_byReverseUV;
-    bool        m_bCreateTails;
     int			TargetIndex[5];
     BYTE		m_bySkillSerialNum;
     int			m_iChaIndex;
     short int	m_sTargetIndex;
+
+    // Fields about the "Tails" of effects:
+    bool        m_bCreateTails; // Flag, if tails are created.
+    int         NumTails; // The number of currently used tail entries. Usually this gets increased by one in every frame until the maximum is reached.
+    int         MaxTails; // The maximum number of tail entries to use.
+    vec3_t      Tails[MAX_TAILS][4]; // The tail entries, which are getting moved back by one in every frame.
 } JOINT;
 //character end
 

--- a/Source Main 5.2/source/_struct.h
+++ b/Source Main 5.2/source/_struct.h
@@ -524,7 +524,7 @@ typedef struct
     OBJECT* Target;
     vec3_t      TargetPosition;
     BYTE        byOnlyOneRender;
-    int			NumTails;
+    float		NumTails;
     int			MaxTails;
     vec3_t		Tails[MAX_TAILS][4];
     float  		LifeTime;

--- a/Source Main 5.2/source/_struct.h
+++ b/Source Main 5.2/source/_struct.h
@@ -533,8 +533,8 @@ typedef struct
     vec3_t		Direction;
     short       PKKey;
     WORD		Skill;
-    BYTE		Weapon;
-    float			MultiUse;
+    float		Weapon;
+    float		MultiUse;
     bool        bTileMapping;
     BYTE        m_byReverseUV;
     bool        m_bCreateTails;

--- a/Source Main 5.2/source/w_CharacterInfo.h
+++ b/Source Main 5.2/source/w_CharacterInfo.h
@@ -154,7 +154,6 @@ public:
     BYTE		AttackTime;
     BYTE        TargetAngle;
     BYTE        Dead;
-    BYTE        Run;
     WORD		Skill;
     BYTE        SwordCount;
     BYTE		byExtensionSkill;
@@ -205,6 +204,7 @@ public:
     float       Freeze;
     float       Duplication;
     float		Rot;
+    float       Run;
 
     vec3_t		TargetPosition;
     vec3_t      Light;

--- a/Source Main 5.2/source/w_CharacterInfo.h
+++ b/Source Main 5.2/source/w_CharacterInfo.h
@@ -151,29 +151,27 @@ public:
     char		PKPartyLevel;
 #endif //LJH_ADD_MORE_ZEN_FOR_ONE_HAVING_A_PARTY_WITH_MURDERER
     BYTE        AttackFlag;
-    BYTE		AttackTime;
+    
     BYTE        TargetAngle;
     BYTE        Dead;
     WORD		Skill;
     BYTE        SwordCount;
     BYTE		byExtensionSkill;
     WORD		m_byDieType;
-    BYTE		StormTime;
-    BYTE		JumpTime;
     BYTE        TargetX;
     BYTE        TargetY;
     BYTE        SkillX;
     BYTE        SkillY;
     BYTE        Appear;
     BYTE	    CurrentSkill;
-    BYTE        CastRenderTime;
+    BYTE        CastRenderTime; // unused?
     BYTE        m_byFriend;
     WORD        MonsterSkill;
 
     char        ID[32];
     char 		Movement;
     char		MovementType;
-    char		CollisionTime;
+    char		CollisionTime; // unused?
 
     short       GuildMarkIndex;
     SHORT       Key;
@@ -186,7 +184,6 @@ public:
     WORD        MoveSpeed;
 
     int			Action;
-    int         ExtendStateTime;
     int			LongRangeAttack;
     int			SelectItem;
     int			Item;
@@ -195,9 +192,14 @@ public:
     int         PriorPositionY;
     int         PositionX;
     int         PositionY;
-    int         m_iDeleteTime;
     int			m_iFenrirSkillTarget;
+
+    float       m_iDeleteTime;
     float       LastCritDamageEffect;
+    float       ExtendStateTime;
+    float		JumpTime;
+    float		StormTime;
+    float		AttackTime;
 
     float		ProtectGuildMarkWorldTime;
     float		AttackRange;

--- a/Source Main 5.2/source/w_CursedTemple.cpp
+++ b/Source Main 5.2/source/w_CursedTemple.cpp
@@ -569,7 +569,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
         break;
         case 70:
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 float fLumi = (rand() % 10) * 0.007f + 0.03f;
                 Vector(54.f / 256.f * fLumi, 177.f / 256.f * fLumi, 150.f / 256.f * fLumi, Light);
@@ -579,7 +579,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
         case 71:
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 float fLumi = (rand() % 10) * 0.007f + 0.03f;
                 Vector(221.f / 256.f * fLumi, 121.f / 256.f * fLumi, 201.f / 256.f * fLumi, Light);
@@ -589,7 +589,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
         case 72:
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 float fLumi = (rand() % 10) * 0.007f + 0.03f;
                 Vector(54.f / 256.f * fLumi, 177.f / 256.f * fLumi, 150.f / 256.f * fLumi, Light);
@@ -601,7 +601,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
         case 73:
         {
-            if (rand() % 3 == 0)
+            if (rand_fps_check(3))
             {
                 float fLumi = (rand() % 10) * 0.002f + 0.03f;
                 Vector(1.2f * fLumi, 1.2f * fLumi, 1.2f * fLumi, Light);
@@ -611,7 +611,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
         case 74:
         {
-            if (rand() % 2 == 0)
+            if (rand_fps_check(2))
             {
                 Vector(0.f, 0.f, 0.f, Light);
                 CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 16, o->Scale, o);
@@ -685,7 +685,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
         case 79:
         {
-            if (rand() % 1 == 0)
+            if (rand_fps_check(1))
             {
                 for (int i = 0; i < 5; ++i)
                 {

--- a/Source Main 5.2/source/w_CursedTemple.cpp
+++ b/Source Main 5.2/source/w_CursedTemple.cpp
@@ -382,7 +382,7 @@ void CursedTemple::MoveMonsterSoundVisual(OBJECT* o, BMD* b)
 {
     if (!gMapManager.IsCursedTemple()) return;
 
-    float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+    float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
 
     switch (o->Type)
     {
@@ -494,7 +494,7 @@ void CursedTemple::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
             vec3_t StartPos, StartRelative;
             vec3_t EndPos, EndRelative;
 
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
             float fSpeedPerFrame = fActionSpeed / 10.f;
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
             for (int i = 0; i < 10; i++)
@@ -778,7 +778,7 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
         if (o->CurrentAction == MONSTER01_STOP2)
         {
-            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+            float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
 
             if (o->AnimationFrame > 0.5f && o->AnimationFrame < (8.5f + fActionSpeed))
             {
@@ -1228,7 +1228,7 @@ void CursedTemple::ReceiveCursedTempleInfo(const BYTE* ReceiveBuffer)
                 BMD* b = &Models[o->Type];
                 VectorCopy(o->Position, b->BodyOrigin);
 
-                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed;
+                float fActionSpeed = b->Actions[o->CurrentAction].PlaySpeed * static_cast<float>(FPS_ANIMATION_FACTOR);
 
                 float fSpeedPerFrame = fActionSpeed / 10.f;
 

--- a/Source Main 5.2/source/w_ObjectInfo.h
+++ b/Source Main 5.2/source/w_ObjectInfo.h
@@ -153,7 +153,6 @@ public:
 public:
     short         ScreenX;
     short         ScreenY;
-    short         PKKey;
     short         Weapon;
 
 public:
@@ -161,7 +160,7 @@ public:
     int           SubType;
     int			  m_iAnimation;
     int           HiddenMesh;
-    int           LifeTime;
+    float           LifeTime;
     int           BlendMesh;
     int           AttackPoint[2];
     int           RenderType;
@@ -190,6 +189,7 @@ public:
 
 
     float       LastHorseWaveEffect;
+    float         PKKey;
 
 public:
     vec3_t        Light;

--- a/Source Main 5.2/source/w_PetActionCollecter_Add.cpp
+++ b/Source Main 5.2/source/w_PetActionCollecter_Add.cpp
@@ -238,7 +238,7 @@ bool PetActionCollecterAdd::Effect(OBJECT* obj, CHARACTER* Owner, int targetKey,
     b->TransformPosition(BoneTransform[7], vRelativePos, Position, false);
 
     //CreateParticle(BITMAP_LIGHT+3, Position, obj->Angle, Light, 7 );
-    if (rand() % 3 == 0)
+    if (rand_fps_check(3))
     {
         Vector(0.6f, 1.0f, 0.4f, Light);
         CreateParticle(BITMAP_LIGHT + 3, Position, obj->Angle, Light, 1, 1.f);
@@ -564,7 +564,7 @@ bool PetActionCollecterSkeleton::Effect(OBJECT* obj, CHARACTER* Owner, int targe
 
         for (int i = 0; i < 2; ++i)
         {
-            if (i == 1 && rand() % 2 == 0) continue;
+            if (i == 1 && rand_fps_check(2)) continue;
 
             switch (rand() % 3)
             {

--- a/Source Main 5.2/source/w_PetActionUnicorn.cpp
+++ b/Source Main 5.2/source/w_PetActionUnicorn.cpp
@@ -258,7 +258,7 @@ bool PetActionUnicorn::Effect(OBJECT* obj, CHARACTER* Owner, int targetKey, DWOR
     CreateSprite(BITMAP_MAGIC, Position, 0.15f, Light, obj);
 
     Vector(1.0f, 0.7f, 0.3f, Light);
-    if (rand() % 3 == 0)
+    if (rand_fps_check(3))
         CreateEffect(BITMAP_PIN_LIGHT, Position, obj->Angle, Light, 4, obj, -1, 0, 0, 0, 0.45f);
 
     b->TransformPosition(BoneTransform[4], vRelativePos, Position, false);
@@ -267,7 +267,7 @@ bool PetActionUnicorn::Effect(OBJECT* obj, CHARACTER* Owner, int targetKey, DWOR
     CreateSprite(BITMAP_SMOKE, Position, 1.2f, Light, obj);
     CreateSprite(BITMAP_LIGHT, Position, 4.0f, Light, obj);
 
-    if (rand() % 2 == 0)
+    if (rand_fps_check(2))
         CreateParticle(BITMAP_SMOKE, Position, obj->Angle, Light, 67, 1.0f);
 
     Vector(0.7f, 0.7f, 1.0f, Light);

--- a/Source Main 5.2/source/zzzeffectsprite.cpp
+++ b/Source Main 5.2/source/zzzeffectsprite.cpp
@@ -43,7 +43,7 @@ void RenderSprite(OBJECT* o, OBJECT* Owner)
 {
     if (o->Visible)
     {
-        o->AnimationFrame += 0.1f;
+        o->AnimationFrame += 0.1f * static_cast<float>(FPS_ANIMATION_FACTOR);
         if (o->AnimationFrame > 1.f)
         {
             o->AnimationFrame = 1.f;
@@ -51,7 +51,7 @@ void RenderSprite(OBJECT* o, OBJECT* Owner)
     }
     else
     {
-        o->AnimationFrame -= 0.1f;
+        o->AnimationFrame -= 0.1f * static_cast<float>(FPS_ANIMATION_FACTOR);
         if (o->AnimationFrame < 0.2f)
         {
             o->AnimationFrame = 0.2f;

--- a/Source Main 5.2/source/zzzeffectsprite.cpp
+++ b/Source Main 5.2/source/zzzeffectsprite.cpp
@@ -13,11 +13,17 @@
 #include "ZzzEffect.h"
 #include "DSPlaySound.h"
 #include "WSClient.h"
+#include "NewUISystem.h"
 
 OBJECT	Sprites[MAX_SPRITES];
 
 int CreateSprite(int Type, vec3_t Position, float Scale, vec3_t Light, OBJECT* Owner, float Rotation, int SubType)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return false;
+    }
+
     for (int i = 0; i < MAX_SPRITES; i++)
     {
         OBJECT* o = &Sprites[i];
@@ -112,6 +118,11 @@ void RenderSprite(OBJECT* o, OBJECT* Owner)
 
 void RenderSprites(BYTE byRenderOneMore)
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_SPRITES; i++)
     {
         OBJECT* o = &Sprites[i];
@@ -165,6 +176,11 @@ void RenderSprites(BYTE byRenderOneMore)
 
 void CheckSprites()
 {
+    if (!g_pOption->GetRenderAllEffects())
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_SPRITES; i++)
     {
         OBJECT* o = &Sprites[i];


### PR DESCRIPTION
FPS can be changed by using the $fps chat command, e.g. "$fps 60". The default is 60 fps now.

Most effects and movements scale correctly now. I introduced a new variable `FPS_ANIMATION_FACTOR` which can be used to scale all frame-dependent value offsets. Previously, these offsets were added on each frame, regardless how long the frame took.