### PR TITLE
Workaround for incorrect harmony option display

### DIFF
--- a/Source Main 5.2/source/UIJewelHarmony.h
+++ b/Source Main 5.2/source/UIJewelHarmony.h
@@ -20,6 +20,7 @@ struct HarmonyJewelOption
 
     HarmonyJewelOption() : OptionType(-1), Minlevel(-1)
     {
+        memset(Name, 0, sizeof(Name));
         for (int i = 0; i < 14; ++i)
         {
             HarmonyJewelLevel[i] = -1;


### PR DESCRIPTION
Fixes https://github.com/sven-n/MuMain/issues/80

![image](https://github.com/user-attachments/assets/dcad84f3-e380-4aae-9a47-67ef9085b35a) 
![image](https://github.com/user-attachments/assets/a35b174c-d247-48b0-9ef2-b9ea34ac0c44)



Note:  
I think the permanent fix would be to update JewelOfHarmonyOption_eng.bmd to use wchar_t[] for the names. If in case this bmd file is updated, we need to undo this patch.