### PR TITLE
Fixed string rendering in goblin dialogs

### DIFF
--- a/Source Main 5.2/source/GameShop/InGameShopSystem.cpp
+++ b/Source Main 5.2/source/GameShop/InGameShopSystem.cpp
@@ -433,12 +433,12 @@ int CInGameShopSystem::GetSizePackageAsDisplayPackage()
     return m_listDisplayPackage.size();
 }
 
-type_listName CInGameShopSystem::GetZoneName()
+type_listName& CInGameShopSystem::GetZoneName()
 {
     return m_listZoneName;
 }
 
-type_listName CInGameShopSystem::GetCategoryName()
+type_listName& CInGameShopSystem::GetCategoryName()
 {
     return m_listCategoryName;
 }

--- a/Source Main 5.2/source/GameShop/InGameShopSystem.h
+++ b/Source Main 5.2/source/GameShop/InGameShopSystem.h
@@ -94,8 +94,8 @@ public:
 
     WORD GetPackageItemCode(int iIndex);
 
-    type_listName GetZoneName();
-    type_listName GetCategoryName();
+    type_listName& GetZoneName();
+    type_listName& GetCategoryName();
 
     void SetTotalCash(double dTotalCash);
     void SetTotalPoint(double dTotalPoint);

--- a/Source Main 5.2/source/LoadData.cpp
+++ b/Source Main 5.2/source/LoadData.cpp
@@ -94,7 +94,7 @@ void CLoadData::OpenTexture(int Model, wchar_t* SubFolder, int Wrap, int Type, b
         if (pModel->IndexTexture[i] == BITMAP_UNKNOWN)
         {
             wchar_t szErrorMsg[256] = { 0, };
-            swprintf(szErrorMsg, L"OpenTexture Failed: %s of %s", szFullPath, pModel->Name);
+            swprintf(szErrorMsg, L"OpenTexture Failed: %s of %hs", szFullPath, pModel->Name);
 #ifdef FOR_WORK
             PopUpErrorCheckMsgBox(szErrorMsg);
 #else // FOR_WORK

--- a/Source Main 5.2/source/NewUIMixInventory.cpp
+++ b/Source Main 5.2/source/NewUIMixInventory.cpp
@@ -525,7 +525,7 @@ void CNewUIMixInventory::RenderFrame()
         g_pRenderText->SetTextColor(220, 220, 220, 255);
         g_pRenderText->SetBgColor(40, 40, 40, 128);
 
-        wchar_t szTempText[2][100];
+        wchar_t szTempText[2][100] = { 0 };
         int iTextLines = 0;
         if (!g_MixRecipeMgr.IsReadyToMix() && g_MixRecipeMgr.GetMostSimilarRecipeName(szTempText[0], 1) == TRUE)
         {

--- a/Source Main 5.2/source/NewUIMuHelper.cpp
+++ b/Source Main 5.2/source/NewUIMuHelper.cpp
@@ -914,7 +914,7 @@ void CNewUIMuHelper::SaveExtraItem()
 
     m_ItemInput.GetText(wsExtraItem, sizeof(wsExtraItem));
 
-    if (wsExtraItem != L"")
+    if (wcscmp(wsExtraItem, L"") != 0)
     {
         m_ItemFilter.AddText(wsExtraItem);
         m_ItemFilter.Scrolling(-m_ItemFilter.GetBoxSize());

--- a/Source Main 5.2/source/UIControls.cpp
+++ b/Source Main 5.2/source/UIControls.cpp
@@ -1589,7 +1589,8 @@ CUIChatPalListBox::CUIChatPalListBox()
 
 void CUIChatPalListBox::AddText(const wchar_t* pszID, BYTE Number, BYTE Server)
 {
-    if (pszID == L"")	return;
+    if (wcscmp(pszID, L"") == 0)
+        return;
 
     static GUILDLIST_TEXT text;
     text.m_bIsSelected = FALSE;

--- a/Source Main 5.2/source/WSclient.cpp
+++ b/Source Main 5.2/source/WSclient.cpp
@@ -10422,7 +10422,6 @@ void ReceiveUseStateItem(const BYTE* ReceiveBuffer)
 
     case 0x02:
     {
-        wchar_t strText[128];
         swprintf(strText, GlobalText[1904], GlobalText[1412]);
         SEASON3B::CreateOkMessageBox(strText);
     }

--- a/Source Main 5.2/source/npcBreeder.cpp
+++ b/Source Main 5.2/source/npcBreeder.cpp
@@ -43,7 +43,11 @@ namespace npcBreeder
                 return -1;
             }
             break;
+        default:
+            swprintf(Text, GlobalText[1229]);
+            return -1;
         }
+
         ITEM_ATTRIBUTE* p = &ItemAttribute[ip->Type];
 
         int maxDurability = CalcMaxDurability(ip, p, ip->Level);

--- a/Source Main 5.2/source/w_BuffScriptLoader.cpp
+++ b/Source Main 5.2/source/w_BuffScriptLoader.cpp
@@ -101,7 +101,7 @@ bool BuffScriptLoader::Load(const std::wstring& pchFileName)
         if (dwCheckSum != GenerateCheckSum2(Buffer, structsize * listsize, 0xE2F1))
         {
             wchar_t Text[256];
-            swprintf(Text, L"%s - File corrupted.", pchFileName);
+            swprintf(Text, L"%s - File corrupted.", pchFileName.c_str());
             g_ErrorReport.Write(Text);
             MessageBox(g_hWnd, Text, NULL, MB_OK);
             SendMessage(g_hWnd, WM_DESTROY, 0, 0);
@@ -141,7 +141,7 @@ bool BuffScriptLoader::Load(const std::wstring& pchFileName)
     else
     {
         wchar_t Text[256];
-        swprintf(Text, L"%s - File not exist.", pchFileName);
+        swprintf(Text, L"%s - File not exist.", pchFileName.c_str());
         g_ErrorReport.Write(Text);
         MessageBox(g_hWnd, Text, NULL, MB_OK);
         SendMessage(g_hWnd, WM_DESTROY, 0, 0);


### PR DESCRIPTION
Fixed gibberish string displayed in the assembly recipe.  
Below is an example in Chaos Goblin (this bug is also present in Aida1 goblins)

Before:
![image](https://github.com/user-attachments/assets/e9a00cf1-dfb3-4c8f-94b2-97c422754e70)

After:
![image](https://github.com/user-attachments/assets/1a84d0da-98f2-400b-89c1-8c07623c8c9c)
