### PR TITLE
Vertex arrays for BMD::RenderMesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ to Season 6 Episode 3.
 What I have done so far:
   * 🔥 The framerate has been increased to 60 fps and can be adjusted with the chat
     command `$fps <value>`. The options menu includes a checkbox to reduce effects.
+  * 🔥 Optimized some OpenGL calls by using vertex arrays. This should result in
+    a better frame rate when many players and objects are visible.
   * 🔥 Added inventory and vault extensions.
   * 🔥 Replaced the network stack with MUnique.OpenMU.Network to make it easier to
     apply changes. I included a .NET 7 runtime for this and had to change some

--- a/Source Main 5.2/source/Math/ZzzMathLib.h
+++ b/Source Main 5.2/source/Math/ZzzMathLib.h
@@ -24,6 +24,7 @@ extern "C" {
     bool QuaternionCompare(const vec4_t v1, const vec4_t v2);
 
 #define Vector(a,b,c,d) {(d)[0]=a;(d)[1]=b;(d)[2]=c;}
+#define Vector4(a,b,c,d,target) {(target)[0]=a;(target)[1]=b;(target)[2]=c;(target)[3]=d;}
 #define VectorAvg(a) ( ( (a)[0] + (a)[1] + (a)[2] ) / 3 )
 #define VectorSubtract(a,b,c) {(c)[0]=(a)[0]-(b)[0];(c)[1]=(a)[1]-(b)[1];(c)[2]=(a)[2]-(b)[2];}
 #define VectorSubtractScaled(a,b,c,d) {(c)[0]=(a)[0]-(b)[0]*(d);(c)[1]=(a)[1]-(b)[1]*(d);(c)[2]=(a)[2]-(b)[2]*(d);}

--- a/Source Main 5.2/source/PhysicsManager.cpp
+++ b/Source Main 5.2/source/PhysicsManager.cpp
@@ -945,7 +945,6 @@ void CPhysicsClothMesh::Clear(void)
     CPhysicsCloth::Destroy();
 }
 
-extern vec3_t VertexTransform[MAX_MESH][MAX_VERTICES];
 extern float BoneScale;
 
 BOOL CPhysicsClothMesh::Create(OBJECT* o, int iMesh, int iBone, DWORD dwType, int iBMDType)

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -2461,8 +2461,6 @@ void BlurShadow()
 
 void BMD::Release()
 {
-    // glDeleteVertexArrays(1, &VertexArrayObject);
-
     for (int i = 0; i < NumBones; i++)
     {
         Bone_t* b = &Bones[i];
@@ -3060,9 +3058,6 @@ void BMD::Init(bool Dummy)
     BoneHead = -1;
     StreamMesh = -1;
     CreateBoundingBox();
-
-    //glGenVertexArrays(1, &VertexArrayObject);
-    //glBindVertexArray(VertexArrayObject);
 }
 
 void BMD::CreateBoundingBox()

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -911,103 +911,120 @@ void BMD::EndRender()
 extern double WorldTime;
 extern int WaterTextureNumber;
 
-void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float BlendMeshLight, float BlendMeshTexCoordU, float BlendMeshTexCoordV, int MeshTexture)
+void BMD::RenderMesh(int meshIndex, int renderFlags, float alpha, int blendMeshIndex, float blendMeshAlpha, float blendMeshTextureCoordU, float blendMeshTextureCoordV, int explicitTextureIndex)
 {
-    if (i >= NumMeshs || i < 0) return;
+    if (meshIndex >= NumMeshs || meshIndex < 0) return;
 
-    Mesh_t* m = &Meshs[i];
+    Mesh_t* m = &Meshs[meshIndex];
     if (m->NumTriangles == 0) return;
 
-    float Wave = (long)WorldTime % 10000 * 0.0001f;
+    float wave = static_cast<long>(WorldTime) % 10000 * 0.0001f;
 
-    int Texture = IndexTexture[m->Texture];
-    if (Texture == BITMAP_HIDE)
+    int textureIndex = IndexTexture[m->Texture];
+    if (textureIndex == BITMAP_HIDE)
         return;
-    else if (Texture == BITMAP_SKIN)
+
+    if (textureIndex == BITMAP_SKIN)
+    {
+        if (HideSkin)
+        {
+            return;
+        }
+
+        textureIndex = BITMAP_SKIN + Skin;
+    }
+    else if (textureIndex == BITMAP_WATER)
+    {
+        textureIndex = BITMAP_WATER + WaterTextureNumber;
+    }
+    else  if (textureIndex == BITMAP_HAIR)
     {
         if (HideSkin) return;
-        Texture = BITMAP_SKIN + Skin;
-    }
-    else if (Texture == BITMAP_WATER)
-    {
-        Texture = BITMAP_WATER + WaterTextureNumber;
-    }
-    else  if (Texture == BITMAP_HAIR)
-    {
-        if (HideSkin) return;
-        Texture = BITMAP_HAIR + (Skin - 8);
+        textureIndex = BITMAP_HAIR + (Skin - 8);
     }
 
-    if (MeshTexture != -1)
-        Texture = MeshTexture;
+    if (explicitTextureIndex != -1)
+    {
+        textureIndex = explicitTextureIndex;
+    }
 
-    BITMAP_t* pBitmap = Bitmaps.GetTexture(Texture);
+    const auto texture = Bitmaps.GetTexture(textureIndex);
 
     bool EnableWave = false;
-    int streamMesh = StreamMesh;
-    if (m->m_csTScript != NULL)
+    int streamMesh = static_cast<u_char>(this->StreamMesh);
+    if (m->m_csTScript != nullptr)
     {
         if (m->m_csTScript->getStreamMesh())
         {
-            streamMesh = i;
+            streamMesh = meshIndex;
         }
     }
-    if ((i == BlendMesh || i == streamMesh) && (BlendMeshTexCoordU != 0.f || BlendMeshTexCoordV != 0.f))
-        EnableWave = true;
 
-    bool EnableLight = LightEnable;
-    if (i == StreamMesh)
+    if ((meshIndex == blendMeshIndex || meshIndex == streamMesh)
+        && (blendMeshTextureCoordU != 0.f || blendMeshTextureCoordV != 0.f))
+    {
+        EnableWave = true;
+    }
+
+    bool enableLight = LightEnable;
+    if (meshIndex == StreamMesh)
     {
         glColor3fv(BodyLight);
-        EnableLight = false;
+        enableLight = false;
     }
-    else if (EnableLight)
+    else if (enableLight)
     {
         for (int j = 0; j < m->NumNormals; j++)
         {
-            VectorScale(BodyLight, IntensityTransform[i][j], LightTransform[i][j]);
+            VectorScale(BodyLight, IntensityTransform[meshIndex][j], LightTransform[meshIndex][j]);
         }
     }
 
-    int Render = RenderFlag;
-    if ((RenderFlag & RENDER_COLOR) == RENDER_COLOR)
+    int finalRenderFlags = renderFlags;
+    if ((renderFlags & RENDER_COLOR) == RENDER_COLOR)
     {
-        Render = RENDER_COLOR;
-        if ((RenderFlag & RENDER_BRIGHT) == RENDER_BRIGHT)
+        finalRenderFlags = RENDER_COLOR;
+        if ((renderFlags & RENDER_BRIGHT) == RENDER_BRIGHT)
+        {
             EnableAlphaBlend();
-        else if ((RenderFlag & RENDER_DARK) == RENDER_DARK)
+        }
+        else if ((renderFlags & RENDER_DARK) == RENDER_DARK)
+        {
             EnableAlphaBlendMinus();
+        }
         else
+        {
             DisableAlphaBlend();
+        }
 
-        if ((RenderFlag & RENDER_NODEPTH) == RENDER_NODEPTH)
+        if ((renderFlags & RENDER_NODEPTH) == RENDER_NODEPTH)
         {
             DisableDepthTest();
         }
 
         DisableTexture();
-        if (Alpha >= 0.99f)
+        if (alpha >= 0.99f)
         {
             glColor3fv(BodyLight);
         }
         else
         {
             EnableAlphaTest();
-            glColor4f(BodyLight[0], BodyLight[1], BodyLight[2], Alpha);
+            glColor4f(BodyLight[0], BodyLight[1], BodyLight[2], alpha);
         }
     }
-    else if ((RenderFlag & RENDER_CHROME) == RENDER_CHROME ||
-        (RenderFlag & RENDER_CHROME2) == RENDER_CHROME2 ||
-        (RenderFlag & RENDER_CHROME3) == RENDER_CHROME3 ||
-        (RenderFlag & RENDER_CHROME4) == RENDER_CHROME4 ||
-        (RenderFlag & RENDER_CHROME5) == RENDER_CHROME5 ||
-        (RenderFlag & RENDER_CHROME6) == RENDER_CHROME6 ||
-        (RenderFlag & RENDER_CHROME7) == RENDER_CHROME7 ||
-        (RenderFlag & RENDER_METAL) == RENDER_METAL ||
-        (RenderFlag & RENDER_OIL) == RENDER_OIL
+    else if ((renderFlags & RENDER_CHROME) == RENDER_CHROME ||
+        (renderFlags & RENDER_CHROME2) == RENDER_CHROME2 ||
+        (renderFlags & RENDER_CHROME3) == RENDER_CHROME3 ||
+        (renderFlags & RENDER_CHROME4) == RENDER_CHROME4 ||
+        (renderFlags & RENDER_CHROME5) == RENDER_CHROME5 ||
+        (renderFlags & RENDER_CHROME6) == RENDER_CHROME6 ||
+        (renderFlags & RENDER_CHROME7) == RENDER_CHROME7 ||
+        (renderFlags & RENDER_METAL) == RENDER_METAL ||
+        (renderFlags & RENDER_OIL) == RENDER_OIL
         )
     {
-        if (m->m_csTScript != NULL)
+        if (m->m_csTScript != nullptr)
         {
             if (m->m_csTScript->getNoneBlendMesh()) return;
         }
@@ -1015,14 +1032,14 @@ void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float Bl
         if (m->NoneBlendMesh)
             return;
 
-        Render = RENDER_CHROME;
-        if ((RenderFlag & RENDER_CHROME4) == RENDER_CHROME4)
+        finalRenderFlags = RENDER_CHROME;
+        if ((renderFlags & RENDER_CHROME4) == RENDER_CHROME4)
         {
-            Render = RENDER_CHROME4;
+            finalRenderFlags = RENDER_CHROME4;
         }
-        if ((RenderFlag & RENDER_OIL) == RENDER_OIL)
+        if ((renderFlags & RENDER_OIL) == RENDER_OIL)
         {
-            Render = RENDER_OIL;
+            finalRenderFlags = RENDER_OIL;
         }
 
         float Wave2 = (int)WorldTime % 5000 * 0.00024f - 0.4f;
@@ -1031,84 +1048,80 @@ void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float Bl
         for (int j = 0; j < m->NumNormals; j++)
         {
             if (j > MAX_VERTICES) break;
-            float* Normal = NormalTransform[i][j];
+            const auto normal = NormalTransform[meshIndex][j];
 
-            if ((RenderFlag & RENDER_CHROME2) == RENDER_CHROME2)
+            if ((renderFlags & RENDER_CHROME2) == RENDER_CHROME2)
             {
-                g_chrome[j][0] = (Normal[2] + Normal[0]) * 0.8f + Wave2 * 2.f;
-                g_chrome[j][1] = (Normal[1] + Normal[0]) * 1.0f + Wave2 * 3.f;
+                g_chrome[j][0] = (normal[2] + normal[0]) * 0.8f + Wave2 * 2.f;
+                g_chrome[j][1] = (normal[1] + normal[0]) * 1.0f + Wave2 * 3.f;
             }
-            else if ((RenderFlag & RENDER_CHROME3) == RENDER_CHROME3)
+            else if ((renderFlags & RENDER_CHROME3) == RENDER_CHROME3)
             {
-                g_chrome[j][0] = DotProduct(Normal, LightVector);
-                g_chrome[j][1] = 1.f - DotProduct(Normal, LightVector);
+                g_chrome[j][0] = DotProduct(normal, LightVector);
+                g_chrome[j][1] = 1.f - DotProduct(normal, LightVector);
             }
-            else if ((RenderFlag & RENDER_CHROME4) == RENDER_CHROME4)
+            else if ((renderFlags & RENDER_CHROME4) == RENDER_CHROME4)
             {
-                g_chrome[j][0] = DotProduct(Normal, L);
-                g_chrome[j][1] = 1.f - DotProduct(Normal, L);
-                g_chrome[j][1] -= Normal[2] * 0.5f + Wave * 3.f;
-                g_chrome[j][0] += Normal[1] * 0.5f + L[1] * 3.f;
+                g_chrome[j][0] = DotProduct(normal, L);
+                g_chrome[j][1] = 1.f - DotProduct(normal, L);
+                g_chrome[j][1] -= normal[2] * 0.5f + wave * 3.f;
+                g_chrome[j][0] += normal[1] * 0.5f + L[1] * 3.f;
             }
-            else if ((RenderFlag & RENDER_CHROME5) == RENDER_CHROME5)
+            else if ((renderFlags & RENDER_CHROME5) == RENDER_CHROME5)
             {
-                g_chrome[j][0] = DotProduct(Normal, L);
-                g_chrome[j][1] = 1.f - DotProduct(Normal, L);
-                g_chrome[j][1] -= Normal[2] * 2.5f + Wave * 1.f;
-                g_chrome[j][0] += Normal[1] * 3.f + L[1] * 5.f;
+                g_chrome[j][0] = DotProduct(normal, L);
+                g_chrome[j][1] = 1.f - DotProduct(normal, L);
+                g_chrome[j][1] -= normal[2] * 2.5f + wave * 1.f;
+                g_chrome[j][0] += normal[1] * 3.f + L[1] * 5.f;
             }
-            else if ((RenderFlag & RENDER_CHROME6) == RENDER_CHROME6)
+            else if ((renderFlags & RENDER_CHROME6) == RENDER_CHROME6)
             {
-                g_chrome[j][0] = (Normal[2] + Normal[0]) * 0.8f + Wave2 * 2.f;
-                g_chrome[j][1] = (Normal[2] + Normal[0]) * 0.8f + Wave2 * 2.f;
+                g_chrome[j][0] = (normal[2] + normal[0]) * 0.8f + Wave2 * 2.f;
+                g_chrome[j][1] = (normal[2] + normal[0]) * 0.8f + Wave2 * 2.f;
             }
-            else if ((RenderFlag & RENDER_CHROME7) == RENDER_CHROME7)
+            else if ((renderFlags & RENDER_CHROME7) == RENDER_CHROME7)
             {
-                g_chrome[j][0] = (Normal[2] + Normal[0]) * 0.8f + WorldTime * 0.00006f;
-                g_chrome[j][1] = (Normal[2] + Normal[0]) * 0.8f + WorldTime * 0.00006f;
+                g_chrome[j][0] = (normal[2] + normal[0]) * 0.8f + static_cast<float>(WorldTime) * 0.00006f;
+                g_chrome[j][1] = (normal[2] + normal[0]) * 0.8f + static_cast<float>(WorldTime) * 0.00006f;
             }
-            else if ((RenderFlag & RENDER_OIL) == RENDER_OIL)
+            else if ((renderFlags & RENDER_OIL) == RENDER_OIL)
             {
-                g_chrome[j][0] = Normal[0];
-                g_chrome[j][1] = Normal[1];
+                g_chrome[j][0] = normal[0];
+                g_chrome[j][1] = normal[1];
             }
-            else if ((RenderFlag & RENDER_CHROME) == RENDER_CHROME)
+            else if ((renderFlags & RENDER_CHROME) == RENDER_CHROME)
             {
-                g_chrome[j][0] = Normal[2] * 0.5f + Wave;
-                g_chrome[j][1] = Normal[1] * 0.5f + Wave * 2.f;
+                g_chrome[j][0] = normal[2] * 0.5f + wave;
+                g_chrome[j][1] = normal[1] * 0.5f + wave * 2.f;
             }
             else
             {
-                g_chrome[j][0] = Normal[2] * 0.5f + 0.2f;
-                g_chrome[j][1] = Normal[1] * 0.5f + 0.5f;
+                g_chrome[j][0] = normal[2] * 0.5f + 0.2f;
+                g_chrome[j][1] = normal[1] * 0.5f + 0.5f;
             }
         }
 
-        if ((RenderFlag & RENDER_CHROME3) == RENDER_CHROME3
-            || (RenderFlag & RENDER_CHROME4) == RENDER_CHROME4
-            || (RenderFlag & RENDER_CHROME5) == RENDER_CHROME5
-            || (RenderFlag & RENDER_CHROME7) == RENDER_CHROME7
+        if ((renderFlags & RENDER_CHROME3) == RENDER_CHROME3
+            || (renderFlags & RENDER_CHROME4) == RENDER_CHROME4
+            || (renderFlags & RENDER_CHROME5) == RENDER_CHROME5
+            || (renderFlags & RENDER_CHROME7) == RENDER_CHROME7
+            || (renderFlags & RENDER_BRIGHT) == RENDER_BRIGHT
             )
         {
-            if (Alpha < 0.99f)
+            if (alpha < 0.99f)
             {
-                BodyLight[0] *= Alpha; BodyLight[1] *= Alpha; BodyLight[2] *= Alpha;
+                BodyLight[0] *= alpha;
+                BodyLight[1] *= alpha;
+                BodyLight[2] *= alpha;
             }
+
             EnableAlphaBlend();
         }
-        else if ((RenderFlag & RENDER_BRIGHT) == RENDER_BRIGHT)
-        {
-            if (Alpha < 0.99f)
-            {
-                BodyLight[0] *= Alpha; BodyLight[1] *= Alpha; BodyLight[2] *= Alpha;
-            }
-            EnableAlphaBlend();
-        }
-        else if ((RenderFlag & RENDER_DARK) == RENDER_DARK)
+        else if ((renderFlags & RENDER_DARK) == RENDER_DARK)
             EnableAlphaBlendMinus();
-        else if ((RenderFlag & RENDER_LIGHTMAP) == RENDER_LIGHTMAP)
+        else if ((renderFlags & RENDER_LIGHTMAP) == RENDER_LIGHTMAP)
             EnableLightMap();
-        else if (Alpha >= 0.99f)
+        else if (alpha >= 0.99f)
         {
             DisableAlphaBlend();
         }
@@ -1117,65 +1130,67 @@ void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float Bl
             EnableAlphaTest();
         }
 
-        if ((RenderFlag & RENDER_NODEPTH) == RENDER_NODEPTH)
+        if ((renderFlags & RENDER_NODEPTH) == RENDER_NODEPTH)
         {
             DisableDepthTest();
         }
 
-        if ((RenderFlag & RENDER_CHROME2) == RENDER_CHROME2 && MeshTexture == -1)
+        if ((renderFlags & RENDER_CHROME2) == RENDER_CHROME2 && explicitTextureIndex == -1)
         {
             BindTexture(BITMAP_CHROME2);
         }
-        else if ((RenderFlag & RENDER_CHROME3) == RENDER_CHROME3 && MeshTexture == -1)
+        else if ((renderFlags & RENDER_CHROME3) == RENDER_CHROME3 && explicitTextureIndex == -1)
         {
             BindTexture(BITMAP_CHROME2);
         }
-        else if ((RenderFlag & RENDER_CHROME4) == RENDER_CHROME4 && MeshTexture == -1)
+        else if ((renderFlags & RENDER_CHROME4) == RENDER_CHROME4 && explicitTextureIndex == -1)
         {
             BindTexture(BITMAP_CHROME2);
         }
-        else if ((RenderFlag & RENDER_CHROME6) == RENDER_CHROME6 && MeshTexture == -1)
+        else if ((renderFlags & RENDER_CHROME6) == RENDER_CHROME6 && explicitTextureIndex == -1)
         {
             BindTexture(BITMAP_CHROME6);
         }
-        else if ((RenderFlag & RENDER_CHROME) == RENDER_CHROME && MeshTexture == -1)
+        else if ((renderFlags & RENDER_CHROME) == RENDER_CHROME && explicitTextureIndex == -1)
             BindTexture(BITMAP_CHROME);
-        else if ((RenderFlag & RENDER_METAL) == RENDER_METAL && MeshTexture == -1)
+        else if ((renderFlags & RENDER_METAL) == RENDER_METAL && explicitTextureIndex == -1)
             BindTexture(BITMAP_SHINY);
         else
-            BindTexture(Texture);
+            BindTexture(textureIndex);
     }
-    else if (BlendMesh <= -2 || m->Texture == BlendMesh)
+    else if (blendMeshIndex <= -2 || m->Texture == blendMeshIndex)
     {
-        Render = RENDER_TEXTURE;
-        BindTexture(Texture);
-        if ((RenderFlag & RENDER_DARK) == RENDER_DARK)
+        finalRenderFlags = RENDER_TEXTURE;
+        BindTexture(textureIndex);
+        if ((renderFlags & RENDER_DARK) == RENDER_DARK)
             EnableAlphaBlendMinus();
         else
             EnableAlphaBlend();
 
-        if ((RenderFlag & RENDER_NODEPTH) == RENDER_NODEPTH)
+        if ((renderFlags & RENDER_NODEPTH) == RENDER_NODEPTH)
         {
             DisableDepthTest();
         }
 
-        glColor3f(BodyLight[0] * BlendMeshLight, BodyLight[1] * BlendMeshLight, BodyLight[2] * BlendMeshLight);
+        glColor3f(BodyLight[0] * blendMeshAlpha, 
+            BodyLight[1] * blendMeshAlpha,
+            BodyLight[2] * blendMeshAlpha);
         //glColor3f(BlendMeshLight,BlendMeshLight,BlendMeshLight);
-        EnableLight = false;
+        enableLight = false;
     }
-    else if ((RenderFlag & RENDER_TEXTURE) == RENDER_TEXTURE)
+    else if ((renderFlags & RENDER_TEXTURE) == RENDER_TEXTURE)
     {
-        Render = RENDER_TEXTURE;
-        BindTexture(Texture);
-        if ((RenderFlag & RENDER_BRIGHT) == RENDER_BRIGHT)
+        finalRenderFlags = RENDER_TEXTURE;
+        BindTexture(textureIndex);
+        if ((renderFlags & RENDER_BRIGHT) == RENDER_BRIGHT)
         {
             EnableAlphaBlend();
         }
-        else if ((RenderFlag & RENDER_DARK) == RENDER_DARK)
+        else if ((renderFlags & RENDER_DARK) == RENDER_DARK)
         {
             EnableAlphaBlendMinus();
         }
-        else if (Alpha < 0.99f || pBitmap->Components == 4)
+        else if (alpha < 0.99f || texture->Components == 4)
         {
             EnableAlphaTest();
         }
@@ -1184,119 +1199,120 @@ void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float Bl
             DisableAlphaBlend();
         }
 
-        if ((RenderFlag & RENDER_NODEPTH) == RENDER_NODEPTH)
+        if ((renderFlags & RENDER_NODEPTH) == RENDER_NODEPTH)
         {
             DisableDepthTest();
         }
     }
-    else if ((RenderFlag & RENDER_BRIGHT) == RENDER_BRIGHT)
+    else if ((renderFlags & RENDER_BRIGHT) == RENDER_BRIGHT)
     {
-        if (pBitmap->Components == 4 || m->Texture == BlendMesh)
+        if (texture->Components == 4 || m->Texture == blendMeshIndex)
         {
             return;
         }
 
-        Render = RENDER_BRIGHT;
+        finalRenderFlags = RENDER_BRIGHT;
         EnableAlphaBlend();
         DisableTexture();
         DisableDepthMask();
 
-        if ((RenderFlag & RENDER_NODEPTH) == RENDER_NODEPTH)
+        if ((renderFlags & RENDER_NODEPTH) == RENDER_NODEPTH)
         {
             DisableDepthTest();
         }
     }
     else
     {
-        Render = RENDER_TEXTURE;
+        finalRenderFlags = RENDER_TEXTURE;
     }
-    if (RenderFlag & RENDER_DOPPELGANGER)
+    if (renderFlags & RENDER_DOPPELGANGER)
     {
-        if (pBitmap->Components != 4)
+        if (texture->Components != 4)
         {
             EnableCullFace();
             EnableDepthMask();
         }
     }
-
+    
     // ver 1.0 (triangle)
     glBegin(GL_TRIANGLES);
+
     for (int j = 0; j < m->NumTriangles; j++)
     {
-        Triangle_t* tp = &m->Triangles[j];
-        for (int k = 0; k < tp->Polygon; k++)
+        const auto triangle = &m->Triangles[j];
+        for (int k = 0; k < triangle->Polygon; k++)
         {
-            int vi = tp->VertexIndex[k];
-            switch (Render)
+            const int vertexIndex = triangle->VertexIndex[k];
+            switch (finalRenderFlags)
             {
-            case RENDER_TEXTURE:
-            {
-                TexCoord_t* texp = &m->TexCoords[tp->TexCoordIndex[k]];
-                if (EnableWave)
+                case RENDER_TEXTURE:
                 {
-                    glTexCoord2f(texp->TexCoordU + BlendMeshTexCoordU, texp->TexCoordV + BlendMeshTexCoordV);
-                }
-                else
-                {
-                    glTexCoord2f(texp->TexCoordU, texp->TexCoordV);
-                }
-
-                if (EnableLight)
-                {
-                    int ni = tp->NormalIndex[k];
-
-                    if (Alpha >= 0.99f)
+                    const auto texp = &m->TexCoords[triangle->TexCoordIndex[k]];
+                    if (EnableWave)
                     {
-                        glColor3fv(LightTransform[i][ni]);
+                        glTexCoord2f(texp->TexCoordU + blendMeshTextureCoordU, texp->TexCoordV + blendMeshTextureCoordV);
                     }
                     else
                     {
-                        float* Light = LightTransform[i][ni];
-                        glColor4f(Light[0], Light[1], Light[2], Alpha);
+                        glTexCoord2f(texp->TexCoordU, texp->TexCoordV);
                     }
+
+                    if (enableLight)
+                    {
+                        int normalIndex = triangle->NormalIndex[k];
+
+                        if (alpha >= 0.99f)
+                        {
+                            glColor3fv(LightTransform[meshIndex][normalIndex]);
+                        }
+                        else
+                        {
+                            float* Light = LightTransform[meshIndex][normalIndex];
+                            glColor4f(Light[0], Light[1], Light[2], alpha);
+                        }
+                    }
+                    break;
+                }
+                case RENDER_CHROME:
+                {
+                    if (alpha >= 0.99f)
+                        glColor3fv(BodyLight);
+                    else
+                        glColor4f(BodyLight[0], BodyLight[1], BodyLight[2], alpha);
+                    int ni = triangle->NormalIndex[k];
+                    glTexCoord2f(g_chrome[ni][0], g_chrome[ni][1]);
+                    break;
+                }
+                case RENDER_CHROME4:
+                {
+                    if (alpha >= 0.99f)
+                        glColor3fv(BodyLight);
+                    else
+                        glColor4f(BodyLight[0], BodyLight[1], BodyLight[2], alpha);
+                    int ni = triangle->NormalIndex[k];
+                    glTexCoord2f(g_chrome[ni][0] + blendMeshTextureCoordU, g_chrome[ni][1] + blendMeshTextureCoordV);
+                    //					glTexCoord2f(BlendMeshTexCoordU,BlendMeshTexCoordV);
                 }
                 break;
-            }
-            case RENDER_CHROME:
-            {
-                if (Alpha >= 0.99f)
-                    glColor3fv(BodyLight);
-                else
-                    glColor4f(BodyLight[0], BodyLight[1], BodyLight[2], Alpha);
-                int ni = tp->NormalIndex[k];
-                glTexCoord2f(g_chrome[ni][0], g_chrome[ni][1]);
-                break;
-            }
-            case RENDER_CHROME4:
-            {
-                if (Alpha >= 0.99f)
-                    glColor3fv(BodyLight);
-                else
-                    glColor4f(BodyLight[0], BodyLight[1], BodyLight[2], Alpha);
-                int ni = tp->NormalIndex[k];
-                glTexCoord2f(g_chrome[ni][0] + BlendMeshTexCoordU, g_chrome[ni][1] + BlendMeshTexCoordV);
-                //					glTexCoord2f(BlendMeshTexCoordU,BlendMeshTexCoordV);
-            }
-            break;
 
-            case RENDER_OIL:
-            {
-                if (Alpha >= 0.99f)
-                    glColor3fv(BodyLight);
-                else
-                    glColor4f(BodyLight[0], BodyLight[1], BodyLight[2], Alpha);
-                TexCoord_t* texp = &m->TexCoords[tp->TexCoordIndex[k]];
-                int ni = tp->VertexIndex[k];
-                glTexCoord2f(g_chrome[ni][0] * texp->TexCoordU + BlendMeshTexCoordU, g_chrome[ni][1] * texp->TexCoordV + BlendMeshTexCoordV);
-                break;
-            }
+                case RENDER_OIL:
+                {
+                    if (alpha >= 0.99f)
+                        glColor3fv(BodyLight);
+                    else
+                        glColor4f(BodyLight[0], BodyLight[1], BodyLight[2], alpha);
+                    TexCoord_t* texp = &m->TexCoords[triangle->TexCoordIndex[k]];
+                    int ni = triangle->VertexIndex[k];
+                    glTexCoord2f(g_chrome[ni][0] * texp->TexCoordU + blendMeshTextureCoordU, g_chrome[ni][1] * texp->TexCoordV + blendMeshTextureCoordV);
+                    break;
+                }
             }
 
-            if ((RenderFlag & RENDER_SHADOWMAP) == RENDER_SHADOWMAP)
+            if ((renderFlags & RENDER_SHADOWMAP) == RENDER_SHADOWMAP)
             {
-                int vi = tp->VertexIndex[k];
+                int vi = triangle->VertexIndex[k];
                 vec3_t Position;
-                VectorSubtract(VertexTransform[i][vi], BodyOrigin, Position);
+                VectorSubtract(VertexTransform[meshIndex][vi], BodyOrigin, Position);
 
                 Position[0] += Position[2] * (Position[0] + 2000.f) / (Position[2] - 4000.f);
                 Position[2] = 5.f;
@@ -1304,28 +1320,29 @@ void BMD::RenderMesh(int i, int RenderFlag, float Alpha, int BlendMesh, float Bl
                 VectorAdd(Position, BodyOrigin, Position);
                 glVertex3fv(Position);
             }
-            else if ((RenderFlag & RENDER_WAVE) == RENDER_WAVE)
+            else if ((renderFlags & RENDER_WAVE) == RENDER_WAVE)
             {
                 float vPos[3];
-                float fParam = (float)((int)WorldTime + vi * 931) * 0.007f;
+                float fParam = (float)((int)WorldTime + vertexIndex * 931) * 0.007f;
                 float fSin = sinf(fParam);
                 float fCos = cosf(fParam);
 
-                int ni = tp->NormalIndex[k];
+                int ni = triangle->NormalIndex[k];
                 Normal_t* np = &m->Normals[ni];
-                float* Normal = NormalTransform[i][ni];
+                float* Normal = NormalTransform[meshIndex][ni];
                 for (int iCoord = 0; iCoord < 3; ++iCoord)
                 {
-                    vPos[iCoord] = VertexTransform[i][vi][iCoord] + Normal[iCoord] * fSin * 28.0f;
+                    vPos[iCoord] = VertexTransform[meshIndex][vertexIndex][iCoord] + Normal[iCoord] * fSin * 28.0f;
                 }
                 glVertex3fv(vPos);
             }
             else
             {
-                glVertex3fv(VertexTransform[i][vi]);
+                glVertex3fv(VertexTransform[meshIndex][vertexIndex]);
             }
         }
     }
+
     glEnd();
 }
 

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -37,9 +37,9 @@ vec3_t NormalTransform[MAX_MESH][MAX_VERTICES];
 float  IntensityTransform[MAX_MESH][MAX_VERTICES];
 vec3_t LightTransform[MAX_MESH][MAX_VERTICES];
 
-vec3_t RenderArrayVertices[MAX_MESH][MAX_VERTICES * 3];
-vec4_t RenderArrayColors[MAX_MESH][MAX_VERTICES * 3];
-vec2_t RenderArrayTexCoords[MAX_MESH][MAX_VERTICES * 3];
+vec3_t RenderArrayVertices[MAX_VERTICES * 3];
+vec4_t RenderArrayColors[MAX_VERTICES * 3];
+vec2_t RenderArrayTexCoords[MAX_VERTICES * 3];
 
 unsigned char ShadowBuffer[256 * 256];
 int           ShadowBufferWidth = 256;
@@ -1256,9 +1256,9 @@ void BMD::RenderMesh(int meshIndex, int renderFlags, float alpha, int blendMeshI
     if (enableColor) glEnableClientState(GL_COLOR_ARRAY);
     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
-    auto vertices = RenderArrayVertices[meshIndex];
-    auto colors = RenderArrayColors[meshIndex];
-    auto texCoords = RenderArrayTexCoords[meshIndex];
+    auto vertices = RenderArrayVertices;
+    auto colors = RenderArrayColors;
+    auto texCoords = RenderArrayTexCoords;
 
     int target_vertex_index = -1;
     for (int j = 0; j < m->NumTriangles; j++)

--- a/Source Main 5.2/source/ZzzBMD.cpp
+++ b/Source Main 5.2/source/ZzzBMD.cpp
@@ -37,6 +37,10 @@ vec3_t NormalTransform[MAX_MESH][MAX_VERTICES];
 float  IntensityTransform[MAX_MESH][MAX_VERTICES];
 vec3_t LightTransform[MAX_MESH][MAX_VERTICES];
 
+vec3_t RenderArrayVertices[MAX_MESH][MAX_VERTICES * 3];
+vec4_t RenderArrayColors[MAX_MESH][MAX_VERTICES * 3];
+vec2_t RenderArrayTexCoords[MAX_MESH][MAX_VERTICES * 3];
+
 unsigned char ShadowBuffer[256 * 256];
 int           ShadowBufferWidth = 256;
 int           ShadowBufferHeight = 256;
@@ -1252,9 +1256,9 @@ void BMD::RenderMesh(int meshIndex, int renderFlags, float alpha, int blendMeshI
     if (enableColor) glEnableClientState(GL_COLOR_ARRAY);
     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
-    auto vertices = new vec3_t[m->NumTriangles * 3];
-    auto colors = new vec4_t[m->NumTriangles * 3];
-    auto texCoords = new vec2_t[m->NumTriangles * 3];
+    auto vertices = RenderArrayVertices[meshIndex];
+    auto colors = RenderArrayColors[meshIndex];
+    auto texCoords = RenderArrayTexCoords[meshIndex];
 
     int target_vertex_index = -1;
     for (int j = 0; j < m->NumTriangles; j++)
@@ -1343,10 +1347,6 @@ void BMD::RenderMesh(int meshIndex, int renderFlags, float alpha, int blendMeshI
     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
     if (enableColor) glDisableClientState(GL_COLOR_ARRAY);
     glDisableClientState(GL_VERTEX_ARRAY);
-
-    SAFE_DELETE(vertices);
-    SAFE_DELETE(colors);
-    SAFE_DELETE(texCoords);
 }
 
 void BMD::RenderMeshAlternative(int iRndExtFlag, int iParam, int i, int RenderFlag, float Alpha, int BlendMesh, float BlendMeshLight, float BlendMeshTexCoordU, float BlendMeshTexCoordV, int MeshTexture)

--- a/Source Main 5.2/source/ZzzBMD.h
+++ b/Source Main 5.2/source/ZzzBMD.h
@@ -284,7 +284,18 @@ public:
 
     void RenderMeshEffect(int i, int iType, int iSubType = 0, vec3_t Angle = 0, VOID* obj = NULL);
 
-    void RenderMesh(int i, int RenderFlag, float Alpha = 1.f, int BlendMesh = -1, float BlendMeshLight = 1.f, float BlendMeshTexCoordU = 0.f, float BlendMeshTexCoordV = 0.f, int Texture = -1);
+    /**
+     * \brief Renders a mesh of the BMD file.
+     * \param meshIndex The index of the mesh in the file.
+     * \param renderFlags The render flags.
+     * \param alpha The alpha for the texture of the mesh.
+     * \param blendMeshIndex The blend mesh index, if available.
+     * \param blendMeshAlpha The blend mesh alpha, if available.
+     * \param blendMeshTextureCoordU The blend mesh texture U-coordinate.
+     * \param blendMeshTextureCoordV The blend mesh texture V-coordinate.
+     * \param textureIndex The texture index of the mesh, if another texture should be used, other than defined in the BMD.
+     */
+    void RenderMesh(int meshIndex, int renderFlags, float alpha = 1.f, int blendMeshIndex = -1, float blendMeshAlpha = 1.f, float blendMeshTextureCoordU = 0.f, float blendMeshTextureCoordV = 0.f, int textureIndex = -1);
     void RenderMeshAlternative(int iRndExtFlag, int iParam, int i, int RenderFlag, float Alpha = 1.f, int BlendMesh = -1, float BlendMeshLight = 1.f, float BlendMeshTexCoordU = 0.f, float BlendMeshTexCoordV = 0.f, int Texture = -1);
     void RenderBody(int RenderFlag, float Alpha = 1.f, int BlendMesh = -1, float BlendMeshLight = 1.f, float BlendMeshTexCoordU = 0.f, float BlendMeshTexCoordV = 0.f, int HiddenMesh = -1, int Texture = -1);
     void RenderBodyAlternative(int iRndExtFlag, int iParam, int RenderFlag, float Alpha = 1.f, int BlendMesh = -1, float BlendMeshLight = 1.f, float BlendMeshTexCoordU = 0.f, float BlendMeshTexCoordV = 0.f, int HiddenMesh = -1, int Texture = -1);


### PR DESCRIPTION
It was hard to find any examples on this on the internet how to use vertex arrays in legacy open gl versions. Found this one for OpenTK and adapted it back to C++:
https://gdbooks.gitbooks.io/legacyopengl/content/Chapter8/va_p5.html

Basically, instead of calling a lot of opengl functions for each vertex, we call one with all the required data in some arrays.
Further improvements require to use VAO and VBO, or newer methods (shaders). However, these would require a major refactor/rewrite of the game clients rendering code.