### PR TITLE
Fixed Client crash when switching char right after logging in (see #56)

### DIFF
--- a/Source Main 5.2/source/WSclient.cpp
+++ b/Source Main 5.2/source/WSclient.cpp
@@ -809,6 +809,7 @@ BOOL ReceiveLogOut(const BYTE* ReceiveBuffer, BOOL bEncrypted)
         if (SocketClient != nullptr)
         {
             SocketClient->Close();
+            g_bGameServerConnected = false;
         }
 
         ReleaseCharacterSceneData();

--- a/Source Main 5.2/source/Winmain.cpp
+++ b/Source Main 5.2/source/Winmain.cpp
@@ -599,6 +599,7 @@ LONG FAR PASCAL WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             if (SocketClient != nullptr)
             {
                 SocketClient->Close();
+                g_bGameServerConnected = false;
             }
 
             CUIMng::Instance().PopUpMsgWin(MESSAGE_SERVER_LOST);
@@ -627,6 +628,7 @@ LONG FAR PASCAL WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         if (SocketClient != nullptr)
         {
             SocketClient->Close();
+            g_bGameServerConnected = false;
         }
 
         DestroySound();


### PR DESCRIPTION
The problem was, that the client sent ping packets to the connect server. However, the connect server of OpenMU only accepts up to 6 bytes in a packet and disconnects all clients which send more.
The global variable `g_bGameServerConnected` needs to be reset when the connection to the game server is closed before going back to the server selection screen. In this case, the ping packet is not sent and no crash happens.