### PR TITLE
Fixed ancient set handling and rendering

### DIFF
--- a/Source Main 5.2/source/CSItemOption.cpp
+++ b/Source Main 5.2/source/CSItemOption.cpp
@@ -22,8 +22,6 @@ extern	int  TextBold[50];
 
 static  CSItemOption csItemOption; // do not delete, required for singleton initialization.
 
-constexpr int MAX_EQUIPPED_SETS = MAX_EQUIPMENT_INDEX - 2; // No Wings and Helper slots
-
 struct ITEM_SET_OPTION_FILE
 {
     char	strSetName[MAX_ITEM_SET_NAME];
@@ -147,6 +145,8 @@ bool CSItemOption::OpenItemSetOption(const wchar_t* filename)
                         target->byStandardOption[optionIndex][setIndex] = current.byStandardOption[optionIndex][setIndex];
                         target->byStandardOptionValue[optionIndex][setIndex] = current.byStandardOptionValue[optionIndex][setIndex];
                     }
+
+                    target->bySetItemCount = 0; // Is calculated below
                 }
 
                 for (int optionIndex = 0; optionIndex < MAX_ITEM_SET_FULL_OPTION_COUNT; ++optionIndex)
@@ -161,6 +161,19 @@ bool CSItemOption::OpenItemSetOption(const wchar_t* filename)
                 }
 
                 pSeek += Size;
+            }
+
+            for (int j = 0; j < MAX_ITEM; j++)
+            {
+                ITEM_SET_TYPE& temptype = m_ItemSetType[j];
+                for (int i = 0; i < MAX_ITEM_SETS_PER_ITEM; i++)
+                {
+                    BYTE setIndex = temptype.byOption[i];
+                    if (setIndex < 64)
+                    {
+                        m_ItemSetOption[setIndex].bySetItemCount++;
+                    }
+                }
             }
         }
         delete[] Buffer;
@@ -332,25 +345,26 @@ void CSItemOption::checkItemType(SET_SEARCH_RESULT* optionList, const int iType,
 
     const ITEM_SET_TYPE& itemSetType = m_ItemSetType[iType];
     const auto itemSetNumber = itemSetType.byOption[setTypeIndex];
-
+    
     if (itemSetNumber != 255 && itemSetNumber != 0)
     {
         // add set item to list
-        for (int i = 0; i < MAX_EQUIPPED_SETS; ++i)
+        for (int i = 0; i < MAX_EQUIPPED_SET_ITEMS; ++i)
         {
             const auto current = &optionList[i];
             if (current->SetNumber == 0)
             {
                 // The set wasn't found in another item yet, so add it
                 current->SetNumber = itemSetNumber;
+                current->CompleteSetItemCount = m_ItemSetOption[itemSetNumber].bySetItemCount;
                 current->ItemCount++;
                 current->SetTypeIndex = setTypeIndex;
+                wcscpy(current->SetName, m_ItemSetOption[itemSetNumber].strSetName);
                 break;
             }
 
             if (current->SetNumber == itemSetNumber)
             {
-                // The set wasn't found in another item yet, so add it
                 current->ItemCount++;
                 current->SetTypeIndex = setTypeIndex;
                 break;
@@ -359,231 +373,109 @@ void CSItemOption::checkItemType(SET_SEARCH_RESULT* optionList, const int iType,
     }
 }
 
+
+BYTE CSItemOption::calcClassRequirement(const ITEM_SET_OPTION &setOptions, int firstClass, int secondClass)
+{
+  BYTE RequireClass = 0;
+  if (setOptions.byRequireClass[0] == 1 && firstClass == CLASS_WIZARD) RequireClass = 1;
+  if (setOptions.byRequireClass[0] == 2 && firstClass == CLASS_WIZARD && secondClass) RequireClass = 1;
+  if (setOptions.byRequireClass[1] == 1 && firstClass == CLASS_KNIGHT) RequireClass = 1;
+  if (setOptions.byRequireClass[1] == 2 && firstClass == CLASS_KNIGHT && secondClass) RequireClass = 1;
+  if (setOptions.byRequireClass[2] == 1 && firstClass == CLASS_ELF) RequireClass = 1;
+  if (setOptions.byRequireClass[2] == 2 && firstClass == CLASS_ELF && secondClass) RequireClass = 1;
+  if (setOptions.byRequireClass[3] == 1 && firstClass == CLASS_DARK) RequireClass = 1;
+  if (setOptions.byRequireClass[3] == 1 && firstClass == CLASS_DARK && secondClass) RequireClass = 1;
+  if (setOptions.byRequireClass[4] == 1 && firstClass == CLASS_DARK_LORD) RequireClass = 1;
+  if (setOptions.byRequireClass[4] == 1 && firstClass == CLASS_DARK_LORD && secondClass) RequireClass = 1;
+  if (setOptions.byRequireClass[5] == 1 && firstClass == CLASS_SUMMONER) RequireClass = 1;
+  if (setOptions.byRequireClass[5] == 1 && firstClass == CLASS_SUMMONER && secondClass) RequireClass = 1;
+  if (setOptions.byRequireClass[6] == 1 && firstClass == CLASS_RAGEFIGHTER) RequireClass = 1;
+  if (setOptions.byRequireClass[6] == 1 && firstClass == CLASS_RAGEFIGHTER && secondClass) RequireClass = 1;
+
+  return RequireClass;
+}
+
 void CSItemOption::calcSetOptionList(SET_SEARCH_RESULT* optionList)
 {
-    int Class = gCharacterManager.GetBaseClass(Hero->Class);
-    int ExClass = gCharacterManager.IsSecondClass(Hero->Class);
+  constexpr BYTE EMPTY_OPTION = 0xFF;
 
-    BYTE    bySetOptionListTmp[MAX_ITEM_SETS_PER_ITEM][MAX_OPTIONS_PER_ITEM_SET];
-    BYTE    bySetOptionListTmp2[MAX_ITEM_SETS_PER_ITEM][MAX_OPTIONS_PER_ITEM_SET];
-    int     iSetOptionListValue[MAX_ITEM_SETS_PER_ITEM][MAX_OPTIONS_PER_ITEM_SET];
+  int firstClass = gCharacterManager.GetBaseClass(Hero->Class);
+  int secondClass = gCharacterManager.IsSecondClass(Hero->Class);
 
-    unsigned int arruiSetItemTypeSequence[MAX_ITEM_SETS_PER_ITEM][MAX_OPTIONS_PER_ITEM_SET] = {};
-
-    BYTE    optionCount[2] = { 0, 0 };  //
-    BYTE    setType = 0;
-
-    m_bySameSetItem = 0;
-    for (auto& i : m_strSetName)
+  int setCount = 0;
+  for (int i = 0; i < MAX_EQUIPPED_SET_ITEMS; ++i)
+  {
+    if (optionList[i].SetNumber == 0)
     {
-        i[0] = 0;
+      break;
     }
 
-    for (auto& i : m_bySetOptionIndex)
+    if (optionList[i].ItemCount >= 2)
     {
-        i = 0;
+      memcpy(&m_SetSearchResult[setCount], &optionList[i], sizeof(SET_SEARCH_RESULT));
+      setCount++;
+    }
+  }
+
+  m_SetSearchResultCount = setCount;
+
+  // now we have all our equipped sets together and can continue to
+  // build up the corresponding option list
+
+  m_bySameSetItem = 0;
+
+  Hero->ExtendState = 0;
+  for (int i = 0; i < m_SetSearchResultCount; ++i)
+  {
+    auto& set = m_SetSearchResult[i];
+
+    const ITEM_SET_OPTION& setOptions = m_ItemSetOption[set.SetNumber];
+    bool isThisSetComplete = false;
+    if (set.CompleteSetItemCount <= set.ItemCount)
+    {
+      Hero->ExtendState = 1;
+      isThisSetComplete = true;
     }
 
-    m_bySetOptionANum = 0;
-    m_bySetOptionBNum = 0;
-    Hero->ExtendState = 0;
+    const auto requireClass = calcClassRequirement(setOptions, firstClass, secondClass);
 
-    unsigned int iSetItemTypeSequence = 0, iCurrentSetItemTypeSequence = 0;
 
-    m_mapEquippedSetItemName.clear();
-    m_mapEquippedSetItemSequence.clear();
-
-    for (int i = 0; i < MAX_EQUIPPED_SETS; i += 3)
+    const auto standardOptionCount = set.CompleteSetItemCount - 1;
+    for (int o = 0; o < MAX_ITEM_SET_STANDARD_OPTION_COUNT + MAX_ITEM_SET_FULL_OPTION_COUNT; ++o)
     {
-        const auto current = &optionList[i];
-        if (current->SetNumber == 0)
-        {
-            // we can already stop here
-            break;
-        }
+      BYTE option;
+      int value;
+      if (o < set.CompleteSetItemCount - 1)
+      {
+        option = setOptions.byStandardOption[o][0];
+        value = setOptions.byStandardOptionValue[o][0];
+        // TODO: either remove the second array element, or use it. In the game data, it's unused!
+      }
+      else
+      {
+        const auto fullOptionIndex = o - standardOptionCount;
+        option = setOptions.byFullOption[fullOptionIndex];
+        value = setOptions.byFullOptionValue[fullOptionIndex];
+      }
 
-        assert(current->SetNumber < MAX_SET_OPTION);
+      // todo: Ext Option
 
-        if (current->ItemCount >= 2)
-        {
-            const int standardCount = min(current->ItemCount - 1, MAX_ITEM_SET_STANDARD_OPTION_COUNT);
-            setType = current->SetTypeIndex;
-            assert(setType < MAX_ITEM_SETS_PER_ITEM);
+      if (option != EMPTY_OPTION
+        && value != 0
+        && (option < MASTERY_OPTION || (setOptions.byRequireClass[firstClass] && secondClass >= setOptions.byRequireClass[firstClass] - 1)))
+      {
+        const auto setOption = &set.SetOption[o];
+        setOption->OptionNumber = option;
+        setOption->RequireClass = requireClass;
+        setOption->Value = value;
+        setOption->IsActive = isThisSetComplete || o < set.ItemCount - 1;
 
-            ITEM_SET_OPTION& itemOption = m_ItemSetOption[current->SetNumber];
-
-            BYTE RequireClass = 0;
-            if (itemOption.byRequireClass[0] == 1 && Class == CLASS_WIZARD) RequireClass = 1;
-            if (itemOption.byRequireClass[0] == 2 && Class == CLASS_WIZARD && ExClass) RequireClass = 1;
-            if (itemOption.byRequireClass[1] == 1 && Class == CLASS_KNIGHT) RequireClass = 1;
-            if (itemOption.byRequireClass[1] == 2 && Class == CLASS_KNIGHT && ExClass) RequireClass = 1;
-            if (itemOption.byRequireClass[2] == 1 && Class == CLASS_ELF) RequireClass = 1;
-            if (itemOption.byRequireClass[2] == 2 && Class == CLASS_ELF && ExClass) RequireClass = 1;
-            if (itemOption.byRequireClass[3] == 1 && Class == CLASS_DARK) RequireClass = 1;
-            if (itemOption.byRequireClass[3] == 1 && Class == CLASS_DARK && ExClass) RequireClass = 1;
-            if (itemOption.byRequireClass[4] == 1 && Class == CLASS_DARK_LORD) RequireClass = 1;
-            if (itemOption.byRequireClass[4] == 1 && Class == CLASS_DARK_LORD && ExClass) RequireClass = 1;
-            if (itemOption.byRequireClass[5] == 1 && Class == CLASS_SUMMONER) RequireClass = 1;
-            if (itemOption.byRequireClass[5] == 1 && Class == CLASS_SUMMONER && ExClass) RequireClass = 1;
-            if (itemOption.byRequireClass[6] == 1 && Class == CLASS_RAGEFIGHTER) RequireClass = 1;
-            if (itemOption.byRequireClass[6] == 1 && Class == CLASS_RAGEFIGHTER && ExClass) RequireClass = 1;
-
-            m_bySetOptionIndex[setType] = optionList[i].SetNumber;
-
-            if (m_strSetName[setType][0] != 0
-                && wcscmp(m_strSetName[setType], itemOption.strSetName) != 0)
-            {
-                if (m_strSetName[0][0] == 0)
-                    wcscpy(m_strSetName[0], itemOption.strSetName);
-                else
-                    wcscpy(m_strSetName[1], itemOption.strSetName);
-                m_bySameSetItem = current->ItemCount;
-            }
-            else
-            {
-                wcscpy(m_strSetName[setType], itemOption.strSetName);
-            }
-
-            bool	bFind = false;
-            for (m_iterESIN = m_mapEquippedSetItemName.begin(); m_iterESIN != m_mapEquippedSetItemName.end(); ++m_iterESIN)
-            {
-                std::wstring strCur = m_iterESIN->second;
-
-                if (wcscmp(itemOption.strSetName, strCur.c_str()) == 0)
-                {
-                    bFind = true;
-                    break;
-                }
-            }
-
-            if (false == bFind)
-            {
-                iCurrentSetItemTypeSequence = iSetItemTypeSequence++;
-                m_mapEquippedSetItemName.insert(std::pair<int, std::wstring>(iCurrentSetItemTypeSequence, itemOption.strSetName));
-            }
-
-            constexpr BYTE EMPTY_OPTION = 0xFF;
-            BYTE option[MAX_ITEM_SETS_PER_ITEM];
-            int  value[MAX_ITEM_SETS_PER_ITEM];
-            for (int j = 0; j < current->ItemCount; ++j)
-            {
-                option[0] = EMPTY_OPTION;
-                option[1] = EMPTY_OPTION;
-                if (j < standardCount)
-                {
-                    option[0] = itemOption.byStandardOption[j][0];
-                    value[0] = itemOption.byStandardOptionValue[j][0];
-                    option[1] = itemOption.byStandardOption[j][1];
-                    value[1] = itemOption.byStandardOptionValue[j][1];
-                }
-                else if (j < (current->ItemCount - standardCount))
-                {
-                    option[0] = itemOption.byExtOption[j];
-                    value[0] = itemOption.byExtOptionValue[j];
-                }
-
-                if (option[0] != EMPTY_OPTION)
-                {
-                    if (option[0] < MASTERY_OPTION)
-                    {
-                        arruiSetItemTypeSequence[setType][optionCount[setType]] = iCurrentSetItemTypeSequence;
-                        bySetOptionListTmp[setType][optionCount[setType]] = option[0];
-                        bySetOptionListTmp2[setType][optionCount[setType]] = RequireClass;
-                        iSetOptionListValue[setType][optionCount[setType]] = value[0];
-                        optionCount[setType]++;
-                    }
-                    else
-                    {
-                        if (itemOption.byRequireClass[Class] && ExClass >= itemOption.byRequireClass[Class] - 1)
-                        {
-                            arruiSetItemTypeSequence[setType][optionCount[setType]] = iCurrentSetItemTypeSequence;
-                            bySetOptionListTmp[setType][optionCount[setType]] = option[0];
-                            bySetOptionListTmp2[setType][optionCount[setType]] = RequireClass;
-                            iSetOptionListValue[setType][optionCount[setType]] = value[0];
-                            optionCount[setType]++;
-                        }
-                    }
-                }
-                if (option[1] != EMPTY_OPTION)
-                {
-                    if (option[1] < MASTERY_OPTION)
-                    {
-                        arruiSetItemTypeSequence[setType][optionCount[setType]] = iCurrentSetItemTypeSequence;
-                        bySetOptionListTmp[setType][optionCount[setType]] = option[1];
-                        bySetOptionListTmp2[setType][optionCount[setType]] = RequireClass;
-                        iSetOptionListValue[setType][optionCount[setType]] = value[1];
-                        optionCount[setType]++;
-                        assert(optionCount[setType] < MAX_OPTIONS_PER_ITEM_SET);
-                    }
-                    else
-                    {
-                        if (itemOption.byRequireClass[Class] && ExClass >= itemOption.byRequireClass[Class] - 1)
-                        {
-                            arruiSetItemTypeSequence[setType][optionCount[setType]] = iCurrentSetItemTypeSequence;
-                            bySetOptionListTmp[setType][optionCount[setType]] = option[1];
-                            bySetOptionListTmp2[setType][optionCount[setType]] = RequireClass;
-                            iSetOptionListValue[setType][optionCount[setType]] = value[1];
-                            optionCount[setType]++;
-                            assert(optionCount[setType] < MAX_OPTIONS_PER_ITEM_SET);
-                        }
-                    }
-                }
-            }
-
-            if (current->ItemCount >= itemOption.byOptionCount - 2)
-            {
-                for (int j = 0; j < MAX_ITEM_SET_FULL_OPTION_COUNT; ++j)
-                {
-                    option[0] = itemOption.byFullOption[j];
-                    value[0] = itemOption.byFullOptionValue[j];
-                    if (option[0] != EMPTY_OPTION)
-                    {
-                        if (option[0] < MASTERY_OPTION)
-                        {
-                            arruiSetItemTypeSequence[setType][optionCount[setType]] = iCurrentSetItemTypeSequence;
-                            bySetOptionListTmp[setType][optionCount[setType]] = option[0];
-                            bySetOptionListTmp2[setType][optionCount[setType]] = RequireClass;
-                            iSetOptionListValue[setType][optionCount[setType]] = value[0];
-                            optionCount[setType]++;
-                            assert(optionCount[setType] < MAX_OPTIONS_PER_ITEM_SET);
-
-                            if (m_bySameSetItem != 0) m_bySameSetItem++;
-                        }
-                        else
-                        {
-                            if (itemOption.byRequireClass[Class] && ExClass >= itemOption.byRequireClass[Class] - 1)
-                            {
-                                arruiSetItemTypeSequence[setType][optionCount[setType]] = iCurrentSetItemTypeSequence;
-                                bySetOptionListTmp[setType][optionCount[setType]] = option[0];
-                                bySetOptionListTmp2[setType][optionCount[setType]] = RequireClass;
-                                iSetOptionListValue[setType][optionCount[setType]] = value[0];
-                                optionCount[setType]++;
-                                assert(optionCount[setType] < MAX_OPTIONS_PER_ITEM_SET);
-
-                                if (m_bySameSetItem != 0) m_bySameSetItem++;
-                            }
-                        }
-                    }
-                }
-
-                Hero->ExtendState = 1;
-            }
-        }
+        set.SetOptionCount++;
+      }
     }
 
-    for (int i = 0; i < MAX_ITEM_SETS_PER_ITEM; ++i)
-    {
-        for (int j = 0; j < optionCount[i]; ++j)
-        {
-            m_mapEquippedSetItemSequence.insert(std::pair<BYTE, int>((i * optionCount[0]) + j, arruiSetItemTypeSequence[i][j]));
-            m_bySetOptionList[(i * optionCount[0]) + j][0] = bySetOptionListTmp[i][j];
-            m_bySetOptionList[(i * optionCount[0]) + j][1] = bySetOptionListTmp2[i][j];
-            m_iSetOptionListValue[(i * optionCount[0]) + j][0] = iSetOptionListValue[i][j];
-            m_iSetOptionListValue[(i * optionCount[0]) + j][1] = iSetOptionListValue[i][j];
-        }
-    }
-    m_bySetOptionANum = optionCount[0];
-    m_bySetOptionBNum = optionCount[1];
+    // todo: what are ExtOptions?
+  }
 }
 
 void CSItemOption::getExplainText(wchar_t* text, const BYTE option, const BYTE value, const BYTE SetIndex)
@@ -655,12 +547,20 @@ void CSItemOption::PlusSpecial(WORD* Value, int Special)
 {
     Special -= AT_SET_OPTION_IMPROVE_STRENGTH;
     int optionValue = 0;
-    for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
+
+    for (int i = 0; i < m_SetSearchResultCount; i++)
     {
-        if (m_bySetOptionList[i][0] == Special && m_bySetOptionListOnOff[i] == 0)
+        const auto& set = m_SetSearchResult[i];
+        for (int j = 0; j < set.SetOptionCount; j++)
         {
-            optionValue += m_iSetOptionListValue[i][0];
-            m_bySetOptionListOnOff[i] = 1;
+            const auto& option = set.SetOption[j];
+
+            if (option.IsActive
+                && option.OptionNumber == Special
+                && option.Value != 0)
+            {
+                optionValue += option.Value;
+            }
         }
     }
 
@@ -674,12 +574,20 @@ void CSItemOption::PlusSpecialPercent(WORD* Value, int Special)
 {
     Special -= AT_SET_OPTION_IMPROVE_STRENGTH;
     int optionValue = 0;
-    for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
+
+    for (int i = 0; i < m_SetSearchResultCount; i++)
     {
-        if (m_bySetOptionList[i][0] == Special && m_bySetOptionListOnOff[i] == 0)
+        const auto& set = m_SetSearchResult[i];
+        for (int j = 0; j < set.SetOptionCount; j++)
         {
-            optionValue += m_iSetOptionListValue[i][0];
-            m_bySetOptionListOnOff[i] = 1;
+            const auto& option = set.SetOption[j];
+
+            if (option.IsActive
+                && option.OptionNumber == Special
+                && option.Value != 0)
+            {
+                optionValue += option.Value;
+            }
         }
     }
 
@@ -694,13 +602,20 @@ void CSItemOption::PlusSpecialLevel(WORD* Value, const WORD SrcValue, int Specia
     Special -= AT_SET_OPTION_IMPROVE_STRENGTH;
     int optionValue = 0;
     int count = 0;
-    for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
+
+    for (int i = 0; i < m_SetSearchResultCount; i++)
     {
-        if (m_bySetOptionList[i][0] == Special && m_bySetOptionList[i][1] != 0 && m_bySetOptionListOnOff[i] == 0)
+        const auto& set = m_SetSearchResult[i];
+        for (int j = 0; j < set.SetOptionCount; j++)
         {
-            optionValue = m_iSetOptionListValue[i][0];
-            m_bySetOptionListOnOff[i] = 1;
-            count++;
+            const auto& option = set.SetOption[j];
+            if (option.IsActive
+                && option.OptionNumber == Special
+                && option.Value != 0)
+            {
+                optionValue += option.Value;
+                count++;
+            }
         }
     }
 
@@ -714,97 +629,26 @@ void CSItemOption::PlusSpecialLevel(WORD* Value, const WORD SrcValue, int Specia
 void CSItemOption::PlusMastery(int* Value, const BYTE MasteryType)
 {
     int optionValue = 0;
-    for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
+
+    for (int i = 0; i < m_SetSearchResultCount; i++)
     {
-        if (m_bySetOptionList[i][0] >= MASTERY_OPTION && (m_bySetOptionList[i][0] - MASTERY_OPTION - 5) == MasteryType && m_bySetOptionList[i][1] != 0 && m_bySetOptionListOnOff[i] == 0)
+        const auto& set = m_SetSearchResult[i];
+        for (int j = 0; j < set.SetOptionCount; j++)
         {
-            optionValue += m_iSetOptionListValue[i][0];
-            m_bySetOptionListOnOff[i] = 1;
+            const auto& option = set.SetOption[j];
+            if (option.IsActive
+                && option.OptionNumber >= MASTERY_OPTION
+                && (option.OptionNumber - MASTERY_OPTION - 5) == MasteryType
+                && option.Value != 0)
+            {
+                optionValue += option.Value;
+            }
         }
     }
 
     if (optionValue)
     {
         *Value += optionValue;
-    }
-}
-
-void CSItemOption::MinusSpecialPercent(int* Value, int Special)
-{
-    Special -= AT_SET_OPTION_IMPROVE_STRENGTH;
-    int optionValue = 0;
-    for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
-    {
-        if (m_bySetOptionList[i][0] == Special && m_bySetOptionList[i][1] != 0 && m_bySetOptionListOnOff[i] == 0)
-        {
-            optionValue += m_iSetOptionListValue[i][0];
-            m_bySetOptionListOnOff[i] = 1;
-        }
-    }
-
-    if (optionValue)
-    {
-        *Value -= *Value * optionValue / 100;
-    }
-}
-
-void CSItemOption::GetSpecial(WORD* Value, int Special)
-{
-    Special -= AT_SET_OPTION_IMPROVE_STRENGTH;
-    int optionValue = 0;
-    for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
-    {
-        if (m_bySetOptionList[i][0] == Special && m_bySetOptionListOnOff[i] == 0)
-        {
-            optionValue += m_iSetOptionListValue[i][0];
-            m_bySetOptionListOnOff[i] = 1;
-        }
-    }
-
-    if (optionValue)
-    {
-        *Value += optionValue;
-    }
-}
-
-void	CSItemOption::GetSpecialPercent(WORD* Value, int Special)
-{
-    Special -= AT_SET_OPTION_IMPROVE_STRENGTH;
-    int optionValue = 0;
-    for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
-    {
-        if (m_bySetOptionList[i][0] == Special && m_bySetOptionListOnOff[i] == 0)
-        {
-            optionValue += m_iSetOptionListValue[i][0];
-            m_bySetOptionListOnOff[i] = 1;
-        }
-    }
-
-    if (optionValue)
-    {
-        *Value += *Value * optionValue / 100;
-    }
-}
-
-void	CSItemOption::GetSpecialLevel(WORD* Value, const WORD SrcValue, int Special)
-{
-    Special -= AT_SET_OPTION_IMPROVE_STRENGTH;
-    int optionValue = 0;
-    int count = 0;
-    for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
-    {
-        if (m_bySetOptionList[i][0] == Special && m_bySetOptionList[i][1] != 0 && m_bySetOptionListOnOff[i] == 0)
-        {
-            optionValue = m_iSetOptionListValue[i][0];
-            m_bySetOptionListOnOff[i] = 1;
-            count++;
-        }
-    }
-
-    if (optionValue)
-    {
-        optionValue = SrcValue * optionValue / 100;
-        *Value += (optionValue * count);
     }
 }
 
@@ -896,7 +740,7 @@ int CSItemOption::RenderDefaultOptionText(const ITEM* ip, int TextNum)
 
         if ((ip->Type >= ITEM_HELPER + 8 && ip->Type <= ITEM_HELPER + 9) || (ip->Type >= ITEM_HELPER + 12 && ip->Type <= ITEM_HELPER + 13) || (ip->Type >= ITEM_HELPER + 21 && ip->Type <= ITEM_HELPER + 27))
         {
-            swprintf(TextList[TNum], GlobalText[1165]);
+            swprintf(TextList[TNum], GlobalText[1165]); // "Increase Attribute Damage"
             TextListColor[TNum] = TEXT_COLOR_BLUE;
             TNum++;
         }
@@ -937,18 +781,54 @@ void CSItemOption::getAllAddState(WORD* Strength, WORD* Dexterity, WORD* Energy,
         }
     }
 
-    GetSpecial(Strength, AT_SET_OPTION_IMPROVE_STRENGTH);
-    GetSpecial(Dexterity, AT_SET_OPTION_IMPROVE_DEXTERITY);
-    GetSpecial(Energy, AT_SET_OPTION_IMPROVE_ENERGY);
-    GetSpecial(Vitality, AT_SET_OPTION_IMPROVE_VITALITY);
-    GetSpecial(Charisma, AT_SET_OPTION_IMPROVE_CHARISMA);
+    AddStatsBySetOptions(Strength, Dexterity, Energy, Vitality, Charisma);
+}
+
+void    CSItemOption::AddStatsBySetOptions(WORD* Strength, WORD* Dexterity, WORD* Energy, WORD* Vitality, WORD* Charisma) const
+{
+    for (int i = 0; i < m_SetSearchResultCount; i++)
+    {
+        auto& set = m_SetSearchResult[i];
+        for (int j = 0; j < set.SetOptionCount; j++)
+        {
+            auto& option = set.SetOption[j];
+            if (!option.IsActive)
+            {
+                continue;
+            }
+
+            switch (option.OptionNumber)
+            {
+            case AT_SET_OPTION_IMPROVE_STRENGTH:
+                *Strength += option.Value;
+                break;
+
+            case AT_SET_OPTION_IMPROVE_DEXTERITY:
+                *Dexterity += option.Value;
+                break;
+
+            case AT_SET_OPTION_IMPROVE_ENERGY:
+                *Energy += option.Value;
+                break;
+
+            case AT_SET_OPTION_IMPROVE_VITALITY:
+                *Vitality += option.Value;
+                break;
+
+            case AT_SET_OPTION_IMPROVE_CHARISMA:
+                *Charisma += option.Value;
+                break;
+            default:
+                // other options are not handled here.
+                break;
+            }
+        }
+    }
 }
 
 void CSItemOption::getAllAddStateOnlyAddValue(WORD* AddStrength, WORD* AddDexterity, WORD* AddEnergy, WORD* AddVitality, WORD* AddCharisma)
 {
     *AddStrength = *AddDexterity = *AddEnergy = *AddVitality = *AddCharisma = 0;
-    memset(m_bySetOptionListOnOff, 0, sizeof m_bySetOptionListOnOff);
-
     getAllAddState(AddStrength, AddDexterity, AddEnergy, AddVitality, AddCharisma);
 }
 
@@ -991,44 +871,7 @@ void CSItemOption::getAllAddOptionStatesbyCompare(WORD* Strength, WORD* Dexterit
         }
     }
 
-    memset(m_bySetOptionListOnOff, 0, sizeof m_bySetOptionListOnOff);
-
-    GetSpecial(Strength, AT_SET_OPTION_IMPROVE_STRENGTH);
-    GetSpecial(Dexterity, AT_SET_OPTION_IMPROVE_DEXTERITY);
-    GetSpecial(Energy, AT_SET_OPTION_IMPROVE_ENERGY);
-    GetSpecial(Vitality, AT_SET_OPTION_IMPROVE_VITALITY);
-    GetSpecial(Charisma, AT_SET_OPTION_IMPROVE_CHARISMA);
-}
-
-void CSItemOption::UpdateCount_SetOptionPerEquippedSetItem(const SET_SEARCH_RESULT* byOptionList, int* arLimitSetItemOptionCount, ITEM* ItemsEquipment)
-{
-    for (int iE = 0; iE < MAX_EQUIPMENT_INDEX; ++iE)
-    {
-        int& iCurCount = arLimitSetItemOptionCount[iE];
-        ITEM& CurItem = ItemsEquipment[iE];
-
-        iCurCount = GetCurrentTypeSetitemCount(CurItem, byOptionList);
-    }
-}
-
-int CSItemOption::Search_From_EquippedSetItemNameMapTable(wchar_t* szSetItemname)
-{
-    int		iSizeFindName = wcslen(szSetItemname);
-
-    for (m_iterESIN = m_mapEquippedSetItemName.begin(); m_iterESIN != m_mapEquippedSetItemName.end(); ++m_iterESIN)
-    {
-        std::wstring	strCur;
-
-        strCur = m_iterESIN->second;
-        int iSizeCurName = strCur.size();
-
-        if (!wcsncmp(szSetItemname, strCur.c_str(), iSizeFindName)
-            && !wcsncmp(szSetItemname, strCur.c_str(), iSizeCurName))
-        {
-            return m_iterESIN->first;
-        }
-    }
-    return -1;
+    AddStatsBySetOptions(Strength, Dexterity, Energy, Vitality, Charisma);
 }
 
 int CSItemOption::GetCurrentTypeSetitemCount(const ITEM& CurItem_, const SET_SEARCH_RESULT* byOptionList)
@@ -1059,10 +902,11 @@ int CSItemOption::GetCurrentTypeSetitemCount(const ITEM& CurItem_, const SET_SEA
 
 void CSItemOption::CheckItemSetOptions()
 {
-    SET_SEARCH_RESULT byOptionList[MAX_EQUIPPED_SETS] = { };
+    SET_SEARCH_RESULT byOptionList[MAX_EQUIPPED_SET_ITEMS] = { };
+
     const ITEM* itemRight = nullptr;
 
-    ZeroMemory(m_bySetOptionList, sizeof(BYTE) * MAX_OPTIONS_PER_ITEM_SET * MAX_ITEM_SETS_PER_ITEM);
+    ZeroMemory(m_SetSearchResult, sizeof(SET_SEARCH_RESULT_OPT) * MAX_EQUIPPED_SETS);
 
     for (int i = 0; i < MAX_EQUIPMENT_INDEX; ++i)
     {
@@ -1071,27 +915,28 @@ void CSItemOption::CheckItemSetOptions()
             continue;
         }
 
-        ITEM* ip = &CharacterMachine->Equipment[i];
+        ITEM* item = &CharacterMachine->Equipment[i];
 
-        if (ip->Durability <= 0)
+        if (item->Durability <= 0)
         {
             continue;
         }
 
         if ((i == EQUIPMENT_WEAPON_LEFT || i == EQUIPMENT_RING_LEFT)
-            && itemRight != nullptr && itemRight->Type == ip->Type && (itemRight->ExtOption % 0x04) == (ip->ExtOption % 0x04))
+            && itemRight != nullptr && itemRight->Type == item->Type && (itemRight->ExtOption % 0x04) == (item->ExtOption % 0x04))
         {
+            // same item of a set should only count once
             continue;
         }
 
-        if (ip->Type > -1)
+        if (item->Type > -1)
         {
-            checkItemType(byOptionList, ip->Type, ip->ExtOption);
+            checkItemType(byOptionList, item->Type, item->ExtOption);
         }
 
         if (i == EQUIPMENT_WEAPON_RIGHT || i == EQUIPMENT_RING_RIGHT)
         {
-            itemRight = ip;
+            itemRight = item;
         }
     }
 
@@ -1105,10 +950,11 @@ void CSItemOption::CheckItemSetOptions()
     WORD AllCharisma = CharacterAttribute->Charisma + CharacterAttribute->AddCharisma;
     WORD AllLevel = CharacterAttribute->Level;
 
-    
-    ZeroMemory(byOptionList, sizeof byOptionList);
+    // And now we're doing all that again, just for checking the required stats?!
+    // TODO: How can this be improved?
 
-    memset(m_bySetOptionList, 0xFF, sizeof m_bySetOptionList);
+    ZeroMemory(m_SetSearchResult, sizeof(SET_SEARCH_RESULT_OPT) * MAX_EQUIPPED_SETS);
+    ZeroMemory(byOptionList, sizeof byOptionList);
 
     for (int i = 0; i < MAX_EQUIPMENT_INDEX; ++i)
     {
@@ -1140,7 +986,6 @@ void CSItemOption::CheckItemSetOptions()
         }
     }
 
-    UpdateCount_SetOptionPerEquippedSetItem(byOptionList, m_arLimitSetItemOptionCount, CharacterMachine->Equipment);
     calcSetOptionList(byOptionList);
 }
 
@@ -1174,7 +1019,7 @@ void CSItemOption::RenderSetOptionButton(const int StartX, const int StartY)
     g_pRenderText->RenderText(StartX + 96, (int)(y + 3), Text, 0, 0, RT3_WRITE_CENTER);
 
     g_pRenderText->SetTextColor(0xffffffff);
-    if (m_bySetOptionANum > 0 || m_bySetOptionBNum > 0)
+    if (m_SetSearchResultCount > 0)
         g_pRenderText->SetTextColor(255, 204, 25, 255);
     else
         g_pRenderText->SetTextColor(128, 128, 128, 255);
@@ -1184,7 +1029,7 @@ void CSItemOption::RenderSetOptionButton(const int StartX, const int StartY)
 
 void CSItemOption::RenderSetOptionList(const int StartX, const int StartY)
 {
-    if (m_bViewOptionList && (m_bySetOptionANum > 0 || m_bySetOptionBNum > 0))
+    if (m_bViewOptionList && m_SetSearchResultCount > 0)
     {
         g_pRenderText->SetTextColor(255, 255, 255, 255);
         g_pRenderText->SetBgColor(100, 0, 0, 0);
@@ -1204,44 +1049,17 @@ void CSItemOption::RenderSetOptionList(const int StartX, const int StartY)
 
         int		iCurSetItemTypeSequence = 0, iCurSetItemType = -1;
 
-        for (int i = 0; i < m_bySetOptionANum + m_bySetOptionBNum; ++i)
+        for (int i = 0; i < m_SetSearchResultCount; i++)
         {
-            std::wstring	strCurrent;
+            const auto& set = m_SetSearchResult[i];
 
-            m_iterESIS = m_mapEquippedSetItemSequence.find(i);
-
-            if (m_mapEquippedSetItemSequence.end() != m_iterESIS)
-            {
-                iCurSetItemTypeSequence = m_iterESIS->second;
-            }
-            else
-            {
-                iCurSetItemTypeSequence = -1;
-            }
-
-            if (iCurSetItemType != iCurSetItemTypeSequence)
-            {
-                iCurSetItemType = iCurSetItemTypeSequence;
-
-                m_iterESIN = m_mapEquippedSetItemName.find(iCurSetItemTypeSequence);
-
-                if (m_iterESIN != m_mapEquippedSetItemName.end())
-                {
-                    strCurrent = m_iterESIN->second;
-
-                    swprintf(TextList[TextNum], L"%s %s", strCurrent.c_str(), GlobalText[1089]);
-                    TextListColor[TextNum] = 3;
-                    TextBold[TextNum] = true;
-                    TextNum++;
-                }
-            }
-            getExplainText(TextList[TextNum], m_bySetOptionList[i][0], m_iSetOptionListValue[i][0], setIndex);
-            if (m_bySetOptionList[i][0] >= AT_SET_OPTION_IMPROVE_ATTACK_1 && m_bySetOptionList[i][1] == 0)
-                TextListColor[TextNum] = 2;
-            else
-                TextListColor[TextNum] = 1;
-            TextBold[TextNum] = false;
+            // print set name:
+            swprintf(TextList[TextNum], L"%s %s", set.SetName, GlobalText[1089]);
+            TextListColor[TextNum] = TEXT_COLOR_YELLOW;
+            TextBold[TextNum] = true;
             TextNum++;
+
+            TextNum = RenderSetOptionList(set, TextNum, true, false);
         }
 
         RenderTipTextList(PosX, PosY, TextNum, 120, RT3_SORT_CENTER);
@@ -1351,76 +1169,7 @@ void CSItemOption::RenderOptionHelper(void)
     RenderTipTextList(sx, sy, TextNum, 0);
 }
 
-int CSItemOption::GetSetItmeCount(const ITEM* pselecteditem)
-{
-    ITEM_SET_TYPE& itemsettype = m_ItemSetType[pselecteditem->Type];
-    BYTE subtype = itemsettype.byOption[(pselecteditem->ExtOption % 0x04) - 1];
-
-    int setitemcount = 0;
-
-    for (int j = 0; j < MAX_ITEM; j++)
-    {
-        ITEM_SET_TYPE& temptype = m_ItemSetType[j];
-        for (int i = 0; i < 2; i++)
-        {
-            BYTE tempsubtype = temptype.byOption[i];
-
-            if (subtype == tempsubtype)
-            {
-                setitemcount++;
-            }
-        }
-    }
-
-    return setitemcount;
-}
-
-bool CSItemOption::isFullseteffect(const ITEM* pselecteditem)
-{
-    int mysetitemcount = 0;
-
-    ITEM_SET_TYPE& selectedItemType = m_ItemSetType[pselecteditem->Type];
-    BYTE selectedItemOption = selectedItemType.byOption[(pselecteditem->ExtOption % 0x04) - 1];
-    ITEM_SET_OPTION& selecteditemoption = m_ItemSetOption[selectedItemOption];
-    int	Cmp_Buff[10] = { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1 };
-
-    for (int i = 0; i < MAX_EQUIPMENT; i++)
-    {
-        ITEM* p = &CharacterMachine->Equipment[i];
-
-        if (p)
-        {
-            bool Continue_Set = false;
-            for (int ipjh = 0; ipjh < mysetitemcount; ipjh++)
-            {
-                if (p->Type == Cmp_Buff[ipjh])
-                {
-                    Continue_Set = true;
-                    break;
-                }
-            }
-            if (Continue_Set == true)
-                continue;
-
-            ITEM_SET_TYPE& myitemSType = m_ItemSetType[p->Type];
-            BYTE myItemOption = myitemSType.byOption[(p->ExtOption % 0x04) - 1];
-            ITEM_SET_OPTION& setOption = m_ItemSetOption[myItemOption];
-
-            if (wcscmp(selecteditemoption.strSetName, setOption.strSetName) == NULL)
-            {
-                Cmp_Buff[mysetitemcount] = p->Type;
-                mysetitemcount++;
-            }
-        }
-    }
-
-    if (mysetitemcount == GetSetItmeCount(pselecteditem))
-        return true;
-    else
-        return false;
-}
-
-int     CSItemOption::RenderSetOptionListInItem(const ITEM* ip, int TextNum, bool bIsEquippedItem)
+int CSItemOption::RenderSetOptionListInItem(const ITEM* ip, int TextNum, bool bIsEquippedItem)
 {
     ITEM_SET_TYPE& itemSType = m_ItemSetType[ip->Type];
 
@@ -1437,34 +1186,8 @@ int     CSItemOption::RenderSetOptionListInItem(const ITEM* ip, int TextNum, boo
         return TNum;
     }
 
-    BYTE    option1 = 255;
-    BYTE    option2 = 255;
-    BYTE    value1 = 255;
-    BYTE    value2 = 255;
-    BYTE    count1 = 0;
 
-    BYTE    byLimitOptionNum;
-
-    if (m_bySetOptionANum > 0)
-        byLimitOptionNum = m_bySetOptionANum - m_bySameSetItem;//m_bySetOptionANum-1;
-    else
-        byLimitOptionNum = 0;
-
-    if (m_bySetOptionBNum > 0)
-        byLimitOptionNum += m_bySetOptionBNum - m_bySameSetItem;//m_bySetOptionANum-1;
-
-    count1 = Search_From_EquippedSetItemNameSequence(setOption.strSetName);
-
-    if (255 == count1)
-    {
-        byLimitOptionNum = 0;
-    }
-    else
-    {
-        byLimitOptionNum = abs((m_bySetOptionANum + m_bySetOptionBNum) - m_bySameSetItem);
-    }
-
-    swprintf(TextList[TNum], L"\n"); TNum += 1;
+    swprintf(TextList[TNum], L"\n"); TNum++;
     swprintf(TextList[TNum], L"%s %s", GlobalText[1089], GlobalText[159]);
     TextListColor[TNum] = TEXT_COLOR_YELLOW;
     TNum++;
@@ -1472,115 +1195,57 @@ int     CSItemOption::RenderSetOptionListInItem(const ITEM* ip, int TextNum, boo
     swprintf(TextList[TNum], L"\n"); TNum++;
     swprintf(TextList[TNum], L"\n"); TNum++;
 
-    bool isfulloption = isFullseteffect(ip);
 
-    if (isfulloption)
+    for (int i = 0; i < m_SetSearchResultCount; i++)
     {
-        byLimitOptionNum = 13;
+        const auto& set = m_SetSearchResult[i];
+        if (wcscmp(set.SetName, setOption.strSetName) == 0)
+        {
+            // Set Found.
+            TNum = RenderSetOptionList(set, TNum, bIsEquippedItem, true);
+            break;
+        }
     }
 
-    BYTE byCurrentSelectedSlotIndex = ip->bySelectedSlotIndex;
-
-    int iLimitOptionCount = m_arLimitSetItemOptionCount[byCurrentSelectedSlotIndex] - 1;
-
-    for (int i = 0; i <= MAX_SETITEM_OPTIONS; ++i)
-    {
-        if (i < 6)
-        {
-            option1 = setOption.byStandardOption[i][0];
-            option2 = setOption.byStandardOption[i][1];
-            value1 = setOption.byStandardOptionValue[i][0];
-            value2 = setOption.byStandardOptionValue[i][1];
-        }
-        else if (i < 8)
-        {
-            if (((ip->ExtOption % 0x04) - 1) == 0)
-            {
-                option1 = setOption.byExtOption[i - 6];
-                value1 = setOption.byExtOptionValue[i - 6];
-            }
-            else
-            {
-                option2 = setOption.byExtOption[i - 6];
-                value2 = setOption.byExtOptionValue[i - 6];
-            }
-        }
-        else
-        {
-            if (((ip->ExtOption % 0x04) - 1) == 0)
-            {
-                option1 = setOption.byFullOption[i - 8];
-                value1 = setOption.byFullOptionValue[i - 8];
-            }
-            else
-            {
-                option2 = setOption.byFullOption[i - 8];
-                value2 = setOption.byFullOptionValue[i - 8];
-            }
-
-            if (isfulloption)
-            {
-                byLimitOptionNum = 13;
-            }
-            else
-            {
-                byLimitOptionNum = 255;
-            }
-        }
-
-        if (option1 != 255)
-        {
-            getExplainText(TextList[TNum], option1, value1, 0);
-
-            if (m_bySetOptionList[count1][0] == option1
-                && byLimitOptionNum != 255
-                && iLimitOptionCount > i
-                && byLimitOptionNum != 0
-                && bIsEquippedItem == true
-                )
-            {
-                TextListColor[TNum] = TEXT_COLOR_BLUE;
-                count1++;
-            }
-            else
-            {
-                TextListColor[TNum] = TEXT_COLOR_GRAY;
-            }
-            TextBold[TNum] = false; TNum++;
-        }
-        if (option2 != 255)
-        {
-            getExplainText(TextList[TNum], option2, value2, 0);
-            if (m_bySetOptionList[count1][0] == option2
-                && byLimitOptionNum != 255
-                && iLimitOptionCount > i
-                && byLimitOptionNum != 0
-                )
-            {
-                TextListColor[TNum] = TEXT_COLOR_BLUE;
-                count1++;
-            }
-            else
-            {
-                TextListColor[TNum] = TEXT_COLOR_GRAY;
-            }
-            TextBold[TNum] = false; TNum++;
-        }
-    }
     swprintf(TextList[TNum], L"\n"); TNum++;
     swprintf(TextList[TNum], L"\n"); TNum++;
 
     return TNum;
 }
 
-BYTE CSItemOption::GetSetOptionANum()
+int  CSItemOption::RenderSetOptionList(const SET_SEARCH_RESULT_OPT& set, BYTE textIndex, bool bIsEquippedItem, bool bShowInactive)
 {
-    return m_bySetOptionANum;
-}
+    for (int j = 0; j < set.SetOptionCount; j++)
+    {
+        const auto option = set.SetOption[j];
+        if (!bShowInactive && !option.IsActive)
+        {
+            break;
+        }
 
-BYTE CSItemOption::GetSetOptionBNum()
-{
-    return m_bySetOptionBNum;
+        getExplainText(TextList[textIndex], option.OptionNumber, option.Value, set.SetTypeIndex);
+        if (!bIsEquippedItem || option.IsActive == 0)
+        {
+            TextListColor[textIndex] = TEXT_COLOR_GRAY;
+        }
+        else if (option.OptionNumber >= AT_SET_OPTION_IMPROVE_ATTACK_1 && option.RequireClass == 0)
+        {
+            // Mastery
+            TextListColor[textIndex] = TEXT_COLOR_RED;
+        }
+        else
+        {
+            TextListColor[textIndex] = TEXT_COLOR_BLUE;
+        }
+
+        TextBold[textIndex] = false;
+        textIndex++;
+    }
+
+    swprintf(TextList[textIndex], L"\n");
+    textIndex++;
+
+    return textIndex;
 }
 
 void CSItemOption::SetViewOptionList(bool bView)

--- a/Source Main 5.2/source/CSItemOption.h
+++ b/Source Main 5.2/source/CSItemOption.h
@@ -7,12 +7,17 @@
 #include "zzzinfomation.h"
 #include <map>
 
-const BYTE MAX_SET_OPTION = 64; // Maximum number of possible ancient sets
-const BYTE MASTERY_OPTION = 24;
+constexpr BYTE MAX_SET_OPTION = 64; // Maximum number of possible ancient sets
+constexpr BYTE MASTERY_OPTION = 24; // A mastery option increases a specific skill
 
 // Each item can be part of up to 2 ancient sets. The following are their identifier.
-const BYTE EXT_A_SET_OPTION = 1;
-const BYTE EXT_B_SET_OPTION = 2;
+constexpr BYTE EXT_A_SET_OPTION = 1;
+constexpr BYTE EXT_B_SET_OPTION = 2;
+
+// Maximum number of equipped sets. This is the maximum number of sets that can be equipped at the same time.
+// It's 5, because the number of equippable items is 12, but one is a wing and one is a pet. To make any set, you need at least 2 items.
+constexpr BYTE MAX_EQUIPPED_SET_ITEMS = MAX_EQUIPMENT_INDEX - 2;
+constexpr BYTE MAX_EQUIPPED_SETS = MAX_EQUIPPED_SET_ITEMS / 2;
 
 constexpr auto MAX_ITEM_SET_NAME = 64;
 
@@ -31,21 +36,48 @@ struct ITEM_SET_TYPE
 struct ITEM_SET_OPTION
 {
     wchar_t	strSetName[MAX_ITEM_SET_NAME];
-    BYTE	byStandardOption[MAX_ITEM_SET_STANDARD_OPTION_COUNT][MAX_ITEM_SETS_PER_ITEM];
-    BYTE	byStandardOptionValue[MAX_ITEM_SET_STANDARD_OPTION_COUNT][MAX_ITEM_SETS_PER_ITEM];
-    BYTE	byExtOption[MAX_ITEM_SETS_PER_ITEM];
-    BYTE	byExtOptionValue[MAX_ITEM_SETS_PER_ITEM];
+    BYTE	bySetItemCount; // The number of items in the set
+
+    // The following arrays are used to store the standard options of the ancient sets.
+    // There is typically one option less than the number of items in the set.
+    // These 2-element-arrays are somehow strange. Only the first element is actually used, I found no use case for the second one.
+    // Theoretically Webzen planned to have 2 options per item, but never implemented it.
+    BYTE	byStandardOption[MAX_ITEM_SET_STANDARD_OPTION_COUNT][2];
+    BYTE	byStandardOptionValue[MAX_ITEM_SET_STANDARD_OPTION_COUNT][2];
+
+    // todo: what are these? Found no set which uses that. If I understand the code correctly, it's an option which always applies.
+    BYTE	byExtOption[MAX_ITEM_SETS_PER_ITEM]; // ???
+    BYTE	byExtOptionValue[MAX_ITEM_SETS_PER_ITEM]; // ???
+
     BYTE	byOptionCount;
     BYTE	byFullOption[MAX_ITEM_SET_FULL_OPTION_COUNT];
     BYTE	byFullOptionValue[MAX_ITEM_SET_FULL_OPTION_COUNT];
     BYTE	byRequireClass[MAX_CLASS];
 };
 
+
+struct SET_OPTION
+{
+    BYTE IsActive;
+    BYTE OptionNumber; // m_bySetOptionList[x][0]
+    BYTE RequireClass; //m_bySetOptionList[x][1]
+    int Value; //m_iSetOptionListValue
+};
+
 struct SET_SEARCH_RESULT
 {
     BYTE SetNumber;
+    BYTE CompleteSetItemCount;
     BYTE ItemCount;
     BYTE SetTypeIndex;
+    wchar_t SetName[MAX_ITEM_SET_NAME];
+};
+
+struct SET_SEARCH_RESULT_OPT
+    : SET_SEARCH_RESULT
+{
+    int SetOptionCount;
+    SET_OPTION SetOption[MAX_OPTIONS_PER_ITEM_SET];
 };
 
 class CSItemOption : public Singleton<CSItemOption>
@@ -54,11 +86,13 @@ private:
     ITEM_SET_TYPE	m_ItemSetType[MAX_ITEM];
     ITEM_SET_OPTION	m_ItemSetOption[MAX_SET_OPTION];
 
+    int m_SetSearchResultCount;
+    SET_SEARCH_RESULT_OPT m_SetSearchResult[MAX_EQUIPPED_SETS];
+
     bool	m_bViewOptionList;
     BYTE    m_byRenderOptionList;
     BYTE    m_bySelectedItemOption;
     BYTE    m_bySameSetItem;
-    wchar_t m_strSetName[MAX_ITEM_SETS_PER_ITEM][MAX_ITEM_SET_NAME];
 
     typedef std::map<int, std::wstring>	MAP_EQUIPPEDSETITEMNAME;
     typedef std::map<BYTE, int>		MAP_EQUIPPEDSETITEM_SEQUENCE;
@@ -66,72 +100,24 @@ private:
     MAP_EQUIPPEDSETITEMNAME	            m_mapEquippedSetItemName;
     MAP_EQUIPPEDSETITEMNAME::iterator   m_iterESIN;
 
-    MAP_EQUIPPEDSETITEM_SEQUENCE            m_mapEquippedSetItemSequence;
-    MAP_EQUIPPEDSETITEM_SEQUENCE::iterator  m_iterESIS;
-private:
     void  UpdateCount_SetOptionPerEquippedSetItem(const SET_SEARCH_RESULT* byOptionList, int* arLimitSetItemOptionCount, ITEM* ItemsEquipment);
     int GetCurrentTypeSetitemCount(const ITEM& CurItem_, const SET_SEARCH_RESULT* byOptionList);
     int Search_From_EquippedSetItemNameMapTable(wchar_t* szSetItemname);
 
-public:
-    bool	Find_From_EquippedSetItemNameMapTable(wchar_t* szSetItemname)
-    {
-        int iResult = Search_From_EquippedSetItemNameMapTable(szSetItemname);
-
-        if (-1 == iResult)
-        {
-            return false;
-        }
-        else
-        {
-            return true;
-        }
-    }
-
-    BYTE Search_From_EquippedSetItemNameSequence(wchar_t* szSetItemname)
-    {
-        BYTE	byCur = 0;
-        int		iResult = Search_From_EquippedSetItemNameMapTable(szSetItemname);
-
-        if (-1 != iResult)
-        {
-            for (m_iterESIS = m_mapEquippedSetItemSequence.begin(); m_iterESIS != m_mapEquippedSetItemSequence.end(); ++m_iterESIS)
-            {
-                if ((int)(m_iterESIS->second) == iResult)
-                {
-                    return (BYTE)m_iterESIS->first;
-                }
-            }
-        }
-
-        return 255;
-    }
-
-    BYTE	m_bySetOptionANum;
-    BYTE	m_bySetOptionBNum;
-    BYTE    m_bySetOptionIndex[MAX_ITEM_SETS_PER_ITEM];
-    BYTE	m_bySetOptionList[MAX_OPTIONS_PER_ITEM_SET][MAX_ITEM_SETS_PER_ITEM];
-    BYTE	m_bySetOptionListOnOff[MAX_OPTIONS_PER_ITEM_SET];
-    int     m_iSetOptionListValue[MAX_OPTIONS_PER_ITEM_SET][MAX_ITEM_SETS_PER_ITEM];
-
     bool	OpenItemSetType(const wchar_t* filename);
     bool	OpenItemSetOption(const wchar_t* filename);
-
     void	checkItemType(SET_SEARCH_RESULT* optionList, const int iType, const int setType);
-
     void	calcSetOptionList(SET_SEARCH_RESULT* optionList);
+    BYTE    calcClassRequirement(const ITEM_SET_OPTION& setOptions, int firstClass, int secondClass);
 
     void	getExplainText(wchar_t* text, const BYTE option, const BYTE value, const BYTE SetA);
-
     void    getAllAddState(WORD* Strength, WORD* Dexterity, WORD* Energy, WORD* Vitality, WORD* Charisma);
-    int     GetSetItmeCount(const ITEM* pselecteditem);
-    bool	isFullseteffect(const ITEM* ip);
 
-public:
+    void    AddStatsBySetOptions(WORD* Strength, WORD* Dexterity, WORD* Energy, WORD* Vitality, WORD* Charisma) const; //Adds the stats of the active ancient set options to the given pointers, without bonus options
 
-    void	getAllAddOptionStatesbyCompare(WORD* Strength, WORD* Dexterity, WORD* Energy, WORD* Vitality, WORD* Charisma, WORD iCompareStrength, WORD iCompareDexterity, WORD iCompareEnergy, WORD iCompareVitality, WORD iC);
+    int     RenderSetOptionList(const SET_SEARCH_RESULT_OPT &set, BYTE textIndex, bool bIsEquippedItem, bool bShowInactive);
 
-    void	getAllAddStateOnlyAddValue(WORD* AddStrength, WORD* AddDexterity, WORD* AddEnergy, WORD* AddVitality, WORD* AddCharisma);
+
 
 public:
     CSItemOption(void) { init(); };
@@ -139,9 +125,6 @@ public:
 
     void init(void)
     {
-        m_strSetName[0][0] = L'\0';
-        m_strSetName[1][0] = L'\0';
-
         m_bViewOptionList = false;
         m_byRenderOptionList = 0;
         m_bySelectedItemOption = 0;
@@ -149,7 +132,7 @@ public:
     }
     void    ClearListOnOff(void)
     {
-        memset(m_bySetOptionListOnOff, 0, sizeof(BYTE) * MAX_OPTIONS_PER_ITEM_SET);
+        //memset(m_bySetOptionListOnOff, 0, sizeof(BYTE) * MAX_OPTIONS_PER_ITEM_SET);
     }
     bool    OpenItemSetScript(bool bTestServer);
 
@@ -163,12 +146,6 @@ public:
     void	PlusSpecialLevel(WORD* Value, const WORD SrcValue, const int Special);
     void    PlusMastery(int* Value, const BYTE MasteryType);
 
-    void    MinusSpecialPercent(int* Value, const int Special);
-
-    void	GetSpecial(WORD* Value, int Special);
-
-    void	GetSpecialPercent(WORD* Value, int Special);
-    void	GetSpecialLevel(WORD* Value, const WORD SrcValue, int Special);
     int     GetDefaultOptionValue(ITEM* ip, WORD* Value);
     bool    GetDefaultOptionText(const ITEM* ip, wchar_t* Text);
     int     RenderDefaultOptionText(const ITEM* ip, int TextNum);
@@ -179,19 +156,20 @@ public:
     void	RenderSetOptionButton(const int StartX, const int StartY);
     void	RenderSetOptionList(const int StartX, const int StartY);
 
-    int		m_arLimitSetItemOptionCount[MAX_EQUIPMENT];
-
     int     RenderSetOptionListInItem(const ITEM* ip, int TextNum, bool bIsEquippedItem = false);
 
     void    ClearOptionHelper(void) { m_byRenderOptionList = 0; }
     void    CheckRenderOptionHelper(const wchar_t* FilterName);
     void    RenderOptionHelper(void);
 
-    BYTE GetSetOptionANum();
-    BYTE GetSetOptionBNum();
+    bool IsAncientSetEquipped() const { return m_SetSearchResultCount > 0; }
 
     void SetViewOptionList(bool bView);
     bool IsViewOptionList();
+
+    void	getAllAddOptionStatesbyCompare(WORD* Strength, WORD* Dexterity, WORD* Energy, WORD* Vitality, WORD* Charisma, WORD iCompareStrength, WORD iCompareDexterity, WORD iCompareEnergy, WORD iCompareVitality, WORD iC);
+
+    void	getAllAddStateOnlyAddValue(WORD* AddStrength, WORD* AddDexterity, WORD* AddEnergy, WORD* AddVitality, WORD* AddCharisma); // Gets only the added stats of the active ancient set options plus bonus options
 };
 
 #define g_csItemOption CSItemOption::GetSingleton ()

--- a/Source Main 5.2/source/NewUIMyInventory.cpp
+++ b/Source Main 5.2/source/NewUIMyInventory.cpp
@@ -172,6 +172,7 @@ void CNewUIMyInventory::UnequipItem(int iIndex)
             pEquippedItem->Level = 0;
             pEquippedItem->Number = -1;
             pEquippedItem->Option1 = 0;
+            pEquippedItem->Durability = 0;
             pEquippedItem->ExtOption = 0;
             pEquippedItem->SocketCount = 0;
             for (int i = 0; i < MAX_SOCKETS; ++i)
@@ -696,7 +697,7 @@ void CNewUIMyInventory::RenderSetOption()
 {
     g_pRenderText->SetFont(g_hFontBold);
     g_pRenderText->SetBgColor(0, 0, 0, 0);
-    if (g_csItemOption.GetSetOptionANum() > 0 || g_csItemOption.GetSetOptionBNum() > 0)
+    if (g_csItemOption.IsAncientSetEquipped())
     {
         g_pRenderText->SetTextColor(255, 204, 25, 255);
     }

--- a/Source Main 5.2/source/ZzzInfomation.cpp
+++ b/Source Main 5.2/source/ZzzInfomation.cpp
@@ -2852,7 +2852,6 @@ void CHARACTER_MACHINE::CalculateDamage()
 
     WORD    Damage = 0;
 
-    memset(g_csItemOption.m_bySetOptionListOnOff, 0, sizeof(BYTE) * 16);
 
     g_csItemOption.PlusSpecial(&Damage, AT_SET_OPTION_IMPROVE_ATTACK_MIN);
     Character.AttackDamageMinLeft += Damage;


### PR DESCRIPTION
The original code was a mess and limited to two concurrently equipped ancient sets. Now it supports the theoretical limit of 5 sets.

In the process of refactoring I found some interesting features, which were implemented but never used by webzen:
  * A second option per stage, which means you could add two options by adding one item of the set. I didn't implement that to keep the code simpler.
  * "byExtOption", which seems to be an option which always applies when having at least two items of the set. I didn't implement that to keep the code simpler.
  * Options to boost specific skills (mastery). I don't know if that applies to all skills or just a master skill.