### PR TITLE
Reduced number of effects on high fps

### DIFF
--- a/Source Main 5.2/source/CDirection.cpp
+++ b/Source Main 5.2/source/CDirection.cpp
@@ -384,14 +384,14 @@ void CDirection::FaillingEffect()
     Pos[1] = Hero->Object.Position[1] + (float)(rand() % 20 - 10) * 70.0f;
     Pos[2] = Hero->Object.Position[2] - rand() % 200 - 500.0f;
 
-    CreateParticle(BITMAP_CLOUD, Pos, Hero->Object.Angle, Light, 13, Scale);
+    CreateParticleFpsChecked(BITMAP_CLOUD, Pos, Hero->Object.Angle, Light, 13, Scale);
 
     Pos[0] = Hero->Object.Position[0] + (float)(rand() % 20 - 10) * 70.0f;
     Pos[1] = Hero->Object.Position[1] + (float)(rand() % 20 - 10) * 70.0f;
     Pos[2] = Hero->Object.Position[2] - rand() % 200 - 500.0f;
 
     Vector(0.05f, 0.05f, 0.05f, Light);
-    CreateParticle(BITMAP_CLOUD, Pos, Hero->Object.Angle, Light, 13, Scale);
+    CreateParticleFpsChecked(BITMAP_CLOUD, Pos, Hero->Object.Angle, Light, 13, Scale);
 }
 
 void CDirection::HeroFallingDownInit()

--- a/Source Main 5.2/source/CSChaosCastle.cpp
+++ b/Source Main 5.2/source/CSChaosCastle.cpp
@@ -453,6 +453,7 @@ bool RenderChaosCastleVisual(OBJECT* o, BMD* b)
 
                 int randValue = rand() % 2;
                 PlayBuffer(static_cast<ESound>(SOUND_CHAOS_THUNDER01 + randValue));
+                o->LifeTime = 9.9f;
             }
 
             if (o->LifeTime < 5)
@@ -524,7 +525,7 @@ void RenderTerrainVisual(int xi, int yi)
         Position[0] = (xi * TERRAIN_SCALE) + (rand() % 30 - 15.f);
         Position[1] = (yi * TERRAIN_SCALE) + (rand() % 30 - 15.f);
         Position[2] = Hero->Object.Position[2];
-        CreateParticle(BITMAP_SMOKE + 4, Position, Angle, Light, 0, 1.5f);
+        CreateParticleFpsChecked(BITMAP_SMOKE + 4, Position, Angle, Light, 0, 1.5f);
 
         if (rand_fps_check(5))
         {

--- a/Source Main 5.2/source/CSPetSystem.cpp
+++ b/Source Main 5.2/source/CSPetSystem.cpp
@@ -242,6 +242,7 @@ void CSPetSystem::SetAttack(int Key, int attackType)
 
     m_PetCharacter.TargetCharacter = Index;
     m_PetCharacter.AttackTime = 0;
+    m_PetCharacter.LastAttackEffectTime = -1;
     SetAI(PET_ATTACK + attackType);
 
     if (m_PetCharacter.Object.AI == PET_ATTACK)
@@ -710,16 +711,18 @@ void CSPetDarkSpirit::AttackEffect(CHARACTER* c, OBJECT* o)
             {
                 CreateJoint(BITMAP_LIGHT, o->Position, o->Position, o->Angle, 1, NULL, (float)(rand() % 40 + 20));
             }
-            if ((int)c->AttackTime == 1)
+
+            if (c->CheckAttackTime(1))
             {
                 vec3_t Angle, Light;
 
                 Vector(45.f, (float)(rand() % 180) - 90, 0.f, Angle);
                 Vector(1.f, 0.8f, 0.6f, Light);
                 CreateEffect(MODEL_DARKLORD_SKILL, o->Position, Angle, Light, 3);
+                c->SetLastAttackEffectTime();
             }
         }
-        if (c->AttackTime > 3 && (int)c->AttackTime % 2)
+        if (c->AttackTime > 3 && (int)c->AttackTime % 2 && rand_fps_check(1))
         {
             if (o->Position[2] > (m_PetOwner->Object.Position[2] + 100.f))
             {
@@ -763,6 +766,7 @@ void CSPetDarkSpirit::AttackEffect(CHARACTER* c, OBJECT* o)
                 SetAI(PET_FLYING);
             }
             c->AttackTime = 0;
+            c->LastAttackEffectTime = -1;
         }
         break;
 

--- a/Source Main 5.2/source/CSPetSystem.cpp
+++ b/Source Main 5.2/source/CSPetSystem.cpp
@@ -410,7 +410,7 @@ void CSPetDarkSpirit::MovePet(void)
             {
                 b->TransformPosition(o->BoneTransform[rand() % 66], p, Pos);
 
-                CreateParticle(BITMAP_SPARK + 1, Pos, o->Angle, Light, 5, 0.8f);
+                CreateParticleFpsChecked(BITMAP_SPARK + 1, Pos, o->Angle, Light, 5, 0.8f);
             }
         }
 
@@ -746,7 +746,7 @@ void CSPetDarkSpirit::AttackEffect(CHARACTER* c, OBJECT* o)
                     if (!b->Bones[i].Dummy && i < b->NumBones)
                     {
                         b->TransformPosition(o->BoneTransform[i], p, Pos);
-                        CreateParticle(BITMAP_LIGHT, Pos, o->Angle, Light, 6, 1.3f);
+                        CreateParticleFpsChecked(BITMAP_LIGHT, Pos, o->Angle, Light, 6, 1.3f);
                     }
                 }
             }

--- a/Source Main 5.2/source/Event.cpp
+++ b/Source Main 5.2/source/Event.cpp
@@ -342,19 +342,19 @@ bool CNewYearsDayEvent::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             if (o->AnimationFrame <= 0.3f)
             {
                 o->m_iAnimation = rand() % 6 + MODEL_NEWYEARSDAY_EVENT_BEKSULKI;
-                CreateParticle(BITMAP_EXPLOTION, vWorldPos, o->Angle, vLight, 0, 0.5f);
+                CreateParticleFpsChecked(BITMAP_EXPLOTION, vWorldPos, o->Angle, vLight, 0, 0.5f);
                 if (rand_fps_check(4)) o->m_iAnimation = MODEL_NEWYEARSDAY_EVENT_PIG;
 
                 PlayBuffer(SOUND_NEWYEARSDAY_DIE);
             }
 
             if (o->AnimationFrame >= 4.5f)
-                CreateEffect(MODEL_NEWYEARSDAY_EVENT_MONEY, vWorldPos, o->Angle, vLight);
+                CreateEffectFpsChecked(MODEL_NEWYEARSDAY_EVENT_MONEY, vWorldPos, o->Angle, vLight);
 
             if (o->m_iAnimation != 0 && rand_fps_check(3))
             {
                 if (o->AnimationFrame >= 4.5f)
-                    CreateEffect(o->m_iAnimation, vWorldPos, o->Angle, vLight);
+                    CreateEffectFpsChecked(o->m_iAnimation, vWorldPos, o->Angle, vLight);
             }
         }
     }
@@ -487,7 +487,7 @@ bool C09SummerEvent::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     }break;
     case MONSTER01_DIE:
     {
-        if (o->AnimationFrame > 0.0f && o->AnimationFrame <= 0.3f)
+        if (o->AnimationFrame > 0.0f && o->AnimationFrame <= 0.3f && rand_fps_check(1))
         {
             CreateEffect(MODEL_EFFECT_SKURA_ITEM, o->Position, o->Angle, o->Light, 1, o);
             vec3_t Position, Angle, Light;

--- a/Source Main 5.2/source/GM3rdChangeUp.cpp
+++ b/Source Main 5.2/source/GM3rdChangeUp.cpp
@@ -163,10 +163,10 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         Vector(0.2f, 0.2f, 0.2f, Light);
 
         if (pObject->HiddenMesh != -2) {
-            CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
-            CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 2, pObject->Scale, pObject);
-            CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 3, pObject->Scale, pObject);
-            CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 4, pObject->Scale, pObject);
+            CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
+            CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 2, pObject->Scale, pObject);
+            CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 3, pObject->Scale, pObject);
+            CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 4, pObject->Scale, pObject);
         }
         pObject->HiddenMesh = -2;
     }
@@ -183,7 +183,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 60:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, pObject->Position, pObject->Angle, Light, 3, pObject->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, pObject->Position, pObject->Angle, Light, 3, pObject->Scale);
         break;
     case 85:
         if (rand_fps_check(2))
@@ -245,7 +245,7 @@ bool SEASON3A::CGM3rdChangeUp::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         {
             for (int i = 0; i < 2; ++i)
             {
-                CreateEffect(BITMAP_FIRE_RED, pObject->Position, pObject->Angle, Light, 0, NULL, -1, 0, pObject->Scale);
+                CreateEffectFpsChecked(BITMAP_FIRE_RED, pObject->Position, pObject->Angle, Light, 0, NULL, -1, 0, pObject->Scale);
             }
         }
     }
@@ -524,7 +524,7 @@ bool SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackMonsterVisual(CHARACTER* c, OBJE
 
         if (o->CurrentAction == MONSTER01_ATTACK1)
         {
-            if (o->AnimationFrame >= 6.5f && o->AnimationFrame < (6.5f + fActionSpeed))
+            if (o->AnimationFrame >= 6.5f && o->AnimationFrame < (6.5f + fActionSpeed) && rand_fps_check(1))
             {
                 Vector(0.0f, 0.0f, 0.0f, EndRelative);
                 b->TransformPosition(o->BoneTransform[27], EndRelative, EndPos, true);
@@ -657,7 +657,7 @@ void SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackBlurEffect(CHARACTER* c, OBJECT*
                 Vector(0.f, 100.f, -150.f, EndRelative);
                 b->TransformPosition(BoneTransform[16], EndRelative, EndPos, false);
 
-                if (o->AnimationFrame > 5.0f && o->AnimationFrame < 7.0f)
+                if (o->AnimationFrame > 5.0f && o->AnimationFrame < 7.0f && rand_fps_check(1))
                 {
                     CreateParticle(BITMAP_FIRE, EndPos, o->Angle, Light);
                 }
@@ -692,7 +692,7 @@ void SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackBlurEffect(CHARACTER* c, OBJECT*
             float fAnimationFrame = o->AnimationFrame - fActionSpeed;
 
             if (o->CurrentAction == MONSTER01_ATTACK2 && (o->AnimationFrame > 4.5f && o->AnimationFrame < 5.0f))
-                CreateEffect(MODEL_DARK_ELF_SKILL, o->Position, o->Angle, o->Light, 2, o);
+                CreateEffectFpsChecked(MODEL_DARK_ELF_SKILL, o->Position, o->Angle, o->Light, 2, o);
 
             VectorCopy(o->Angle, TempAngle);
             for (int i = 0; i < 10; i++) {
@@ -708,7 +708,7 @@ void SEASON3A::CGM3rdChangeUp::MoveBalgasBarrackBlurEffect(CHARACTER* c, OBJECT*
             }
             VectorCopy(TempAngle, o->Angle);
         }
-        else if (o->CurrentAction == MONSTER01_ATTACK3)
+        else if (o->CurrentAction == MONSTER01_ATTACK3 && rand_fps_check(1))
         {
             vec3_t Position, Light;
             BoneManager::GetBonePosition(o, L"Left_Hand", Position);

--- a/Source Main 5.2/source/GM3rdChangeUp.cpp
+++ b/Source Main 5.2/source/GM3rdChangeUp.cpp
@@ -474,9 +474,10 @@ bool SEASON3A::CGM3rdChangeUp::AttackEffectBalgasBarrackMonster(CHARACTER* c, OB
     switch (o->Type)
     {
     case MODEL_BALRAM:
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             CreateEffect(MODEL_ARROW_HOLY, o->Position, o->Angle, o->Light, 1, o, o->PKKey);
+            c->SetLastAttackEffectTime();
             return true;
         }
         break;

--- a/Source Main 5.2/source/GMAida.cpp
+++ b/Source Main 5.2/source/GMAida.cpp
@@ -173,7 +173,7 @@ bool M33Aida::RenderAidaObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 57:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, pObject->Position, pObject->Angle, Light, 4, pObject->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, pObject->Position, pObject->Angle, Light, 4, pObject->Scale);
         break;
     case 58:
         Vector(1.f, 1.f, 1.f, Light);
@@ -189,14 +189,13 @@ bool M33Aida::RenderAidaObjectVisual(OBJECT* pObject, BMD* pModel)
             Vector(0.01f, 0.03f, 0.05f, Light);
             for (int i = 0; i < 20; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
+                CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
             }
         }
         break;
     case 60:
     {
-        int time = timeGetTime() % 1024;
-        if (time >= 0 && time < 10) {
+        if (rand_fps_check(25)) {
             vec3_t Light;
             Vector(1.f, 1.f, 1.f, Light);
             CreateEffect(MODEL_BUTTERFLY01, pObject->Position, pObject->Angle, Light, 3, pObject);
@@ -211,7 +210,7 @@ bool M33Aida::RenderAidaObjectVisual(OBJECT* pObject, BMD* pModel)
             Vector(0.05f, 0.05f, 0.05f, Light);
             for (int i = 0; i < 20; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
+                CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
             }
         }
         break;
@@ -222,7 +221,7 @@ bool M33Aida::RenderAidaObjectVisual(OBJECT* pObject, BMD* pModel)
             Vector(0.05f, 0.02f, 0.02f, Light);
             for (int i = 0; i < 20; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
+                CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
             }
         }
         break;
@@ -240,12 +239,12 @@ bool M33Aida::RenderAidaObjectVisual(OBJECT* pObject, BMD* pModel)
     break;
     case	67:
         Vector(0.3f, 0.3f, 0.3f, pObject->Light);
-        CreateParticle(BITMAP_FLAME, pObject->Position, pObject->Angle, pObject->Light, 7, pObject->Scale);
+        CreateParticleFpsChecked(BITMAP_FLAME, pObject->Position, pObject->Angle, pObject->Light, 7, pObject->Scale);
         break;
     case	70:
     {
         int time = timeGetTime() % 1024;
-        if (rand() % 5 == 1 && (time >= 0 && time < 30))
+        if (rand_fps_check(5) && (time >= 0 && time < 30))
         {
             Vector(0.1f, 0.1f, 0.1f, Light);
             CreateEffect(MODEL_GHOST, pObject->Position, pObject->Angle, Light, 0, pObject, -1, 0, pObject->Scale);
@@ -722,7 +721,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
         Vector(0.7f, 0.5f, 0.7f, Light);
         vec3_t Relative = { 0.0f, 0.0f, -65.0f };
         BoneManager::GetBonePosition(pObject, L"Monster100_Footstepst", Relative, Position);
-        CreateParticle(BITMAP_LIGHT + 1, Position, Angle, Light, 4, 4.0f);
+        CreateParticleFpsChecked(BITMAP_LIGHT + 1, Position, Angle, Light, 4, 4.0f);
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
@@ -760,9 +759,9 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
                 BoneManager::GetBonePosition(pObject, L"Monster100_Footstepst", Relative, Position);
 
                 Vector(0.5f, 0.2f, 0.5f, Light);
-                CreateParticle(BITMAP_SMOKE, Position, Angle, Light, 27, 2.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, Angle, Light, 27, 2.0f);
                 Vector(1.0f, 1.0f, 1.0f, Light);
-                CreateParticle(BITMAP_LIGHT + 1, Position, Angle, Light, 2, 1.0f);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 1, Position, Angle, Light, 2, 1.0f);
             }
             if (pObject->AnimationFrame >= 6.0f && pObject->CurrentAction == MONSTER01_ATTACK1)
             {
@@ -770,7 +769,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
                 vec3_t Relative = { 70.0f, 0.0f, 0.0f };
                 BoneManager::GetBonePosition(pObject, L"Monster100_Footstepst", Relative, Position);
                 Vector(1.0f, 1.0f, 1.0f, Light);
-                CreateParticle(BITMAP_LIGHT + 1, Position, Angle, Light, 3, 1.3f);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 1, Position, Angle, Light, 3, 1.3f);
             }
             if (pCharacter->TargetCharacter >= 0 && pCharacter->TargetCharacter < MAX_CHARACTERS_CLIENT)
             {
@@ -783,11 +782,11 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
                 if (pObject->AnimationFrame >= 6.0f && pObject->CurrentAction == MONSTER01_ATTACK1)
                 {
-                    CreateParticle(BITMAP_LIGHT + 1, vTemp, Angle, Light, 3, 1.3f);
+                    CreateParticleFpsChecked(BITMAP_LIGHT + 1, vTemp, Angle, Light, 3, 1.3f);
                 }
                 if (pObject->AnimationFrame >= 6.0f && pObject->CurrentAction == MONSTER01_ATTACK2)
                 {
-                    CreateJoint(BITMAP_JOINT_THUNDER, to->Position, vTemp, pObject->Angle, 16);
+                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, to->Position, vTemp, pObject->Angle, 16);
                 }
             }
         }
@@ -802,11 +801,11 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
         Vector(1.0f, 1.0f, 1.0f, Light);
 
         BoneManager::GetBonePosition(pObject, L"Monster101_L_Arm", Position);
-        CreateParticle(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
         BoneManager::GetBonePosition(pObject, L"Monster101_R_Arm", Position);
-        CreateParticle(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
         BoneManager::GetBonePosition(pObject, L"Monster101_Head", Position);
-        CreateParticle(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
@@ -844,13 +843,13 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
                 Vector(0.0f, 45.0f, 45.0f, Angle);
                 vec3_t Relative = { 30.0f, 0.0f, 0.0f };
                 BoneManager::GetBonePosition(pObject, L"Monster101_L_Arm", Relative, Position);
-                CreateParticle(BITMAP_SMOKE, Position, Angle, Light, 25);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, Angle, Light, 25);
 
                 if (pObject->AnimationFrame >= 5.0f && pObject->AnimationFrame <= 5.5f)
                 {
                     Vector(5.0f, 5.0f, 5.0f, Light);
                     BoneManager::GetBonePosition(pObject, L"Monster101_L_Arm", Relative, Position);
-                    CreateParticle(BITMAP_SHOCK_WAVE, Position, Angle, Light, 3, 0.5f);
+                    CreateParticleFpsChecked(BITMAP_SHOCK_WAVE, Position, Angle, Light, 3, 0.5f);
                 }
             }
 
@@ -863,7 +862,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
                 VectorCopy(to->Position, vTemp);
                 vTemp[2] += 100.0f;
 
-                CreateJoint(BITMAP_JOINT_ENERGY, vTemp, pObject->Position, to->Angle, 16, pObject, 20.0f);
+                CreateJointFpsChecked(BITMAP_JOINT_ENERGY, vTemp, pObject->Position, to->Angle, 16, pObject, 20.0f);
             }
         }
 
@@ -881,7 +880,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         BoneManager::GetBonePosition(pObject, L"Monster102_Head", Relative, Position);
         CreateSprite(BITMAP_LIGHT + 1, Position, 3.0f, Light, pObject);
-        CreateParticle(BITMAP_SPARK + 1, Position, Angle, Light, 7);
+        CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, Angle, Light, 7);
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
@@ -988,13 +987,13 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
             Vector(0.4f, Random_Light, 0.5f, Light);
             BoneManager::GetBonePosition(pObject, Bone_Name, Position);
             CreateSprite(BITMAP_LIGHT + 1, Position, 0.4f, Light, pObject);
-            CreateParticle(BITMAP_SPARK + 1, Position, Angle, Light, 6);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, Angle, Light, 6);
         }
         if (pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             vec3_t Position, Relative = { 0.0f, -100.0f, 20.0f }, Light = { 0.5f, 0.7f, 0.5f };
             BoneManager::GetBonePosition(pObject, L"Monster104_Footsteps", Relative, Position);
-            CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 26);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, pObject->Angle, Light, 26);
         }
 
         if (pObject->CurrentAction == MONSTER01_STOP1 || pObject->CurrentAction == MONSTER01_STOP2)
@@ -1061,23 +1060,23 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
         if (pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             BoneManager::GetBonePosition(pObject, L"Monster105_L_Hand", Position);
-            CreateParticle(BITMAP_TRUE_FIRE, Position, Angle, Light, 6, 5.0f);
+            CreateParticleFpsChecked(BITMAP_TRUE_FIRE, Position, Angle, Light, 6, 5.0f);
 
             BoneManager::GetBonePosition(pObject, L"Monster105_R_Hand", Position);
-            CreateParticle(BITMAP_TRUE_FIRE, Position, Angle, Light, 6, 5.0f);
+            CreateParticleFpsChecked(BITMAP_TRUE_FIRE, Position, Angle, Light, 6, 5.0f);
         }
         else
         {
             BoneManager::GetBonePosition(pObject, L"Monster105_L_Hand", Position);
-            CreateParticle(BITMAP_TRUE_FIRE, Position, Angle, Light, 6, 2.5f);
+            CreateParticleFpsChecked(BITMAP_TRUE_FIRE, Position, Angle, Light, 6, 2.5f);
 
             Vector(0.0f, 0.0f, -10.0f, Relative);
             BoneManager::GetBonePosition(pObject, L"Monster105_R_Hand", Relative, Position);
-            CreateParticle(BITMAP_TRUE_FIRE, Position, Angle, Light, 6, 2.1f);
+            CreateParticleFpsChecked(BITMAP_TRUE_FIRE, Position, Angle, Light, 6, 2.1f);
         }
         if ((pObject->AnimationFrame >= 9.0f && pObject->AnimationFrame <= 10.0f) && pObject->CurrentAction == MONSTER01_ATTACK2)
         {
-            CreateEffect(BITMAP_BOSS_LASER, Position, pObject->Angle, Light, 1);
+            CreateEffectFpsChecked(BITMAP_BOSS_LASER, Position, pObject->Angle, Light, 1);
         }
 
         if (pObject->CurrentAction == MONSTER01_STOP1 || pObject->CurrentAction == MONSTER01_STOP2)
@@ -1127,7 +1126,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
         BoneManager::GetBonePosition(pObject, L"Monster102_Head", Relative, Position);
         CreateSprite(BITMAP_LIGHT + 1, Position, 3.0f, Light, pObject);
-        CreateParticle(BITMAP_SPARK + 1, Position, Angle, Light, 7);
+        CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, Angle, Light, 7);
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
@@ -1167,11 +1166,11 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
         Vector(1.0f, 1.0f, 1.0f, Light);
 
         BoneManager::GetBonePosition(pObject, L"Monster101_L_Arm", Position);
-        CreateParticle(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
         BoneManager::GetBonePosition(pObject, L"Monster101_R_Arm", Position);
-        CreateParticle(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
         BoneManager::GetBonePosition(pObject, L"Monster101_Head", Position);
-        CreateParticle(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_2, Position, Angle, Light, 1);
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
@@ -1209,13 +1208,13 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
                 Vector(0.0f, 45.0f, 45.0f, Angle);
                 vec3_t Relative = { 30.0f, 0.0f, 0.0f };
                 BoneManager::GetBonePosition(pObject, L"Monster101_L_Arm", Relative, Position);
-                CreateParticle(BITMAP_SMOKE, Position, Angle, Light, 25);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, Angle, Light, 25);
 
                 if (pObject->AnimationFrame >= 5.0f && pObject->AnimationFrame <= 5.5f)
                 {
                     Vector(5.0f, 5.0f, 5.0f, Light);
                     BoneManager::GetBonePosition(pObject, L"Monster101_L_Arm", Relative, Position);
-                    CreateParticle(BITMAP_SHOCK_WAVE, Position, Angle, Light, 3, 0.5f);
+                    CreateParticleFpsChecked(BITMAP_SHOCK_WAVE, Position, Angle, Light, 3, 0.5f);
                 }
             }
 
@@ -1228,7 +1227,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
                 VectorCopy(to->Position, vTemp);
                 vTemp[2] += 100.0f;
 
-                CreateJoint(BITMAP_JOINT_ENERGY, vTemp, pObject->Position, to->Angle, 16, pObject, 20.0f);
+                CreateJointFpsChecked(BITMAP_JOINT_ENERGY, vTemp, pObject->Position, to->Angle, 16, pObject, 20.0f);
             }
         }
 
@@ -1256,7 +1255,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
         Vector(0.7f, 0.5f, 0.7f, Light);
         vec3_t Relative = { 0.0f, 0.0f, -65.0f };
         BoneManager::GetBonePosition(pObject, L"Monster100_Footstepst", Relative, Position);
-        CreateParticle(BITMAP_LIGHT + 1, Position, Angle, Light, 4, 4.0f);
+        CreateParticleFpsChecked(BITMAP_LIGHT + 1, Position, Angle, Light, 4, 4.0f);
 
         if (pObject->CurrentAction == MONSTER01_WALK || pObject->CurrentAction == MONSTER01_RUN)
         {
@@ -1294,9 +1293,9 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
                 BoneManager::GetBonePosition(pObject, L"Monster100_Footstepst", Relative, Position);
 
                 Vector(0.5f, 0.2f, 0.5f, Light);
-                CreateParticle(BITMAP_SMOKE, Position, Angle, Light, 27, 2.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, Angle, Light, 27, 2.0f);
                 Vector(1.0f, 1.0f, 1.0f, Light);
-                CreateParticle(BITMAP_LIGHT + 1, Position, Angle, Light, 2, 1.0f);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 1, Position, Angle, Light, 2, 1.0f);
             }
             if (pObject->AnimationFrame >= 6.0f && pObject->CurrentAction == MONSTER01_ATTACK1)
             {
@@ -1304,7 +1303,7 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
                 vec3_t Relative = { 70.0f, 0.0f, 0.0f };
                 BoneManager::GetBonePosition(pObject, L"Monster100_Footstepst", Relative, Position);
                 Vector(1.0f, 1.0f, 1.0f, Light);
-                CreateParticle(BITMAP_LIGHT + 1, Position, Angle, Light, 3, 1.3f);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 1, Position, Angle, Light, 3, 1.3f);
             }
             if (pCharacter->TargetCharacter >= 0 && pCharacter->TargetCharacter < MAX_CHARACTERS_CLIENT)
             {
@@ -1317,11 +1316,11 @@ bool M33Aida::RenderAidaMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BM
 
                 if (pObject->AnimationFrame >= 6.0f && pObject->CurrentAction == MONSTER01_ATTACK1)
                 {
-                    CreateParticle(BITMAP_LIGHT + 1, vTemp, Angle, Light, 3, 1.3f);
+                    CreateParticleFpsChecked(BITMAP_LIGHT + 1, vTemp, Angle, Light, 3, 1.3f);
                 }
                 if (pObject->AnimationFrame >= 6.0f && pObject->CurrentAction == MONSTER01_ATTACK2)
                 {
-                    CreateJoint(BITMAP_JOINT_THUNDER, to->Position, vTemp, pObject->Angle, 16);
+                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, to->Position, vTemp, pObject->Angle, 16);
                 }
             }
         }

--- a/Source Main 5.2/source/GMAida.cpp
+++ b/Source Main 5.2/source/GMAida.cpp
@@ -1465,21 +1465,23 @@ bool M33Aida::AttackEffectAidaMonster(CHARACTER* pCharacter, OBJECT* pObject, BM
     {
     case MONSTER_WITCH_QUEEN:
     {
-        if ((int)pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
+        if (pCharacter->CheckAttackTime(10) && pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             vec3_t Light;
             Vector(1.f, 1.f, 1.f, Light);
             CreateEffect(BITMAP_JOINT_FORCE, pObject->Position, pObject->Angle, Light, 1);
+            pCharacter->SetLastAttackEffectTime();
         }
     }
     return true;
     case MONSTER_DEATH_TREE:
     {
-        if ((int)pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
+        if (pCharacter->CheckAttackTime(10) && pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             vec3_t Light;
             Vector(1.f, 1.f, 1.f, Light);
             CreateEffect(MODEL_TREE_ATTACK, pObject->Position, pObject->Angle, Light);
+            pCharacter->SetLastAttackEffectTime();
         }
     }
     return true;
@@ -1487,22 +1489,24 @@ bool M33Aida::AttackEffectAidaMonster(CHARACTER* pCharacter, OBJECT* pObject, BM
     {
         for (int i = 0; i < 5; i++)
         {
-            if ((int)pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK1)
+            if (pCharacter->CheckAttackTime(10) && pObject->CurrentAction == MONSTER01_ATTACK1)
             {
                 vec3_t Light;
                 Vector(1.f, 1.f, 1.f, Light);
                 CreateEffect(MODEL_STORM, pObject->Position, pObject->Angle, Light, 3 + i);
+                pCharacter->SetLastAttackEffectTime();
             }
         }
     }
     return true;
     case MONSTER_BLOODY_WITCH_QUEEN:
     {
-        if ((int)pCharacter->AttackTime == 10 && pObject->CurrentAction == MONSTER01_ATTACK2)
+        if (pCharacter->CheckAttackTime(10) && pObject->CurrentAction == MONSTER01_ATTACK2)
         {
             vec3_t Light;
             Vector(1.f, 1.f, 1.f, Light);
             CreateEffect(BITMAP_JOINT_FORCE, pObject->Position, pObject->Angle, Light, 1);
+            pCharacter->SetLastAttackEffectTime();
         }
     }
     return true;

--- a/Source Main 5.2/source/GMBattleCastle.cpp
+++ b/Source Main 5.2/source/GMBattleCastle.cpp
@@ -1156,7 +1156,7 @@ namespace battleCastle
             if (IsBattleCastleStart() == false)
             {
                 Vector(1.f, 1.f, 1.f, Light);
-                CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 6, o->Scale);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 6, o->Scale);
             }
             break;
         case 53:
@@ -1170,7 +1170,7 @@ namespace battleCastle
             if (IsBattleCastleStart() == false)
             {
                 Vector(1.f, 1.f, 1.f, Light);
-                CreateParticle(BITMAP_WATERFALL_3 + (rand() % 2), o->Position, o->Angle, Light, 0);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_3 + (rand() % 2), o->Position, o->Angle, Light, 0);
             }
             break;
         }

--- a/Source Main 5.2/source/GMBattleCastle.cpp
+++ b/Source Main 5.2/source/GMBattleCastle.cpp
@@ -1704,16 +1704,20 @@ namespace battleCastle
         switch (c->MonsterIndex)
         {
         case MONSTER_TRAP:
-            if ((int)c->AttackTime == 5)
+            if (c->CheckAttackTime(5))
             {
                 VectorCopy(o->Position, Position);
                 Position[2] += 500.f;
                 CreateEffect(MODEL_BATTLE_GUARD2, Position, o->Angle, o->Light, 0);
+                c->SetLastAttackEffectTime();
             }
             return true;
 
         case MONSTER_CANON_TOWER:
-            CreateEffect(BITMAP_JOINT_FORCE, o->Position, o->Angle, o->Light);
+            if (rand_fps_check(1))
+            {
+                CreateEffect(BITMAP_JOINT_FORCE, o->Position, o->Angle, o->Light);
+            }
             return true;
         }
         return false;

--- a/Source Main 5.2/source/GMCryingWolf2nd.cpp
+++ b/Source Main 5.2/source/GMCryingWolf2nd.cpp
@@ -98,10 +98,10 @@ bool M34CryingWolf2nd::RenderCryingWolf2ndObjectVisual(OBJECT* pObject, BMD* pMo
         //CreateParticle ( BITMAP_CLOUD, o->Position, o->Angle, Light, 8, o->Scale);
         if (pObject->HiddenMesh != -2)
         {
-            CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
-            CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 2, pObject->Scale, pObject);
-            CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 3, pObject->Scale, pObject);
-            CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 4, pObject->Scale, pObject);
+            CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 1, pObject->Scale, pObject);
+            CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 2, pObject->Scale, pObject);
+            CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 3, pObject->Scale, pObject);
+            CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle, Light, 4, pObject->Scale, pObject);
         }
         pObject->HiddenMesh = -2;
         //}

--- a/Source Main 5.2/source/GMCryingWolf2nd.cpp
+++ b/Source Main 5.2/source/GMCryingWolf2nd.cpp
@@ -345,18 +345,20 @@ bool M34CryingWolf2nd::AttackEffectCryingWolf2ndMonster(CHARACTER* pCharacter, O
     {
     case MODEL_VALAM:
     {
-        if ((int)pCharacter->AttackTime == 14)
+        if (pCharacter->CheckAttackTime(14))
         {
             CreateEffect(MODEL_ARROW_NATURE, pObject->Position, pObject->Angle, pObject->Light, 1, pObject, pObject->PKKey);
+            pCharacter->SetLastAttackEffectTime();
             return true;
         }
     }
     break;
     case MODEL_BALRAM:
     {
-        if ((int)pCharacter->AttackTime == 14)
+        if (pCharacter->CheckAttackTime(14))
         {
             CreateEffect(MODEL_ARROW_HOLY, pObject->Position, pObject->Angle, pObject->Light, 1, pObject, pObject->PKKey);
+            pCharacter->SetLastAttackEffectTime();
             return true;
         }
     }

--- a/Source Main 5.2/source/GMCrywolf1st.cpp
+++ b/Source Main 5.2/source/GMCrywolf1st.cpp
@@ -999,18 +999,20 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     {
     case MODEL_VALAM:
     {
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             CreateEffect(MODEL_ARROW_NATURE, o->Position, o->Angle, o->Light, 1, o, o->PKKey);
+            c->SetLastAttackEffectTime();
             return true;
         }
     }
     break;
     case MODEL_BALRAM:
     {
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             CreateEffect(MODEL_ARROW_HOLY, o->Position, o->Angle, o->Light, 1, o, o->PKKey);
+            c->SetLastAttackEffectTime();
             return true;
         }
     }
@@ -1018,11 +1020,12 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     case MODEL_TANTALLOS:
     {
         vec3_t Angle;
-        if ((int)c->AttackTime == 1)
+        if (c->CheckAttackTime(1))
         {
             CreateInferno(o->Position);
+            c->SetLastAttackEffectTime();
         }
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             if (c->MonsterIndex == MONSTER_ZAIKAN)
             {
@@ -1036,6 +1039,8 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
                     }
                 }
             }
+
+            c->SetLastAttackEffectTime();
         }
     }
     break;
@@ -1055,8 +1060,11 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
                 CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
             }
         }
-        if ((int)c->AttackTime == 1)
+        if (c->CheckAttackTime(1))
+        {
             PlayBuffer(SOUND_EVIL);
+            c->SetLastAttackEffectTime();
+        }
 
         for (int i = 0; i < 4; i++)
         {
@@ -1072,9 +1080,10 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     break;
     case MODEL_BALLISTA:
     {
-        if ((int)c->AttackTime == 15)
+        if (c->CheckAttackTime(15))
         {
             CreateEffect(MODEL_ARROW_TANKER, o->Position, o->Angle, o->Light, 1, o, o->PKKey);
+            c->SetLastAttackEffectTime();
             return true;
         }
     }

--- a/Source Main 5.2/source/GMCrywolf1st.cpp
+++ b/Source Main 5.2/source/GMCrywolf1st.cpp
@@ -743,8 +743,8 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
                 for (int iu = 0; iu < 6; iu++)
                 {
-                    CreateEffect(MODEL_STONE2, EndPos, o->Angle, o->Light);
-                    CreateEffect(MODEL_STONE2, EndPos1, o->Angle, o->Light);
+                    CreateEffectFpsChecked(MODEL_STONE2, EndPos, o->Angle, o->Light);
+                    CreateEffectFpsChecked(MODEL_STONE2, EndPos1, o->Angle, o->Light);
                 }
             }
         }
@@ -766,7 +766,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
         if (o->CurrentAction == MONSTER01_ATTACK1)
         {
-            if (o->AnimationFrame >= 6.5f && o->AnimationFrame < (6.5f + fActionSpeed))
+            if (o->AnimationFrame >= 6.5f && o->AnimationFrame < (6.5f + fActionSpeed) && rand_fps_check(1))
             {
                 Vector(0.0f, 0.0f, 0.0f, EndRelative);
                 b->TransformPosition(o->BoneTransform[27], EndRelative, EndPos, true);
@@ -807,7 +807,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         if (o->CurrentAction == MONSTER01_ATTACK2)
         {
             vec3_t EndPos, EndRelative;
-            if (o->AnimationFrame >= 7.5f && o->AnimationFrame < (7.5f + fActionSpeed))
+            if (o->AnimationFrame >= 7.5f && o->AnimationFrame < (7.5f + fActionSpeed) && rand_fps_check(1))
             {
                 Vector(0.f, 0.f, 0.f, EndRelative);
                 b->TransformPosition(BoneTransform[33], EndRelative, EndPos, false);
@@ -894,7 +894,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         //			CreateParticle(BITMAP_FIRE,EndPos,o->Angle,Light);
         if (o->CurrentAction == MONSTER01_ATTACK1)
         {
-            if (o->AnimationFrame >= 2.5f && o->AnimationFrame < (2.5f + fActionSpeed))
+            if (o->AnimationFrame >= 2.5f && o->AnimationFrame < (2.5f + fActionSpeed) && rand_fps_check(1))
             {
                 Vector(0.0f, 0.0f, 100.0f, EndRelative);
                 b->TransformPosition(o->BoneTransform[20], EndRelative, EndPos, true);
@@ -927,7 +927,7 @@ bool M34CryWolf1st::MoveCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             VectorRotate(o->Direction, Matrix, Position);
 
             Vector(1.f, 0.0f, 0.5f, Light);
-            CreateEffect(MODEL_PIERCING2, o->Position, o->Angle, Light, 1);
+            CreateEffectFpsChecked(MODEL_PIERCING2, o->Position, o->Angle, Light, 1);
         }
     }
     break;
@@ -1056,8 +1056,8 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
 
             if (to != NULL)
             {
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 50.f);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 50.f);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
             }
         }
         if (c->CheckAttackTime(1))
@@ -1073,8 +1073,8 @@ bool M34CryWolf1st::AttackEffectCryWolf1stMonster(CHARACTER* c, OBJECT* o, BMD* 
             b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
             Vector(0.f, 0.f, (float)(rand() % 360), Angle);
             if (to != NULL)
-                CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 0, to, 50.f);
-            CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                CreateJointFpsChecked(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 0, to, 50.f);
+            CreateParticleFpsChecked(BITMAP_FIRE, Position, o->Angle, o->Light);
         }
     }
     break;
@@ -1589,8 +1589,8 @@ bool M34CryWolf1st::RenderCryWolf1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
             fRotation2 = -WorldTime * 0.01f;
             Vector(0.09f, 0.09f, 0.04f, o->Light);
 
-            CreateParticle(BITMAP_EFFECT, o->Position, o->Angle, o->Light);
-            CreateParticle(BITMAP_EFFECT, o->Position, o->Angle, o->Light, 1);
+            CreateParticleFpsChecked(BITMAP_EFFECT, o->Position, o->Angle, o->Light);
+            CreateParticleFpsChecked(BITMAP_EFFECT, o->Position, o->Angle, o->Light, 1);
         }
         if (g_isCharacterBuff(o, eBuff_CrywolfAltarOccufied))
         {

--- a/Source Main 5.2/source/GMDoppelGanger1.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger1.cpp
@@ -239,9 +239,9 @@ bool CGMDoppelGanger1::MoveMonsterVisual(OBJECT* o, BMD* b)
             float Scale = 3.5f;
             Vector(1.f, 1.f, 1.f, o->Light);
             b->TransformByObjectBone(vPos, o, 6);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, 3, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, 3, Scale);
             b->TransformByObjectBone(vPos, o, 79);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, 53, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, 53, Scale);
         }
         break;
         }
@@ -272,7 +272,7 @@ bool CGMDoppelGanger1::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] += (float)(rand() % 140 - 70);
                         vPos[1] += (float)(rand() % 140 - 70);
                         Vector(0.2f, 1.0f, 0.3f, vLight);
-                        CreateEffect(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
+                        CreateEffectFpsChecked(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
                     }
 
                     Vector(0.4f, 1.0f, 0.6f, vLight);
@@ -281,7 +281,7 @@ bool CGMDoppelGanger1::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 100 - 50) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 100 - 50) * 1.0f;
                         vPos[2] = o->Position[2] + 10.f + (rand() % 20) * 10.0f;
-                        CreateParticle(BITMAP_EXPLOTION_MONO, vPos, o->Angle, vLight, 0, (rand() % 8 + 7) * 0.1f);
+                        CreateParticleFpsChecked(BITMAP_EXPLOTION_MONO, vPos, o->Angle, vLight, 0, (rand() % 8 + 7) * 0.1f);
                     }
 
                     Vector(0.0f, 0.5f, 0.0f, vLight);
@@ -290,7 +290,7 @@ bool CGMDoppelGanger1::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 200 - 100) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 200 - 100) * 1.0f;
                         vPos[2] = o->Position[2] + (rand() % 10) * 10.0f;
-                        CreateEffect(MODEL_DOPPELGANGER_SLIME_CHIP, vPos, o->Angle, vLight, 0, o, 0, 0);
+                        CreateEffectFpsChecked(MODEL_DOPPELGANGER_SLIME_CHIP, vPos, o->Angle, vLight, 0, o, 0, 0);
                     }
 
                     Vector(0.2f, 0.9f, 0.3f, vLight);
@@ -299,11 +299,11 @@ bool CGMDoppelGanger1::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 300 - 150) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 300 - 150) * 1.0f;
                         vPos[2] = o->Position[2] + 20.0f + (rand() % 10) * 10.0f;
-                        CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 31);
+                        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 31);
                     }
 
                     Vector(0.8f, 1.0f, 0.8f, vLight);
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
 
                     SetAction(o, MONSTER01_ATTACK1);
                 }
@@ -424,17 +424,17 @@ bool CGMDoppelGanger1::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         }
 
-        CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+        CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
     }
     return true;
     case 80:
@@ -445,16 +445,16 @@ bool CGMDoppelGanger1::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         }
-        CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+        CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
     }
     return true;
     case 99:
@@ -464,7 +464,7 @@ bool CGMDoppelGanger1::RenderObjectVisual(OBJECT* o, BMD* b)
             //Vector(0.02f, 0.03f, 0.04f, Light);
             Vector(0.04f, 0.06f, 0.08f, Light);
             for (int i = 0; i < 10; ++i)
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 3, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 3, o->Scale, o);
             //CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 0, o->Scale, o);
         }
         return true;
@@ -477,7 +477,7 @@ bool CGMDoppelGanger1::RenderObjectVisual(OBJECT* o, BMD* b)
             int iScale = o->Scale * 60;
             vPos[0] += rand() % iScale - iScale / 2;
             vPos[1] += rand() % iScale - iScale / 2;
-            CreateParticle(BITMAP_LIGHT, vPos, o->Angle, Light, 15, o->Scale, o);
+            CreateParticleFpsChecked(BITMAP_LIGHT, vPos, o->Angle, Light, 15, o->Scale, o);
         }
         return true;
     }
@@ -534,13 +534,13 @@ bool CGMDoppelGanger1::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
                     break;
                 }
             }

--- a/Source Main 5.2/source/GMDoppelGanger2.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger2.cpp
@@ -120,9 +120,9 @@ bool CGMDoppelGanger2::MoveMonsterVisual(OBJECT* o, BMD* b)
             float Scale = 3.5f;
             Vector(1.f, 1.f, 1.f, o->Light);
             b->TransformByObjectBone(vPos, o, 6);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, 3, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, 3, Scale);
             b->TransformByObjectBone(vPos, o, 79);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, 53, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, 53, Scale);
         }
         break;
         }
@@ -153,7 +153,7 @@ bool CGMDoppelGanger2::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] += (float)(rand() % 140 - 70);
                         vPos[1] += (float)(rand() % 140 - 70);
                         Vector(0.2f, 1.0f, 0.3f, vLight);
-                        CreateEffect(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
+                        CreateEffectFpsChecked(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
                     }
 
                     Vector(0.4f, 1.0f, 0.6f, vLight);
@@ -162,7 +162,7 @@ bool CGMDoppelGanger2::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 100 - 50) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 100 - 50) * 1.0f;
                         vPos[2] = o->Position[2] + 10.f + (rand() % 20) * 10.0f;
-                        CreateParticle(BITMAP_EXPLOTION_MONO, vPos, o->Angle, vLight, 0, (rand() % 8 + 7) * 0.1f);
+                        CreateParticleFpsChecked(BITMAP_EXPLOTION_MONO, vPos, o->Angle, vLight, 0, (rand() % 8 + 7) * 0.1f);
                     }
 
                     Vector(0.0f, 0.5f, 0.0f, vLight);
@@ -171,7 +171,7 @@ bool CGMDoppelGanger2::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 200 - 100) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 200 - 100) * 1.0f;
                         vPos[2] = o->Position[2] + (rand() % 10) * 10.0f;
-                        CreateEffect(MODEL_DOPPELGANGER_SLIME_CHIP, vPos, o->Angle, vLight, 0, o, 0, 0);
+                        CreateEffectFpsChecked(MODEL_DOPPELGANGER_SLIME_CHIP, vPos, o->Angle, vLight, 0, o, 0, 0);
                     }
 
                     Vector(0.2f, 0.9f, 0.3f, vLight);
@@ -180,11 +180,11 @@ bool CGMDoppelGanger2::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 300 - 150) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 300 - 150) * 1.0f;
                         vPos[2] = o->Position[2] + 20.0f + (rand() % 10) * 10.0f;
-                        CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 31);
+                        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 31);
                     }
 
                     Vector(0.8f, 1.0f, 0.8f, vLight);
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
 
                     SetAction(o, MONSTER01_ATTACK1);
                 }
@@ -308,7 +308,7 @@ bool CGMDoppelGanger2::RenderObjectMesh(OBJECT* o, BMD* b, bool ExtraMon)
         Vector(-150.0f, 0.0f, 0.0f, p);
         b->TransformPosition(BoneTransform[4], p, Pos, false);
         if (o->AnimationFrame >= 35.0f && o->AnimationFrame < 50.0f)
-            CreateParticle(BITMAP_SMOKE, Pos, o->Angle, Light, 24, o->Scale * 1.5f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Pos, o->Angle, Light, 24, o->Scale * 1.5f);
         return true;
     }
     case 68:
@@ -340,7 +340,7 @@ bool CGMDoppelGanger2::RenderObjectMesh(OBJECT* o, BMD* b, bool ExtraMon)
         Vector(rand() % 20 - 30.0f, rand() % 20 - 30.0f, 0.0f, p);
         b->TransformPosition(BoneTransform[4], p, Pos, false);
         if (o->AnimationFrame >= 7.0f && o->AnimationFrame < 13.0f)
-            CreateParticle(BITMAP_SMOKE, Pos, o->Angle, Light, 18, o->Scale * 1.5f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Pos, o->Angle, Light, 18, o->Scale * 1.5f);
         return true;
     }
     case 72:
@@ -409,7 +409,7 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
             Vector(1.0f, 1.0f, 1.0f, Light);
             for (int i = 0; i < 20; ++i)
             {
-                CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 6, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 6, o->Scale, o);
             }
         }
     }
@@ -484,13 +484,13 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }
@@ -502,16 +502,16 @@ bool CGMDoppelGanger2::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         }
-        CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+        CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
     }
     return true;
     case 48:
@@ -580,13 +580,13 @@ bool CGMDoppelGanger2::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
                     break;
                 }
             }

--- a/Source Main 5.2/source/GMDoppelGanger3.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger3.cpp
@@ -71,7 +71,7 @@ bool CGMDoppelGanger3::MoveObject(OBJECT* o)
         if (o->Timer > 10.f)
             o->Timer = 0.f;
         if (o->Timer > 5.f)
-            CreateParticle(BITMAP_BUBBLE, o->Position, o->Angle, o->Light);
+            CreateParticleFpsChecked(BITMAP_BUBBLE, o->Position, o->Angle, o->Light);
         return true;
     case 23:
         o->BlendMesh = 0;
@@ -135,9 +135,9 @@ bool CGMDoppelGanger3::MoveMonsterVisual(OBJECT* o, BMD* b)
             float Scale = 3.5f;
             Vector(1.f, 1.f, 1.f, o->Light);
             b->TransformByObjectBone(vPos, o, 6);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, 3, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, 3, Scale);
             b->TransformByObjectBone(vPos, o, 79);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, 53, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, 53, Scale);
         }
         break;
         }
@@ -168,7 +168,7 @@ bool CGMDoppelGanger3::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] += (float)(rand() % 140 - 70);
                         vPos[1] += (float)(rand() % 140 - 70);
                         Vector(0.2f, 1.0f, 0.3f, vLight);
-                        CreateEffect(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
+                        CreateEffectFpsChecked(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
                     }
 
                     Vector(0.4f, 1.0f, 0.6f, vLight);
@@ -177,7 +177,7 @@ bool CGMDoppelGanger3::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 100 - 50) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 100 - 50) * 1.0f;
                         vPos[2] = o->Position[2] + 10.f + (rand() % 20) * 10.0f;
-                        CreateParticle(BITMAP_EXPLOTION_MONO, vPos, o->Angle, vLight, 0, (rand() % 8 + 7) * 0.1f);
+                        CreateParticleFpsChecked(BITMAP_EXPLOTION_MONO, vPos, o->Angle, vLight, 0, (rand() % 8 + 7) * 0.1f);
                     }
 
                     Vector(0.0f, 0.5f, 0.0f, vLight);
@@ -186,7 +186,7 @@ bool CGMDoppelGanger3::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 200 - 100) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 200 - 100) * 1.0f;
                         vPos[2] = o->Position[2] + (rand() % 10) * 10.0f;
-                        CreateEffect(MODEL_DOPPELGANGER_SLIME_CHIP, vPos, o->Angle, vLight, 0, o, 0, 0);
+                        CreateEffectFpsChecked(MODEL_DOPPELGANGER_SLIME_CHIP, vPos, o->Angle, vLight, 0, o, 0, 0);
                     }
 
                     Vector(0.2f, 0.9f, 0.3f, vLight);
@@ -195,11 +195,11 @@ bool CGMDoppelGanger3::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 300 - 150) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 300 - 150) * 1.0f;
                         vPos[2] = o->Position[2] + 20.0f + (rand() % 10) * 10.0f;
-                        CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 31);
+                        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 31);
                     }
 
                     Vector(0.8f, 1.0f, 0.8f, vLight);
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
 
                     SetAction(o, MONSTER01_ATTACK1);
                 }
@@ -315,16 +315,16 @@ bool CGMDoppelGanger3::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         }
-        CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+        CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
     }
     return true;
     case 48:
@@ -392,13 +392,13 @@ bool CGMDoppelGanger3::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
                     break;
                 }
             }

--- a/Source Main 5.2/source/GMDoppelGanger4.cpp
+++ b/Source Main 5.2/source/GMDoppelGanger4.cpp
@@ -123,7 +123,7 @@ bool CGMDoppelGanger4::MoveObject(OBJECT* o)
         if (o->Timer > 10.f)
             o->Timer = 0.f;
         if (o->Timer > 5.f)
-            CreateParticle(BITMAP_BUBBLE, o->Position, o->Angle, o->Light, 5);
+            CreateParticleFpsChecked(BITMAP_BUBBLE, o->Position, o->Angle, o->Light, 5);
         return true;
     case 102:
         o->BlendMeshLight = (float)sinf(WorldTime * 0.0010f) + 1.0f;
@@ -167,9 +167,9 @@ bool CGMDoppelGanger4::MoveMonsterVisual(OBJECT* o, BMD* b)
             float Scale = 3.5f;
             Vector(1.f, 1.f, 1.f, o->Light);
             b->TransformByObjectBone(vPos, o, 6);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, 3, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, 3, Scale);
             b->TransformByObjectBone(vPos, o, 79);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, 53, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, 53, Scale);
         }
         break;
         }
@@ -200,7 +200,7 @@ bool CGMDoppelGanger4::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] += (float)(rand() % 140 - 70);
                         vPos[1] += (float)(rand() % 140 - 70);
                         Vector(0.2f, 1.0f, 0.3f, vLight);
-                        CreateEffect(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
+                        CreateEffectFpsChecked(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
                     }
 
                     Vector(0.4f, 1.0f, 0.6f, vLight);
@@ -209,7 +209,7 @@ bool CGMDoppelGanger4::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 100 - 50) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 100 - 50) * 1.0f;
                         vPos[2] = o->Position[2] + 10.f + (rand() % 20) * 10.0f;
-                        CreateParticle(BITMAP_EXPLOTION_MONO, vPos, o->Angle, vLight, 0, (rand() % 8 + 7) * 0.1f);
+                        CreateParticleFpsChecked(BITMAP_EXPLOTION_MONO, vPos, o->Angle, vLight, 0, (rand() % 8 + 7) * 0.1f);
                     }
 
                     Vector(0.0f, 0.5f, 0.0f, vLight);
@@ -218,7 +218,7 @@ bool CGMDoppelGanger4::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 200 - 100) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 200 - 100) * 1.0f;
                         vPos[2] = o->Position[2] + (rand() % 10) * 10.0f;
-                        CreateEffect(MODEL_DOPPELGANGER_SLIME_CHIP, vPos, o->Angle, vLight, 0, o, 0, 0);
+                        CreateEffectFpsChecked(MODEL_DOPPELGANGER_SLIME_CHIP, vPos, o->Angle, vLight, 0, o, 0, 0);
                     }
 
                     Vector(0.2f, 0.9f, 0.3f, vLight);
@@ -227,11 +227,11 @@ bool CGMDoppelGanger4::MoveMonsterVisual(OBJECT* o, BMD* b)
                         vPos[0] = o->Position[0] + (rand() % 300 - 150) * 1.0f;
                         vPos[1] = o->Position[1] + (rand() % 300 - 150) * 1.0f;
                         vPos[2] = o->Position[2] + 20.0f + (rand() % 10) * 10.0f;
-                        CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 31);
+                        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 31);
                     }
 
                     Vector(0.8f, 1.0f, 0.8f, vLight);
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
 
                     SetAction(o, MONSTER01_ATTACK1);
                 }
@@ -371,16 +371,16 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, vLight, 6, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
             break;
         }
-        CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
+        CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, vLight, 2, o->Scale);
     }
     return true;
     case 48:
@@ -418,7 +418,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
             Vector(0.04f, 0.04f, 0.04f, Light);
 
             for (int i = 0; i < 20; ++i)
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 0, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 0, o->Scale, o);
         }
         return true;
     case 70:
@@ -437,7 +437,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         return true;
     case 82:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 3, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 3, o->Scale);
         return true;
     case 83:
         Vector(1.f, 1.f, 1.f, Light);
@@ -457,7 +457,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
         b->TransformPosition(BoneTransform[1], EndRelative, StartPos, false);
         b->TransformPosition(BoneTransform[2], EndRelative, EndPos, false);
         if (rand() % 30 == 1)
-            CreateJoint(BITMAP_JOINT_THUNDER, StartPos, EndPos, o->Angle, 8, NULL, 50.f);
+            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, StartPos, EndPos, o->Angle, 8, NULL, 50.f);
     }
     return true;
     case 96:
@@ -513,7 +513,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
             vec3_t  Light;
             Vector(0.06f, 0.06f, 0.06f, Light);
             for (int i = 0; i < 20; ++i)
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 2, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 2, o->Scale, o);
         }
         return true;
     case 108:
@@ -522,7 +522,7 @@ bool CGMDoppelGanger4::RenderObjectVisual(OBJECT* o, BMD* b)
             vec3_t  Light;
             Vector(0.2f, 0.2f, 0.2f, Light);
             for (int i = 0; i < 20; ++i)
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 7, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 7, o->Scale, o);
         }
         return true;
     case 110:
@@ -589,13 +589,13 @@ bool CGMDoppelGanger4::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
                     break;
                 }
             }

--- a/Source Main 5.2/source/GMDuelArena.cpp
+++ b/Source Main 5.2/source/GMDuelArena.cpp
@@ -148,13 +148,13 @@ bool CGMDuelArena::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }

--- a/Source Main 5.2/source/GMEmpireGuardian1.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian1.cpp
@@ -391,6 +391,11 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
     {
     case MODEL_RAYMOND:
     {
+        if (!rand_fps_check(1))
+        {
+            break;
+        }
+
         float _fActSpdTemp = b->Actions[o->CurrentAction].PlaySpeed;
         vec3_t EndPos, EndRelative, Light, vPos;
         Vector(1.0f, 1.0f, 1.0f, Light);
@@ -516,8 +521,8 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vec3_t ap, P, dp;
 
                 VectorCopy(pObj->Position, ap);
-                CreateEffect(MODEL_DARK_SCREAM, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
-                CreateEffect(MODEL_DARK_SCREAM_FIRE, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
+                CreateEffectFpsChecked(MODEL_DARK_SCREAM, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
+                CreateEffectFpsChecked(MODEL_DARK_SCREAM_FIRE, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
 
                 Vector(80.f, 0.f, 0.f, P);
 
@@ -526,8 +531,8 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 AngleMatrix(pObj->Angle, pObj->Matrix);
                 VectorRotate(P, pObj->Matrix, dp);
                 VectorAdd(dp, pObj->Position, pObj->Position);
-                CreateEffect(MODEL_DARK_SCREAM, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
-                CreateEffect(MODEL_DARK_SCREAM_FIRE, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
+                CreateEffectFpsChecked(MODEL_DARK_SCREAM, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
+                CreateEffectFpsChecked(MODEL_DARK_SCREAM_FIRE, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
 
                 VectorCopy(ap, pObj->Position);
                 VectorCopy(pObj->Position, ap);
@@ -537,8 +542,8 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 AngleMatrix(pObj->Angle, pObj->Matrix);
                 VectorRotate(P, pObj->Matrix, dp);
                 VectorAdd(dp, pObj->Position, pObj->Position);
-                CreateEffect(MODEL_DARK_SCREAM, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
-                CreateEffect(MODEL_DARK_SCREAM_FIRE, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
+                CreateEffectFpsChecked(MODEL_DARK_SCREAM, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
+                CreateEffectFpsChecked(MODEL_DARK_SCREAM_FIRE, pObj->Position, pObj->Angle, pObj->Light, 1, pObj, pObj->PKKey, SkillIndex);
                 VectorCopy(ap, pObj->Position);
             }
 
@@ -615,8 +620,8 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     Vector(1.0f, 1.0f, 1.0f, Light);
                     CreateInferno(o->Position);
 
-                    CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
-                    CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
+                    CreateEffectFpsChecked(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
+                    CreateEffectFpsChecked(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
                     m_bCurrentIsRage_Ercanne = false;
                 }
             }
@@ -661,7 +666,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
                 Vector(0.0f, 0.0f, 0.0f, v3RelativePos);
                 b->TransformPosition(o->BoneTransform[20], v3RelativePos, v3StartPos, true);
-                CreateEffect(MODEL_DEASULER, v3StartPos, Angle, v3PosTo, 0, o, -1, 0, 0, 0, 1.8f);
+                CreateEffectFpsChecked(MODEL_DEASULER, v3StartPos, Angle, v3PosTo, 0, o, -1, 0, 0, 0, 1.8f);
             }
         }
         break;
@@ -677,7 +682,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 VectorRotate(p, Matrix, Position);
                 VectorSubtract(o->Position, Position, Position);
                 Position[2] += 120.f;
-                CreateJoint(BITMAP_JOINT_HEALING, Position, o->Position, Angle, 17, o, 10.f);
+                CreateJointFpsChecked(BITMAP_JOINT_HEALING, Position, o->Position, Angle, 17, o, 10.f);
             }
             vec3_t Light;
             Vector(1.f, 0.1f, 0.f, Light);
@@ -685,10 +690,10 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             for (int i = 0; i < 10; i++)
             {
                 b->TransformPosition(o->BoneTransform[rand() % 62], p, Position, true);
-                CreateParticle(BITMAP_LIGHT, Position, o->Angle, Light, 5, 0.5f + (rand() % 100) / 50.f);
+                CreateParticleFpsChecked(BITMAP_LIGHT, Position, o->Angle, Light, 5, 0.5f + (rand() % 100) / 50.f);
 
                 b->TransformPosition(o->BoneTransform[50], p, Position, true);
-                CreateParticle(BITMAP_LIGHT, Position, o->Angle, Light, 5, 0.5f + (rand() % 100) / 50.f);
+                CreateParticleFpsChecked(BITMAP_LIGHT, Position, o->Angle, Light, 5, 0.5f + (rand() % 100) / 50.f);
             }
 
             float _fActSpdTemp = b->Actions[o->CurrentAction].PlaySpeed;
@@ -700,7 +705,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
                 Vector(0.0f, 0.0f, 0.0f, EndRelative);
                 b->TransformPosition(o->BoneTransform[11], EndRelative, EndPos, true);
-                CreateEffect(MODEL_SKILL_FURY_STRIKE, EndPos, o->Angle, Light, 1, o, -1, 0, 0);
+                CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE, EndPos, o->Angle, Light, 1, o, -1, 0, 0);
             }
         }
         break;
@@ -714,8 +719,8 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     Vector(1.0f, 1.0f, 1.0f, Light);
                     CreateInferno(o->Position);
 
-                    CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
-                    CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
+                    CreateEffectFpsChecked(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
+                    CreateEffectFpsChecked(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
                     m_bCurrentIsRage_Daesuler = false;
                 }
             }
@@ -818,7 +823,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
                 Vector(0.0f, 0.0f, 100.0f, EndRelative);
                 b->TransformPosition(o->BoneTransform[11], EndRelative, EndPos, true);
-                CreateEffect(MODEL_SKILL_FURY_STRIKE, EndPos, o->Angle, Light, 1, o, -1, 0, 0);
+                CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE, EndPos, o->Angle, Light, 1, o, -1, 0, 0);
             }
         }
         break;
@@ -840,8 +845,8 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     Vector(1.0f, 1.0f, 1.0f, Light);
                     CreateInferno(o->Position);
 
-                    CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
-                    CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
+                    CreateEffectFpsChecked(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
+                    CreateEffectFpsChecked(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
                     m_bCurrentIsRage_Gallia = false;
                 }
             }
@@ -863,13 +868,13 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 b->TransformByObjectBone(vPos, o, 53);
                 vPos[2] += 25.0f;
-                CreateParticle(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1);
+                CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1);
             }
             if (1.0f <= o->AnimationFrame && o->AnimationFrame < 2.0f)
             {
                 b->TransformByObjectBone(vPos, o, 48);
                 vPos[2] += 25.0f;
-                CreateParticle(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1);
+                CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1);
             }
         }
         break;
@@ -885,9 +890,9 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         {
             if (o->AnimationFrame >= 5.0f && o->AnimationFrame <= 5.8f)
             {
-                CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 1);
-                CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 1);
-                CreateEffect(MODEL_PIERCING2, o->Position, o->Angle, o->Light);
+                CreateEffectFpsChecked(MODEL_WAVES, o->Position, o->Angle, o->Light, 1);
+                CreateEffectFpsChecked(MODEL_WAVES, o->Position, o->Angle, o->Light, 1);
+                CreateEffectFpsChecked(MODEL_PIERCING2, o->Position, o->Angle, o->Light);
                 PlayBuffer(SOUND_ATTACK_SPEAR);
             }
         }
@@ -917,7 +922,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
                 Vector(0.8f, 0.8f, 1.0f, vLight);
 
-                CreateEffect(MODEL_EFFECT_EG_GUARDIANDEFENDER_ATTACK2, vPosition, o->Angle, vLight, 0, o);
+                CreateEffectFpsChecked(MODEL_EFFECT_EG_GUARDIANDEFENDER_ATTACK2, vPosition, o->Angle, vLight, 0, o);
             }
         }
         break;
@@ -973,9 +978,9 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 b->TransformPosition(o->BoneTransform[55], p, vPos, true);
                 Vector(-60.0f, 0.0f, o->Angle[2], Angle);
                 Vector(-60.0f, 0.0f, o->Angle[2], Angle);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, to->Position, Angle, 27, to, 50.0f, -1, 0, 0, 0, vLight);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, to->Position, Angle, 27, to, 10.0f, -1, 0, 0, 0, vLight);
-                CreateParticle(BITMAP_ENERGY, vPos, o->Angle, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, to->Position, Angle, 27, to, 50.0f, -1, 0, 0, 0, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, to->Position, Angle, 27, to, 10.0f, -1, 0, 0, 0, vLight);
+                CreateParticleFpsChecked(BITMAP_ENERGY, vPos, o->Angle, vLight);
             }
         }
         break;
@@ -995,7 +1000,7 @@ bool GMEmpireGuardian1::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             OBJECT* to = &tc->Object;
 
             if (o->AnimationFrame > 4.5f && o->AnimationFrame <= 4.8f)
-                CreateEffect(BITMAP_MAGIC + 1, to->Position, to->Angle, to->Light, 1, to);
+                CreateEffectFpsChecked(BITMAP_MAGIC + 1, to->Position, to->Angle, to->Light, 1, to);
         }
         break;
         }
@@ -1554,7 +1559,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 20:
     {
-        if (o->AnimationFrame > 5.4f && o->AnimationFrame < 6.5f)
+        if (o->AnimationFrame > 5.4f && o->AnimationFrame < 6.5f && rand_fps_check(1))
         {
             vec3_t	Angle;
             for (int i = 0; i < 4; ++i)
@@ -1564,7 +1569,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
             }
             CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
-        else if (o->AnimationFrame > 15.4f && o->AnimationFrame < 16.5f)
+        else if (o->AnimationFrame > 15.4f && o->AnimationFrame < 16.5f && rand_fps_check(1))
         {
             vec3_t	Angle;
             for (int i = 0; i < 4; ++i)
@@ -1602,8 +1607,8 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
         for (int i = 2; i <= 7; i++)
         {
             b->TransformPosition(BoneTransform[i], vRelativePos, vPos);
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight1, 4, o->Scale * 0.6f);
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight2, 4, o->Scale * 0.3f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight1, 4, o->Scale * 0.6f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight2, 4, o->Scale * 0.3f);
         }
     }
     return true;
@@ -1616,9 +1621,9 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2] + 180, Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
     }
     return true;
@@ -1639,7 +1644,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
             Vector(0.04f, 0.03f, 0.02f, Light);
             for (int i = 0; i < 3; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, Position, o->Angle, Light, 22, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, Position, o->Angle, Light, 22, o->Scale, o);
             }
         }
     }
@@ -1657,13 +1662,13 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }
@@ -1681,14 +1686,14 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 82:
     {
-        CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 9, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 9, o->Scale);
     }
     return true;
 
     case 83:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 14, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 14, o->Scale);
     }
     return true;
 
@@ -1697,7 +1702,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
         Vector(1.f, 1.f, 1.f, Light);
         if (rand_fps_check(8))
         {
-            CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
         }
     }
     return true;
@@ -1714,7 +1719,7 @@ bool GMEmpireGuardian1::RenderObjectVisual(OBJECT* o, BMD* b)
             int iRand = rand() % 4 + 4;
             for (int i = 0; i < iRand; ++i)
             {
-                CreateEffect(BITMAP_FLAME, o->Position, o->Angle, vLight, 6, NULL, -1, 0, o->Scale);
+                CreateEffectFpsChecked(BITMAP_FLAME, o->Position, o->Angle, vLight, 6, NULL, -1, 0, o->Scale);
             }
         }
     }
@@ -2012,8 +2017,8 @@ bool GMEmpireGuardian1::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 if (i % 5 == 0)
                 {
                     b->TransformByObjectBone(vPosRage, o, i);
-                    CreateParticle(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
-                    CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
                 }
             }
         }
@@ -2067,8 +2072,8 @@ bool GMEmpireGuardian1::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 if (i % 5 == 0)
                 {
                     b->TransformByObjectBone(vPosRage, o, i);
-                    CreateParticle(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
-                    CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
                 }
             }
         }
@@ -2088,8 +2093,8 @@ bool GMEmpireGuardian1::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 if (i % 5 == 0)
                 {
                     b->TransformByObjectBone(vPosRage, o, i);
-                    CreateParticle(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
-                    CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
                 }
             }
         }
@@ -2109,8 +2114,8 @@ bool GMEmpireGuardian1::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 if (i % 5 == 0)
                 {
                     b->TransformByObjectBone(vPosRage, o, i);
-                    CreateParticle(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
-                    CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
                 }
             }
         }
@@ -2133,7 +2138,7 @@ bool GMEmpireGuardian1::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             b->TransformByObjectBone(vPos, o, 11);
 
             Vector(1.0f, 1.0f, 1.0f, vLight);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 4, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 4, 1.0f);
         }
     }
     return true;

--- a/Source Main 5.2/source/GMEmpireGuardian2.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian2.cpp
@@ -244,7 +244,7 @@ bool GMEmpireGuardian2::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vPos[2] += 25.0f;
                 vPos[1] += 0.0f;
                 //vPos[0] += 100.0f;
-                CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, iTypeSubType, 1.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, iTypeSubType, 1.0f);
             }
             if (0.8f <= o->AnimationFrame && o->AnimationFrame < 1.5f)
             {
@@ -252,7 +252,7 @@ bool GMEmpireGuardian2::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vPos[2] += 25.0f;
                 vPos[1] += 0.0f;
                 //vPos[0] += 100.0f;
-                CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, iTypeSubType, 1.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, iTypeSubType, 1.0f);
             }
         }
         break;
@@ -417,7 +417,7 @@ bool GMEmpireGuardian2::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vPos[2] += 25.0f;
                 vPos[1] += 0.0f;
                 //vPos[0] += 100.0f;
-                CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, iTypeSubType, 2.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, iTypeSubType, 2.0f);
             }
             if (1.0f <= o->AnimationFrame && o->AnimationFrame < 2.0f)
             {
@@ -425,7 +425,7 @@ bool GMEmpireGuardian2::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 vPos[2] += 25.0f;
                 vPos[1] += 0.0f;
                 //vPos[0] += 100.0f;
-                CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->Light, iTypeSubType, 2.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->Light, iTypeSubType, 2.0f);
             }
         }
         break;
@@ -594,9 +594,9 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2] + 180, Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
         else if (o->AnimationFrame > 15.4f && o->AnimationFrame < 16.5f)
         {
@@ -604,9 +604,9 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2], Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
     }
     return true;
@@ -636,8 +636,8 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
         for (int i = 2; i <= 7; i++)
         {
             b->TransformPosition(BoneTransform[i], vRelativePos, vPos);
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight1, 4, o->Scale * 0.6f);
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight2, 4, o->Scale * 0.3f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight1, 4, o->Scale * 0.6f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight2, 4, o->Scale * 0.3f);
         }
     }
     return true;
@@ -650,9 +650,9 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2] + 180, Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
     }
     return true;
@@ -673,7 +673,7 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
             Vector(0.04f, 0.03f, 0.02f, Light);
             for (int i = 0; i < 3; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, Position, o->Angle, Light, 22, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, Position, o->Angle, Light, 22, o->Scale, o);
             }
         }
     }
@@ -691,13 +691,13 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }
@@ -713,14 +713,14 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
     return true;
     case 82:
     {
-        CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 9, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 9, o->Scale);
     }
     return true;
 
     case 83:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 14, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 14, o->Scale);
     }
     return true;
 
@@ -746,7 +746,7 @@ bool GMEmpireGuardian2::RenderObjectVisual(OBJECT* o, BMD* b)
             int iRand = rand() % 4 + 4;
             for (int i = 0; i < iRand; ++i)
             {
-                CreateEffect(BITMAP_FLAME, o->Position, o->Angle, vLight, 6, NULL, -1, 0, o->Scale);
+                CreateEffectFpsChecked(BITMAP_FLAME, o->Position, o->Angle, vLight, 6, NULL, -1, 0, o->Scale);
             }
         }
     }
@@ -919,7 +919,7 @@ bool GMEmpireGuardian2::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(0.1f * fLumi, 1.0f * fLumi, 0.3f * fLumi, vLight);
             CreateSprite(BITMAP_LIGHT, vPos, 3.0f, vLight, o);
             Vector(0.5f, 0.5f, 0.5f, vLight);
-            CreateParticle(BITMAP_CHROME2, vPos, o->Angle, vLight, 0, 0.9f, o);
+            CreateParticleFpsChecked(BITMAP_CHROME2, vPos, o->Angle, vLight, 0, 0.9f, o);
         }
 
         MoveEye(o, b, 80, 34);
@@ -930,10 +930,10 @@ bool GMEmpireGuardian2::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 b->TransformByObjectBone(vPos, o, iBigGreenLights[i]);
                 Vector(0.3f, 1.0f, 0.8f, vLight);
-                CreateParticle(BITMAP_WATERFALL_4, vPos, o->Angle, vLight, 15, 2.0f);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_4, vPos, o->Angle, vLight, 15, 2.0f);
                 Vector(0.0f, 0.4f, 0.0f, vLight);
-                CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 13, 1.0f, o);
-                CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 13, 1.0f, o);
+                CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 13, 1.0f, o);
+                CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 13, 1.0f, o);
             }
         }
         else if (o->CurrentAction == MONSTER01_DIE)
@@ -945,16 +945,16 @@ bool GMEmpireGuardian2::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 Vector(0.1f, 1.0f, 0.2f, vLight);
                 for (int i = 0; i < 5; i++)
                 {
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 39);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 39);
                 }
 
-                CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light, 9, o);
+                CreateEffectFpsChecked(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light, 9, o);
 
                 if (o->AnimationFrame <= 0.2f)
                 {
                     Vector(0.4f, 1.0f, 0.6f, vLight);
-                    CreateEffect(MODEL_TWINTAIL_EFFECT, o->Position, o->Angle, vLight, 1, o);
-                    CreateEffect(MODEL_TWINTAIL_EFFECT, o->Position, o->Angle, vLight, 2, o);
+                    CreateEffectFpsChecked(MODEL_TWINTAIL_EFFECT, o->Position, o->Angle, vLight, 1, o);
+                    CreateEffectFpsChecked(MODEL_TWINTAIL_EFFECT, o->Position, o->Angle, vLight, 2, o);
                 }
             }
         }

--- a/Source Main 5.2/source/GMEmpireGuardian3.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian3.cpp
@@ -402,8 +402,8 @@ bool GMEmpireGuardian3::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 Vector(0.8f, 0.4f, 0.1f, o->Light);
 
                 b->TransformByObjectBone(vPos, o, 15);
-                CreateParticle(BITMAP_CLUD64, vPos, o->Angle, o->Light, 3, 0.2f);
-                CreateParticle(BITMAP_WATERFALL_3, vPos, o->Angle, o->Light, 13, 1.0f);
+                CreateParticleFpsChecked(BITMAP_CLUD64, vPos, o->Angle, o->Light, 3, 0.2f);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_3, vPos, o->Angle, o->Light, 13, 1.0f);
             }
         }
         break;
@@ -415,13 +415,13 @@ bool GMEmpireGuardian3::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             {
                 b->TransformByObjectBone(vPos, o, 32);
                 vPos[2] += 25.0f;
-                CreateParticle(BITMAP_ADV_SMOKE, vPos, o->Angle, o->Light, 3, 2.0f);
+                CreateParticleFpsChecked(BITMAP_ADV_SMOKE, vPos, o->Angle, o->Light, 3, 2.0f);
             }
             if (1.0f <= o->AnimationFrame && o->AnimationFrame < 2.0f)
             {
                 b->TransformByObjectBone(vPos, o, 19);
                 vPos[2] += 25.0f;
-                CreateParticle(BITMAP_ADV_SMOKE, vPos, o->Angle, o->Light, 3, 2.0f);
+                CreateParticleFpsChecked(BITMAP_ADV_SMOKE, vPos, o->Angle, o->Light, 3, 2.0f);
             }
         }
         break;
@@ -453,28 +453,28 @@ bool GMEmpireGuardian3::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         {
             float Scale = 0.3f;
             b->TransformByObjectBone(vPos, o, 30);
-            CreateParticle(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
 
             b->TransformByObjectBone(vPos, o, 17);
-            CreateParticle(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
 
             b->TransformByObjectBone(vPos, o, 2);
-            CreateParticle(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
 
             b->TransformByObjectBone(vPos, o, 6);
-            CreateParticle(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
 
             b->TransformByObjectBone(vPos, o, 98);
-            CreateParticle(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
 
             b->TransformByObjectBone(vPos, o, 91);
-            CreateParticle(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, o->Angle, o->Light, 1, Scale);
 
             b->TransformByObjectBone(vPos, o, 2);
-            CreateParticle(BITMAP_SMOKE + 3, vPos, o->Angle, o->Light, 3, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 3, vPos, o->Angle, o->Light, 3, Scale);
 
             b->TransformByObjectBone(vPos, o, 3);
-            CreateParticle(BITMAP_SMOKE + 3, vPos, o->Angle, o->Light, 3, Scale);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 3, vPos, o->Angle, o->Light, 3, Scale);
         }
         break;
         } //switch end
@@ -621,25 +621,25 @@ void GMEmpireGuardian3::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
                             vRelative[1] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[2] = ((rand() % iOffset) - iOffset * 0.5f);
                             b->TransformPosition(BoneTransform[24], vRelative, vPosition, false);
-                            CreateParticle(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
+                            CreateParticleFpsChecked(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
 
                             vRelative[0] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[1] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[2] = ((rand() % iOffset) - iOffset * 0.5f);
                             b->TransformPosition(BoneTransform[25], vRelative, vPosition, false);
-                            CreateParticle(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
+                            CreateParticleFpsChecked(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
 
                             vRelative[0] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[1] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[2] = ((rand() % iOffset) - iOffset * 0.5f);
                             b->TransformPosition(BoneTransform[43], vRelative, vPosition, false);
-                            CreateParticle(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
+                            CreateParticleFpsChecked(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
 
                             vRelative[0] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[1] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[2] = ((rand() % iOffset) - iOffset * 0.5f);
                             b->TransformPosition(BoneTransform[44], vRelative, vPosition, false);
-                            CreateParticle(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
+                            CreateParticleFpsChecked(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
 
                             vec3_t	vLight__;
                             Vector(0.9f, 0.9f, 0.9f, vLight__);
@@ -648,25 +648,25 @@ void GMEmpireGuardian3::MoveBlurEffect(CHARACTER* c, OBJECT* o, BMD* b)
                             vRelative[1] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[2] = ((rand() % iOffset) - iOffset * 0.5f);
                             b->TransformPosition(BoneTransform[24], vRelative, vPosition, false);
-                            CreateParticle(BITMAP_SMOKELINE2, vPosition, o->Angle, vLight__, 3);
+                            CreateParticleFpsChecked(BITMAP_SMOKELINE2, vPosition, o->Angle, vLight__, 3);
 
                             vRelative[0] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[1] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[2] = ((rand() % iOffset) - iOffset * 0.5f);
                             b->TransformPosition(BoneTransform[25], vRelative, vPosition, false);
-                            CreateParticle(BITMAP_SMOKELINE2, vPosition, o->Angle, vLight__, 3);
+                            CreateParticleFpsChecked(BITMAP_SMOKELINE2, vPosition, o->Angle, vLight__, 3);
 
                             vRelative[0] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[1] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[2] = ((rand() % iOffset) - iOffset * 0.5f);
                             b->TransformPosition(BoneTransform[43], vRelative, vPosition, false);
-                            CreateParticle(BITMAP_SMOKELINE2, vPosition, o->Angle, vLight__, 3);
+                            CreateParticleFpsChecked(BITMAP_SMOKELINE2, vPosition, o->Angle, vLight__, 3);
 
                             vRelative[0] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[1] = ((rand() % iOffset) - iOffset * 0.5f);
                             vRelative[2] = ((rand() % iOffset) - iOffset * 0.5f);
                             b->TransformPosition(BoneTransform[44], vRelative, vPosition, false);
-                            CreateParticle(BITMAP_SMOKELINE2, vPosition, o->Angle, vLight__, 3);
+                            CreateParticleFpsChecked(BITMAP_SMOKELINE2, vPosition, o->Angle, vLight__, 3);
                         }
                     } // 검기
                 }
@@ -773,9 +773,9 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2] + 180, Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
         else if (o->AnimationFrame > 15.4f && o->AnimationFrame < 16.5f)
         {
@@ -783,9 +783,9 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2], Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
     }
     return true;
@@ -815,8 +815,8 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
         for (int i = 2; i <= 7; i++)
         {
             b->TransformPosition(BoneTransform[i], vRelativePos, vPos);
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight1, 4, o->Scale * 0.6f);
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight2, 4, o->Scale * 0.3f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight1, 4, o->Scale * 0.6f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight2, 4, o->Scale * 0.3f);
         }
     }
     return true;
@@ -829,9 +829,9 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2] + 180, Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
     }
     return true;
@@ -852,7 +852,7 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
             Vector(0.04f, 0.03f, 0.02f, Light);
             for (int i = 0; i < 3; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, Position, o->Angle, Light, 22, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, Position, o->Angle, Light, 22, o->Scale, o);
             }
         }
     }
@@ -870,13 +870,13 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }
@@ -892,14 +892,14 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
     return true;
     case 82:
     {
-        CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 9, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 9, o->Scale);
     }
     return true;
 
     case 83:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 14, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 14, o->Scale);
     }
     return true;
 
@@ -925,7 +925,7 @@ bool GMEmpireGuardian3::RenderObjectVisual(OBJECT* o, BMD* b)
             int iRand = rand() % 4 + 4;
             for (int i = 0; i < iRand; ++i)
             {
-                CreateEffect(BITMAP_FLAME, o->Position, o->Angle, vLight, 6, NULL, -1, 0, o->Scale);
+                CreateEffectFpsChecked(BITMAP_FLAME, o->Position, o->Angle, vLight, 6, NULL, -1, 0, o->Scale);
             }
         }
     }
@@ -1087,8 +1087,8 @@ bool GMEmpireGuardian3::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 if (i % 5 == 0)
                 {
                     b->TransformByObjectBone(vPosRage, o, i);
-                    CreateParticle(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
-                    CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
                 }
             }
         }

--- a/Source Main 5.2/source/GMEmpireGuardian4.cpp
+++ b/Source Main 5.2/source/GMEmpireGuardian4.cpp
@@ -537,13 +537,13 @@ bool GMEmpireGuardian4::MoveMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     b->Animation(BoneTransform, fAnimationFrame, o->PriorAnimationFrame, o->PriorAction, o->Angle, o->HeadAngle);
 
                     b->TransformPosition(BoneTransform[61], vRelative, vPosition, false);
-                    CreateParticle(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
+                    CreateParticleFpsChecked(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
 
                     Vector((float)(rand() % 360), 0.f, (float)(rand() % 360), vAngle);
                     AngleMatrix(vAngle, matRandomRotation);
                     VectorRotate(vRandomDir, matRandomRotation, vRandomDirPosition);
                     VectorAdd(vPosition, vRandomDirPosition, vResultRandomPosition);
-                    CreateJoint(BITMAP_JOINT_THUNDER, vResultRandomPosition, vPosition, vAngle, 3, NULL, 10.f, 10, 10);
+                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vResultRandomPosition, vPosition, vAngle, 3, NULL, 10.f, 10, 10);
 
                     fAnimationFrame += fSpeedPerFrame;
                 }
@@ -812,9 +812,9 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2] + 180, Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
         else if (o->AnimationFrame > 15.4f && o->AnimationFrame < 16.5f)
         {
@@ -822,9 +822,9 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2], Angle);
-                CreateJoint(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
+                CreateJointFpsChecked(BITMAP_JOINT_SPARK, o->Position, o->Position, Angle, 5, o);
             }
-            CreateParticle(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
+            CreateParticleFpsChecked(BITMAP_SPARK, o->Position, Angle, o->Light, 11);
         }
     }
     return true;
@@ -854,8 +854,8 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
         for (int i = 2; i <= 7; i++)
         {
             b->TransformPosition(BoneTransform[i], vRelativePos, vPos);
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight1, 4, o->Scale * 0.6f);
-            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight2, 4, o->Scale * 0.3f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight1, 4, o->Scale * 0.6f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLight2, 4, o->Scale * 0.3f);
         }
     }
     return true;
@@ -876,7 +876,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
             Vector(0.04f, 0.03f, 0.02f, Light);
             for (int i = 0; i < 3; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, Position, o->Angle, Light, 22, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, Position, o->Angle, Light, 22, o->Scale, o);
             }
         }
     }
@@ -894,13 +894,13 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }
@@ -918,14 +918,14 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
 
     case 82:
     {
-        CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 9, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 9, o->Scale);
     }
     return true;
 
     case 83:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 14, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 14, o->Scale);
     }
     return true;
 
@@ -934,7 +934,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
         Vector(1.f, 1.f, 1.f, Light);
         if (rand_fps_check(8))
         {
-            CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 4, o->Scale);
         }
     }
     return true;
@@ -950,7 +950,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
             int iRand = rand() % 4 + 4;
             for (int i = 0; i < iRand; ++i)
             {
-                CreateEffect(BITMAP_FLAME, o->Position, o->Angle, vLight, 6, NULL, -1, 0, o->Scale);
+                CreateEffectFpsChecked(BITMAP_FLAME, o->Position, o->Angle, vLight, 6, NULL, -1, 0, o->Scale);
             }
         }
     }
@@ -1041,8 +1041,8 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
 
                 for (int j = 0; j < 5; ++j)
                 {
-                    CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLightFire01, 3, o->Scale * 0.2f);
-                    CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLightFire02, 3, o->Scale * 0.1f);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLightFire01, 3, o->Scale * 0.2f);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vLightFire02, 3, o->Scale * 0.1f);
                 }
             }
         }
@@ -1058,7 +1058,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
 
                 for (int j = 0; j < 4; ++j)
                 {
-                    CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLightSmoke, 65, o->Scale * 0.1, o);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLightSmoke, 65, o->Scale * 0.1, o);
                 }
             }
         }
@@ -1068,7 +1068,7 @@ bool GMEmpireGuardian4::RenderObjectVisual(OBJECT* o, BMD* b)
     {
         for (int i_ = 0; i_ < 1; ++i_)
         {
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 64, o->Scale, o);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 64, o->Scale, o);
         }
     }
     return true;
@@ -1140,7 +1140,7 @@ bool GMEmpireGuardian4::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         Vector(0.0f, -10.0f, 0.0f, vRelative);
         b->TransformByObjectBone(vPos, o, 57, vRelative);
         Vector(1.0f, 0.0f, 0.0f, vLight);
-        CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 2.0f);
+        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 2.0f);
 
         if (g_isNotCharacterBuff(o) == true && g_isCharacterBuff(o, eBuff_Berserker) == true)
         {
@@ -1154,8 +1154,8 @@ bool GMEmpireGuardian4::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 if (i % 5 == 0)
                 {
                     b->TransformByObjectBone(vPosRage, o, i);
-                    CreateParticle(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
-                    CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPosRage, o->Angle, vLightRage, 0, 1.0f);
                 }
             }
         }
@@ -1279,8 +1279,7 @@ bool GMEmpireGuardian4::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(1.0f, 0.1f, 0.1f, vLightRage);
             for (int i = 0; i < iBoneCount; ++i)
             {
-                if (rand() % 6 > 0) continue;
-                if (i % 5 == 0)
+                if (i % 5 == 0 && rand_fps_check(5))
                 {
                     b->TransformByObjectBone(vPosRage, o, i);
                     CreateParticle(BITMAP_SMOKE, vPosRage, o->Angle, vLightRage, 50, 1.0f);

--- a/Source Main 5.2/source/GMHellas.cpp
+++ b/Source Main 5.2/source/GMHellas.cpp
@@ -1078,7 +1078,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
     case MONSTER_DEATH_ANGEL_5:
     case MONSTER_DEATH_ANGEL_6:
     case MONSTER_DEATH_ANGEL_7:
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             Vector(1.f, 1.f, 1.f, Light);
 
@@ -1092,6 +1092,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             }
             Position[2] += 150.f;
             CreateParticle(BITMAP_SHINY + 4, Position, o->Angle, Light, 1, 1.f);
+            c->SetLastAttackEffectTime();
         }
         return true;
 
@@ -1156,7 +1157,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
     case MONSTER_BLOOD_SOLDIER_5:
     case MONSTER_BLOOD_SOLDIER_6:
     case MONSTER_BLOOD_SOLDIER_7:
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             Vector(1.f, 1.f, 1.f, Light);
 
@@ -1170,6 +1171,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
             }
             Position[2] += 150.f;
             CreateParticle(BITMAP_SHINY + 4, Position, o->Angle, Light, 1, 1.f);
+            c->SetLastAttackEffectTime();
         }
         return true;
 
@@ -1196,9 +1198,10 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
         switch ((c->Skill))
         {
         case AT_SKILL_ENERGYBALL:
-            if ((int)c->AttackTime == 14)
+            if (c->CheckAttackTime(14))
             {
                 CreateEffect(MODEL_SKILL_FURY_STRIKE, o->Position, o->Angle, o->Light, 1, o, -1, 0, 1);
+                c->SetLastAttackEffectTime();
             }
             break;
 
@@ -1217,7 +1220,7 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
         switch ((c->Skill))
         {
         case AT_SKILL_POISON:
-            if ((int)c->AttackTime == 14)
+            if (c->CheckAttackTime(14))
             {
                 vec3_t Light, Position;
 
@@ -1231,11 +1234,12 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
 
                     CreateEffect(MODEL_FIRE, Position, o->Angle, Light, 7, NULL, 0);
                 }
+                c->SetLastAttackEffectTime();
             }
             break;
 
         case AT_SKILL_ENERGYBALL:
-            if ((int)c->AttackTime == 14)
+            if (c->CheckAttackTime(14))
             {
                 if (c->TargetCharacter >= 0 && c->TargetCharacter < MAX_CHARACTERS_CLIENT)
                 {
@@ -1253,6 +1257,8 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
                     Angle[2] += 15.f;
                     CreateJoint(BITMAP_FLARE + 1, Position, to->Position, Angle, 6, to, 30.f, 50);
                 }
+
+                c->SetLastAttackEffectTime();
             }
             break;
         }
@@ -1320,15 +1326,16 @@ bool AttackEffect_HellasMonster(CHARACTER* c, CHARACTER* tc, OBJECT* o, OBJECT* 
 
         if (o->CurrentAction == MONSTER01_ATTACK1)
         {
-            if ((int)c->AttackTime == 7)
+            if (c->CheckAttackTime(7))
             {
                 CreateEffect(MODEL_SKILL_FURY_STRIKE, o->Position, o->Angle, o->Light, 0, o, -1, 0, 0);
+                c->SetLastAttackEffectTime();
             }
-            else if ((int)c->AttackTime >= 13)
+            else if (c->CheckAttackTime(13))
             {
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light, 0, o);
                 CreateEffect(BITMAP_FLAME, o->Position, o->Angle, o->Light, 1, o);
-                c->AttackTime = 15;
+                c->SetLastAttackEffectTime();
             }
         }
         return true;

--- a/Source Main 5.2/source/GMHellas.cpp
+++ b/Source Main 5.2/source/GMHellas.cpp
@@ -460,12 +460,12 @@ bool RenderHellasVisual(OBJECT* o, BMD* b)
         break;
     case 35:
         Vector(0.3f, 0.6f, 1.f, Light);
-        CreateParticle(BITMAP_LIGHT, o->Position, o->Angle, Light, 6, 1.f, o);
+        CreateParticleFpsChecked(BITMAP_LIGHT, o->Position, o->Angle, Light, 6, 1.f, o);
         o->HiddenMesh = -2;
         break;
     case 36:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_TRUE_BLUE, o->Position, o->Angle, Light, 0);
+        CreateParticleFpsChecked(BITMAP_TRUE_BLUE, o->Position, o->Angle, Light, 0);
 
         o->Scale = 0.5f;
         o->HiddenMesh = -2;
@@ -473,7 +473,7 @@ bool RenderHellasVisual(OBJECT* o, BMD* b)
 
     case 37:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 0);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 0);
         o->Scale = 0.5f;
         PlayBuffer(SOUND_KALIMA_WATER_FALL);
         break;
@@ -488,7 +488,7 @@ bool RenderHellasVisual(OBJECT* o, BMD* b)
         break;
     case 39:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3 + (rand() % 2), o->Position, o->Angle, Light, 0);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3 + (rand() % 2), o->Position, o->Angle, Light, 0);
         o->Scale = 0.5f;
         break;
     case 40:
@@ -578,7 +578,7 @@ bool RenderHellasObjectMesh(OBJECT* o, BMD* b)
             Vector(2.f, 10.f, 0.f, p);
             b->TransformPosition(BoneTransform[6], p, Position, false);
             Vector(1.0f, 0.2f, 0.0f, Light);
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 17, 3.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 17, 3.0f);
         }
         return true;
     }
@@ -696,7 +696,7 @@ void CreateMonsterSkill_ReduceDef(OBJECT* o, int AttackTime, BYTE time, float He
         for (int i = 0; i < 3; i++)
         {
             Vector(0.f, 0.f, i * 120.f, Angle);
-            CreateEffect(MODEL_SKULL, Position, Angle, Light, 1, o);
+            CreateEffectFpsChecked(MODEL_SKULL, Position, Angle, Light, 1, o);
         }
 
         PlayBuffer(SOUND_SKILL_SKULL);
@@ -720,7 +720,7 @@ void CreateMonsterSkill_Poison(OBJECT* o, int AttackTime, BYTE time)
             VectorRotate(p, Matrix, Position);
             VectorAdd(o->Position, Position, Position);
 
-            CreateEffect(MODEL_FIRE, Position, o->Angle, Light, 8, NULL, 0);
+            CreateEffectFpsChecked(MODEL_FIRE, Position, o->Angle, Light, 8, NULL, 0);
         }
 
         PlayBuffer(SOUND_GREAT_POISON);
@@ -1393,7 +1393,7 @@ void MonsterMoveWaterSmoke(OBJECT* o)
     {
         vec3_t Position;
         Vector(o->Position[0] + rand() % 200 - 100, o->Position[1] + rand() % 200 - 100, o->Position[2], Position);
-        CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
+        CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
     }
 }
 void MonsterDieWaterSmoke(OBJECT* o)
@@ -1407,7 +1407,7 @@ void MonsterDieWaterSmoke(OBJECT* o)
             Vector(o->Position[0] + (float)(rand() % 64 - 32),
                 o->Position[1] + (float)(rand() % 64 - 32),
                 o->Position[2] + (float)(rand() % 32 - 16), Position);
-            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light, 1);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, o->Light, 1);
         }
     }
 }
@@ -1426,10 +1426,10 @@ bool MoveHellasMonsterVisual(OBJECT* o, BMD* b)
             Position[1] = o->Position[1] + rand() % 100 - 50;
             Position[2] = o->Position[2];
 
-            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
-            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
-            CreateEffect(MODEL_STONE1, o->Position, o->Angle, o->Light);
-            CreateEffect(MODEL_STONE2, o->Position, o->Angle, o->Light);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
+            CreateEffectFpsChecked(MODEL_STONE1, o->Position, o->Angle, o->Light);
+            CreateEffectFpsChecked(MODEL_STONE2, o->Position, o->Angle, o->Light);
         }
         o->BlendMesh = 1;
         o->BlendMeshLight = sinf(WorldTime * 0.001f) * 0.5f + 0.5f;
@@ -1445,7 +1445,7 @@ bool MoveHellasMonsterVisual(OBJECT* o, BMD* b)
             Vector(2.f, 30.f, 0.f, p);
             b->TransformPosition(o->BoneTransform[6], p, Position, true);
             Vector(1.0f, 0.2f, 0.0f, Light);
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 17);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 17);
         }
         return true;
 
@@ -1477,7 +1477,7 @@ bool MoveHellasMonsterVisual(OBJECT* o, BMD* b)
                 {
                     Vector(0.0f, 0.3f, 1.0f, Light);
                 }
-                CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 17);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 17);
             }
         }
         return true;
@@ -1677,7 +1677,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                         Position[0] = o->Position[0] + sinf(fAngle) * fDistance;
                         Position[1] = o->Position[1] + cosf(fAngle) * fDistance;
                         Position[2] = o->Position[2] + 800.f;
-                        CreateEffect(9, Position, Angle, Light);
+                        CreateEffectFpsChecked(9, Position, Angle, Light);
                     }
                 }
             }
@@ -1694,7 +1694,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     b->TransformPosition(o->BoneTransform[49], p, Position, true);
                     float fHeight = Position[2];
                     Vector(o->Position[0], o->Position[1], fHeight, Position);
-                    CreateEffect(MODEL_CUNDUN_SKILL, Position, o->Angle, o->Light, 0);
+                    CreateEffectFpsChecked(MODEL_CUNDUN_SKILL, Position, o->Angle, o->Light, 0);
                 }
             }
             if (o->CurrentAction == MONSTER01_ATTACK2)
@@ -1711,7 +1711,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     Vector(0.f, 0.f, 0.f, p);
                     b->TransformPosition(o->BoneTransform[49], p, Position, true);
                     Position[2] = 400;
-                    CreateEffect(MODEL_CUNDUN_SKILL, Position, o->Angle, o->Light, 1);
+                    CreateEffectFpsChecked(MODEL_CUNDUN_SKILL, Position, o->Angle, o->Light, 1);
                 }
                 if ((int)o->LifeTime == 101 && o->AnimationFrame > 6.0f)
                 {
@@ -1727,7 +1727,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     for (i = 0; i < 24; ++i)
                     {
                         Angle[2] = (float)(i * 30);
-                        CreateJoint(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 14, NULL, 100.f, 0, 0);
+                        CreateJointFpsChecked(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 14, NULL, 100.f, 0, 0);
                     }
                     if (gMapManager.InHellas())
                     {
@@ -1833,13 +1833,13 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 {
                     b->TransformPosition(o->BoneTransform[i], p, pos1, true);
                     b->TransformPosition(o->BoneTransform[i + 1], p, pos2, true);
-                    CreateJoint(BITMAP_JOINT_THUNDER, pos1, pos2, o->Angle, 7, NULL, 30.f);
+                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, pos1, pos2, o->Angle, 7, NULL, 30.f);
                 }
                 for (i = 31; i < 37; ++i)
                 {
                     b->TransformPosition(o->BoneTransform[i], p, pos1, true);
                     b->TransformPosition(o->BoneTransform[i + 1], p, pos2, true);
-                    CreateJoint(BITMAP_JOINT_THUNDER, pos1, pos2, o->Angle, 7, NULL, 30.f);
+                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, pos1, pos2, o->Angle, 7, NULL, 30.f);
                 }
             }
         }
@@ -1910,7 +1910,7 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             b->TransformPosition(o->BoneTransform[60], p, pos, true);
             CreateSprite(BITMAP_ENERGY, pos, 0.5f + (Luminosity * 0.2f), Light, o, WorldTime * 0.1f);
             CreateSprite(BITMAP_ENERGY, pos, 0.5f + (Luminosity * 0.2f), Light, o, -WorldTime * 0.1f);
-            CreateParticle(BITMAP_LIGHT, pos, o->Angle, Light, 0, 1.1f);
+            CreateParticleFpsChecked(BITMAP_LIGHT, pos, o->Angle, Light, 0, 1.1f);
 
             Vector(0.1f, 0.4f, 1.f, Light);
             CreateSprite(BITMAP_LIGHT, Position, 1.f, Light, o, 0.f);
@@ -1975,13 +1975,13 @@ bool RenderHellasMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 b->TransformPosition(o->BoneTransform[51], p, Pos2, true);
                 if (o->SubType == 9)
                 {
-                    CreateParticle(BITMAP_FIRE + 1, Pos1, o->Angle, Light, 1, 7.2f / (i / 2 + 6));
-                    CreateParticle(BITMAP_FIRE + 1, Pos2, o->Angle, Light, 1, 7.2f / (i / 2 + 6));
+                    CreateParticleFpsChecked(BITMAP_FIRE + 1, Pos1, o->Angle, Light, 1, 7.2f / (i / 2 + 6));
+                    CreateParticleFpsChecked(BITMAP_FIRE + 1, Pos2, o->Angle, Light, 1, 7.2f / (i / 2 + 6));
                 }
                 else
                 {
-                    CreateParticle(BITMAP_FIRE + 3, Pos1, o->Angle, Light, 12, 7.2f / (i / 2 + 6) * 0.5f);
-                    CreateParticle(BITMAP_FIRE + 3, Pos2, o->Angle, Light, 12, 7.2f / (i / 2 + 6) * 0.5f);
+                    CreateParticleFpsChecked(BITMAP_FIRE + 3, Pos1, o->Angle, Light, 12, 7.2f / (i / 2 + 6) * 0.5f);
+                    CreateParticleFpsChecked(BITMAP_FIRE + 3, Pos2, o->Angle, Light, 12, 7.2f / (i / 2 + 6) * 0.5f);
                 }
             }
         }
@@ -2028,33 +2028,36 @@ bool RenderHellasMonsterObjectMesh(OBJECT* o, BMD* b)
             b->RenderMesh(0, RENDER_TEXTURE, o->Alpha, o->BlendMesh, o->BlendMeshLight, o->BlendMeshTexCoordU, o->BlendMeshTexCoordV, o->HiddenMesh);
             EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
 
-            vec3_t p, Position;
-            Vector(39.0f, -7.5f, -0.5, p);
-            b->TransformPosition(o->BoneTransform[4], p, Position, true);
-            CreateEffect(MODEL_CUNDUN_PART8, Position, o->Angle, o->Light, 3, o, -130, 3);
-            Vector(24.0f, -7.5f, 32.5f, p);
-            b->TransformPosition(o->BoneTransform[4], p, Position, true);
-            CreateEffect(MODEL_CUNDUN_PART1, Position, o->Angle, o->Light, 3, o, -130, 4);
-            Vector(24.0f, -8.5f, -32.5f, p);
-            b->TransformPosition(o->BoneTransform[4], p, Position, true);
-            CreateEffect(MODEL_CUNDUN_PART2, Position, o->Angle, o->Light, 3, o, -130, 5);
-            Vector(-0.5f, 4.0f, 0.5f, p);
-            b->TransformPosition(o->BoneTransform[4], p, Position, true);
-            CreateEffect(MODEL_CUNDUN_PART3, Position, o->Angle, o->Light, 2, o, -130, 6);
-            Vector(-2.5f, -22.0f, 54.0f, p);
-            b->TransformPosition(o->BoneTransform[4], p, Position, true);
-            CreateEffect(MODEL_CUNDUN_PART4, Position, o->Angle, o->Light, 3, o, -130, 1);
-            Vector(-4.5f, -24.5f, -53, p);
-            b->TransformPosition(o->BoneTransform[4], p, Position, true);
-            CreateEffect(MODEL_CUNDUN_PART5, Position, o->Angle, o->Light, 3, o, -130, 2);
-            Vector(-136.0f, -153.5f, 0, p);
-            b->TransformPosition(o->BoneTransform[4], p, Position, true);
-            CreateEffect(MODEL_CUNDUN_PART6, Position, o->Angle, o->Light, 4, o, -10, 2);
-            Vector(-135.0f, -153.0f, 0.0f, p);
-            b->TransformPosition(o->BoneTransform[4], p, Position, true);
-            CreateEffect(MODEL_CUNDUN_PART7, Position, o->Angle, o->Light, 5, o, -130, 2);
+            if (rand_fps_check(1))
+            {
+                vec3_t p, Position;
+                Vector(39.0f, -7.5f, -0.5, p);
+                b->TransformPosition(o->BoneTransform[4], p, Position, true);
+                CreateEffect(MODEL_CUNDUN_PART8, Position, o->Angle, o->Light, 3, o, -130, 3);
+                Vector(24.0f, -7.5f, 32.5f, p);
+                b->TransformPosition(o->BoneTransform[4], p, Position, true);
+                CreateEffect(MODEL_CUNDUN_PART1, Position, o->Angle, o->Light, 3, o, -130, 4);
+                Vector(24.0f, -8.5f, -32.5f, p);
+                b->TransformPosition(o->BoneTransform[4], p, Position, true);
+                CreateEffect(MODEL_CUNDUN_PART2, Position, o->Angle, o->Light, 3, o, -130, 5);
+                Vector(-0.5f, 4.0f, 0.5f, p);
+                b->TransformPosition(o->BoneTransform[4], p, Position, true);
+                CreateEffect(MODEL_CUNDUN_PART3, Position, o->Angle, o->Light, 2, o, -130, 6);
+                Vector(-2.5f, -22.0f, 54.0f, p);
+                b->TransformPosition(o->BoneTransform[4], p, Position, true);
+                CreateEffect(MODEL_CUNDUN_PART4, Position, o->Angle, o->Light, 3, o, -130, 1);
+                Vector(-4.5f, -24.5f, -53, p);
+                b->TransformPosition(o->BoneTransform[4], p, Position, true);
+                CreateEffect(MODEL_CUNDUN_PART5, Position, o->Angle, o->Light, 3, o, -130, 2);
+                Vector(-136.0f, -153.5f, 0, p);
+                b->TransformPosition(o->BoneTransform[4], p, Position, true);
+                CreateEffect(MODEL_CUNDUN_PART6, Position, o->Angle, o->Light, 4, o, -10, 2);
+                Vector(-135.0f, -153.0f, 0.0f, p);
+                b->TransformPosition(o->BoneTransform[4], p, Position, true);
+                CreateEffect(MODEL_CUNDUN_PART7, Position, o->Angle, o->Light, 5, o, -130, 2);
 
-            CreateEffect(MODEL_CUNDUN_SKILL, o->Position, o->Angle, o->Light, 2);
+                CreateEffect(MODEL_CUNDUN_SKILL, o->Position, o->Angle, o->Light, 2);
+            }
         }
         else
         {
@@ -2065,21 +2068,24 @@ bool RenderHellasMonsterObjectMesh(OBJECT* o, BMD* b)
                     PlayBuffer(SOUND_KUNDUN_DESTROY);
                 }
                 o->LifeTime = 90;
-
-                vec3_t Angle = { 0.0f, 0.0f, 0.0f };
-                int iCount = 86;
-                for (int i = 0; i < iCount; ++i)
+                if (rand_fps_check(1))
                 {
-                    Angle[0] = -10.f;
-                    Angle[1] = 0.f;
-                    Angle[2] = i * (10.f + rand() % 10);
+                    vec3_t Angle = { 0.0f, 0.0f, 0.0f };
+                    int iCount = 86;
+                    for (int i = 0; i < iCount; ++i)
+                    {
+                        Angle[0] = -10.f;
+                        Angle[1] = 0.f;
+                        Angle[2] = i * (10.f + rand() % 10);
 
-                    vec3_t Position;
-                    VectorCopy(o->Position, Position);
-                    Position[2] += 200.f;
-                    CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 3, NULL, 50.f, 0, 0);
-                    CreateJoint(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 3, NULL, 50.f, 0, 0);
+                        vec3_t Position;
+                        VectorCopy(o->Position, Position);
+                        Position[2] += 200.f;
+                        CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 3, NULL, 50.f, 0, 0);
+                        CreateJoint(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 3, NULL, 50.f, 0, 0);
+                    }
                 }
+
                 EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
             }
 

--- a/Source Main 5.2/source/GMHuntingGround.cpp
+++ b/Source Main 5.2/source/GMHuntingGround.cpp
@@ -407,7 +407,8 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
             pObject->Live = false;
             PlayBuffer(SOUND_BC_FIREGOLEM_DIE);
         }
-        else {
+        else if (rand_fps_check(1))
+        {
             Vector(5.f, 10.f, 5.f, Relative);
             BoneManager::GetBonePosition(pObject, L"Monster82_LHand", Relative, Position);
             CreateParticle(BITMAP_TRUE_FIRE, Position, pObject->Angle, Light, 3, 3.4f, pObject);
@@ -514,8 +515,8 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
 
             CreateSprite(BITMAP_SHINY + 1, Position, 2.5f, pObject->Light, pObject, 0.f, 1);
             CreateSprite(BITMAP_MAGIC + 1, Position, 0.8f, pObject->Light, pObject, 0.f);
-            CreateParticle(BITMAP_ENERGY, Position, pObject->Angle, Light);
-            CreateParticle(BITMAP_ENERGY, Position, pObject->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_ENERGY, Position, pObject->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_ENERGY, Position, pObject->Angle, Light);
         }
         if (pObject->CurrentAction == MONSTER01_STOP1 || pObject->CurrentAction == MONSTER01_STOP2)
             pObject->SubType = FALSE;
@@ -560,7 +561,7 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
                     BoneManager::GetBonePosition(pObject, L"Monster84_PoisonLeft", Position);
                 CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 11, (float)(rand() % 32 + 50) * 0.025f);
             }
-            CreateEffect(MODEL_BIG_STONE_PART2, Position, Angle, Light, 3);
+            CreateEffectFpsChecked(MODEL_BIG_STONE_PART2, Position, Angle, Light, 3);
         }
         if (pObject->CurrentAction == MONSTER01_ATTACK2 && pObject->AnimationFrame >= 3.5f && pObject->AnimationFrame <= 4.2f) {
             if (pObject->SubType == FALSE) {
@@ -570,11 +571,11 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
 
             BoneManager::GetBonePosition(pObject, L"Monster84_RightHand", Position);
             Position[2] = pObject->Position[2];
-            CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 11, (float)(rand() % 32 + 50) * 0.05f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, pObject->Angle, Light, 11, (float)(rand() % 32 + 50) * 0.05f);
 
             BoneManager::GetBonePosition(pObject, L"Monster84_LeftHand", Position);
             Position[2] = pObject->Position[2];
-            CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 11, (float)(rand() % 32 + 50) * 0.05f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, pObject->Angle, Light, 11, (float)(rand() % 32 + 50) * 0.05f);
         }
 
         if (rand_fps_check(10)) {
@@ -660,8 +661,8 @@ bool M31HuntingGround::RenderHuntingGroundMonsterVisual(CHARACTER* pCharacter, O
             }
             Vector(0.f, 0.f, -10.f, Relative);
             BoneManager::GetBonePosition(pObject, L"Monster87_LeftHand", Relative, Position);
-            CreateParticle(BITMAP_TRUE_FIRE, Position, pObject->Angle, Light, 3, 3.f, pObject);
-            CreateParticle(BITMAP_SMOKE, Position, pObject->Angle, Light, 21, 2.f);
+            CreateParticleFpsChecked(BITMAP_TRUE_FIRE, Position, pObject->Angle, Light, 3, 3.f, pObject);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, pObject->Angle, Light, 21, 2.f);
         }
         if (pObject->CurrentAction == MONSTER01_STOP1 || pObject->CurrentAction == MONSTER01_STOP2)
             pObject->SubType = FALSE;

--- a/Source Main 5.2/source/GMKarutan1.cpp
+++ b/Source Main 5.2/source/GMKarutan1.cpp
@@ -117,13 +117,13 @@ bool CGMKarutan1::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }
@@ -142,7 +142,7 @@ bool CGMKarutan1::RenderObjectVisual(OBJECT* o, BMD* b)
             vec3_t vLight;
             Vector(0.04f, 0.04f, 0.04f, vLight);
             for (int i = 0; i < 20; ++i)
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, vLight, 0, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, vLight, 0, o->Scale, o);
         }
         return true;
     case 116:
@@ -160,7 +160,7 @@ bool CGMKarutan1::RenderObjectVisual(OBJECT* o, BMD* b)
             vec3_t vLight;
             Vector(0.27f, 0.2f, 0.1f, vLight);
             for (int i = 0; i < 4; ++i)
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, vLight, 0, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, vLight, 0, o->Scale, o);
         }
         return true;
     }
@@ -454,7 +454,7 @@ bool CGMKarutan1::MoveMonsterVisual(OBJECT* o, BMD* b)
         {
             vec3_t Position;
             Vector(o->Position[0] + rand() % 200 - 100, o->Position[1] + rand() % 200 - 100, o->Position[2], Position);
-            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
         }
         return true;
     case MODEL_CONDRA:
@@ -513,7 +513,7 @@ bool CGMKarutan1::MoveMonsterVisual(OBJECT* o, BMD* b)
         }
         else if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
         {
-            if (o->AnimationFrame >= 12.5f && o->AnimationFrame < 13.0f)
+            if (o->AnimationFrame >= 12.5f && o->AnimationFrame < 13.0f && rand_fps_check(1))
             {
                 vec3_t Light;
                 vec3_t EndPos, EndRelative;
@@ -728,8 +728,9 @@ bool CGMKarutan1::AttackEffectMonster(CHARACTER* c, OBJECT* o, BMD* b)
     switch (o->Type)
     {
     case MODEL_CRYPOS:
-        if (o->CurrentAction == MONSTER01_ATTACK2 &&
-            (o->AnimationFrame >= 3.5f && o->AnimationFrame <= 4.5f))
+        if (o->CurrentAction == MONSTER01_ATTACK2
+            && (o->AnimationFrame >= 3.5f && o->AnimationFrame <= 4.5f)
+            && rand_fps_check(1))
         {
             CHARACTER* tc = &CharactersClient[c->TargetCharacter];
             OBJECT* to = &tc->Object;

--- a/Source Main 5.2/source/GMNewTown.cpp
+++ b/Source Main 5.2/source/GMNewTown.cpp
@@ -310,11 +310,11 @@ bool GMNewTown::RenderObjectVisual(OBJECT* pObject, BMD* pModel)
         }
         break;
     case 58:
-        CreateParticle(BITMAP_WATERFALL_5, pObject->Position, pObject->Angle, Light, 0);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_5, pObject->Position, pObject->Angle, Light, 0);
         break;
     case 59:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, pObject->Position, pObject->Angle, Light, 8, pObject->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, pObject->Position, pObject->Angle, Light, 8, pObject->Scale);
         break;
     case 60:
         if (pObject->HiddenMesh != -2)
@@ -1179,7 +1179,7 @@ bool GMNewTown::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BMD*
         {
             Vector(0, (rand() % 300 - 150) * 0.1f, (rand() % 200 - 100) * 0.1f, vRelative);
             pModel->TransformPosition(pObject->BoneTransform[30], vRelative, vPos, true);
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, pObject->Angle, pObject->Light, 0, 1, pObject);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, pObject->Angle, pObject->Light, 0, 1, pObject);
         }
         break;
     case MODEL_TOTEM_GOLEM:
@@ -1187,7 +1187,7 @@ bool GMNewTown::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject, BMD*
         {
             vec3_t Position;
             Vector(pObject->Position[0] + rand() % 200 - 100, pObject->Position[1] + rand() % 200 - 100, pObject->Position[2], Position);
-            CreateParticle(BITMAP_SMOKE + 1, Position, pObject->Angle, pObject->Light);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, pObject->Angle, pObject->Light);
         }
         if (pObject->CurrentAction == MONSTER01_DIE)
         {

--- a/Source Main 5.2/source/GMSwampOfQuiet.cpp
+++ b/Source Main 5.2/source/GMSwampOfQuiet.cpp
@@ -452,23 +452,23 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
                 VectorRotate(vPosition, matRotate, vLook);
                 VectorAdd(pObject->Position, vLook, vPosition);
 
-                CreateEffect(BITMAP_CRATER, vPosition, pObject->Angle, vLight, 2, NULL, -1, 0, 0, 0, 1.5f);
+                CreateEffectFpsChecked(BITMAP_CRATER, vPosition, pObject->Angle, vLight, 2, NULL, -1, 0, 0, 0, 1.5f);
                 for (int iu = 0; iu < 20; iu++)
                 {
                     //CreateEffect ( MODEL_BIG_STONE1, vPosition,pObject->Angle,pObject->Light,10);
-                    CreateEffect(MODEL_STONE2, vPosition, pObject->Angle, pObject->Light);
+                    CreateEffectFpsChecked(MODEL_STONE2, vPosition, pObject->Angle, pObject->Light);
                 }
                 Vector(0.7f, 0.7f, 1.f, vLight);
-                CreateParticle(BITMAP_CLUD64, vPosition, pObject->Angle, vLight, 7, 2.0f);
-                CreateParticle(BITMAP_CLUD64, vPosition, pObject->Angle, vLight, 7, 2.0f);
+                CreateParticleFpsChecked(BITMAP_CLUD64, vPosition, pObject->Angle, vLight, 7, 2.0f);
+                CreateParticleFpsChecked(BITMAP_CLUD64, vPosition, pObject->Angle, vLight, 7, 2.0f);
 
                 Vector(0.3f, 0.2f, 1.f, vLight);
-                CreateEffect(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 11);
-                CreateEffect(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 11);
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 11);
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 11);
 
                 vPosition[2] += 100.0f;
                 Vector(0.0f, 0.2f, 1.0f, vLight);
-                CreateEffect(MODEL_EFFECT_THUNDER_NAPIN_ATTACK_1, vPosition, pObject->Angle, vLight, 0);
+                CreateEffectFpsChecked(MODEL_EFFECT_THUNDER_NAPIN_ATTACK_1, vPosition, pObject->Angle, vLight, 0);
             }
         }
         break;
@@ -492,20 +492,20 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
                 {
                     Vector(vPosition[0] + (rand() % 20 - 10) * 1.0f,
                         vPosition[1] + (rand() % 20 - 10) * 1.0f, vPosition[2] + (rand() % 20 - 10) * 1.0f, vSmokePosition);
-                    CreateParticle(BITMAP_SMOKE, vSmokePosition, pObject->Angle, vLight, 51);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vSmokePosition, pObject->Angle, vLight, 51);
                 }
                 if (pObject->AnimationFrame < End_Frame)
                 {
                     Vector(4.0f, 10.0f, 4.0f, vLight);
-                    CreateParticle(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 3, 0.5f);
-                    CreateParticle(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 3, 0.8f);
+                    CreateParticleFpsChecked(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 3, 0.5f);
+                    CreateParticleFpsChecked(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 3, 0.8f);
                 }
 
                 Vector(0.0f, -100.0f, 100.0f, vPosition);
                 AngleMatrix(pObject->Angle, matRotate);
                 VectorRotate(vPosition, matRotate, vLook);
                 VectorAdd(pObject->Position, vLook, vPosition);
-                CreateJoint(BITMAP_JOINT_ENERGY, vPosition, pObject->Position, pObject->Angle, 46, pObject, 20.0f);
+                CreateJointFpsChecked(BITMAP_JOINT_ENERGY, vPosition, pObject->Position, pObject->Angle, 46, pObject, 20.0f);
             }
         }
         break;
@@ -527,16 +527,16 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
                 VectorRotate(vPosition, matRotate, vLook);
                 VectorAdd(pObject->Position, vLook, vPosition);
 
-                CreateEffect(BITMAP_FIRE_CURSEDLICH, vPosition, pObject->Angle, vLight, 1, pObject);
+                CreateEffectFpsChecked(BITMAP_FIRE_CURSEDLICH, vPosition, pObject->Angle, vLight, 1, pObject);
 
-                CreateEffect(BITMAP_CRATER, vPosition, pObject->Angle, vLight, 2, NULL, -1, 0, 0, 0, 1.5f);
+                CreateEffectFpsChecked(BITMAP_CRATER, vPosition, pObject->Angle, vLight, 2, NULL, -1, 0, 0, 0, 1.5f);
                 for (int iu = 0; iu < 20; iu++)
                 {
-                    CreateEffect(MODEL_STONE2, vPosition, pObject->Angle, pObject->Light);
+                    CreateEffectFpsChecked(MODEL_STONE2, vPosition, pObject->Angle, pObject->Light);
                 }
 
                 Vector(0.5f, 0.1f, 0.0f, vLight);
-                CreateEffect(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 12, NULL, -1, 0, 0, 0, 0.1f);
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 12, NULL, -1, 0, 0, 0, 0.1f);
             }
         }
         break;
@@ -548,7 +548,7 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
         {
         case MONSTER01_WALK:
             Vector(pObject->Position[0] + rand() % 200 - 100, pObject->Position[1] + rand() % 200 - 100, pObject->Position[2], vPos);
-            CreateParticle(BITMAP_SMOKE + 1, vPos, pObject->Angle, pObject->Light);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, vPos, pObject->Angle, pObject->Light);
             break;
 
         case MONSTER01_ATTACK1:
@@ -572,13 +572,13 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
                         switch (rand() % 3)
                         {
                         case 0:
-                            CreateParticle(BITMAP_FIRE_HIK1_MONO, vPos, vAngle, vColor, 4, pObject->Scale, pObject);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, vPos, vAngle, vColor, 4, pObject->Scale, pObject);
                             break;
                         case 1:
-                            CreateParticle(BITMAP_FIRE_HIK2_MONO, vPos, vAngle, vColor, 8, pObject->Scale, pObject);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, vPos, vAngle, vColor, 8, pObject->Scale, pObject);
                             break;
                         case 2:
-                            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vColor, 5, pObject->Scale, pObject);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, vAngle, vColor, 5, pObject->Scale, pObject);
                             break;
                         }
                     }
@@ -609,16 +609,16 @@ bool GMSwampOfQuiet::MoveMonsterVisual(OBJECT* pObject, BMD* pModel)
                 VectorRotate(vPosition, matRotate, vLook);
                 VectorAdd(pObject->Position, vLook, vPosition);
 
-                CreateEffect(BITMAP_FIRE_CURSEDLICH, vPosition, pObject->Angle, vLight, 1, pObject);
+                CreateEffectFpsChecked(BITMAP_FIRE_CURSEDLICH, vPosition, pObject->Angle, vLight, 1, pObject);
 
-                CreateEffect(BITMAP_CRATER, vPosition, pObject->Angle, vLight, 2, NULL, -1, 0, 0, 0, 1.5f);
+                CreateEffectFpsChecked(BITMAP_CRATER, vPosition, pObject->Angle, vLight, 2, NULL, -1, 0, 0, 0, 1.5f);
                 for (int iu = 0; iu < 20; iu++)
                 {
-                    CreateEffect(MODEL_STONE2, vPosition, pObject->Angle, pObject->Light);
+                    CreateEffectFpsChecked(MODEL_STONE2, vPosition, pObject->Angle, pObject->Light);
                 }
 
                 Vector(0.5f, 0.1f, 0.0f, vLight);
-                CreateEffect(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 12, NULL, -1, 0, 0, 0, 0.1f);
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, vPosition, pObject->Angle, vLight, 12, NULL, -1, 0, 0, 0, 0.1f);
             }
         }
         break;
@@ -858,8 +858,8 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
         {
             if (rand() % 6 > 0) continue;
             pModel->TransformByObjectBone(vPos, pObject, iBones[i]);
-            CreateParticle(BITMAP_SMOKE, vPos, pObject->Angle, vLight, 50, 1.0f);
-            CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 0, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, pObject->Angle, vLight, 50, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 0, 1.0f);
         }
     }
     if (pObject->CurrentAction == MONSTER01_DIE)
@@ -901,8 +901,8 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
         {
             if (rand() % 6 > 0) continue;
             pModel->TransformByObjectBone(vPos, pObject, iBones[i]);
-            CreateParticle(BITMAP_SMOKE, vPos, pObject->Angle, vLight, 50, 1.0f);
-            CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 0, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, pObject->Angle, vLight, 50, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 0, 1.0f);
         }
     }
     if (pObject->CurrentAction == MONSTER01_DIE)
@@ -944,8 +944,8 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
         {
             if (rand() % 6 > 0) continue;
             pModel->TransformByObjectBone(vPos, pObject, iBones[i]);
-            CreateParticle(BITMAP_SMOKE, vPos, pObject->Angle, vLight, 50, 1.5f);
-            CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 0, 1.1f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, pObject->Angle, vLight, 50, 1.5f);
+            CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 0, 1.1f);
         }
     }
     if (pObject->CurrentAction == MONSTER01_DIE)
@@ -994,7 +994,7 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
             Vector((rand() % 30 - 15) * 1.0f, (rand() % 30 - 15) * 1.0f, (rand() % 30 - 15) * 1.0f, vRelative);
             pModel->TransformByObjectBone(vPos, pObject, iBones[i], vRelative);
             fScale = (float)(rand() % 80 + 32) * 0.01f * 1.0f;
-            CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, pObject->Angle, vLight, 0, fScale);
+            CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, pObject->Angle, vLight, 0, fScale);
         }
     }
     break;
@@ -1005,8 +1005,8 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
         for (int i = 0; i < 7; ++i)
         {
             pModel->TransformByObjectBone(vPos, pObject, iBones[i]);
-            CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 1, 1.0f, pObject);
-            CreateParticle(BITMAP_CLUD64, vPos, pObject->Angle, vLight, 6, 1.0f, pObject);
+            CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 1, 1.0f, pObject);
+            CreateParticleFpsChecked(BITMAP_CLUD64, vPos, pObject->Angle, vLight, 6, 1.0f, pObject);
         }
     }
     break;
@@ -1040,13 +1040,13 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
             switch (rand() % 3)
             {
             case 0:
-                CreateParticle(BITMAP_FIRE_HIK1, vPos, pObject->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, pObject->Angle, vLight, 0, fScale);
                 break;
             case 1:
-                CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, pObject->Angle, vLight, 4, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, pObject->Angle, vLight, 4, fScale);
                 break;
             case 2:
-                CreateParticle(BITMAP_FIRE_HIK3, vPos, pObject->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, pObject->Angle, vLight, 0, fScale);
                 break;
             }
         }
@@ -1071,8 +1071,8 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
 
         MoveEye(pObject, pModel, 34, 35);
         Vector(1.0f, 0.0f, 0.0f, vColor);
-        CreateJoint(BITMAP_JOINT_ENERGY, vPos, pObject->Position, pObject->Angle, 55, pObject, 6.0f, -1, 0, 0, -1, vColor);
-        CreateJoint(BITMAP_JOINT_ENERGY, vPos, pObject->Position, pObject->Angle, 56, pObject, 6.0f, -1, 0, 0, -1, vColor);
+        CreateJointFpsChecked(BITMAP_JOINT_ENERGY, vPos, pObject->Position, pObject->Angle, 55, pObject, 6.0f, -1, 0, 0, -1, vColor);
+        CreateJointFpsChecked(BITMAP_JOINT_ENERGY, vPos, pObject->Position, pObject->Angle, 56, pObject, 6.0f, -1, 0, 0, -1, vColor);
         Vector(1.0f, 1.0f, 1.0f, vColor);
         pModel->TransformByObjectBone(vPos, pObject, 34);
         vPos[1] -= 0.8f;
@@ -1096,8 +1096,8 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
         }
 
         Vector(0.1f, 0.6f, 0.3f, vColor);
-        CreateJoint(BITMAP_JOINT_ENERGY, vPos, pObject->Position, pObject->Angle, 57, pObject, 10.0f, 67, 0, 0, 15, vColor); //57 - pk:node , ichaindex:maxtail
-        CreateJoint(BITMAP_JOINT_ENERGY, vPos, pObject->Position, pObject->Angle, 57, pObject, 10.0f, 70, 0, 0, 15, vColor); //57 - pk:node , ichaindex:maxtail
+        CreateJointFpsChecked(BITMAP_JOINT_ENERGY, vPos, pObject->Position, pObject->Angle, 57, pObject, 10.0f, 67, 0, 0, 15, vColor); //57 - pk:node , ichaindex:maxtail
+        CreateJointFpsChecked(BITMAP_JOINT_ENERGY, vPos, pObject->Position, pObject->Angle, 57, pObject, 10.0f, 70, 0, 0, 15, vColor); //57 - pk:node , ichaindex:maxtail
 
         Vector(1.0f, 1.0f, 1.0f, vColor);
         pModel->TransformByObjectBone(vPos, pObject, 66);
@@ -1117,8 +1117,8 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
             if (i % 5 == 0)
             {
                 pModel->TransformByObjectBone(vPos, pObject, temp[i]);
-                CreateParticle(BITMAP_SMOKE, vPos, pObject->Angle, vColor, 50, 1.0f);
-                CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vColor, 0, 1.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPos, pObject->Angle, vColor, 50, 1.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vColor, 0, 1.0f);
             }
         }
 
@@ -1186,13 +1186,13 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
             switch (rand() % 3)
             {
             case 0:
-                CreateParticle(BITMAP_FIRE_HIK1, vPos, pObject->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, pObject->Angle, vLight, 0, fScale);
                 break;
             case 1:
-                CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, pObject->Angle, vLight, 4, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, pObject->Angle, vLight, 4, fScale);
                 break;
             case 2:
-                CreateParticle(BITMAP_FIRE_HIK3, vPos, pObject->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, pObject->Angle, vLight, 0, fScale);
                 break;
             }
         }
@@ -1206,8 +1206,8 @@ bool GMSwampOfQuiet::RenderMonsterVisual(CHARACTER* pCharacter, OBJECT* pObject,
         {
             if (rand() % 6 > 0) continue;
             pModel->TransformByObjectBone(vPos, pObject, iBones[i]);
-            CreateParticle(BITMAP_SMOKE, vPos, pObject->Angle, vLight, 50, 1.5f);
-            CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 0, 1.1f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, pObject->Angle, vLight, 50, 1.5f);
+            CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPos, pObject->Angle, vLight, 0, 1.1f);
         }
     }
     if (pObject->CurrentAction == MONSTER01_DIE)

--- a/Source Main 5.2/source/GMUnitedMarketPlace.cpp
+++ b/Source Main 5.2/source/GMUnitedMarketPlace.cpp
@@ -277,13 +277,13 @@ bool GMUnitedMarketPlace::RenderObjectVisual(OBJECT* o, BMD* b)
     return true;
     case 54:
     {
-        CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 0);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 0);
     }
     return true;
     case 55:
     {
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 8, o->Scale);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, o->Position, o->Angle, Light, 8, o->Scale);
     }
     return true;
     case 56:
@@ -307,13 +307,13 @@ bool GMUnitedMarketPlace::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }
@@ -366,8 +366,8 @@ bool GMUnitedMarketPlace::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         vec3_t vAngle;
         Vector(10.0f, 0.0f, 0.0f, vAngle);
         b->TransformPosition(o->BoneTransform[43], vRelativePos, vWorldPos, true);
-        CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vWorldPos, o->Angle, Light, 1, 0.6f, o);
-        CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 6, 0.6f, o);
+        CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vWorldPos, o->Angle, Light, 1, 0.6f, o);
+        CreateParticleFpsChecked(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 6, 0.6f, o);
 
         Vector(1.0f, 1.0f, 1.0f, Light);
         Vector(0.0f, 0.0f, 0.0f, vRelativePos);
@@ -546,7 +546,7 @@ bool GMUnitedMarketPlace::MoveRain(PARTICLE* o)
             o->Position[2] = Height + 10.f;
             if (rand_fps_check(4))
                 CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light, 2);
-            else
+            else if (rand_fps_check(1))
                 CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light, 2);
         }
     }

--- a/Source Main 5.2/source/GM_Kanturu_2nd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_2nd.cpp
@@ -1389,6 +1389,7 @@ CHARACTER* CTrapCanon::Create_TrapCanon(int iPosX, int iPosY, int iKey)
     pCha = CreateCharacter(iKey, MODEL_TRAP_CANON, iPosX, iPosY);
     pCha->Object.Scale = 1.0f;
     pCha->AttackTime = 0;
+    pCha->LastAttackEffectTime = -1;
 
     return pCha;
 }
@@ -1402,7 +1403,7 @@ void CTrapCanon::Render_Object(OBJECT* o, BMD* b)
 
 void CTrapCanon::Render_Object_Visual(CHARACTER* c, OBJECT* o, BMD* b)
 {
-    if ((int)c->AttackTime == 0)
+    if (c->CheckAttackTime(0))
     {
         float fLumi;
         vec3_t vPos, vLight;
@@ -1417,12 +1418,14 @@ void CTrapCanon::Render_Object_Visual(CHARACTER* c, OBJECT* o, BMD* b)
         Vector(2.0f + (rand() % 10) * 0.03f, 0.4f + (rand() % 10) * 0.03f, 0.4f + (rand() % 10) * 0.03f, vLight);
         CreateSprite(BITMAP_LIGHT, vPos, 2.0f, vLight, o, -(WorldTime * 0.1f));
         CreateSprite(BITMAP_LIGHT, vPos, 2.0f, vLight, o, (WorldTime * 0.12f));
+
+        c->SetLastAttackEffectTime();
     }
 }
 
 void CTrapCanon::Render_AttackEffect(CHARACTER* c, OBJECT* o, BMD* b)
 {
-    if ((int)c->AttackTime == 1)
+    if (c->CheckAttackTime(1))
     {
         CHARACTER* tc = &CharactersClient[c->TargetCharacter];
         OBJECT* to = &tc->Object;
@@ -1431,5 +1434,6 @@ void CTrapCanon::Render_AttackEffect(CHARACTER* c, OBJECT* o, BMD* b)
         VectorCopy(to->Position, vPos2);
         vPos[2] += 85.f;
         CreateJoint(BITMAP_JOINT_ENERGY, vPos, vPos2, to->Angle, 43, to, 30.0f);
+        c->SetLastAttackEffectTime();
     }
 }

--- a/Source Main 5.2/source/GM_Kanturu_2nd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_2nd.cpp
@@ -1403,7 +1403,7 @@ void CTrapCanon::Render_Object(OBJECT* o, BMD* b)
 
 void CTrapCanon::Render_Object_Visual(CHARACTER* c, OBJECT* o, BMD* b)
 {
-    if (c->CheckAttackTime(0))
+    if (c->AttackTime < 1)
     {
         float fLumi;
         vec3_t vPos, vLight;

--- a/Source Main 5.2/source/GM_Kanturu_2nd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_2nd.cpp
@@ -283,8 +283,10 @@ bool M38Kanturu2nd::Move_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
     break;
     case MODEL_TWIN_TAIL:
     {
-        if (o->CurrentAction == MONSTER01_ATTACK2 &&
-            (o->AnimationFrame >= 5.5f && o->AnimationFrame <= 6.5f))
+        if (o->CurrentAction == MONSTER01_ATTACK2
+            && o->AnimationFrame >= 5.5f
+            && o->AnimationFrame <= 6.5f
+            && rand_fps_check(1))
         {
             CHARACTER* tc = &CharactersClient[c->TargetCharacter];
             OBJECT* to = &tc->Object;
@@ -354,7 +356,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
         Vector(0.0f, 0.0f, 0.0f, vPos);
         Vector(fLumi, fLumi, fLumi, Light);
         b->TransformPosition(BoneTransform[4], vPos, Position, false);
-        CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light, 0, 1.5f);
+        CreateParticleFpsChecked(BITMAP_ENERGY, Position, o->Angle, Light, 0, 1.5f);
         CreateSprite(BITMAP_SPARK + 1, Position, 10.0f, Light, o);
         vec3_t StartPos, EndPos;
         VectorCopy(Position, StartPos);
@@ -392,7 +394,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
             Vector(0.06f, 0.06f, 0.06f, Light);
             for (int i = 0; i < 20; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 1, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 1, o->Scale, o);
             }
         }
     }
@@ -405,14 +407,14 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
             Vector(0.06f, 0.06f, 0.06f, Light);
             for (int i = 0; i < 20; ++i)
             {
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 2, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 2, o->Scale, o);
             }
         }
     }
     break;
     case 47:
     {
-        if (o->HiddenMesh != -2)
+        if (o->HiddenMesh != -2 && rand_fps_check(1))
         {
             vec3_t  Light;
             Vector(0.2f, 0.2f, 0.2f, Light);
@@ -435,7 +437,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_ObjectVisual(OBJECT* o, BMD* b)
     break;
     case 49:
     {
-        if (o->HiddenMesh != -2)
+        if (o->HiddenMesh != -2 && rand_fps_check(1))
         {
             vec3_t  Light;
             Vector(0.0f, 0.01f, 0.03f, Light);
@@ -820,12 +822,12 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
             CreateParticle(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 5, 0.8f, o);
         }
 
-        if (o->CurrentAction == MONSTER01_ATTACK1 && (o->AnimationFrame >= 3.f && o->AnimationFrame <= 4.f))
+        if (o->CurrentAction == MONSTER01_ATTACK1 && (o->AnimationFrame >= 3.f && o->AnimationFrame <= 4.f) && rand_fps_check(1))
         {
             Vector(0.6f, 0.6f, 1.0f, vLight);
             CreateEffect(MODEL_STORM, o->Position, o->Angle, vLight, 0);
         }
-        else if (o->CurrentAction == MONSTER01_ATTACK2 && (o->AnimationFrame >= 3.f && o->AnimationFrame <= 4.f))
+        else if (o->CurrentAction == MONSTER01_ATTACK2 && (o->AnimationFrame >= 3.f && o->AnimationFrame <= 4.f) && rand_fps_check(1))
         {
             vec3_t vPos;
             VectorCopy(o->Position, vPos);
@@ -848,9 +850,9 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
             o->BlendMesh = -2;
             Vector(0.5f, 0.5f, 0.5f, vLight);
             BoneManager::GetBonePosition(o, L"PRSona_Tail", vPos);
-            CreateParticle(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 6, 0.8f, o);
+            CreateParticleFpsChecked(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 6, 0.8f, o);
             BoneManager::GetBonePosition(o, L"PRSona_Tail1", vPos);
-            CreateParticle(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 6, 0.8f, o);
+            CreateParticleFpsChecked(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 6, 0.8f, o);
 
             for (int i = 0; i < 5; i++)
             {
@@ -859,7 +861,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
                 Vector(0.f, 0.f, 0.f, p);
                 Vector(0.5f, 0.5f, 0.5f, vLight);
                 b->TransformPosition(o->BoneTransform[j], p, vPos, true);
-                CreateParticle(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 6, 0.8f, o);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_3, vPos, o->Angle, vLight, 6, 0.8f, o);
             }
         }
 
@@ -959,7 +961,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
         {
             o->BlendMesh = -2;
             o->m_bRenderShadow = false;
-            if (o->AnimationFrame <= 3.0f)
+            if (o->AnimationFrame <= 3.0f && rand_fps_check(1))
             {
                 Vector(0.1f, 1.0f, 0.2f, vLight);
                 for (int i = 0; i < 5; i++)
@@ -1062,7 +1064,7 @@ bool M38Kanturu2nd::Render_Kanturu2nd_MonsterVisual(CHARACTER* c, OBJECT* o, BMD
                 CreateParticle(BITMAP_CLUD64, vPos, o->Angle, vLight, 0);
             }
         }
-        else if (o->CurrentAction == MONSTER01_DIE)
+        else if (o->CurrentAction == MONSTER01_DIE && rand_fps_check(1))
         {
             vec3_t vRelative;
             Vector(0.f, 0.f, 0.f, vRelative);

--- a/Source Main 5.2/source/GM_Kanturu_3rd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_3rd.cpp
@@ -234,7 +234,7 @@ bool M39Kanturu3rd::RenderKanturu3rdObjectVisual(OBJECT* o, BMD* b)
             Vector(rand() % 20 - 30.0f, rand() % 20 - 30.0f, 0.0f, p);
             b->TransformPosition(BoneTransform[34], p, Pos, false);
             if (o->AnimationFrame >= 5.0f && o->AnimationFrame < 12.5f)
-                CreateParticle(BITMAP_SMOKE, Pos, o->Angle, Light, 43, 1.5f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Pos, o->Angle, Light, 43, 1.5f);
         }
 
         if (g_Direction.m_CKanturu.m_iMayaState == KANTURU_MAYA_DIRECTION_ENDCYCLE || g_Direction.m_CKanturu.m_iKanturuState == KANTURU_STATE_STANDBY)
@@ -863,7 +863,7 @@ bool M39Kanturu3rd::MoveKanturu3rdMonsterVisual(OBJECT* o, BMD* b)
             CreateEffect(MODEL_STORM2, Position, o->Angle, Light, 0);
             CreateEffect(BITMAP_BOSS_LASER, Position, o->Angle, Light, 2);
         }
-        else if (o->CurrentAction == MONSTER01_DIE && o->AnimationFrame >= 3.0f)
+        else if (o->CurrentAction == MONSTER01_DIE && o->AnimationFrame >= 3.0f && rand_fps_check(1))
         {
             vec3_t Position;
             BoneManager::GetBonePosition(o, L"Body_Bone13", Position);
@@ -883,7 +883,7 @@ bool M39Kanturu3rd::MoveKanturu3rdMonsterVisual(OBJECT* o, BMD* b)
     {
         vec3_t Pos;
 
-        if (o->CurrentAction == MONSTER01_DIE && g_Direction.m_CKanturu.m_iMayaState < KANTURU_MAYA_DIRECTION_MAYA3)
+        if (o->CurrentAction == MONSTER01_DIE && g_Direction.m_CKanturu.m_iMayaState < KANTURU_MAYA_DIRECTION_MAYA3 && rand_fps_check(1))
         {
             o->BlendMesh = -2;
             Vector(0.0f, 0.0f, 0.0f, Position);
@@ -898,7 +898,7 @@ bool M39Kanturu3rd::MoveKanturu3rdMonsterVisual(OBJECT* o, BMD* b)
         else
             o->BlendMesh = -1;
 
-        if (o->CurrentAction == MONSTER01_STOP2 && g_Direction.m_CKanturu.m_iMayaState >= KANTURU_MAYA_DIRECTION_MAYA3)
+        if (o->CurrentAction == MONSTER01_STOP2 && g_Direction.m_CKanturu.m_iMayaState >= KANTURU_MAYA_DIRECTION_MAYA3 && rand_fps_check(1))
         {
             Vector(1.0f, 1.0f, 1.0f, Light);
             Vector(0.0f, -50.0f, 0.0f, Position);
@@ -912,7 +912,7 @@ bool M39Kanturu3rd::MoveKanturu3rdMonsterVisual(OBJECT* o, BMD* b)
     {
         vec3_t Pos;
 
-        if (o->CurrentAction == MONSTER01_DIE && g_Direction.m_CKanturu.m_iMayaState < KANTURU_MAYA_DIRECTION_MAYA3)
+        if (o->CurrentAction == MONSTER01_DIE && g_Direction.m_CKanturu.m_iMayaState < KANTURU_MAYA_DIRECTION_MAYA3 && rand_fps_check(1))
         {
             o->BlendMesh = -2;
             Vector(0.0f, 0.0f, 0.0f, Position);
@@ -927,7 +927,7 @@ bool M39Kanturu3rd::MoveKanturu3rdMonsterVisual(OBJECT* o, BMD* b)
         else
             o->BlendMesh = -1;
 
-        if (o->CurrentAction == MONSTER01_STOP2 && g_Direction.m_CKanturu.m_iMayaState >= KANTURU_MAYA_DIRECTION_MAYA3)
+        if (o->CurrentAction == MONSTER01_STOP2 && g_Direction.m_CKanturu.m_iMayaState >= KANTURU_MAYA_DIRECTION_MAYA3 && rand_fps_check(1))
         {
             Vector(1.0f, 1.0f, 1.0f, Light);
             Vector(50.0f, 0.0f, 0.0f, Position);
@@ -1064,7 +1064,7 @@ bool M39Kanturu3rd::RenderKanturu3rdMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         CreateSprite(BITMAP_FLARE_BLUE, Position, 0.7f, Light, o);
 
         BoneManager::GetBonePosition(o, L"Body_Bone13", Position);
-        CreateParticle(BITMAP_FIRE + 1, Position, o->Angle, Light, 3, 1.7f);
+        CreateParticleFpsChecked(BITMAP_FIRE + 1, Position, o->Angle, Light, 3, 1.7f);
 
         Vector(3.0f, 0.0f, 0.0f, Position);
         BoneManager::GetBonePosition(o, L"Sword_Bone1", Position, Position);

--- a/Source Main 5.2/source/GM_Kanturu_3rd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_3rd.cpp
@@ -1396,7 +1396,7 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
             Vector(0.3f, 0.2f, 0.1f, Light);
             CreateEffect(MODEL_SUMMON, o->Position, o->Angle, Light, 3);
         }
-        else if (o->CurrentAction == MONSTER01_ATTACK4 && c->AttackTime >= 10 %% rand_fps_check(1))
+        else if (o->CurrentAction == MONSTER01_ATTACK4 && c->AttackTime >= 10 && rand_fps_check(1))
         {
             Vector(1.0f, 1.0f, 1.0f, Light);
             CreateInferno(o->Position);

--- a/Source Main 5.2/source/GM_Kanturu_3rd.cpp
+++ b/Source Main 5.2/source/GM_Kanturu_3rd.cpp
@@ -1369,7 +1369,7 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
         {
-            if ((int)c->AttackTime == 14)
+            if (c->CheckAttackTime(14))
             {
                 vec3_t vPos, vRelative, Light;
                 Vector(140.f, 0.f, -30.f, vRelative);
@@ -1384,39 +1384,47 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
                 CreateParticle(BITMAP_EXPLOTION + 1, vPos, o->Angle, o->Light, 0, 1.3f);
                 CreateParticle(BITMAP_EXPLOTION + 1, vPos, o->Angle, o->Light, 0, 2.3f);
                 CreateParticle(BITMAP_EXPLOTION + 1, vPos, o->Angle, o->Light, 0, 1.8f);
+                c->SetLastAttackEffectTime();
             }
         }
     }
     return true;
     case MONSTER_NIGHTMARE:
     {
-        if (o->CurrentAction == MONSTER01_ATTACK3 && c->AttackTime >= 14)
+        if (o->CurrentAction == MONSTER01_ATTACK3 && c->AttackTime >= 14 && rand_fps_check(1))
         {
             Vector(0.3f, 0.2f, 0.1f, Light);
             CreateEffect(MODEL_SUMMON, o->Position, o->Angle, Light, 3);
         }
-        else if (o->CurrentAction == MONSTER01_ATTACK4 && c->AttackTime >= 10)
+        else if (o->CurrentAction == MONSTER01_ATTACK4 && c->AttackTime >= 10 %% rand_fps_check(1))
         {
             Vector(1.0f, 1.0f, 1.0f, Light);
             CreateInferno(o->Position);
-            if ((int)c->AttackTime == 10)
+            if (c->CheckAttackTime(10))
+            {
                 CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
-            else if ((int)c->AttackTime == 14)
+                c->SetLastAttackEffectTime();
+            }
+            else if (c->CheckAttackTime(14))
+            {
                 CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, Light, 4, o);
+                c->SetLastAttackEffectTime();
+            }
         }
     }
     return true;
     case MONSTER_MAYA_HAND_LEFT:
     {
-        if (o->CurrentAction == MONSTER01_ATTACK1 && (int)c->AttackTime == 14)
+        if (o->CurrentAction == MONSTER01_ATTACK1 && c->CheckAttackTime(14))
         {
             CreateInferno(o->Position, 2);
             Vector(0.0f, 0.5f, 1.0f, Light);
             CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, Light, 7);
 
             PlayBuffer(SOUND_KANTURU_3RD_MAYAHAND_ATTACK1);
+            c->SetLastAttackEffectTime();
         }
-        else if (o->CurrentAction == MONSTER01_ATTACK2 && (int)c->AttackTime == 14)
+        else if (o->CurrentAction == MONSTER01_ATTACK2 && c->CheckAttackTime(14))
         {
             float Matrix[3][4];
             Vector(0.0f, 0.0f, 0.0f, Angle);
@@ -1429,20 +1437,22 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
             CreateEffect(MODEL_MAYAHANDSKILL, Position, o->Angle, Light, 0, NULL, -1, 0, 0, 0, 1.0f);
 
             PlayBuffer(SOUND_KANTURU_3RD_MAYAHAND_ATTACK2);
+            c->SetLastAttackEffectTime();
         }
     }
     return true;
     case MONSTER_MAYA_HAND_RIGHT:
     {
-        if (o->CurrentAction == MONSTER01_ATTACK1 && (int)c->AttackTime == 14)
+        if (o->CurrentAction == MONSTER01_ATTACK1 && c->CheckAttackTime(14))
         {
             CreateInferno(o->Position, 3);
             Vector(1.0f, 0.5f, 0.0f, Light);
             CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, Light, 7);
 
             PlayBuffer(SOUND_KANTURU_3RD_MAYAHAND_ATTACK1);
+            c->SetLastAttackEffectTime();
         }
-        else if (o->CurrentAction == MONSTER01_ATTACK2 && (int)c->AttackTime == 14)
+        else if (o->CurrentAction == MONSTER01_ATTACK2 && c->CheckAttackTime(14))
         {
             float Matrix[3][4];
             Vector(0.0f, 0.0f, 0.0f, Angle);
@@ -1455,6 +1465,7 @@ bool M39Kanturu3rd::AttackEffectKanturu3rdMonster(CHARACTER* c, OBJECT* o, BMD* 
             CreateEffect(MODEL_MAYAHANDSKILL, Position, o->Angle, Light, 0, NULL, -1, 0, 0, 0, 1.0f);
 
             PlayBuffer(SOUND_KANTURU_3RD_MAYAHAND_ATTACK2);
+            c->SetLastAttackEffectTime();
         }
     }
     return true;

--- a/Source Main 5.2/source/GM_PK_Field.cpp
+++ b/Source Main 5.2/source/GM_PK_Field.cpp
@@ -372,7 +372,7 @@ bool CGM_PK_Field::RenderObjectVisual(OBJECT* o, BMD* b)
             Vector(1.0f, 1.0f, 1.0f, Light);
             for (int i = 0; i < 20; ++i)
             {
-                CreateParticle(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 6, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_2, o->Position, o->Angle, Light, 6, o->Scale, o);
             }
         }
     }
@@ -446,13 +446,13 @@ bool CGM_PK_Field::RenderObjectVisual(OBJECT* o, BMD* b)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, o->Scale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, o->Scale);
             break;
         }
     }
@@ -529,7 +529,7 @@ bool CGM_PK_Field::RenderObjectMesh(OBJECT* o, BMD* b, bool ExtraMon)
         Vector(-150.0f, 0.0f, 0.0f, p);
         b->TransformPosition(BoneTransform[4], p, Pos, false);
         if (o->AnimationFrame >= 35.0f && o->AnimationFrame < 50.0f)
-            CreateParticle(BITMAP_SMOKE, Pos, o->Angle, Light, 63, o->Scale * 1.5f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Pos, o->Angle, Light, 63, o->Scale * 1.5f);
 
         return true;
     }
@@ -562,7 +562,7 @@ bool CGM_PK_Field::RenderObjectMesh(OBJECT* o, BMD* b, bool ExtraMon)
         Vector(rand() % 20 - 30.0f, rand() % 20 - 30.0f, 0.0f, p);
         b->TransformPosition(BoneTransform[4], p, Pos, false);
         if (o->AnimationFrame >= 7.0f && o->AnimationFrame < 13.0f)
-            CreateParticle(BITMAP_SMOKE, Pos, o->Angle, Light, 18, o->Scale * 1.5f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Pos, o->Angle, Light, 18, o->Scale * 1.5f);
 
         return true;
     }
@@ -640,13 +640,13 @@ bool CGM_PK_Field::MoveMonsterVisual(OBJECT* o, BMD* b)
                         switch (rand() % 3)
                         {
                         case 0:
-                            CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
                             break;
                         case 1:
-                            CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
                             break;
                         case 2:
-                            CreateParticle(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
                             break;
                         }
                     }
@@ -660,13 +660,13 @@ bool CGM_PK_Field::MoveMonsterVisual(OBJECT* o, BMD* b)
                         switch (rand() % 3)
                         {
                         case 0:
-                            CreateParticle(BITMAP_FIRE_HIK1_MONO, vPos, o->Angle, o->Light, 0, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, vPos, o->Angle, o->Light, 0, fScale);
                             break;
                         case 1:
-                            CreateParticle(BITMAP_FIRE_HIK2_MONO, vPos, o->Angle, o->Light, 4, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, vPos, o->Angle, o->Light, 4, fScale);
                             break;
                         case 2:
-                            CreateParticle(BITMAP_FIRE_HIK3_MONO, vPos, o->Angle, o->Light, 0, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPos, o->Angle, o->Light, 0, fScale);
                             break;
                         }
                     }
@@ -707,7 +707,7 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             b->TransformPosition(o->BoneTransform[6], p, Position, true);
 
             Vector(1.0f, 1.0f, 1.0f, o->Light);
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light, 61);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, o->Light, 61);
         }
     }
     return true;
@@ -732,8 +732,8 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 if (rand() % 4 > 0) continue;
 
                 b->TransformByObjectBone(vPos, o, iBones[i]);
-                CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 50, 1.0f);
-                CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vPos, o->Angle, vLight, 0, 0.01f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 50, 1.0f);
+                CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vPos, o->Angle, vLight, 0, 0.01f);
             }
 
             if (o->CurrentAction == MONSTER01_ATTACK1)
@@ -752,7 +752,7 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
                 VectorAdd(vPos, TempPos, vPos);
 
-                CreateParticle(BITMAP_LIGHT + 2, vPos, o->Angle, vLight, 7, 0.5f);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 2, vPos, o->Angle, vLight, 7, 0.5f);
 
                 switch (o->Type)
                 {
@@ -763,7 +763,7 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     Vector(0.6f, 0.9f, 0.2f, vLight);	//green
                     break;
                 }
-                CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 29, 1.0f);
+                CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 29, 1.0f);
             }
         }
         else					//o->CurrentAction == MONSTER01_DIE
@@ -827,14 +827,14 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
 
         if (o->CurrentAction == MONSTER01_WALK)
         {
-            if (o->AnimationFrame >= 2.0f && o->AnimationFrame <= 2.4f)
+            if (o->AnimationFrame >= 2.0f && o->AnimationFrame <= 2.4f && rand_fps_check(1))
             {
                 Vector(0.0f, 0.0f, 0.0f, vPos);
                 b->TransformPosition(o->BoneTransform[36], vPos, vRelative, true);
                 CreateEffect(iModel, vRelative, o->Angle, vLight, 0, o, -1, 0, 0, 0, 1.3f);
                 CreateParticle(BITMAP_SMOKE, vRelative, o->Angle, vLight, 62, 1.0f);
             }
-            else if (o->AnimationFrame >= 7.0f && o->AnimationFrame <= 7.4f)
+            else if (o->AnimationFrame >= 7.0f && o->AnimationFrame <= 7.4f && rand_fps_check(1))
             {
                 Vector(0.0f, 0.0f, 0.0f, vPos);
                 b->TransformPosition(o->BoneTransform[42], vPos, vRelative, true);
@@ -844,7 +844,7 @@ bool CGM_PK_Field::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         }
         else if (o->CurrentAction == MONSTER01_ATTACK2)
         {
-            if (o->AnimationFrame >= 6.0f && o->AnimationFrame <= 6.4f)
+            if (o->AnimationFrame >= 6.0f && o->AnimationFrame <= 6.4f && rand_fps_check(1))
             {
                 Vector(0.0f, 0.0f, 0.0f, vPos);
                 b->TransformPosition(o->BoneTransform[42], vPos, vRelative, true);

--- a/Source Main 5.2/source/GM_Raklion.cpp
+++ b/Source Main 5.2/source/GM_Raklion.cpp
@@ -1859,7 +1859,7 @@ bool CGM_Raklion::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             // 				PlayBuffer(SOUND_SKILL_SWORD2);
             // 			}
 
-            if (2 <= c->AttackTime && c->AttackTime <= 8)
+            if (2 <= c->AttackTime && c->AttackTime <= 8 && rand_fps_check(1))
             {
                 for (int j = 0; j < 3; ++j)
                 {
@@ -1874,7 +1874,7 @@ bool CGM_Raklion::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     CreateJoint(MODEL_SPEARSKILL, TempPos, TempPos, o->Angle, 2, o, 40.0f);
                 }
             }
-            if (c->AttackTime <= 8)
+            if (c->AttackTime <= 8 && rand_fps_check(1))
             {
                 vec3_t Position2 = { 0.0f, 0.0f, 0.0f };
                 b->TransformPosition(o->BoneTransform[26], Position2, o->m_vPosSword, true);
@@ -1918,7 +1918,7 @@ bool CGM_Raklion::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 //				PlayBuffer(SOUND_COMBO);
             }
         }
-        else if (o->CurrentAction == MONSTER01_DIE && o->AnimationFrame < 1.0f)
+        else if (o->CurrentAction == MONSTER01_DIE && o->AnimationFrame < 1.0f && rand_fps_check(1))
         {
             int iBones[] = { 20, 37, 45, 51 };
             for (int i = 0; i < 4; ++i)

--- a/Source Main 5.2/source/GM_kanturu_1st.cpp
+++ b/Source Main 5.2/source/GM_kanturu_1st.cpp
@@ -111,8 +111,7 @@ bool M37Kanturu1st::MoveKanturu1stObject(OBJECT* pObject)
         if (pObject->Timer > 10.f)
             pObject->Timer = 0.f;
         if (pObject->Timer > 5.f)
-            CreateParticle(BITMAP_BUBBLE, pObject->Position, pObject->Angle,
-                pObject->Light, 5);
+            CreateParticleFpsChecked(BITMAP_BUBBLE, pObject->Position, pObject->Angle, pObject->Light, 5);
         break;
     case 98:
         ::PlayBuffer(SOUND_KANTURU_1ST_BG_PLANT);
@@ -169,7 +168,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
         {
             Vector(0.04f, 0.04f, 0.04f, Light);
             for (int i = 0; i < 20; ++i)
-                CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle,
+                CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle,
                     Light, 20, pObject->Scale, pObject);
         }
         break;
@@ -193,7 +192,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
         break;
     case 82:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_WATERFALL_3, pObject->Position,
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, pObject->Position,
             pObject->Angle, Light, 4, pObject->Scale);
         break;
     case 83:
@@ -254,7 +253,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
         Vector(0.0f, 0.0f, 0.0f, vPos);
         Vector(fLumi, fLumi, fLumi, Light);
         pModel->TransformPosition(BoneTransform[4], vPos, Position, false);
-        CreateParticle(
+        CreateParticleFpsChecked(
             BITMAP_ENERGY, Position, pObject->Angle, Light, 0, 1.5f);
         CreateSprite(BITMAP_SPARK + 1, Position, 10.0f, Light, pObject);
         vec3_t StartPos, EndPos;
@@ -278,7 +277,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
             vec3_t Light;
             Vector(0.06f, 0.06f, 0.06f, Light);
             for (int i = 0; i < 20; ++i)
-                CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle,
+                CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle,
                     Light, 2, pObject->Scale, pObject);
         }
         break;
@@ -288,7 +287,7 @@ bool M37Kanturu1st::RenderKanturu1stObjectVisual(OBJECT* pObject, BMD* pModel)
             vec3_t Light;
             Vector(0.2f, 0.2f, 0.2f, Light);
             for (int i = 0; i < 20; ++i)
-                CreateParticle(BITMAP_CLOUD, pObject->Position, pObject->Angle,
+                CreateParticleFpsChecked(BITMAP_CLOUD, pObject->Position, pObject->Angle,
                     Light, 7, pObject->Scale, pObject);
         }
         break;
@@ -706,7 +705,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
             vRelative[1] = (float)(4 - rand() % 5);
             vRelative[2] = (float)(4 - rand() % 5);
             BoneManager::GetBonePosition(o, L"IRON_RIDER_BOW_6", vRelative, vPos);
-            CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 4.0f);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 4.0f);
         }
 
         if (c->CheckAttackTime(10))
@@ -1213,7 +1212,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         if (o->CurrentAction == MONSTER01_STOP1 || o->CurrentAction == MONSTER01_STOP2)
             o->SubType = FALSE;
 
-        if (o->CurrentAction == MONSTER01_WALK)
+        if (o->CurrentAction == MONSTER01_WALK && rand_fps_check(1))
         {
             vec3_t vPos, vRelative;
             Vector(0.f, 0.f, 0.f, vRelative);
@@ -1265,9 +1264,9 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
             vRelative[1] = (float)(4 - rand() % 5);
             vRelative[2] = (float)(4 - rand() % 5);
             BoneManager::GetBonePosition(o, L"IRON_RIDER_BOW_15", vRelative, vPos);
-            CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 4.0f);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 4.0f);
             BoneManager::GetBonePosition(o, L"IRON_RIDER_BOW_16", vRelative, vPos);
-            CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 4.0f);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 4.0f);
 
             if (o->CurrentAction == MONSTER01_WALK)
             {
@@ -1289,8 +1288,8 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
             vec3_t vPos, vRelative;
             Vector(0.f, 0.f, 0.f, vRelative);
             BoneManager::GetBonePosition(o, L"IRON_RIDER_BIP01", vRelative, vPos);
-            CreateParticle(BITMAP_SMOKE + 3, vPos, o->Angle, vLight, 3, 2.0f);
-            CreateParticle(BITMAP_SMOKE + 3, vPos, o->Angle, vLight, 4, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 3, vPos, o->Angle, vLight, 3, 2.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 3, vPos, o->Angle, vLight, 4, 1.0f);
             if (o->SubType == FALSE)
             {
                 o->SubType = TRUE;
@@ -1403,7 +1402,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         }
         vec3_t vPos, vRelative;
         Vector(0.f, 0.f, 0.f, vRelative);
-        if (o->CurrentAction == MONSTER01_DIE)
+        if (o->CurrentAction == MONSTER01_DIE && rand_fps_check(1))
         {
             float Scale = 0.3f;
             BoneManager::GetBonePosition(o, L"KENTAUROS_BIP_TAIL", vRelative, vPos);
@@ -1463,7 +1462,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         vec3_t vPos, vRelative;
         Vector(0.f, 0.f, 0.f, vRelative);
         BoneManager::GetBonePosition(o, L"BERSERK_MOUTH", vRelative, vPos);
-        CreateParticle(
+        CreateParticleFpsChecked(
             BITMAP_SMOKE, vPos, o->Angle, o->Light, 42, o->Scale);
     }
     return true;
@@ -1492,7 +1491,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         }
         vec3_t vPos, vRelative;
         Vector(0.f, 0.f, 0.f, vRelative);
-        if (o->CurrentAction == MONSTER01_DIE)
+        if (o->CurrentAction == MONSTER01_DIE && rand_fps_check(1))
         {
             float Scale = 0.3f;
             BoneManager::GetBonePosition(o, L"KENTAUROS_BIP_TAIL", vRelative, vPos);
@@ -1592,7 +1591,7 @@ bool M37Kanturu1st::RenderKanturu1stMonsterVisual(CHARACTER* c, OBJECT* o, BMD* 
         if (o->CurrentAction == MONSTER01_STOP1 || o->CurrentAction == MONSTER01_STOP2)
             o->SubType = FALSE;
 
-        if (o->CurrentAction == MONSTER01_WALK)
+        if (o->CurrentAction == MONSTER01_WALK && rand_fps_check(1))
         {
             vec3_t vPos, vRelative;
             Vector(0.f, 0.f, 0.f, vRelative);

--- a/Source Main 5.2/source/GM_kanturu_1st.cpp
+++ b/Source Main 5.2/source/GM_kanturu_1st.cpp
@@ -709,12 +709,13 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
             CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 10, 4.0f);
         }
 
-        if ((int)c->AttackTime == 10)
+        if (c->CheckAttackTime(10))
         {
             vec3_t vPos, vRelative;
             Vector(0.f, 0.f, 0.f, vRelative);
             BoneManager::GetBonePosition(o, L"IRON_RIDER_BOW_6", vRelative, vPos);
             CreateEffect(MODEL_IRON_RIDER_ARROW, vPos, o->Angle, o->Light, 0);
+            c->SetLastAttackEffectTime();
         }
 
         return true;
@@ -724,7 +725,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
     {
         if (o->CurrentAction == MONSTER01_ATTACK1 || o->CurrentAction == MONSTER01_ATTACK2)
         {
-            if ((int)c->AttackTime == 14)
+            if (c->CheckAttackTime(14))
                 //				if(o->AnimationFrame >= StartAction && o->AnimationFrame < (StartAction + fActionSpeed))
             {
                 vec3_t vPos, vRelative, Light;
@@ -740,6 +741,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
                 CreateParticle(BITMAP_EXPLOTION + 1, vPos, o->Angle, o->Light, 0, 1.3f);
                 CreateParticle(BITMAP_EXPLOTION + 1, vPos, o->Angle, o->Light, 0, 2.3f);
                 CreateParticle(BITMAP_EXPLOTION + 1, vPos, o->Angle, o->Light, 0, 1.8f);
+                c->SetLastAttackEffectTime();
             }
         }
 
@@ -772,7 +774,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
             BoneManager::GetBonePosition(o, L"KENTAUROS_BIP_21", vRelative, vPos);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, index, Width);
         }
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             vec3_t vPos, vRelative;
 
@@ -793,6 +795,8 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
                 CreateEffect(MODEL_KENTAUROS_ARROW, vPos, o->Angle, o->Light, 0);
                 o->Angle[2] += 15.f;
             }
+
+            c->SetLastAttackEffectTime();
         }
 
         return true;
@@ -829,7 +833,7 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
             BoneManager::GetBonePosition(o, L"KENTAUROS_BIP_21", vRelative, vPos);
             CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, index, Width);
         }
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             vec3_t vPos, vRelative;
 
@@ -850,6 +854,8 @@ bool M37Kanturu1st::AttackEffectKanturu1stMonster(CHARACTER* c, OBJECT* o, BMD* 
                 CreateEffect(MODEL_KENTAUROS_ARROW, vPos, o->Angle, o->Light, 0);
                 o->Angle[2] += 15.f;
             }
+
+            c->SetLastAttackEffectTime();
         }
 
         return true;

--- a/Source Main 5.2/source/GOBoid.cpp
+++ b/Source Main 5.2/source/GOBoid.cpp
@@ -291,7 +291,7 @@ bool MoveMount(OBJECT* o, bool bForceRender)
                         bWave = true;
                     }
 
-                    if (bWave)
+                    if (bWave && rand_fps_check(1))
                     {
                         Vector(Position[0], Position[1], Position[2], p);
                         CreateEffect(BITMAP_SHOCK_WAVE, p, o->Angle, Light, 1);
@@ -609,11 +609,14 @@ bool MoveMount(OBJECT* o, bool bForceRender)
                 FlyRange = 150.f;
                 vec3_t Position, Light;
                 Vector(0.4f, 0.4f, 0.4f, Light);
-                for (j = 0; j < 4; j++)
+                if (rand_fps_check(1))
                 {
-                    Vector((float)(rand() % 16 - 8), (float)(rand() % 16 - 8), (float)(rand() % 16 - 8), Position);
-                    VectorAdd(Position, o->Position, Position);
-                    CreateParticle(BITMAP_SPARK, Position, o->Angle, Light, 1);
+                    for (j = 0; j < 4; j++)
+                    {
+                        Vector((float)(rand() % 16 - 8), (float)(rand() % 16 - 8), (float)(rand() % 16 - 8), Position);
+                        VectorAdd(Position, o->Position, Position);
+                        CreateParticle(BITMAP_SPARK, Position, o->Angle, Light, 1);
+                    }
                 }
             }
         case MODEL_IMP:
@@ -1582,7 +1585,7 @@ void RenderBoids(bool bAfterCharacter)
                         Vector(1.f, 0.f, 0.f, Light);
                         CreateSprite(BITMAP_LIGHTNING + 1, Position, 1.f, Light, o);
                         Vector(1.f, 1.f, 1.f, Light);
-                        CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
+                        CreateParticleFpsChecked(BITMAP_FIRE, Position, o->Angle, Light);
                     }
                     break;
 
@@ -1597,7 +1600,7 @@ void RenderBoids(bool bAfterCharacter)
 
                 case MODEL_MAP_TORNADO:
                 {
-                    CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, o->Light, 18, o->Scale, o);
+                    CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, o->Light, 18, o->Scale, o);
                 }
                 break;
 
@@ -1762,7 +1765,7 @@ void MoveFishs()
                     o->Gravity = 9;
                     o->LifeTime = 100;
                     VectorCopy(o->Position, o->EyeLeft);
-                    CreateJoint(BITMAP_JOINT_ENERGY, o->Position, o->Position, o->Angle, 4, o, 30.f);
+                    CreateJointFpsChecked(BITMAP_JOINT_ENERGY, o->Position, o->Position, o->Angle, 4, o, 30.f);
                     break;
                 case WD_34CRYWOLF_1ST:
                     if (Hero->SafeZone != true)
@@ -1773,7 +1776,7 @@ void MoveFishs()
                         VectorCopy(o->Position, o->EyeLeft);
                         o->Gravity = 1;
                         o->LifeTime = 100;
-                        CreateJoint(BITMAP_SCOLPION_TAIL, o->Position, o->Position, o->Angle, 0, o, 30.f);
+                        CreateJointFpsChecked(BITMAP_SCOLPION_TAIL, o->Position, o->Position, o->Angle, 0, o, 30.f);
                     }
                     else
                         o->Live = false;
@@ -1816,7 +1819,7 @@ void MoveFishs()
                     o->Velocity = 2.5f / o->Scale;
                     o->Gravity = 9;
                     o->LifeTime = 70;
-                    CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 8, o, 50.f);
+                    CreateJointFpsChecked(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 8, o, 50.f);
                 }
             }
         }

--- a/Source Main 5.2/source/MonkSystem.cpp
+++ b/Source Main 5.2/source/MonkSystem.cpp
@@ -729,7 +729,7 @@ void CMonkSystem::DarksideRendering(CHARACTER* pCha, PART_t* pPart, bool Transla
         }
         if (m_bDarkSideEffOnce)
         {
-            CreateParticle(BITMAP_DAMAGE2, vPos, pObj->Angle, vLight, 0, 1.0f);
+            CreateParticleFpsChecked(BITMAP_DAMAGE2, vPos, pObj->Angle, vLight, 0, 1.0f);
             m_bDarkSideEffOnce = false;
         }
 
@@ -809,7 +809,7 @@ void CMonkSystem::DarksideRendering(CHARACTER* pCha, PART_t* pPart, bool Transla
                 if (DamageEff == 10 && (GetDarksideEffectTotal() > m_nDarksideEffectAttCnt))
                 {
                     Vector(1.0f, 1.0f, 1.0f, vLight);
-                    CreateParticle(BITMAP_DAMAGE2, vPos, pObj->Angle, vLight, 0, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_DAMAGE2, vPos, pObj->Angle, vLight, 0, 1.0f);
                 }
 
                 pObj->AnimationFrame = m_fDummyAniFrame;

--- a/Source Main 5.2/source/SummonSystem.cpp
+++ b/Source Main 5.2/source/SummonSystem.cpp
@@ -279,7 +279,7 @@ void CSummonSystem::CreateEquipEffect_WristRing(CHARACTER* pCharacter, int iItem
     {
         if (rand() % 4)
         {
-            CreateParticle(BITMAP_SPARK + 1, vPos, pObject->Angle, vLight, 23, 0.5f, pObject);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, pObject->Angle, vLight, 23, 0.5f, pObject);
         }
     }
 }

--- a/Source Main 5.2/source/ZzzCharacter.cpp
+++ b/Source Main 5.2/source/ZzzCharacter.cpp
@@ -1742,11 +1742,15 @@ void AttackEffect(CHARACTER* c)
         }
         break;
     case MONSTER_HYDRA:
-        if ((int)c->AttackTime % 5 == 1)
+    {
+        const int attackTime = (int)c->AttackTime;
+        if (attackTime % 5 == 1 && c->CheckAttackTime(attackTime))
         {
             b->TransformPosition(o->BoneTransform[63], p, Position, true);
             CreateEffect(BITMAP_BOSS_LASER + 1, Position, o->Angle, o->Light);
+            c->SetLastAttackEffectTime();
         }
+
         if ((c->Skill) == AT_SKILL_BOSS)
         {
             if (c->CheckAttackTime(1))
@@ -1766,6 +1770,7 @@ void AttackEffect(CHARACTER* c)
             }
         }
         break;
+    }
     case MONSTER_RED_DRAGON:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
@@ -2147,43 +2152,51 @@ void AttackEffect(CHARACTER* c)
                 }
                 break;
             case MONSTER_CURSED_WIZARD:
-
-                for (int i = 0; i < 4; i++)
+                if (rand_fps_check(1))
                 {
-                    int Hand = 0;
-                    if (i >= 2) Hand = 1;
-                    b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
-                    Vector(0.f, 0.f, (float)(rand() % 360), Angle);
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int Hand = 0;
+                        if (i >= 2) Hand = 1;
+                        b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
+                        Vector(0.f, 0.f, (float)(rand() % 360), Angle);
+                        CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 50.f);
+                        CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 10.f);
+                        CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
+                    }
+                }
+                break;
+            case MONSTER_LIZARD_KING://리자드킹
+                if (rand_fps_check(1))
+                {
+                    for (int i = 0; i < 6; i++)
+                    {
+                        int Hand = 0;
+                        if (i >= 3) Hand = 1;
+                        b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);//에러
+                        Vector(0.f, 0.f, (float)(rand() % 360), Angle);
+                        CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 50.f);
+                        CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
+                    }
+                }
+                break;
+            case MONSTER_POISON_SHADOW:
+                if (rand_fps_check(1))
+                {
+                    if (o->Type == MODEL_PLAYER)
+                    {
+                        Vector(0.f, 0.f, 0.f, p);
+                    }
+                    else
+                    {
+                        Vector(0.f, -130.f, 0.f, p);
+                    }
+                    b->TransformPosition(o->BoneTransform[c->Weapon[0].LinkBone], p, Position, true);
+                    Vector(-60.f, 0.f, o->Angle[2], Angle);
                     CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 50.f);
                     CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 10.f);
                     CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                 }
-                break;
-            case MONSTER_LIZARD_KING://리자드킹
-                for (int i = 0; i < 6; i++)
-                {
-                    int Hand = 0;
-                    if (i >= 3) Hand = 1;
-                    b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);//에러
-                    Vector(0.f, 0.f, (float)(rand() % 360), Angle);
-                    CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 50.f);
-                    CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
-                }
-                break;
-            case MONSTER_POISON_SHADOW:
-                if (o->Type == MODEL_PLAYER)
-                {
-                    Vector(0.f, 0.f, 0.f, p);
-                }
-                else
-                {
-                    Vector(0.f, -130.f, 0.f, p);
-                }
-                b->TransformPosition(o->BoneTransform[c->Weapon[0].LinkBone], p, Position, true);
-                Vector(-60.f, 0.f, o->Angle[2], Angle);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 50.f);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 10.f);
-                CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                 break;
             case MONSTER_ILLUSION_SORCERER_SPIRIT1_LIGHTNING:
             case MONSTER_ILLUSION_SORCERER_SPIRIT2_LIGHTNING:
@@ -2192,37 +2205,43 @@ void AttackEffect(CHARACTER* c)
             case MONSTER_ILLUSION_SORCERER_SPIRIT5_LIGHTNING:
             case MONSTER_ILLUSION_SORCERER_SPIRIT6_LIGHTNING:
             {
-                Vector(8.f, 0.f, 0.f, Light);
-                b->TransformPosition(o->BoneTransform[17], p, Position, true);
-                Vector(-60.f, 0.f, o->Angle[2], Angle);
-                //CreateJoint(BITMAP_JOINT_THUNDER,Position,to->Position,Angle,0,to,50.f);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 21, to, 50.f);
-                CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
+                if (rand_fps_check(1))
+                {
+                    Vector(8.f, 0.f, 0.f, Light);
+                    b->TransformPosition(o->BoneTransform[17], p, Position, true);
+                    Vector(-60.f, 0.f, o->Angle[2], Angle);
+                    //CreateJoint(BITMAP_JOINT_THUNDER,Position,to->Position,Angle,0,to,50.f);
+                    CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 21, to, 50.f);
+                    CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
 
-                b->TransformPosition(o->BoneTransform[41], p, Position, true);
-                Vector(-60.f, 0.f, o->Angle[2], Angle);
-                //CreateJoint(BITMAP_JOINT_THUNDER,Position,to->Position,Angle,0,to,50.f);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 21, to, 50.f);
-                CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
+                    b->TransformPosition(o->BoneTransform[41], p, Position, true);
+                    Vector(-60.f, 0.f, o->Angle[2], Angle);
+                    //CreateJoint(BITMAP_JOINT_THUNDER,Position,to->Position,Angle,0,to,50.f);
+                    CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 21, to, 50.f);
+                    CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
+                }
             }
             break;
             // 플레이어 이거나 기타 몬스터가 전기(번개)를 사용했을시
             default:
-                if (b->NumBones < c->Weapon[0].LinkBone) break;
+                if (rand_fps_check(1))
+                {
+                    if (b->NumBones < c->Weapon[0].LinkBone) break;
 
-                if (o->Type == MODEL_PLAYER)
-                {
-                    Vector(0.f, 0.f, 0.f, p);
+                    if (o->Type == MODEL_PLAYER)
+                    {
+                        Vector(0.f, 0.f, 0.f, p);
+                    }
+                    else
+                    {
+                        Vector(0.f, -130.f, 0.f, p);
+                    }
+                    b->TransformPosition(o->BoneTransform[c->Weapon[0].LinkBone], p, Position, true);
+                    Vector(-60.f, 0.f, o->Angle[2], Angle);
+                    CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 50.f);
+                    CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 10.f);
+                    CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                 }
-                else
-                {
-                    Vector(0.f, -130.f, 0.f, p);
-                }
-                b->TransformPosition(o->BoneTransform[c->Weapon[0].LinkBone], p, Position, true);
-                Vector(-60.f, 0.f, o->Angle[2], Angle);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 50.f);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 0, to, 10.f);
-                CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                 break;
             }
         }
@@ -2426,10 +2445,12 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
             break;
         }
 
-        if (8 == c->AttackTime)
+        if (c->CheckAttackTime(8))
         {
             if (SceneFlag != LOG_IN_SCENE)
                 PlayBuffer(SOUND_SKILL_SWORD2);
+
+            c->SetLastAttackEffectTime();
         }
 
         if (2 <= c->AttackTime && c->AttackTime <= 8 && rand_fps_check(1))
@@ -2447,7 +2468,8 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
                 CreateJoint(MODEL_SPEARSKILL, TempPos, TempPos, o->Angle, 2, o, 40.0f);
             }
         }
-        if ((int)c->AttackTime <= 8)
+
+        if (c->AttackTime <= 8 && rand_fps_check(1))
         {	// 기 모일 곳 위치
             vec3_t Position2 = { 0.0f, 0.0f, 0.0f };
             b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], Position2, o->m_vPosSword, true);
@@ -2456,6 +2478,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
             o->m_vPosSword[0] += fDistance * sinf(o->Angle[2] * Q_PI / 180.0f);
             o->m_vPosSword[1] += -fDistance * cosf(o->Angle[2] * Q_PI / 180.0f);
         }
+
         if (6 <= c->AttackTime && c->AttackTime <= 12)
         {	// 꼬깔 만들기
             if (rand_fps_check(2))
@@ -2490,7 +2513,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
                 }
             }
         }
-        if ((int)c->AttackTime >= 12)
+        if (c->AttackTime >= 12)
         {
             c->AttackTime = g_iLimitAttackTime;
         }
@@ -2585,14 +2608,15 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
         {
             SetAction(o, PLAYER_ATTACK_SKILL_WHEEL);
 
-            if ((int)c->AttackTime >= 1 && c->AttackTime <= 2)
+            if (c->CheckAttackTime(1) || c->CheckAttackTime(2))
             {
                 vec3_t Angle;
                 Vector(1.f, 0.f, 0.f, Angle);
                 CreateEffect(BITMAP_GATHERING, o->Position, o->Angle, o->Light, 1, o);
+                c->SetLastAttackEffectTime();
             }
 
-            if (o->AnimationFrame >= 3.f)
+            if (o->AnimationFrame >= 3.f && rand_fps_check(1))
             {
                 o->PKKey = getTargetCharacterKey(c, SelectedCharacter);
 
@@ -2621,7 +2645,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
     case AT_SKILL_POWER_SLASH_UP + 3:
     case AT_SKILL_POWER_SLASH_UP + 4:
     case AT_SKILL_ICE_BLADE:
-        if (o->Type == MODEL_PLAYER && o->CurrentAction == PLAYER_ATTACK_TWO_HAND_SWORD_TWO)
+        if (o->Type == MODEL_PLAYER && o->CurrentAction == PLAYER_ATTACK_TWO_HAND_SWORD_TWO && rand_fps_check(1))
         {
             vec3_t Angle;
 
@@ -2748,6 +2772,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
         {
             c->AttackTime = 15;
         }
+        if (rand_fps_check(1))
         {
             vec3_t Position;
             vec3_t	Angle;
@@ -2768,7 +2793,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
         }
         break;
     case    AT_SKILL_ONEFLASH:
-        if (o->AnimationFrame > 5.f)
+        if (o->AnimationFrame > 5.f && rand_fps_check(1))
         {
             CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 23, NULL, 40.f, 0);
             CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 23, NULL, 40.f, 1);
@@ -2777,7 +2802,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
 
             PlayBuffer(SOUND_BCS_ONE_FLASH);
         }
-        else if (o->AnimationFrame > 2.3f && o->AnimationFrame < 2.6f)
+        else if (o->AnimationFrame > 2.3f && o->AnimationFrame < 2.6f && rand_fps_check(1))
         {
             CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 23, NULL, 40.f, 2);
             CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 23, NULL, 40.f, 3);
@@ -2859,7 +2884,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
             int RightType = CharacterMachine->Equipment[EQUIPMENT_WEAPON_RIGHT].Type;
             int LeftType = CharacterMachine->Equipment[EQUIPMENT_WEAPON_LEFT].Type;
 
-            if ((int)c->AttackTime >= 1 && LeftType == ITEM_SYLPH_WIND_BOW && o->Type == MODEL_PLAYER)
+            if (c->AttackTime >= 1 && LeftType == ITEM_SYLPH_WIND_BOW && o->Type == MODEL_PLAYER && rand_fps_check(1))
             {
                 for (int i = 0; i < 20; i++)
                 {
@@ -3095,7 +3120,7 @@ void DeadCharacter(CHARACTER* c, OBJECT* o, BMD* b)
                 MoveParticle(o, o->HeadAngle);
             }
 
-            if (c->Dead <= 30 && c->m_byDieType == AT_SKILL_BLAST_HELL)
+            if (c->Dead <= 30 && c->m_byDieType == AT_SKILL_BLAST_HELL && rand_fps_check(1))
             {
                 vec3_t Light, p, Position;
                 Vector(0.3f, 0.3f, 1.f, Light);
@@ -3109,7 +3134,7 @@ void DeadCharacter(CHARACTER* c, OBJECT* o, BMD* b)
             break;
         }
     }
-    if (SceneFlag == MAIN_SCENE && (gMapManager.WorldActive == WD_7ATLANSE || gMapManager.WorldActive == WD_67DOPPLEGANGER3))
+    if (SceneFlag == MAIN_SCENE && (gMapManager.WorldActive == WD_7ATLANSE || gMapManager.WorldActive == WD_67DOPPLEGANGER3) && rand_fps_check(1))
     {
         for (int i = 0; i < 4; i++)
         {
@@ -3914,8 +3939,9 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
     }
 
     if ((o->CurrentAction == PLAYER_ATTACK_TELEPORT || o->CurrentAction == PLAYER_ATTACK_RIDE_TELEPORT
-        || o->CurrentAction == PLAYER_FENRIR_ATTACK_DARKLORD_TELEPORT
-        ) && o->AnimationFrame > 5.5f)
+        || o->CurrentAction == PLAYER_FENRIR_ATTACK_DARKLORD_TELEPORT)
+        && o->AnimationFrame > 5.5f
+        && rand_fps_check(1))
     {
         Vector(0.f, 0.f, 0.f, p);
         Vector(0.3f, 0.5f, 1.f, Light);
@@ -5185,7 +5211,7 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
     {
         c->m_iDeleteTime -= FPS_ANIMATION_FACTOR;
     }
-    if (c->m_iDeleteTime != -128 && c->m_iDeleteTime <= 0)
+    if (static_cast<int>(c->m_iDeleteTime) != -128 && c->m_iDeleteTime <= 0)
     {
         c->m_iDeleteTime = -128;
         DeleteCharacter(c, o);
@@ -5425,7 +5451,10 @@ void MonsterDieSandSmoke(OBJECT* o)
             Vector(o->Position[0] + (float)(rand() % 64 - 32),
                 o->Position[1] + (float)(rand() % 64 - 32),
                 o->Position[2] + (float)(rand() % 32 - 16), Position);
-            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light, 1);
+            if (rand_fps_check(1))
+            {
+                CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light, 1);
+            }
         }
     }
 }
@@ -5436,7 +5465,10 @@ void MonsterMoveSandSmoke(OBJECT* o)
     {
         vec3_t Position;
         Vector(o->Position[0] + rand() % 200 - 100, o->Position[1] + rand() % 200 - 100, o->Position[2], Position);
-        CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
+        if (rand_fps_check(1))
+        {
+            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
+        }
     }
 }
 
@@ -5555,7 +5587,10 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
         switch (o->Type)
         {
         case MODEL_PLAYER:
-            if (SceneFlag == MAIN_SCENE && (gMapManager.WorldActive == WD_7ATLANSE || gMapManager.WorldActive == WD_67DOPPLEGANGER3) && (int)WorldTime % 10000 < 1000)
+            if (SceneFlag == MAIN_SCENE
+                && (gMapManager.WorldActive == WD_7ATLANSE || gMapManager.WorldActive == WD_67DOPPLEGANGER3)
+                && (int)WorldTime % 10000 < 1000
+                && rand_fps_check(1))
             {
                 Vector(0.f, 20.f, -10.f, p);
                 b->TransformPosition(o->BoneTransform[b->BoneHead], p, Position, true);
@@ -5576,7 +5611,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                     CreateParticle(BITMAP_RAIN_CIRCLE + 1, Position, o->Angle, Light);
                 }
             }
-            if (o->CurrentAction == PLAYER_SKILL_HELL_BEGIN || o->CurrentAction == PLAYER_SKILL_HELL_START)
+            if (o->CurrentAction == PLAYER_SKILL_HELL_BEGIN || o->CurrentAction == PLAYER_SKILL_HELL_START && rand_fps_check(1))
             {
                 if (o->BoneTransform != NULL)
                 {
@@ -5599,7 +5634,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                 CreateForce(o, Position);
             }
 
-            if (o->CurrentAction == PLAYER_SKILL_HELL)
+            if (o->CurrentAction == PLAYER_SKILL_HELL && rand_fps_check(1))
             {
                 for (int i = 0; i < 10; i++)
                 {
@@ -5722,13 +5757,19 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                     end = wingLeft[i][1];
 
                     dist[0] = MoveHumming(vec[end], angle, vec[start], 360.0f);
-                    CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, scale);
+                    if (rand_fps_check(1))
+                    {
+                        CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, scale);
+                    }
 
                     start = wingRight[i][0];
                     end = wingRight[i][1];
 
                     dist[0] = MoveHumming(vec[end], angle, vec[start], 360.0f);
-                    CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, scale);
+                    if (rand_fps_check(1))
+                    {
+                        CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, scale);
+                    }
                 }
 
                 for (int i = 0; i < 4; ++i)
@@ -5737,13 +5778,19 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                     end = arm_leg_Left[i][1];
 
                     dist[0] = MoveHumming(vec[end], angle, vec[start], 360.0f);
-                    CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, 0.6f);
+                    if (rand_fps_check(1))
+                    {
+                        CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, 0.6f);
+                    }
 
                     start = arm_leg_Right[i][0];
                     end = arm_leg_Right[i][1];
 
                     dist[0] = MoveHumming(vec[end], angle, vec[start], 360.0f);
-                    CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, 0.6f);
+                    if (rand_fps_check(1))
+                    {
+                        CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, 0.6f);
+                    }
                 }
 
                 if ((int)WorldTime % 2 == 0)
@@ -5752,9 +5799,11 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                     end = body[1];
 
                     dist[0] = MoveHumming(vec[end], angle, vec[start], 360.0f);
-                    CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, 1.3f);
-
-                    CreateParticle(BITMAP_FLAME, vec[head], angle, dist, 3, 0.5f);
+                    if (rand_fps_check(1))
+                    {
+                        CreateParticle(BITMAP_FLAME, vec[start], angle, dist, 2, 1.3f);
+                        CreateParticle(BITMAP_FLAME, vec[head], angle, dist, 3, 0.5f);
+                    }
                 }
 
                 Vector(-1.3f, -1.3f, -1.3f, Light);
@@ -5772,12 +5821,18 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                 b->TransformPosition(o->BoneTransform[55], p, pos, true);
                 b->TransformPosition(o->BoneTransform[62], p, Position, true);
                 MoveHumming(pos, angle, Position, 360.0f);
-                CreateParticle(BITMAP_FLAME, Position, angle, Light, 1, 0.2f);
+                if (rand_fps_check(1))
+                {
+                    CreateParticle(BITMAP_FLAME, Position, angle, Light, 1, 0.2f);
+                }
 
                 b->TransformPosition(o->BoneTransform[70], p, pos, true);
                 b->TransformPosition(o->BoneTransform[77], p, Position, true);
                 MoveHumming(pos, angle, Position, 360.0f);
-                CreateParticle(BITMAP_FLAME, Position, angle, Light, 1, 0.2f);
+                if (rand_fps_check(1))
+                {
+                    CreateParticle(BITMAP_FLAME, Position, angle, Light, 1, 0.2f);
+                }
 
                 MonsterMoveSandSmoke(o);
                 MonsterDieSandSmoke(o);
@@ -5792,10 +5847,14 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
             MoveEye(o, b, 24, 25);
             if (o->SubType == 1)
             {
-                b->TransformPosition(o->BoneTransform[6], p, Position, true);
-                CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
-                b->TransformPosition(o->BoneTransform[13], p, Position, true);
-                CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
+                if (rand_fps_check(1))
+                {
+                    b->TransformPosition(o->BoneTransform[6], p, Position, true);
+                    CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
+                    b->TransformPosition(o->BoneTransform[13], p, Position, true);
+                    CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
+                }
+
                 Vector(-1.3f, -1.3f, -1.3f, Light);
                 AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
             }
@@ -5846,35 +5905,35 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
         case MODEL_BALI:
             Vector(0.f, 0.f, 0.f, p);
             Vector(0.6f, 1.f, 0.8f, Light);
-            if (o->CurrentAction == MONSTER01_ATTACK1)
+            if (o->CurrentAction == MONSTER01_ATTACK1 && rand_fps_check(1))
             {
                 b->TransformPosition(o->BoneTransform[33], p, Position, true);
                 CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                 Vector(1.f, 0.6f, 1.f, Light);
                 CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
             }
-            if (o->CurrentAction == MONSTER01_ATTACK2)
+            if (o->CurrentAction == MONSTER01_ATTACK2 && rand_fps_check(1))
             {
                 b->TransformPosition(o->BoneTransform[20], p, Position, true);
                 CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                 Vector(1.f, 0.6f, 1.f, Light);
                 CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
             }
-            if (o->CurrentAction == MONSTER01_ATTACK3)
+            if (o->CurrentAction == MONSTER01_ATTACK3 && rand_fps_check(1))
             {
                 b->TransformPosition(o->BoneTransform[41], p, Position, true);
                 CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                 Vector(1.f, 0.6f, 1.f, Light);
                 CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
             }
-            if (o->CurrentAction == MONSTER01_ATTACK4)
+            if (o->CurrentAction == MONSTER01_ATTACK4 && rand_fps_check(1))
             {
                 b->TransformPosition(o->BoneTransform[49], p, Position, true);
                 CreateParticle(BITMAP_ENERGY, Position, o->Angle, Light);
                 Vector(1.f, 0.6f, 1.f, Light);
                 CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
             }
-            if (o->CurrentAction == MONSTER01_DIE && o->AnimationFrame < 12.f)
+            if (o->CurrentAction == MONSTER01_DIE && o->AnimationFrame < 12.f && rand_fps_check(1))
             {
                 Vector(0.1f, 0.8f, 0.6f, Light);
 
@@ -5889,11 +5948,15 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
             o->BlendMeshLight = (float)(rand() % 10) * 0.1f;
             if (c->Level == 2)
             {
-                for (int i = 0; i < 10; i++)
+                if (rand_fps_check(1))
                 {
-                    b->TransformPosition(o->BoneTransform[rand() % b->NumBones], p, Position, true);
-                    CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
+                    for (int i = 0; i < 10; i++)
+                    {
+                        b->TransformPosition(o->BoneTransform[rand() % b->NumBones], p, Position, true);
+                        CreateParticle(BITMAP_FIRE, Position, o->Angle, Light);
+                    }
                 }
+
                 Vector(Luminosity * 1.f, Luminosity * 0.2f, Luminosity * 0.f, Light);
                 AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
             }
@@ -5920,7 +5983,7 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
             AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
             Vector(1.f, 1.f, 1.f, Light);
             Vector(0.f, 0.f, 0.f, p);
-            if (o->CurrentAction == 0 && o->AnimationFrame >= 5.f && o->AnimationFrame <= 6.f)
+            if (o->CurrentAction == 0 && o->AnimationFrame >= 5.f && o->AnimationFrame <= 6.f && rand_fps_check(1))
             {
                 b->TransformPosition(o->BoneTransform[17], p, Position, true);
                 vec3_t Angle;
@@ -5943,24 +6006,24 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
                 vec3_t Angle;
                 for (int i = 0; i < 4; i++)
                 {
-                    Vector((float)(rand() % 60 + 60 + 30), 0.f, (float)(rand() % 30), Angle);
-                    CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
-                    if (rand() % 2)
-                        CreateParticle(BITMAP_SPARK, Position, Angle, Light);
+                    if (rand_fps_check(1))
+                    {
+                        Vector((float)(rand() % 60 + 60 + 30), 0.f, (float)(rand() % 30), Angle);
+                        CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
+                        if (rand() % 2)
+                            CreateParticle(BITMAP_SPARK, Position, Angle, Light);
+                    }
                 }
             }
             break;
         case MODEL_WEDDING_NPC:
-            if (o->CurrentAction == 1)
+            if (o->CurrentAction == 1 && (o->AnimationFrame > 4.5f && o->AnimationFrame <= 4.8f && rand_fps_check(1)))
             {
-                if (o->AnimationFrame > 4.5f && o->AnimationFrame <= 4.8f)
-                {
-                    CreateEffect(BITMAP_FIRECRACKER0001, o->Position, o->Angle, o->Light, 0);
-                }
+                CreateEffect(BITMAP_FIRECRACKER0001, o->Position, o->Angle, o->Light, 0);
             }
             break;
         case MODEL_BUDGE_DRAGON:
-            if (o->CurrentAction == MONSTER01_ATTACK1 && o->AnimationFrame <= 4.f)
+            if (o->CurrentAction == MONSTER01_ATTACK1 && o->AnimationFrame <= 4.f && rand_fps_check(1))
             {
                 vec3_t Light;
                 Vector(1.f, 1.f, 1.f, Light);
@@ -6078,8 +6141,10 @@ void MoveCharacterVisual(CHARACTER* c, OBJECT* o)
         if ((o->CurrentAction == PLAYER_RUN_RIDE
             || o->CurrentAction == PLAYER_RAGE_UNI_RUN
             || o->CurrentAction == PLAYER_RAGE_UNI_RUN_ONE_RIGHT
-            || o->CurrentAction == PLAYER_RUN_RIDE_WEAPON || o->CurrentAction == PLAYER_RUN_SWIM || o->CurrentAction == PLAYER_WALK_SWIM || o->CurrentAction == PLAYER_FLY || o->CurrentAction == PLAYER_FLY_CROSSBOW || o->CurrentAction == PLAYER_RUN_RIDE_HORSE) &&
-            o->Type == MODEL_PLAYER && gMapManager.InHellas())
+            || o->CurrentAction == PLAYER_RUN_RIDE_WEAPON || o->CurrentAction == PLAYER_RUN_SWIM || o->CurrentAction == PLAYER_WALK_SWIM || o->CurrentAction == PLAYER_FLY || o->CurrentAction == PLAYER_FLY_CROSSBOW || o->CurrentAction == PLAYER_RUN_RIDE_HORSE)
+            && o->Type == MODEL_PLAYER
+            && gMapManager.InHellas()
+            && rand_fps_check(1))
         {
             vec3_t Light = { 0.3f, 0.3f, 0.3f };
             VectorCopy(o->Position, Position);
@@ -6820,7 +6885,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
     {
         Vector(0.8f, 0.8f, 0.2f, Light);
         Vector(0.f, 0.f, 0.f, p);
-        if (rand() % 2 == 1)
+        if (rand_fps_check(2))
         {
             b->TransformPosition(BoneTransform[4], p, Position, true);
             CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 11, 0.8f);
@@ -6925,7 +6990,11 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         CreateSprite(BITMAP_SPARK + 1, Position, fRendomScale, Light, o);
 
         VectorCopy(Position, o->EyeLeft);
-        CreateJoint(BITMAP_JOINT_ENERGY, Position, Position, o->Angle, 17, o, 30.f);
+
+        if (rand_fps_check(1))
+        {
+            CreateJoint(BITMAP_JOINT_ENERGY, Position, Position, o->Angle, 17, o, 30.f);
+        }
 
         fRendomPos = (float)(rand() % 60) / 20.0f - 1.5f;
         fRendomScale = (float)(rand() % 15) / 20.0f + 1.0f;
@@ -6934,7 +7003,10 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         CreateSprite(BITMAP_LIGHT, Position, fRendomScale, Light, o);
         CreateSprite(BITMAP_SHINY + 1, Position, fRendomScale, Light, o);
         CreateSprite(BITMAP_SHINY + 1, Position, fRendomScale - 0.3f, Light, o, 90.0f);
-        CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 11, 2.0f);
+        if (rand_fps_check(1))
+        {
+            CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 11, 2.0f);
+        }
 
         float fLight = (float)sinf((WorldTime) * 0.7f) * 0.2f + 0.5f;
         float fRotation = (WorldTime * 0.0006f) * 360.0f;
@@ -7096,7 +7168,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
 
         Vector(0.f, 0.f, 0.f, p);
         Vector(0.3f, 0.9f, 0.2f, Light);
-        if (rand() % 2 == 1)
+        if (rand_fps_check(2))
         {
             b->TransformPosition(BoneTransform[10], p, Position, true);
             CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 14, 0.05f);
@@ -7518,10 +7590,11 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
 
         for (int i = 1; i <= 7; i++)
         {
-            if (rand() % 4 != 0)
+            if (!rand_fps_check(4))
             {
                 continue;
             }
+
             Vector(0.f, 0.f, 0.f, Position);
             b->TransformByObjectBone(Position, Object, i);
             CreateParticle(BITMAP_WATERFALL_4, Position, Object->Angle, Light, 12, 0.5f, Object);
@@ -7540,8 +7613,11 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         vec3_t vColor;
         VectorCopy(p, o->EyeLeft);
         Vector(0.f, 0.f, 0.9f, vColor);
-        CreateJoint(BITMAP_JOINT_ENERGY, p, p, o->Angle, 17, o, 25.f);
-        //CreateEffect(MODEL_EFFECT_TRACE, p, o->Angle, vColor, 0, NULL, -1, 0, 0, 0, 25.f);
+        if (rand_fps_check(1))
+        {
+            CreateJoint(BITMAP_JOINT_ENERGY, p, p, o->Angle, 17, o, 25.f);
+            //CreateEffect(MODEL_EFFECT_TRACE, p, o->Angle, vColor, 0, NULL, -1, 0, 0, 0, 25.f);
+        }
 
         b->TransformPosition(BoneTransform[9], Position, p, true);		// Zx02
         CreateSprite(BITMAP_FLARE_BLUE, p, 0.4f, o->Light, o);
@@ -7600,7 +7676,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         CreateSprite(BITMAP_PIN_LIGHT, Position, 0.7f, Light, o, -((int)(WorldTime * 0.03f) % 360));
         CreateSprite(BITMAP_PIN_LIGHT, Position, 0.9f, Light, o, ((int)(WorldTime * 0.02f) % 360));
 
-        if (rand() % 3 != 0)
+        if (rand_fps_check(3))
         {
             float fTemp = Position[2];
             Position[2] -= 15.f;
@@ -7715,7 +7791,7 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
             CreateSprite(BITMAP_LIGHT, Position, 0.8f, Light, Object);
         }
 
-        if (o->AnimationFrame >= 4.5f && o->AnimationFrame <= 5.0f)
+        if (o->AnimationFrame >= 4.5f && o->AnimationFrame <= 5.0f && rand_fps_check(1))
         {
             for (int i = 0; i < iNumCreateFeather; i++)
             {
@@ -7758,7 +7834,10 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         vec3_t vColor;
         VectorCopy(p, o->EyeRight);
         Vector(0.9f, 0.f, 0.f, vColor);
-        CreateJoint(BITMAP_JOINT_ENERGY, p, p, o->Angle, 47, o, 25.f);
+        if (rand_fps_check(1))
+        {
+            CreateJoint(BITMAP_JOINT_ENERGY, p, p, o->Angle, 47, o, 25.f);
+        }
     }break;
     case MODEL_IMPERIAL_STAFF:
     {
@@ -7781,14 +7860,18 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         float fRendomScale = (float)(rand() % 15) / 20.0f + 1.0f;
         CreateSprite(BITMAP_SHINY + 1, p, fRendomScale, Light, o);
         CreateSprite(BITMAP_SHINY + 1, p, fRendomScale - 0.3f, Light, o, 90.0f);
-        CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 11, 2.0f);
+        if (rand_fps_check(1))
+        {
+            CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 11, 2.0f);
+            CreateJoint(BITMAP_JOINT_ENERGY, p, p, o->Angle, 17, o, 30.f);
+            //vec3_t vColor;
+            //Vector(0.f, 0.f, 0.9f, vColor);
+            //CreateEffect(MODEL_EFFECT_TRACE, p, o->Angle, vColor, 0, NULL, -1, 0, 0, 0, 30.f);
+        }
 
         // 잔상
-        vec3_t vColor;
+        
         VectorCopy(p, o->EyeLeft);
-        Vector(0.f, 0.f, 0.9f, vColor);
-        CreateJoint(BITMAP_JOINT_ENERGY, p, p, o->Angle, 17, o, 30.f);
-        //CreateEffect(MODEL_EFFECT_TRACE, p, o->Angle, vColor, 0, NULL, -1, 0, 0, 0, 30.f);
 
         Vector(0.7f, 0.7f, 0.7f, Light);
         CreateSprite(BITMAP_SHINY + 2, p, 2.f, Light, o);
@@ -7871,18 +7954,21 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         b->TransformByObjectBone(Position, Object, 1);		// Zx01
         CreateSprite(BITMAP_LIGHT, Position, 2.0f, Light, o);
 
-        Vector(1.f, 1.f, 1.f, Light);
-        switch (rand() % 3)
+        if (rand_fps_check(1))
         {
-        case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, Position, Object->Angle, Light, 0, 0.7f);
-            break;
-        case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, Position, Object->Angle, Light, 4, 0.7f);
-            break;
-        case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, Position, Object->Angle, Light, 0, 0.7);
-            break;
+            Vector(1.f, 1.f, 1.f, Light);
+            switch (rand() % 3)
+            {
+            case 0:
+                CreateParticle(BITMAP_FIRE_HIK1, Position, Object->Angle, Light, 0, 0.7f);
+                break;
+            case 1:
+                CreateParticle(BITMAP_FIRE_CURSEDLICH, Position, Object->Angle, Light, 4, 0.7f);
+                break;
+            case 2:
+                CreateParticle(BITMAP_FIRE_HIK3, Position, Object->Angle, Light, 0, 0.7);
+                break;
+            }
         }
     }break;
     case MODEL_GUARDIAN_SHILED:
@@ -7950,7 +8036,11 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         vLight[1] = 0.1f * absf(sinf(WorldTime * 0.0008f));
         vLight[2] = 0.1f + 0.4f * absf(sinf(WorldTime * 0.0008f));
         CreateSprite(BITMAP_MAGIC, vPos, 0.3f, vLight, Object);
-        CreateEffect(MODEL_MOONHARVEST_MOON, vPos, o->Angle, vLight, 2, NULL, -1, 0, 0, 0, 0.12f);
+        if (rand_fps_check(1))
+        {
+            CreateEffect(MODEL_MOONHARVEST_MOON, vPos, o->Angle, vLight, 2, NULL, -1, 0, 0, 0, 0.12f);
+        }
+
         Vector(0.8f, 0.8f, 0.2f, vLight);
         CreateSprite(BITMAP_SHINY + 1, vPos, 1.0f, vLight, Object);
 
@@ -8467,21 +8557,23 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                 CreateSprite(BITMAP_LIGHTMARKS, v3EffectPosition, 2.5f, v3EffectLightColor, o);
 
                 Vector(1.0f, 0.8f, 0.1f, v3EffectLightColor);
+                if (rand_fps_check(1))
+                {
+                    b->TransformPosition(o->BoneTransform[57], p, v3EffectPosition, true);
+                    CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
 
-                b->TransformPosition(o->BoneTransform[57], p, v3EffectPosition, true);
-                CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
+                    b->TransformPosition(o->BoneTransform[60], p, v3EffectPosition, true);
+                    CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
 
-                b->TransformPosition(o->BoneTransform[60], p, v3EffectPosition, true);
-                CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
+                    b->TransformPosition(o->BoneTransform[66], p, v3EffectPosition, true);
+                    CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
 
-                b->TransformPosition(o->BoneTransform[66], p, v3EffectPosition, true);
-                CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
+                    b->TransformPosition(o->BoneTransform[78], p, v3EffectPosition, true);
+                    CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
 
-                b->TransformPosition(o->BoneTransform[78], p, v3EffectPosition, true);
-                CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
-
-                b->TransformPosition(o->BoneTransform[91], p, v3EffectPosition, true);
-                CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
+                    b->TransformPosition(o->BoneTransform[91], p, v3EffectPosition, true);
+                    CreateEffect(MODEL_EFFECT_FIRE_HIK3_MONO, v3EffectPosition, o->Angle, v3EffectLightColor, 1, NULL, -1, 0, 0, 0, fEffectScale);
+                }
             }
             RenderPartObjectBodyColor(&Models[o->Type], o, o->Type, o->Alpha, RENDER_METAL | RENDER_BRIGHT, Bright);
         }
@@ -8513,11 +8605,14 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
 
         Vector(Luminosity * 0.6f, Luminosity * 0.7f, Luminosity * 0.8f, Light);
 
-        for (int i = 0; i < 3; i++)
+        if (rand_fps_check(1))
         {
-            Vector((float)(rand() % 20 - 10), (float)(rand() % 20 - 10), (float)(rand() % 20 - 10), p);
-            b->TransformPosition(o->BoneTransform[rand() % b->NumBones], p, Position, true);
-            CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 3);
+            for (int i = 0; i < 3; i++)
+            {
+                Vector((float)(rand() % 20 - 10), (float)(rand() % 20 - 10), (float)(rand() % 20 - 10), p);
+                b->TransformPosition(o->BoneTransform[rand() % b->NumBones], p, Position, true);
+                CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 3);
+            }
         }
     }
     else if (c->MonsterIndex == MONSTER_QUEEN_RAINER)
@@ -8559,7 +8654,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                 CreateSprite(BITMAP_LIGHT, Position, 0.8f, Light, o);
 
                 VectorCopy(Position, pos2);
-                if (i >= 14 && i <= 16 || i == 23)
+                if ((i >= 14 && i <= 16 || i == 23) && rand_fps_check(1))
                 {
                     CreateJoint(BITMAP_JOINT_THUNDER, pos1, pos2, o->Angle, 7, NULL, 20.f);
                 }
@@ -8575,11 +8670,14 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
         case MONSTER_GREAT_DRAKAN:
             Vector(1.f, 1.f, 1.0f, Light);
 
-            for (int i = 18; i < 19; ++i)
+            if (rand_fps_check(1))
             {
-                Vector(0.f, 0.f, 0.f, p);
-                b->TransformPosition(o->BoneTransform[i], p, Position, true);
-                CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, 0, 0.3f);
+                for (int i = 18; i < 19; ++i)
+                {
+                    Vector(0.f, 0.f, 0.f, p);
+                    b->TransformPosition(o->BoneTransform[i], p, Position, true);
+                    CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, 0, 0.3f);
+                }
             }
             break;
         }
@@ -8690,19 +8788,19 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
         if (o->CurrentAction == MONSTER01_WALK)
         {
             o->m_iAnimation++;
-            if (o->m_iAnimation % 20 == 0)
+            if (rand_fps_check(20))
                 PlayBuffer(SOUND_MOONRABBIT_WALK);
         }
 
         if (o->CurrentAction == MONSTER01_SHOCK)
         {
-            if (o->AnimationFrame > 2.f && o->AnimationFrame <= 3.f)
+            if (o->AnimationFrame > 2.f && o->AnimationFrame <= 3.f && rand_fps_check(1))
                 PlayBuffer(SOUND_MOONRABBIT_DAMAGE);
         }
 
         if (o->CurrentAction == MONSTER01_DIE)
         {
-            if (o->AnimationFrame > 1.f && o->AnimationFrame <= 2.f)
+            if (o->AnimationFrame > 1.f && o->AnimationFrame <= 2.f && rand_fps_check(1))
                 PlayBuffer(SOUND_MOONRABBIT_DEAD);
 
             if (o->AnimationFrame > 9.f)
@@ -8816,8 +8914,11 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
         b->TransformPosition(BoneTransform[43], vRelativePos, vtaWorldPos, false);
         vtaWorldPos[2] += 20.f;
 
-        CreateParticle(BITMAP_SPARK + 1, vtaWorldPos, o->Angle, rand_fps_check(3) ? vLight2 : vLight1, 25, Scale + 0.2f);
-        CreateParticle(BITMAP_SPARK + 1, vtaWorldPos, o->Angle, rand_fps_check(2) ? vLight2 : vLight1, 25, Scale + 0.3f);
+        if (rand_fps_check(1))
+        {
+            CreateParticle(BITMAP_SPARK + 1, vtaWorldPos, o->Angle, rand_fps_check(3) ? vLight2 : vLight1, 25, Scale + 0.2f);
+            CreateParticle(BITMAP_SPARK + 1, vtaWorldPos, o->Angle, rand_fps_check(2) ? vLight2 : vLight1, 25, Scale + 0.3f);
+        }
 
         Vector(0.7f, 0.5f, 0.2f, vLight);
         CreateSprite(BITMAP_LIGHT, vtaWorldPos, 2.f, vLight, o, 0.f);
@@ -8837,7 +8938,8 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
 
             CreateSprite(BITMAP_LIGHT, vtaWorldPos, 1.5f, vLight, o, 0.f);
 
-            if (rand_fps_check(3)) {
+            if (rand_fps_check(3))
+            {
                 auto randpos = (float)(rand() % 30 + 5);
 
                 if (rand_fps_check(2)) {
@@ -9001,7 +9103,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                 //Vector(0.5f, 0.5f, 0.5f, vLight);
 
                 int iNumBones = Models[o->Type].NumBones;
-                //for (int i = 0; i < 10; ++i)
+                if (rand_fps_check(1))
                 {
                     Models[o->Type].TransformByObjectBone(vPos, o, rand() % iNumBones);
                     CreateParticle(BITMAP_TWINTAIL_WATER, vPos, o->Angle, c->Light, 2, 0.5f);
@@ -10012,7 +10114,10 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         {
                             Vector((float)(rand() % 20 - 10), (float)(rand() % 20 - 10 - 90.f), (float)(rand() % 20 - 10), Position);
                             Models[o->Type].TransformPosition(o->BoneTransform[w->LinkBone], Position, p, true);
-                            CreateParticle(BITMAP_SPARK, p, o->Angle, Light, 1);
+                            if (rand_fps_check(1))
+                            {
+                                CreateParticle(BITMAP_SPARK, p, o->Angle, Light, 1);
+                            }
                         }
                         Vector(Luminosity * 1.f, Luminosity * 0.2f, Luminosity * 0.1f, Light);
 
@@ -10088,11 +10193,12 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                         Vector(1.0f, 0.4f, 0.3f, Light);
                         RenderBrightEffect(b, BITMAP_SHINY + 1, 2, 1.0f, Light, o);
                         Vector(1.0f, 0.2f, 0.0f, Light);
-#ifndef	ASG_ADD_ETERNALWING_STICK_EFFECT
-                        CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 16, 1.0f);
-#endif	// ASG_ADD_ETERNALWING_STICK_EFFECT
+                        if (rand_fps_check(1))
+                        {
+                            CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 16, 1.0f);
+                            CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 23, 1.0f);
+                        }
 
-                        CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 23, 1.0f);
 #ifdef ASG_ADD_ETERNALWING_STICK_EFFECT
                         if (rand_fps_check(20))
                             CreateParticle(BITMAP_SPARK + 1, p, o->Angle, Light, 20, 1.0f);
@@ -10410,20 +10516,22 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
             {
                 Vector(0.25f, 1.f, 0.7f, vLight);
             }
-
-            if (iSkillType == AT_SKILL_ALICE_SLEEP || iSkillType == AT_SKILL_ALICE_THORNS
-                || (AT_SKILL_ALICE_SLEEP_UP <= iSkillType && iSkillType <= AT_SKILL_ALICE_SLEEP_UP + 4)
-                || iSkillType == AT_SKILL_ALICE_BERSERKER
-                || iSkillType == AT_SKILL_ALICE_WEAKNESS || iSkillType == AT_SKILL_ALICE_ENERVATION
-                )
+            if (rand_fps_check(1))
             {
-                CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, vLight, 0, 1.0f);
-                CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, vLight, 3, 0.5f);
-            }
-            else if (iSkillType == AT_SKILL_ALICE_BLIND)
-            {
-                CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, vLight, 4, 1.0f);
-                CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, vLight, 5, 0.5f);
+                if (iSkillType == AT_SKILL_ALICE_SLEEP || iSkillType == AT_SKILL_ALICE_THORNS
+                    || (AT_SKILL_ALICE_SLEEP_UP <= iSkillType && iSkillType <= AT_SKILL_ALICE_SLEEP_UP + 4)
+                    || iSkillType == AT_SKILL_ALICE_BERSERKER
+                    || iSkillType == AT_SKILL_ALICE_WEAKNESS || iSkillType == AT_SKILL_ALICE_ENERVATION
+                    )
+                {
+                    CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, vLight, 0, 1.0f);
+                    CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, vLight, 3, 0.5f);
+                }
+                else if (iSkillType == AT_SKILL_ALICE_BLIND)
+                {
+                    CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, vLight, 4, 1.0f);
+                    CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, vLight, 5, 0.5f);
+                }
             }
         }
         // ChainLighting
@@ -10434,13 +10542,22 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
             Vector(0.4f, 0.4f, 0.8f, vLight);
 
             b->TransformPosition(o->BoneTransform[37], vRelativePos, vWorldPos, true);	// "Bip01 L Hand"
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, vLight, 2, o);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, vLight, 2, o);
+
+            if (rand_fps_check(1))
+            {
+                CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, vLight, 2, o);
+                CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, vLight, 2, o);
+            }
+
             CreateSprite(BITMAP_LIGHT, vWorldPos, 1.5f, vLight, o, 0.f);
 
             b->TransformPosition(o->BoneTransform[28], vRelativePos, vWorldPos, true);	// "Bip01 R Hand"
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, vLight, 2, o);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, vLight, 2, o);
+            if (rand_fps_check(1))
+            {
+                CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, vLight, 2, o);
+                CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, vLight, 2, o);
+            }
+
             CreateSprite(BITMAP_LIGHT, vWorldPos, 1.5f, vLight, o, 0.f);
         }
 

--- a/Source Main 5.2/source/ZzzCharacter.cpp
+++ b/Source Main 5.2/source/ZzzCharacter.cpp
@@ -1498,9 +1498,10 @@ void AttackEffect(CHARACTER* c)
         {
             if (rand_fps_check(2))
             {
-                if ((int)c->AttackTime == 1)
+                if (c->CheckAttackTime(1))
                 {
                     CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light, 1);
+                    c->SetLastAttackEffectTime();
                 }
             }
             else
@@ -1517,7 +1518,7 @@ void AttackEffect(CHARACTER* c)
     case MONSTER_ALQUAMOS:
         break;
     case MONSTER_QUEEN_RAINER:
-        if ((int)c->AttackTime == 5)
+        if (c->CheckAttackTime(5))
         {
             if (c->TargetCharacter != -1)
             {
@@ -1528,6 +1529,8 @@ void AttackEffect(CHARACTER* c)
                     CreateEffect(BITMAP_BLIZZARD, to->Position, to->Angle, Light);
                 }
             }
+
+            c->SetLastAttackEffectTime();
         }
         break;
     case MONSTER_OMEGA_WING:
@@ -1535,17 +1538,18 @@ void AttackEffect(CHARACTER* c)
     case MONSTER_ALPHA_CRUST:
         if (c->Object.CurrentAction == MONSTER01_ATTACK1 || c->Object.CurrentAction == MONSTER01_ATTACK2)
         {
-            if ((int)c->AttackTime == 5)
+            if (c->CheckAttackTime(5))
             {
                 CreateInferno(o->Position);
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light);
+                c->SetLastAttackEffectTime();
             }
         }
         break;
     case MONSTER_PHANTOM_KNIGHT:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if ((int)c->AttackTime == 14)
+            if (c->CheckAttackTime(14))
             {
                 vec3_t Angle = { 0.0f, 0.0f, 0.0f };
                 int iCount = 36;
@@ -1561,6 +1565,8 @@ void AttackEffect(CHARACTER* c)
                     Position[2] += 100.f;
                     CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 1, NULL, 60.f, 0, 0);
                 }
+
+                c->SetLastAttackEffectTime();
             }
         }
         break;
@@ -1568,7 +1574,7 @@ void AttackEffect(CHARACTER* c)
     case MONSTER_GREAT_DRAKAN:
         if (c->Object.CurrentAction == MONSTER01_ATTACK1)
         {
-            if ((int)c->AttackTime == 11)
+            if (c->CheckAttackTime(11))
             {
                 CreateInferno(o->Position);
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light);
@@ -1585,11 +1591,13 @@ void AttackEffect(CHARACTER* c)
                     VectorCopy(Position, o->StartPosition);
                     CreateEffect(MODEL_PIERCING + 1, Position, Angle, Light, 1, o);
                 }
+
+                c->SetLastAttackEffectTime();
             }
         }
         else
         {
-            if ((int)c->AttackTime == 13)
+            if (c->CheckAttackTime(13))
             {
                 Vector(1.f, 0.5f, 0.f, Light);
                 Vector(-50.f, 100.f, 0.f, p);
@@ -1599,14 +1607,16 @@ void AttackEffect(CHARACTER* c)
                 VectorCopy(Position, o->StartPosition);
                 CreateEffect(MODEL_PIERCING + 1, Position, Angle, Light, 1, o);
                 PlayBuffer(SOUND_METEORITE01);
+                c->SetLastAttackEffectTime();
             }
-            else if ((int)c->AttackTime == 9)
+            else if (c->CheckAttackTime(9))
             {
                 Vector(1.f, 0.5f, 0.f, Light);
                 Vector(0.f, 0.f, 0.f, p);
                 VectorCopy(o->Angle, Angle);
                 Angle[0] += 45.f;
                 b->TransformPosition(o->BoneTransform[11], p, Position, true);
+                c->SetLastAttackEffectTime();
             }
         }
 
@@ -1614,7 +1624,7 @@ void AttackEffect(CHARACTER* c)
     case MONSTER_DARK_PHOENIX:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if ((int)c->AttackTime == 2 || c->AttackTime == 6)
+            if (c->CheckAttackTime(2) || c->CheckAttackTime(6))
             {
                 vec3_t Angle = { 0.0f, 0.0f, 0.0f };
                 int iCount = 40;
@@ -1629,6 +1639,8 @@ void AttackEffect(CHARACTER* c)
                     Position[2] += 100.f;
                     CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 3, NULL, 50.f, 0, 0);
                 }
+
+                c->SetLastAttackEffectTime();
             }
         }
         break;
@@ -1636,19 +1648,21 @@ void AttackEffect(CHARACTER* c)
     case MONSTER_BEAM_KNIGHT:
         if (c->MonsterIndex == MONSTER_DEATH_BEAM_KNIGHT)
         {
-            if ((int)c->AttackTime == 1)
+            if (c->CheckAttackTime(1))
             {
                 CreateInferno(o->Position);
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light);
+                c->SetLastAttackEffectTime();
             }
             if ((c->Skill) == AT_SKILL_BOSS)
             {
-                if (c->MonsterIndex == MONSTER_DEATH_BEAM_KNIGHT)
+                if (c->MonsterIndex == MONSTER_DEATH_BEAM_KNIGHT && rand_fps_check(1))
                 {
                     Vector(o->Position[0] + rand() % 800 - 400, o->Position[1] + rand() % 800 - 400, o->Position[2], Position);
                     CreateEffect(MODEL_SKILL_BLAST, Position, o->Angle, o->Light);
                 }
-                if ((int)c->AttackTime == 14)
+
+                if (c->CheckAttackTime(14))
                 {
                     for (int i = 0; i < 18; i++)
                     {
@@ -1656,31 +1670,34 @@ void AttackEffect(CHARACTER* c)
                         Angle[2] += i * 20.f;
                         CreateEffect(MODEL_STAFF_OF_DESTRUCTION, o->Position, Angle, o->Light);
                     }
+                    c->SetLastAttackEffectTime();
                 }
             }
         }
         else
         {
-            if ((int)c->AttackTime == 1)
+            if (c->CheckAttackTime(1))
             {
                 //CreateInferno(o->Position);
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light);
+                c->SetLastAttackEffectTime();
             }
         }
         break;
     case MONSTER_CURSED_KING:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if ((int)c->AttackTime == 1)
+            if (c->CheckAttackTime(1))
             {
                 CreateEffect(MODEL_SKILL_INFERNO, o->Position, o->Angle, o->Light, 1);
+                c->SetLastAttackEffectTime();
             }
         }
         break;
     case MONSTER_GOLDEN_SOLDIER:
     case MONSTER_IRON_WHEEL:
     case MONSTER_SOLDIER:
-        if ((int)c->AttackTime == 1)
+        if (c->CheckAttackTime(1))
         {
             Vector(60.f, -110.f, 0.f, p);
             b->TransformPosition(o->BoneTransform[c->Weapon[0].LinkBone], p, Position, true);
@@ -1694,16 +1711,19 @@ void AttackEffect(CHARACTER* c)
                 Angle[2] -= 40.f;
                 CreateEffect(MODEL_ARROW_BOMB, o->Position, Angle, o->Light, 0, o);
             }
+
+            c->SetLastAttackEffectTime();
         }
         break;
     case MONSTER_GOLDEN_TITAN:
     case MONSTER_TANTALLOS:
     case MONSTER_ZAIKAN:
-        if ((int)c->AttackTime == 1)
+        if (c->CheckAttackTime(1))
         {
             CreateInferno(o->Position);
+            c->SetLastAttackEffectTime();
         }
-        if ((int)c->AttackTime == 14)
+        if (c->CheckAttackTime(14))
         {
             if (c->MonsterIndex == MONSTER_ZAIKAN)
             {
@@ -1717,6 +1737,8 @@ void AttackEffect(CHARACTER* c)
                     }
                 }
             }
+
+            c->SetLastAttackEffectTime();
         }
         break;
     case MONSTER_HYDRA:
@@ -1727,7 +1749,7 @@ void AttackEffect(CHARACTER* c)
         }
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if ((int)c->AttackTime == 1)
+            if (c->CheckAttackTime(1))
             {
                 VectorCopy(o->Angle, Angle); Angle[2] += 20.f;
                 VectorCopy(o->Position, p); p[2] += 50.f;
@@ -1739,13 +1761,15 @@ void AttackEffect(CHARACTER* c)
                     Angle[2] += 40.f;
                     CreateEffect(BITMAP_BOSS_LASER, p, Angle, Light);
                 }
+
+                c->SetLastAttackEffectTime();
             }
         }
         break;
     case MONSTER_RED_DRAGON:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if ((int)c->AttackTime == 1)
+            if (c->CheckAttackTime(1))
             {
                 Vector(0.f, 0.f, 0.f, p);
                 b->TransformPosition(o->BoneTransform[11], p, Position, true);
@@ -1756,16 +1780,20 @@ void AttackEffect(CHARACTER* c)
                 Vector(o->Angle[0] - 20.f, o->Angle[1], o->Angle[2] + 30.f, Angle);
                 CreateEffect(MODEL_FIRE, Position, Angle, o->Light, 2);
                 PlayBuffer(SOUND_METEORITE01);
+                c->SetLastAttackEffectTime();
             }
-            Vector(o->Position[0] + rand() % 1024 - 512, o->Position[1] + rand() % 1024 - 512, o->Position[2], Position);
-            CreateEffect(MODEL_FIRE, Position, o->Angle, o->Light);
-            PlayBuffer(SOUND_METEORITE01);
+            if (rand_fps_check(1))
+            {
+                Vector(o->Position[0] + rand() % 1024 - 512, o->Position[1] + rand() % 1024 - 512, o->Position[2], Position);
+                CreateEffect(MODEL_FIRE, Position, o->Angle, o->Light);
+                PlayBuffer(SOUND_METEORITE01);
+            }
         }
         break;
     case MONSTER_DEATH_GORGON:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if ((int)c->AttackTime == 1)
+            if (c->CheckAttackTime(1))
             {
                 for (int i = 0; i < 18; i++)
                 {
@@ -1773,6 +1801,7 @@ void AttackEffect(CHARACTER* c)
                     CreateEffect(MODEL_FIRE, o->Position, Angle, o->Light, 1, o);
                 }
                 PlayBuffer(SOUND_METEORITE01);
+                c->SetLastAttackEffectTime();
             }
         }
         break;
@@ -1780,19 +1809,24 @@ void AttackEffect(CHARACTER* c)
     case MONSTER_METAL_BALROG:
         if ((c->Skill) == AT_SKILL_BOSS)
         {
-            if ((int)c->AttackTime == 1)
+            if (c->CheckAttackTime(1))
             {
                 CreateEffect(MODEL_CIRCLE, o->Position, o->Angle, o->Light);
                 CreateEffect(MODEL_CIRCLE_LIGHT, o->Position, o->Angle, o->Light);
                 PlayBuffer(SOUND_HELLFIRE);
+                c->SetLastAttackEffectTime();
             }
-            Vector(o->Position[0] + rand() % 1024 - 512, o->Position[1] + rand() % 1024 - 512, o->Position[2], Position);
-            CreateEffect(MODEL_FIRE, Position, o->Angle, o->Light);
-            PlayBuffer(SOUND_METEORITE01);
+
+            if (rand_fps_check(1))
+            {
+                Vector(o->Position[0] + rand() % 1024 - 512, o->Position[1] + rand() % 1024 - 512, o->Position[2], Position);
+                CreateEffect(MODEL_FIRE, Position, o->Angle, o->Light);
+                PlayBuffer(SOUND_METEORITE01);
+            }
         }
         break;
     case MONSTER_METEORITE_TRAP://함정
-        if ((c->Skill) == AT_SKILL_BOSS)
+        if ((c->Skill) == AT_SKILL_BOSS && rand_fps_check(1))
         {
             Vector(o->Position[0] + rand() % 1024 - 512, o->Position[1] + rand() % 1024 - 512, o->Position[2], Position);
             CreateEffect(MODEL_FIRE, Position, o->Angle, o->Light);
@@ -1800,12 +1834,15 @@ void AttackEffect(CHARACTER* c)
         }
         break;
     case MONSTER_BAHAMUT://물고기
-        for (int i = 0; i < 4; i++)
+        if (rand_fps_check(1))
         {
-            Vector((float)(rand() % 32 - 16), (float)(rand() % 32 - 16), (float)(rand() % 32 - 16), p);
-            b->TransformPosition(o->BoneTransform[2], p, Position, true);
-            CreateParticle(BITMAP_BUBBLE, Position, o->Angle, Light);
-            CreateParticle(BITMAP_BLOOD + 1, Position, o->Angle, Light);
+            for (int i = 0; i < 4; i++)
+            {
+                Vector((float)(rand() % 32 - 16), (float)(rand() % 32 - 16), (float)(rand() % 32 - 16), p);
+                b->TransformPosition(o->BoneTransform[2], p, Position, true);
+                CreateParticle(BITMAP_BUBBLE, Position, o->Angle, Light);
+                CreateParticle(BITMAP_BLOOD + 1, Position, o->Angle, Light);
+            }
         }
         break;
     default:
@@ -1830,22 +1867,24 @@ void AttackEffect(CHARACTER* c)
             case MONSTER_CHAOS_CASTLE_14:
                 if (c->Weapon[0].Type == MODEL_GREAT_REIGN_CROSSBOW)
                 {
-                    if ((int)c->AttackTime == 8)
+                    if (c->CheckAttackTime(8))
                     {
                         CreateArrows(c, o, o, 0, 0, 0);
+                        c->SetLastAttackEffectTime();
                     }
                 }
                 else if (c->Object.CurrentAction == MONSTER01_ATTACK1)
                 {
-                    if ((int)c->AttackTime == 15)
+                    if (c->CheckAttackTime(15))
                     {
                         CalcAddPosition(o, -20.f, -90.f, 100.f, Position);
                         CreateEffect(BITMAP_BOSS_LASER, Position, o->Angle, Light, 0, o);
+                        c->SetLastAttackEffectTime();
                     }
                 }
                 else if (c->Object.CurrentAction == MONSTER01_ATTACK2)
                 {
-                    if ((int)c->AttackTime == 8)
+                    if (c->CheckAttackTime(8))
                     {
                         if (rand_fps_check(2))
                         {
@@ -1858,6 +1897,7 @@ void AttackEffect(CHARACTER* c)
                             CreateEffect(MODEL_FIRE, to->Position, o->Angle, Light, 6);
                             CreateEffect(MODEL_FIRE, to->Position, o->Angle, Light, 6);
                         }
+                        c->SetLastAttackEffectTime();
                     }
                 }
                 break;
@@ -1869,13 +1909,14 @@ void AttackEffect(CHARACTER* c)
             case MONSTER_MAGIC_SKELETON_5:
             case MONSTER_MAGIC_SKELETON_6:
             case MONSTER_MAGIC_SKELETON_7:
-                if (14 == c->AttackTime)
+                if (c->CheckAttackTime(14))
                 {
                     Vector(0.f, 0.f, 0.f, p);
                     b->TransformPosition(o->BoneTransform[33], p, Position, true);
                     VectorCopy(o->Angle, Angle);
                     CreateEffect(MODEL_PIERCING + 1, Position, Angle, Light, 1);
                     CreateJoint(BITMAP_JOINT_THUNDER, Position, Position, Angle, 2, to, 50.f);
+                    c->SetLastAttackEffectTime();
                 }
                 break;
 
@@ -1886,7 +1927,7 @@ void AttackEffect(CHARACTER* c)
             case MONSTER_GIANT_OGRE_5:	//. 자이언트오거5
             case MONSTER_GIANT_OGRE_6:	//. 자이언트오거6
             case MONSTER_GIANT_OGRE_7:
-                if ((int)c->AttackTime == 13)
+                if (c->CheckAttackTime(13))
                 {
                     Vector(1.0f, 1.0f, 1.0f, Light);
                     Vector(60.f, 30.f, 0.f, p);
@@ -1894,11 +1935,12 @@ void AttackEffect(CHARACTER* c)
 
                     Vector(o->Angle[0], o->Angle[1], o->Angle[2], Angle);
                     CreateEffect(MODEL_FIRE, Position, Angle, o->Light, 5);
+                    c->SetLastAttackEffectTime();
                 }
                 break;
 
             case MONSTER_DARK_PHOENIX://불사조공격
-                if (14 == c->AttackTime)
+                if (c->CheckAttackTime(14))
                 {
                     Vector(0.f, 0.f, 0.f, p);
                     b->TransformPosition(g_fBoneSave[2], p, Position, true);
@@ -1909,13 +1951,14 @@ void AttackEffect(CHARACTER* c)
                     VectorCopy(o->Angle, Angle);
                     CreateEffect(MODEL_PIERCING + 1, Position, Angle, Light, 1);
                     CreateJoint(BITMAP_JOINT_THUNDER, Position, Position, Angle, 2, to, 50.f);
+                    c->SetLastAttackEffectTime();
                 }
                 break;
             case MONSTER_DRAKAN:
             case MONSTER_GREAT_DRAKAN:
                 if (c->Object.CurrentAction == MONSTER01_ATTACK2)
                 {
-                    if ((int)c->AttackTime == 13)
+                    if (c->CheckAttackTime(13))
                     {
                         Vector(1.f, 0.5f, 0.f, Light);
                         Vector(-50.f, 100.f, 0.f, p);
@@ -1924,85 +1967,113 @@ void AttackEffect(CHARACTER* c)
                         b->TransformPosition(o->BoneTransform[11], p, Position, true);
                         CreateEffect(MODEL_PIERCING + 1, Position, Angle, Light, 1);
                         CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 50.f);
+                        c->SetLastAttackEffectTime();
                     }
                 }
                 break;
             case MONSTER_ALQUAMOS:
-                if ((int)c->AttackTime == 1)
+                if (c->CheckAttackTime(1))
                 {
                     for (int i = 0; i < 4; ++i)
                     {
                         CreateJoint(BITMAP_FLARE, o->Position, o->Position, Angle, 7, to, 50.f);
                         // CreateJoint(BITMAP_FLARE, Position, Position, Angle, 7, to, 50.f);
                     }
-                    c->AttackTime = 2;
+
+                    c->SetLastAttackEffectTime();
                 }
                 break;
             case MONSTER_BEAM_KNIGHT:
-                for (int i = 0; i < 6; i++)
+                if (rand_fps_check(1))
                 {
-                    int Hand = 0;
-                    if (i >= 3) Hand = 1;
-                    b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);//에러
-                    Vector(0.f, 0.f, (float)(rand() % 360), Angle);
-                    CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 50.f);
-                    CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
+                    for (int i = 0; i < 6; i++)
+                    {
+                        int Hand = 0;
+                        if (i >= 3) Hand = 1;
+                        b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);//에러
+                        Vector(0.f, 0.f, (float)(rand() % 360), Angle);
+                        CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 50.f);
+                        CreateJoint(BITMAP_JOINT_THUNDER, Position, to->Position, Angle, 2, to, 10.f);
+                    }
+
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int Hand = 0;
+                        if (i >= 2) Hand = 1;
+                        b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
+                        Vector(0.f, 0.f, (float)(rand() % 360), Angle);
+                        CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 0, to, 50.f);
+                        CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                    }
                 }
 
-                if ((int)c->AttackTime == 1)
+                if (c->CheckAttackTime(1))
+                {
                     PlayBuffer(SOUND_EVIL);
-
-                for (int i = 0; i < 4; i++)
-                {
-                    int Hand = 0;
-                    if (i >= 2) Hand = 1;
-                    b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
-                    Vector(0.f, 0.f, (float)(rand() % 360), Angle);
-                    CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 0, to, 50.f);
-                    CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                    c->SetLastAttackEffectTime();
                 }
+
                 break;
             case MONSTER_VEPAR:
-                if ((int)c->AttackTime == 1)
-                    PlayBuffer(SOUND_EVIL);
-
-                for (int i = 0; i < 4; i++)
+                if (c->CheckAttackTime(1))
                 {
-                    int Hand = 0;
-                    if (i >= 2) Hand = 1;
-                    Vector(0.f, 0.f, 0.f, Angle);
-                    b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
-                    CreateJoint(BITMAP_BLUR + 1, Position, to->Position, Angle, 1, to, 50.f);
-                    CreateJoint(BITMAP_BLUR + 1, Position, to->Position, Angle, 1, to, 10.f);
+                    PlayBuffer(SOUND_EVIL);
+                    c->SetLastAttackEffectTime();
+                }
+
+                if (rand_fps_check(1))
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int Hand = 0;
+                        if (i >= 2) Hand = 1;
+                        Vector(0.f, 0.f, 0.f, Angle);
+                        b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
+                        CreateJoint(BITMAP_BLUR + 1, Position, to->Position, Angle, 1, to, 50.f);
+                        CreateJoint(BITMAP_BLUR + 1, Position, to->Position, Angle, 1, to, 10.f);
+                    }
                 }
                 break;
             case MONSTER_DEVIL:
-                if ((int)c->AttackTime == 1)
-                    PlayBuffer(SOUND_EVIL);
-
-                for (int i = 0; i < 4; i++)
+                if (c->CheckAttackTime(1))
                 {
-                    int Hand = 0;
-                    if (i >= 2) Hand = 1;
-                    b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
-                    Vector(0.f, 0.f, (float)(rand() % 360), Angle);
-                    CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 0, to, 50.f);
-                    CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                    PlayBuffer(SOUND_EVIL);
+                    c->SetLastAttackEffectTime();
+                }
+
+                if (rand_fps_check(1))
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int Hand = 0;
+                        if (i >= 2) Hand = 1;
+                        b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
+                        Vector(0.f, 0.f, (float)(rand() % 360), Angle);
+                        CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 0, to, 50.f);
+                        CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                    }
                 }
                 break;
             case MONSTER_CURSED_KING:
             {
-                if ((int)c->AttackTime == 1)
-                    PlayBuffer(SOUND_THUNDER01);
-                float fAngle = (float)((int)(45.f - (c->AttackTime * 3 + (int)WorldTime / 10)) % 90) + 180.f;
-
-                for (int i = 0; i < 4; i++)
+                if (c->CheckAttackTime(1))
                 {
-                    b->TransformPosition(o->BoneTransform[c->Weapon[i % 2].LinkBone], p, Position, true);
-                    Vector(0.f, 0.f, fAngle, Angle);
-                    CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 1, to, 50.f);
-                    CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
-                    fAngle += 270.f;
+                    PlayBuffer(SOUND_THUNDER01);
+                    c->SetLastAttackEffectTime();
+                }
+
+                if (rand_fps_check(1))
+                {
+                    float fAngle = (float)((int)(45.f - (c->AttackTime * 3 + (int)WorldTime / 10)) % 90) + 180.f;
+
+                    for (int i = 0; i < 4; i++)
+                    {
+                        b->TransformPosition(o->BoneTransform[c->Weapon[i % 2].LinkBone], p, Position, true);
+                        Vector(0.f, 0.f, fAngle, Angle);
+                        CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 1, to, 50.f);
+                        CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                        fAngle += 270.f;
+                    }
                 }
             }
             break;
@@ -2023,22 +2094,28 @@ void AttackEffect(CHARACTER* c)
             case MONSTER_MAGIC_SKELETON_6:
             case MONSTER_MAGIC_SKELETON_7:
             {
-                if ((int)c->AttackTime == 1)
-                    PlayBuffer(SOUND_THUNDER01);
-                float fAngle = (float)(45.f - (int)(c->AttackTime * 3 + (int)WorldTime / 10) % 90) + 180.f;
-                for (int i = 0; i < 4; i++)
+                if (c->CheckAttackTime(1))
                 {
-                    b->TransformPosition(o->BoneTransform[c->Weapon[i % 2].LinkBone], p, Position, true);
-                    Vector(0.f, 0.f, fAngle, Angle);
-                    CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 1, to, 50.f);
-                    CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
-                    fAngle += 270.f;
+                    PlayBuffer(SOUND_THUNDER01);
+                    c->SetLastAttackEffectTime();
+                }
+                if (rand_fps_check(1))
+                {
+                    float fAngle = (float)(45.f - (int)(c->AttackTime * 3 + (int)WorldTime / 10) % 90) + 180.f;
+                    for (int i = 0; i < 4; i++)
+                    {
+                        b->TransformPosition(o->BoneTransform[c->Weapon[i % 2].LinkBone], p, Position, true);
+                        Vector(0.f, 0.f, fAngle, Angle);
+                        CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 1, to, 50.f);
+                        CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                        fAngle += 270.f;
+                    }
                 }
             }
             break;
 
             case MONSTER_DARK_PHOENIX://불사조공격
-                if (8 <= c->AttackTime)
+                if (8 <= c->AttackTime && rand_fps_check(1))
                 {
                     Vector(0.f, 0.f, 0.f, p);
                     b->TransformPosition(g_fBoneSave[0], p, Position, true);
@@ -2050,17 +2127,23 @@ void AttackEffect(CHARACTER* c)
                 }
                 break;
             case MONSTER_DEVIL://데빌
-                if ((int)c->AttackTime == 1)
-                    PlayBuffer(SOUND_EVIL);
-
-                for (int i = 0; i < 4; i++)
+                if (c->CheckAttackTime(1))
                 {
-                    int Hand = 0;
-                    if (i >= 2) Hand = 1;
-                    b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
-                    Vector(0.f, 0.f, (float)(rand() % 360), Angle);
-                    CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 0, to, 50.f);
-                    CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                    PlayBuffer(SOUND_EVIL);
+                    c->SetLastAttackEffectTime();
+                }
+
+                if (rand_fps_check(1))
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int Hand = 0;
+                        if (i >= 2) Hand = 1;
+                        b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], p, Position, true);
+                        Vector(0.f, 0.f, (float)(rand() % 360), Angle);
+                        CreateJoint(BITMAP_JOINT_LASER + 1, Position, to->Position, Angle, 0, to, 50.f);
+                        CreateParticle(BITMAP_FIRE, Position, o->Angle, o->Light);
+                    }
                 }
                 break;
             case MONSTER_CURSED_WIZARD:
@@ -2418,19 +2501,21 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
         BMD* b = &Models[o->Type];
 
         vec3_t p;
-        if ((int)c->AttackTime == 10)
+        if (c->CheckAttackTime(10))
         {
             PlayBuffer(SOUND_RIDINGSPEAR);
+            c->SetLastAttackEffectTime();
         }
-        else if ((int)c->AttackTime == 4)
+        else if (c->CheckAttackTime(4))
         {	// 준비동작
             vec3_t Light = { 1.0f, 1.0f, .5f };
             vec3_t Position2 = { 0.0f, 0.0f, 0.0f };
             b->TransformPosition(o->BoneTransform[c->Weapon[Hand].LinkBone], Position2, p, true);
             CreateEffect(MODEL__SPEAR, p, o->Angle, Light, c->Weapon[Hand].Type, o);
             //CreateEffect(BITMAP_MAGIC+1,o->Position,o->Angle,Light,4,o);
+            c->SetLastAttackEffectTime();
         }
-        else if (8 == c->AttackTime)
+        else if (c->CheckAttackTime(8))
         {	// 꼬깔 만들기
             vec3_t Position;
             memcpy(Position, o->Position, sizeof(vec3_t));
@@ -2440,8 +2525,9 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
             vec3_t Light = { 1.0f, 1.0f, 1.0f };
             CreateEffect(MODEL_SPEAR, Position, o->Angle, Light, 0, o);
             CreateEffect(MODEL_SPEAR, Position, o->Angle, Light, 0, o);
+            c->SetLastAttackEffectTime();
         }
-        if (13 <= c->AttackTime && c->AttackTime <= 14)
+        if (13 <= c->AttackTime && c->AttackTime <= 14 && rand_fps_check(1))
         {	// 현란한 창술
             for (int i = 0; i < 3; ++i)
             {
@@ -2452,7 +2538,7 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
                 Position[2] += 110.0f;
                 //vec3_t Light = { .6f, .6f, .2f};
                 vec3_t Light = { .3f, .3f, .3f };
-                if ((int)c->AttackTime == 11)
+                if (c->CheckAttackTime(11))
                 {
                     /*Light[0] = 1.0f;
                     Light[1] = 0.5f;
@@ -2480,10 +2566,11 @@ bool AttackStage(CHARACTER* c, OBJECT* o)
             }
         }
 
-        if ((int)c->AttackTime == 3)  //  氣 모으기.
+        if (c->CheckAttackTime(3))  //  氣 모으기.
         {
             CreateEffect(BITMAP_GATHERING, o->Position, o->Angle, o->Light, 0, o);
             PlayBuffer(SOUND_PIERCING, o);
+            c->SetLastAttackEffectTime();
         }
         g_iLimitAttackTime = 5;
         break;
@@ -3846,6 +3933,7 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
     if ((int)c->AttackTime >= g_iLimitAttackTime)
     {
         c->AttackTime = 0;
+        c->LastAttackEffectTime = -1;
         o->PKKey = getTargetCharacterKey(c, SelectedCharacter);
 
         switch ((c->Skill))
@@ -11332,6 +11420,7 @@ void CreateCharacterPointer(CHARACTER* c, int Type, unsigned char PositionX, uns
     o->BlendMeshTexCoordV = 0.f;
     c->Skill = 0;
     c->AttackTime = 0;
+    c->LastAttackEffectTime = -1;
     c->TargetCharacter = -1;
     c->AttackFlag = ATTACK_FAIL;
     c->Weapon[0].Type = -1;

--- a/Source Main 5.2/source/ZzzCharacter.h
+++ b/Source Main 5.2/source/ZzzCharacter.h
@@ -88,6 +88,7 @@ extern int       EquipmentLevelSet;
 extern bool      g_bAddDefense;
 
 void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle, int SubType = 0, OBJECT* Target = NULL, float Scale = 10.f, short PK = -1, WORD SkillIndex = 0, WORD SkillSerialNum = 0, int iChaIndex = -1, const float* vColor = NULL, short int sTargetIndex = -1);
+void CreateJointFpsChecked(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle, int SubType = 0, OBJECT* Target = NULL, float Scale = 10.f, short PK = -1, WORD SkillIndex = 0, WORD SkillSerialNum = 0, int iChaIndex = -1, const float* vColor = NULL, short int sTargetIndex = -1);
 bool RenderCharacterBackItem(CHARACTER* c, OBJECT* o, bool bTranslate);
 bool IsBackItem(CHARACTER* c, int iType);
 

--- a/Source Main 5.2/source/ZzzEffect.cpp
+++ b/Source Main 5.2/source/ZzzEffect.cpp
@@ -323,6 +323,14 @@ void CheckTargetRange(OBJECT* o)
     }
 }
 
+void CreateEffectFpsChecked(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType, OBJECT* Owner, short PKKey, WORD SkillIndex, WORD Skill, WORD SkillSerialNum, float Scale, short int sTargetIndex)
+{
+    if (rand_fps_check(1))
+    {
+        CreateEffect(Type, Position, Angle, Light, SubType, Owner, PKKey, SkillIndex, Skill, SkillSerialNum, Scale, sTargetIndex);
+    }
+}
+
 void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType, OBJECT* Owner, short PKKey, WORD SkillIndex, WORD Skill, WORD SkillSerialNum, float Scale, short int sTargetIndex)
 {
     for (int icntEffect = 0; icntEffect < MAX_EFFECTS; icntEffect++)
@@ -6836,7 +6844,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             OBJECT* pOwn = o->Owner;
             if ((int)o->LifeTime % 10 == 0)
             {
-                CreateEffect(MODEL_ARROW_AUTOLOAD, pOwn->Position, pOwn->Angle, pOwn->Light, 1, pOwn);
+                CreateEffectFpsChecked(MODEL_ARROW_AUTOLOAD, pOwn->Position, pOwn->Angle, pOwn->Light, 1, pOwn);
             }
         }
         else if (o->SubType == 1)
@@ -6893,10 +6901,10 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Light[1] *= pow(0.98f, FPS_ANIMATION_FACTOR);
             o->Light[2] *= pow(0.98f, FPS_ANIMATION_FACTOR);
             if ((int)o->LifeTime == 40)
-                CreateEffect(MODEL_INFINITY_ARROW3, o->Position, o->Angle, o->Light, 2, o);
+                CreateEffectFpsChecked(MODEL_INFINITY_ARROW3, o->Position, o->Angle, o->Light, 2, o);
             else
                 if ((int)o->LifeTime == 20)
-                    CreateEffect(MODEL_INFINITY_ARROW3, o->Position, o->Angle, o->Light, 3, o);
+                    CreateEffectFpsChecked(MODEL_INFINITY_ARROW3, o->Position, o->Angle, o->Light, 3, o);
             VectorCopy(o->Owner->Position, o->Position);
         }
         else if (o->SubType == 2)
@@ -6953,19 +6961,19 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->SubType == 1)
             {
                 Vector(0.3f, 0.3f, 0.8f, nLight);
-                CreateEffect(BITMAP_SHOCK_WAVE, o->Owner->Position, o->Owner->Angle,
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Owner->Position, o->Owner->Angle,
                     nLight, 9, o->Owner, -1, 0, 0, 0);
             }
             else if (o->SubType == 2)
             {
                 vec3_t vShockColor = { 0.8f, 0.3f, 0.3f };
-                CreateEffect(BITMAP_SHOCK_WAVE, o->Owner->Position, o->Owner->Angle,
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Owner->Position, o->Owner->Angle,
                     vShockColor, 9, o->Owner, -1, 0, 0, 0);
             }
             else
             {
                 vec3_t vShockColor = { 1.f, 1.f, 1.f };
-                CreateEffect(BITMAP_SHOCK_WAVE, o->Owner->Position, o->Owner->Angle,
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Owner->Position, o->Owner->Angle,
                     vShockColor, 9, o->Owner, -1, 0, 0, 0);
             }
         }
@@ -6976,21 +6984,21 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 1)
         {
             Vector(0.f, 1.f, 5.f, nLight);
-            CreateEffect(MODEL_SKILL_INFERNO, nPos, o->Angle, nLight, 10, o, 30, 0);
+            CreateEffectFpsChecked(MODEL_SKILL_INFERNO, nPos, o->Angle, nLight, 10, o, 30, 0);
             nPos[2] += 120.f;
-            CreateParticle(BITMAP_SMOKE, nPos, o->Angle, o->Light, 11, 2.f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, nPos, o->Angle, o->Light, 11, 2.f);
         }
         else if (o->SubType == 2)
         {
             Vector(0.8f, 0.3f, 0.3f, nLight);
-            CreateEffect(MODEL_SKILL_INFERNO, nPos, o->Angle, nLight, 10, o, 30, 0);
+            CreateEffectFpsChecked(MODEL_SKILL_INFERNO, nPos, o->Angle, nLight, 10, o, 30, 0);
         }
         else if (o->SubType == 0)
         {
             Vector(0.0f, 0.8f, 1.5f, nLight);
-            CreateEffect(MODEL_SKILL_INFERNO, nPos, o->Angle, nLight, 2, o, 30, 0);
+            CreateEffectFpsChecked(MODEL_SKILL_INFERNO, nPos, o->Angle, nLight, 2, o, 30, 0);
             nPos[2] += 120.f;
-            CreateParticle(BITMAP_SMOKE, nPos, o->Angle, o->Light, 11, 2.f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, nPos, o->Angle, o->Light, 11, 2.f);
         }
     }
     break;
@@ -7028,10 +7036,10 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorAdd(o->Position, vPos, o->Position);
         CreateSprite(BITMAP_LIGHT + 3, o->Position, 4.0f, o->Light, o);
         CreateSprite(BITMAP_DS_EFFECT, o->Position, 2.5f, o->Light, o);
-        CreateParticle(BITMAP_SPARK + 1, o->Position, o->Angle, o->Light, 10, 3.0f);
+        CreateParticleFpsChecked(BITMAP_SPARK + 1, o->Position, o->Angle, o->Light, 10, 3.0f);
 
         VectorCopy(o->Position, o->EyeLeft);
-        CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 3, NULL, 0);
+        CreateEffectFpsChecked(MODEL_WAVES, o->Position, o->Angle, o->Light, 3, NULL, 0);
     }
     break;
     case MODEL_MULTI_SHOT3:
@@ -7124,7 +7132,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         CreateSprite(BITMAP_SHINY + 1, p, (float)(rand() % 8 + 8) * 0.07f, Light, o->Owner, (float)(rand() % 360));
                         VectorCopy(o->Owner->Position, p);
                         p[2] += ((rand() % 80 - 40) + 200);
-                        CreateJoint(BITMAP_SPARK + 1, p, p, o->Owner->Angle, 1, o->Owner, 18.7f);
+                        CreateJointFpsChecked(BITMAP_SPARK + 1, p, p, o->Owner->Angle, 1, o->Owner, 18.7f);
                     }
                     CreateArrow(c, o->Owner, to, FindHotKey((o->Skill)), 1, 0);
                     o->Owner->Angle[2] = Angle[2];
@@ -7141,7 +7149,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(0.f, -1.f, 0.f, vDir);
             AngleMatrix(o->Angle, vMat);
             VectorRotate(vDir, vMat, o->Direction);
-            CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 17, o, 15.f, 40);
+            CreateJointFpsChecked(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 17, o, 15.f, 40);
         }
         if (o->LifeTime <= 24)
         {
@@ -7151,8 +7159,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorScale(o->Direction, o->Velocity, vPos);
             VectorAdd(o->Position, vPos, o->Position);
             //			CreateParticle(BITMAP_FLAME, o->Position, o->Angle, vLight, 8, 3.5f);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 26, 0.2f);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 26, 0.2f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 26, 0.2f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 26, 0.2f);
             //			CreateJoint ( BITMAP_FLARE+1, o->Position, o->Position, o->Angle, 9, o, 10.f, 40 );
         }
         //			else
@@ -7209,7 +7217,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->Angle[0] += (sinf((int)WorldTime % 10000 * 0.0001f) * o->Distance / 3.0f) * FPS_ANIMATION_FACTOR;
 
         Vector(o->BlendMeshLight / 10.f, o->BlendMeshLight / 10.f, o->BlendMeshLight / 4.f, o->Light);
-        CreateParticle(BITMAP_LIGHT, o->Position, o->Angle, o->Light, 9, o->Scale);
+        CreateParticleFpsChecked(BITMAP_LIGHT, o->Position, o->Angle, o->Light, 9, o->Scale);
     }
     break;
 
@@ -7267,7 +7275,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 vec3_t Position;
                 Vector((float)(rand() % 16 - 8), (float)(rand() % 16 - 8), (float)(rand() % 16 - 8), Position);
                 VectorAdd(Position, o->Position, Position);
-                CreateParticle(BITMAP_SPARK, Position, o->Angle, o->Light, 7);
+                CreateParticleFpsChecked(BITMAP_SPARK, Position, o->Angle, o->Light, 7);
             }
         }
         CreateSprite(BITMAP_LIGHT, o->Position, 1.f, Light, o);
@@ -7346,7 +7354,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         Position[1] = o->Owner->Position[1] + 50.0f * (float)cosf(fParam + WorldTime * 0.003f);
                         Position[2] = o->Owner->Position[2] + (i + 1) * 50.0f * o->Owner->Scale;
                         vec3_t LightFlame = { 0.6f, 0.6f, 1.0f };
-                        CreateParticle(BITMAP_LIGHT, Position, o->Angle, LightFlame, 5, 0.7f);
+                        CreateParticleFpsChecked(BITMAP_LIGHT, Position, o->Angle, LightFlame, 5, 0.7f);
                     }
                 }
                 break;
@@ -7379,11 +7387,11 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_SPEAR:
         if (1 == o->SubType)
         {
-            CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 12, o, 100.0f);
+            CreateJointFpsChecked(BITMAP_FLARE, o->Position, o->Position, o->Angle, 12, o, 100.0f);
         }
         else if (0 == o->SubType)
         {
-            CreateJoint(BITMAP_FLARE, o->Position, o->Position, o->Angle, 4, o, 50.0f);
+            CreateJointFpsChecked(BITMAP_FLARE, o->Position, o->Position, o->Angle, 4, o, 50.0f);
         }
         break;
     case MODEL__SPEAR:
@@ -7400,7 +7408,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorRotate(p, Matrix, Position);
             VectorSubtract(o->Position, Position, Position);
             //Position[2] += 30.f;
-            CreateJoint(BITMAP_JOINT_HEALING, Position, o->Position, Angle, 6, NULL, 5.f);
+            CreateJointFpsChecked(BITMAP_JOINT_HEALING, Position, o->Position, Angle, 6, NULL, 5.f);
         }
     }
     break;
@@ -7431,7 +7439,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (rand_fps_check(3))
                 {
-                    CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 5, 0.4f + rand() % 10 * 0.01f);
+                    CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, o->Light, 5, 0.4f + rand() % 10 * 0.01f);
                 }
             }
         }
@@ -7507,13 +7515,13 @@ void MoveEffect(OBJECT* o, int iIndex)
         else if (o->SubType == 1)
         {
             VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
-            CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, o->Position, o->Angle, o->Light, 0, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, o->Position, o->Angle, o->Light, 0, 1.0f);
             //CreateParticle(BITMAP_SMOKE, o->Position, o->Angle,o->Light, 23, 1.0f);
             //CreateParticle(BITMAP_SMOKE, o->Position, o->Angle,o->Light, 8, 1.0f);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 11, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 11, 1.0f);
             if (rand_fps_check(2))
             {
-                CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, o->Light, 3, 3.f);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_3, o->Position, o->Angle, o->Light, 3, 3.f);
             }
         }
         else if (o->SubType == 2)
@@ -7558,7 +7566,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             vec3_t vLight;
             Vector(o->Alpha * 0.3f, o->Alpha * 0.3f, o->Alpha * 0.3f, vLight);
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 3, 1, pObject);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 3, 1, pObject);
         }
         else if (o->SubType == 1)
         {
@@ -7571,13 +7579,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1, vFirePosition, o->Angle, o->Light, 1, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vFirePosition, o->Angle, o->Light, 1, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_CURSEDLICH, vFirePosition, o->Angle, o->Light, 5, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vFirePosition, o->Angle, o->Light, 5, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3, vFirePosition, o->Angle, o->Light, 1, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vFirePosition, o->Angle, o->Light, 1, fScale);
                     break;
                 }
             }
@@ -7594,13 +7602,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1, vFirePosition, o->Angle, o->Light, 1, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vFirePosition, o->Angle, o->Light, 1, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_CURSEDLICH, vFirePosition, o->Angle, o->Light, 5, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vFirePosition, o->Angle, o->Light, 5, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3, vFirePosition, o->Angle, o->Light, 1, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vFirePosition, o->Angle, o->Light, 1, fScale);
                     break;
                 }
             }
@@ -7629,13 +7637,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1, vFirePosition, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vFirePosition, o->Angle, vLight, 0, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_CURSEDLICH, vFirePosition, o->Angle, vLight, 4, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vFirePosition, o->Angle, vLight, 4, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3, vFirePosition, o->Angle, vLight, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vFirePosition, o->Angle, vLight, 0, fScale);
                     break;
                 }
             }
@@ -7649,13 +7657,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, o->Light, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, o->Light, 0, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, o->Light, 4, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, o->Light, 4, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, o->Light, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, o->Light, 0, fScale);
                     break;
                 }
             }
@@ -7669,13 +7677,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 switch (rand() % 3)
                 {
                 case 0:
-                    CreateParticle(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, o->Light, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, o->Position, o->Angle, o->Light, 0, fScale);
                     break;
                 case 1:
-                    CreateParticle(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, o->Light, 4, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, o->Position, o->Angle, o->Light, 4, fScale);
                     break;
                 case 2:
-                    CreateParticle(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, o->Light, 0, fScale);
+                    CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, o->Position, o->Angle, o->Light, 0, fScale);
                     break;
                 }
             }
@@ -7734,7 +7742,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 vec3_t vLight;
                 Vector(o->Alpha * 0.3f, o->Alpha * 0.3f, o->Alpha * 0.3f, vLight);
-                CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 1, 1, pObject);
+                CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 1, 1, pObject);
             }
         }
         else if (o->SubType == 1)
@@ -7749,7 +7757,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
                 BMD* pModel = &Models[pObject->Type];
                 int iNumBones = pModel->NumBones;
-                CreateEffect(BITMAP_FIRE_CURSEDLICH, pObject->Position, pObject->Angle, pObject->Light, 0, pObject, -1, rand() % iNumBones);
+                CreateEffectFpsChecked(BITMAP_FIRE_CURSEDLICH, pObject->Position, pObject->Angle, pObject->Light, 0, pObject, -1, rand() % iNumBones);
             }
         }
         break;
@@ -7788,12 +7796,12 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(o->Alpha, o->Alpha, o->Alpha, vLight);
             if (rand_fps_check(1))
             {
-                CreateParticle(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
             }
 
             if (rand_fps_check(2))
             {
-                CreateParticle(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 2, o->Position, o->Angle, o->Light, 3, 0.30f, pObject);
             }
             //DeleteJoint(MODEL_SPEARSKILL, o, 15);
         }
@@ -7807,7 +7815,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
             vec3_t vColor;
             Vector(1.0f, 1.0f, 1.0f, vColor);
-            CreateParticle(BITMAP_LIGHT + 2, pObject->Position, pObject->Angle, vColor, 5, 0.1f, pObject);
+            CreateParticleFpsChecked(BITMAP_LIGHT + 2, pObject->Position, pObject->Angle, vColor, 5, 0.1f, pObject);
         }
         break;
     case MODEL_SUMMONER_EQUIP_HEAD_LAGUL:
@@ -7844,7 +7852,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             vec3_t vLight;
             Vector(o->Alpha * 0.7f, o->Alpha * 0.3f, o->Alpha * 1.f, vLight);
-            CreateParticle(BITMAP_CLUD64, o->Position, o->Angle, vLight, 10, 1.f, pObject);
+            CreateParticleFpsChecked(BITMAP_CLUD64, o->Position, o->Angle, vLight, 10, 1.f, pObject);
         }
     }
     case MODEL_SUMMONER_CASTING_EFFECT1:
@@ -7975,9 +7983,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             pModel->TransformPosition(BoneTransform[iPositions[i]], vRelative, vPos, false);
             VectorAdd(vPos, vTempPosition, vPos);
             Vector(o->Alpha * 0.3f, o->Alpha * 0.3f, o->Alpha * 0.3f, vLight);
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 2, 5, o);
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 2, 4, o);
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 2, 3, o);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 2, 5, o);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 2, 4, o);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 2, 3, o);
         }
     }
     break;
@@ -7989,11 +7997,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->AnimationFrame > 8 && o->Skill == 0)
         {
             o->Skill = 1;
-            CreateEffect(MODEL_SUMMONER_SUMMON_NEIL_NIFE1, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
+            CreateEffectFpsChecked(MODEL_SUMMONER_SUMMON_NEIL_NIFE1, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
             if (o->SubType >= 1)
-                CreateEffect(MODEL_SUMMONER_SUMMON_NEIL_NIFE2, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
+                CreateEffectFpsChecked(MODEL_SUMMONER_SUMMON_NEIL_NIFE2, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
             if (o->SubType >= 2)
-                CreateEffect(MODEL_SUMMONER_SUMMON_NEIL_NIFE3, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
+                CreateEffectFpsChecked(MODEL_SUMMONER_SUMMON_NEIL_NIFE3, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
         }
         if (o->AnimationFrame > 10 && o->Skill == 1)
         {
@@ -8004,13 +8012,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(0, -60.0f, 0, vMoveDir);
             VectorRotate(vMoveDir, Matrix, vPosition);
             VectorAdd(o->Position, vPosition, vPosition);
-            CreateEffect(MODEL_SUMMONER_SUMMON_NEIL_GROUND1, vPosition, o->Angle, o->Light, o->SubType, o);
+            CreateEffectFpsChecked(MODEL_SUMMONER_SUMMON_NEIL_GROUND1, vPosition, o->Angle, o->Light, o->SubType, o);
 
-            CreateEffect(MODEL_SUMMONER_SUMMON_NEIL_GROUND1, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
+            CreateEffectFpsChecked(MODEL_SUMMONER_SUMMON_NEIL_GROUND1, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
             if (o->SubType >= 1)
-                CreateEffect(MODEL_SUMMONER_SUMMON_NEIL_GROUND2, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
+                CreateEffectFpsChecked(MODEL_SUMMONER_SUMMON_NEIL_GROUND2, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
             if (o->SubType >= 2)
-                CreateEffect(MODEL_SUMMONER_SUMMON_NEIL_GROUND3, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
+                CreateEffectFpsChecked(MODEL_SUMMONER_SUMMON_NEIL_GROUND3, o->HeadTargetAngle, o->Angle, o->Light, o->SubType);
 
             PlayBuffer(SOUND_SUMMON_REQUIEM);
         }
@@ -8047,16 +8055,16 @@ void MoveEffect(OBJECT* o, int iIndex)
                 vPos[0] += (float)(rand() % 500 - 250);
                 vPos[1] += (float)(rand() % 500 - 250);
                 Vector(1.0f, 1.0f, 1.0f, vLight);
-                CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 57, 3.5f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 57, 3.5f);
 
                 VectorCopy(o->HeadTargetAngle, vPos);
                 vPos[0] += (float)(rand() % 400 - 200);
                 vPos[1] += (float)(rand() % 400 - 200);
                 Vector(0.6f, 0.1f, 1.f, vLight);
-                CreateEffect(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
+                CreateEffectFpsChecked(BITMAP_CLOUD, vPos, o->Angle, vLight, 0, NULL, -1, 0, 0, 0, 2.0f);
 
                 Vector(0.6f, 0.1f, 1.f, vLight);
-                CreateParticle(BITMAP_TWINTAIL_WATER, vPos, o->Angle, vLight, 1);
+                CreateParticleFpsChecked(BITMAP_TWINTAIL_WATER, vPos, o->Angle, vLight, 1);
             }
         }
         else if (o->SubType == 1)
@@ -8071,22 +8079,22 @@ void MoveEffect(OBJECT* o, int iIndex)
     }
     break;
     case BITMAP_FIRE:
-        CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 9, 1.f, o->Owner);
+        CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light, 9, 1.f, o->Owner);
         break;
 
     case BITMAP_FIRE + 1:
         Vector(1.f, 1.f, 1.f, Light);
-        CreateParticle(BITMAP_FIRE + 1, o->Position, o->Angle, Light, 1);
+        CreateParticleFpsChecked(BITMAP_FIRE + 1, o->Position, o->Angle, Light, 1);
         Vector(Luminosity * 1.f, Luminosity * 0.6f, Luminosity * 0.3f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
         break;
     case BITMAP_MAGIC:
         if (o->SubType == 0)
         {
-            CreateEffect(BITMAP_MAGIC, o->Position, o->Angle, o->Light, 1);
+            CreateEffectFpsChecked(BITMAP_MAGIC, o->Position, o->Angle, o->Light, 1);
             if (o->LifeTime > 5 && o->LifeTime < 10)
             {
-                CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
+                CreateParticleFpsChecked(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
             }
         }
         else if (o->SubType == 2 || o->SubType == 3 || o->SubType == 7)
@@ -8094,14 +8102,14 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime > 5 && o->LifeTime < 10)
             {
                 if (o->SubType == 3)
-                    CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 10, 0.19f, o);
+                    CreateParticleFpsChecked(BITMAP_FLARE, o->Position, o->Angle, o->Light, 10, 0.19f, o);
                 else
-                    CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
+                    CreateParticleFpsChecked(BITMAP_FLARE, o->Position, o->Angle, o->Light, 0, 0.19f, o);
             }
         }
         else if (o->SubType == 4)
         {
-            CreateParticle(BITMAP_FLARE, o->Position, o->Angle, o->Light, 12, 0.19f, o);
+            CreateParticleFpsChecked(BITMAP_FLARE, o->Position, o->Angle, o->Light, 12, 0.19f, o);
         }
         else if (o->SubType == 8)
         {
@@ -8217,7 +8225,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     continue;
                 Vector(-50 + rand() % 100, -10 + rand() % 20, -10 + rand() % 20, p);
                 b->TransformPosition(o->Owner->BoneTransform[iIndex], p, Position, true);
-                CreateParticle(BITMAP_LIGHT, Position, o->Owner->Angle, Light, 8);
+                CreateParticleFpsChecked(BITMAP_LIGHT, Position, o->Owner->Angle, Light, 8);
             }
             o->Owner->Alpha = o->LifeTime / 80.0f;
         }
@@ -8290,7 +8298,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[0] = o->Position[0] + (float)(rand() % 500 - 250);
             Position[1] = o->Position[1] + (float)(rand() % 500 - 250);
             Position[2] = o->Position[2] - (float)(rand() % 100) + 150.0f;
-            CreateParticle(o->Type, Position, o->Angle, o->Light, 0, o->Scale);
+            CreateParticleFpsChecked(o->Type, Position, o->Angle, o->Light, 0, o->Scale);
             break;
         case 1:
         case 2:
@@ -8311,7 +8319,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     if (rand_fps_check(2))
                     {
                         vWorldPos[2] -= 20.f;
-                        CreateParticle(o->Type, vWorldPos, o->Angle, o->Light, 0, o->Scale);
+                        CreateParticleFpsChecked(o->Type, vWorldPos, o->Angle, o->Light, 0, o->Scale);
                     }
                 }
             }
@@ -8343,8 +8351,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             if ((int)o->LifeTime % 10 == 0)
             {
                 //						Vector(0.1f,0.1f,0.1f,Light);
-                CreateEffect(MODEL_FEATHER, o->Position, o->Angle, o->Light, 2, NULL, -1, 0, 0, 0, 1.4f);
-                CreateEffect(MODEL_FEATHER, o->Position, o->Angle, o->Light, 3, NULL, -1, 0, 0, 0, 1.4f);
+                CreateEffectFpsChecked(MODEL_FEATHER, o->Position, o->Angle, o->Light, 2, NULL, -1, 0, 0, 0, 1.4f);
+                CreateEffectFpsChecked(MODEL_FEATHER, o->Position, o->Angle, o->Light, 3, NULL, -1, 0, 0, 0, 1.4f);
             }
         }
     }
@@ -8360,9 +8368,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (rand_fps_check(2))
             {
                 if (o->SubType == 3)
-                    CreateParticle(o->Type, Position, o->Angle, o->Light, 1, o->Scale);
+                    CreateParticleFpsChecked(o->Type, Position, o->Angle, o->Light, 1, o->Scale);
                 else
-                    CreateParticle(o->Type, Position, o->Angle, o->Light, 0, o->Scale);
+                    CreateParticleFpsChecked(o->Type, Position, o->Angle, o->Light, 0, o->Scale);
             }
             break;
         case 1:
@@ -8384,7 +8392,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     if (rand_fps_check(2))
                     {
                         vWorldPos[2] -= 20.f;
-                        CreateParticle(o->Type, vWorldPos, o->Angle, o->Light, 0, o->Scale);
+                        CreateParticleFpsChecked(o->Type, vWorldPos, o->Angle, o->Light, 0, o->Scale);
                     }
                 }
             }
@@ -8425,7 +8433,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime <= 5)
             {
                 o->Live = false;
-                CreateEffect(o->Type, o->Position, o->Angle, o->Light, o->SubType, o->Owner);
+                CreateEffectFpsChecked(o->Type, o->Position, o->Angle, o->Light, o->SubType, o->Owner);
             }
         }
         break;
@@ -8438,7 +8446,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->LifeTime = 100;
 
             if (rand_fps_check(60))
-                CreateParticle(o->Type, o->Position, o->Angle, o->Light, o->SubType, 0.5f, o->Owner);
+                CreateParticleFpsChecked(o->Type, o->Position, o->Angle, o->Light, o->SubType, 0.5f, o->Owner);
         }
         break;
 
@@ -8483,11 +8491,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (((int)o->LifeTime % 2) == 0)
                 {
-                    CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 3, NULL, 10.f, 10, 10);
+                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 3, NULL, 10.f, 10, 10);
                 }
                 else
                 {
-                    CreateParticle(BITMAP_SPARK + 1, Position, Angle, Light, 2, (rand() % 50 + 10) / 100.f, o);
+                    CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, Angle, Light, 2, (rand() % 50 + 10) / 100.f, o);
                 }
                 CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 8 + 8) * 0.2f, o->Light, o, (float)(rand() % 360));
             }
@@ -8495,18 +8503,18 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (((int)o->LifeTime % 2) == 0)
                 {
-                    CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 3, NULL, 10.f, 10, 10);
+                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 3, NULL, 10.f, 10, 10);
                 }
                 CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 8 + 8) * 0.2f, o->Light, o, (float)(rand() % 360));
             }
             else if (o->SubType == 3)
             {
-                CreateParticle(BITMAP_SPARK + 1, Position, Angle, o->Light, 26, (rand() % 10 + 5) / 25.f, o);
+                CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, Angle, o->Light, 26, (rand() % 10 + 5) / 25.f, o);
             }
             else
             {
                 CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 8 + 8) * 0.3f, o->Light, o, (float)(rand() % 360));
-                CreateParticle(BITMAP_SPARK + 1, Position, Angle, Light, 2, (rand() % 50 + 10) / 100.f, o);
+                CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, Angle, Light, 2, (rand() % 50 + 10) / 100.f, o);
             }
         }
         break;
@@ -8525,11 +8533,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (o->SubType == 1)
             {
-                CreateJoint(BITMAP_JOINT_THUNDER, vStartPosition, vPosition, o->Angle, 33, NULL, fScale);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vStartPosition, vPosition, o->Angle, 33, NULL, fScale);
             }
             else
             {
-                CreateJoint(BITMAP_JOINT_THUNDER, vStartPosition, vPosition, o->Angle, 16, NULL, fScale);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vStartPosition, vPosition, o->Angle, 16, NULL, fScale);
             }
         }
 
@@ -8538,22 +8546,22 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->LifeTime > 10)
         {
             if (rand_fps_check(2))
-                CreateEffect(BITMAP_MAGIC + 1, vPosition, o->Angle, vLight, 11, o);
+                CreateEffectFpsChecked(BITMAP_MAGIC + 1, vPosition, o->Angle, vLight, 11, o);
         }
 
         if (rand_fps_check(4))
-            CreateParticle(BITMAP_SMOKE, vPosition, o->Angle, vLight, 54, 2.8f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPosition, o->Angle, vLight, 54, 2.8f);
 
         if (rand_fps_check(4))
         {
-            CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, vLight, 13);
+            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, vLight, 13);
         }
 
         if (o->LifeTime > 5)
         {
             Vector(0.15f, 0.15f, 0.4f, vLight);
             if (rand_fps_check(5))
-                CreateEffect(BITMAP_CHROME_ENERGY2, vPosition, o->Angle, vLight, 0);
+                CreateEffectFpsChecked(BITMAP_CHROME_ENERGY2, vPosition, o->Angle, vLight, 0);
         }
 
         if (o->Owner != NULL && rand_fps_check(5) && o->Owner->BoneTransform != NULL)
@@ -8573,7 +8581,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 Vector(0.2f, 0.2f, 0.8f, vLight);
                 fRandom = 3.0f + ((float)(rand() % 20 - 10) * 0.1f);
-                CreateParticle(BITMAP_LIGHT, vPos, vAngle, vLight, 5, fRandom);
+                CreateParticleFpsChecked(BITMAP_LIGHT, vPos, vAngle, vLight, 5, fRandom);
             }
         }
     }
@@ -8627,11 +8635,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 Vector((float)(rand() % 50 - 25), (float)(rand() % 50 - 25), 0.f, Position);
                 VectorAdd(Position, o->Position, Position);
-                CreateParticle(BITMAP_FLAME, Position, o->Angle, Light);
+                CreateParticleFpsChecked(BITMAP_FLAME, Position, o->Angle, Light);
             }
             if (rand_fps_check(8))
             {
-                CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+                CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
             }
 
             Vector(Luminosity * 1.f, Luminosity * 0.4f, Luminosity * 0.f, Light);
@@ -8656,9 +8664,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Position[0] += rand() % 64 - 32;
                     Position[1] += rand() % 64 - 32;
                     if (o->SubType == 1)
-                        CreateParticle(BITMAP_FLAME, Position, o->Angle, Light, 0, 1.2f);
+                        CreateParticleFpsChecked(BITMAP_FLAME, Position, o->Angle, Light, 0, 1.2f);
                     else if (o->SubType == 2)
-                        CreateParticle(BITMAP_FIRE + 3, Position, o->Angle, Light, 13, 2.5f);
+                        CreateParticleFpsChecked(BITMAP_FIRE + 3, Position, o->Angle, Light, 13, 2.5f);
                 }
             }
         }
@@ -8668,17 +8676,17 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (rand_fps_check(1))
                 {
-                    CreateParticle(BITMAP_FLAME, o->Position, o->Angle, Light, 6);
+                    CreateParticleFpsChecked(BITMAP_FLAME, o->Position, o->Angle, Light, 6);
                     Vector((float)(rand() % 10 - 5), (float)(rand() % 10 - 5), 40.f, Position);
                     VectorAdd(Position, o->Position, Position);
-                    CreateParticle(BITMAP_TRUE_FIRE, Position, o->Angle, Light, 0, 2.8f);
+                    CreateParticleFpsChecked(BITMAP_TRUE_FIRE, Position, o->Angle, Light, 0, 2.8f);
                 }
             }
             Vector((float)(rand() % 10 - 5), (float)(rand() % 10 - 5), -40.f, Position);
             VectorAdd(Position, o->Position, Position);
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 21, 0.8f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 21, 0.8f);
 
-            CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 12);
+            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 12);
 
             Vector(Luminosity * 1.f, Luminosity * 0.4f, Luminosity * 0.f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
@@ -8697,22 +8705,22 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorAdd(Position, o->Position, Position);
                     Position[0] += rand() % 64 - 32;
                     Position[1] += rand() % 64 - 32;
-                    CreateParticle(BITMAP_FLAME, Position, o->Angle, Light, 0, 1.2f);
+                    CreateParticleFpsChecked(BITMAP_FLAME, Position, o->Angle, Light, 0, 1.2f);
                 }
             }
-            CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 12);
+            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 12);
         }
         else if (o->SubType == 5)
         {
             Vector((float)(rand() % 32 - 16), (float)(rand() % 32 - 16), 0.f, Position);
             VectorAdd(Position, o->Position, Position);
-            CreateParticle(BITMAP_FLAME, Position, o->Angle, Light, 0, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FLAME, Position, o->Angle, Light, 0, o->Scale);
         }
         else if (o->SubType == 6)
         {
             Vector((float)(rand() % 32 - 16), (float)(rand() % 32 - 16), 0.f, Position);
             VectorAdd(Position, o->Position, Position);
-            CreateParticle(BITMAP_FLAME, Position, o->Angle, o->Light, 12, o->Scale);
+            CreateParticleFpsChecked(BITMAP_FLAME, Position, o->Angle, o->Light, 12, o->Scale);
         }
         break;
     case MODEL_RAKLION_BOSS_CRACKEFFECT:
@@ -8736,12 +8744,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorAdd(p, o->Position, Position);
                 if (rand() % 3 != 0)
                 {
-                    CreateParticle(BITMAP_FLAME, Position, o->Angle, o->Light, 11, 1.4f);
+                    CreateParticleFpsChecked(BITMAP_FLAME, Position, o->Angle, o->Light, 11, 1.4f);
                 }
 
                 if (rand_fps_check(8))
                 {
-                    CreateEffect(MODEL_ICE_SMALL, Position, o->Angle, o->Light, 0);
+                    CreateEffectFpsChecked(MODEL_ICE_SMALL, Position, o->Angle, o->Light, 0);
                 }
             }
         }
@@ -8758,7 +8766,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorAdd(Position, o->Position, Position);
                     Position[0] += rand() % 64 - 32;
                     Position[1] += rand() % 64 - 32;
-                    CreateParticle(BITMAP_FIRE + 3, Position, o->Angle, Light, 13, 2.5f);
+                    CreateParticleFpsChecked(BITMAP_FIRE + 3, Position, o->Angle, Light, 13, 2.5f);
                 }
             }
         }
@@ -8776,7 +8784,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         Vector((float)(rand() % 32 - 16), (float)(rand() % 32 - 16), 0.f, Position);
         VectorAdd(Position, o->Position, Position);
         Vector(1.0f, 0.4f, 0.4f, Light);
-        CreateParticle(BITMAP_FIRE_RED, Position, o->Angle, Light, 0, o->Scale);
+        CreateParticleFpsChecked(BITMAP_FIRE_RED, Position, o->Angle, Light, 0, o->Scale);
         break;
     case BITMAP_SPARK + 1:
     {
@@ -8791,9 +8799,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 Position[2] += Scale * 4.f;
                 if (j == 0)
-                    CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 1, Scale * 2.f);
+                    CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, o->Angle, Light, 1, Scale * 2.f);
                 else
-                    CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 1, Scale);
+                    CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, o->Angle, Light, 1, Scale);
             }
         }
         break;
@@ -8803,8 +8811,8 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             Luminosity = o->LifeTime * 0.2f;
             Vector(Luminosity, Luminosity, Luminosity, Light);
-            CreateParticle(BITMAP_ENERGY, o->Position, o->Angle, Light);
-            CreateParticle(BITMAP_SPARK + 1, o->Position, o->Angle, Light, 0, 4.f);
+            CreateParticleFpsChecked(BITMAP_ENERGY, o->Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, o->Position, o->Angle, Light, 0, 4.f);
             Vector(Luminosity * 0.2f, Luminosity * 0.4f, Luminosity * 1.f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
             CheckTargetRange(o);
@@ -8831,10 +8839,10 @@ void MoveEffect(OBJECT* o, int iIndex)
             CreateSprite(BITMAP_PIN_LIGHT, o->Position, 2.0f, vLight, o, (float)(rand() % 360));
 
             Vector(0.4f, 0.4f, 1.5f, vLight);
-            CreateParticle(BITMAP_MAGIC, o->Position, o->Angle, vLight, 0, 1.f);
+            CreateParticleFpsChecked(BITMAP_MAGIC, o->Position, o->Angle, vLight, 0, 1.f);
             for (int i = 0; i < 3; ++i)
             {
-                CreateParticle(BITMAP_SPARK + 1, o->Position, o->Angle, o->Light, 13, 1.0f);
+                CreateParticleFpsChecked(BITMAP_SPARK + 1, o->Position, o->Angle, o->Light, 13, 1.0f);
             }
 
             CheckTargetRange(o);
@@ -8860,7 +8868,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 for (int i = 0; i < 5; ++i)
                 {
-                    CreateParticle(BITMAP_SPARK + 1, o->Position, o->Angle, o->Light, 20, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SPARK + 1, o->Position, o->Angle, o->Light, 20, 1.0f);
                 }
             }
 
@@ -8868,21 +8876,21 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime >= 14)
             {
                 Vector(0.4f, 0.3f, 1.0f, vLight);
-                CreateParticle(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 0, 0.3f);
-                CreateParticle(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 0, 0.3f);
+                CreateParticleFpsChecked(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 0, 0.3f);
+                CreateParticleFpsChecked(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 0, 0.3f);
             }
 
             Vector(0.2f, 0.2f, 1.0f, vLight);
             for (int i = 0; i < 2; ++i)
             {
-                CreateEffect(MODEL_FENRIR_THUNDER, o->Position, o->Angle, vLight, 3, o);
+                CreateEffectFpsChecked(MODEL_FENRIR_THUNDER, o->Position, o->Angle, vLight, 3, o);
             }
 
             if (o->LifeTime <= 5)
             {
                 for (int i = 0; i < 2; ++i)
                 {
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 40);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 40);
                 }
             }
 
@@ -8932,19 +8940,19 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(0.4f, 0.4f, 1.0f, vLight);
                 pSourceModel->TransformPosition(pSourceObj->BoneTransform[37], vRelativePos, vPos, true);
                 Vector(-60.f, 0.f, pSourceObj->Angle[2], vAngle);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
                 Vector(0.f, 0.f, (pSourceObj->Angle[2]) + 60.f, vAngle);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
 
                 pSourceModel->TransformPosition(pSourceObj->BoneTransform[28], vRelativePos, vPos, true);
                 Vector(-60.f, 0.f, pSourceObj->Angle[2], vAngle);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
                 Vector(0.f, 0.f, (pSourceObj->Angle[2]) - 60.f, vAngle);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, vAngle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
             }
             else if (o->SubType == 1 || o->SubType == 2)
             {
@@ -8955,8 +8963,8 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorCopy(pTargetObj->Position, vTargetPos);
                 vTargetPos[2] += 80.0f;
                 //Vector(0.f, 0.f, 0.f, vAngle);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, pTargetObj->Angle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
-                CreateJoint(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, pTargetObj->Angle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, pTargetObj->Angle, 0, pTargetObj, 50.f, -1, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vPos, pTargetObj->Position, pTargetObj->Angle, 0, pTargetObj, 10.f, -1, 0, 0, -1, vLight);
             }
 
             if ((int)o->LifeTime == 15)
@@ -8970,7 +8978,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     Vector(0.2f, 0.2f, 0.8f, vLight);
                     fRandom = 3.0f + ((float)(rand() % 20 - 10) * 0.1f);
-                    CreateParticle(BITMAP_LIGHT, vPos, vAngle, vLight, 5, fRandom);
+                    CreateParticleFpsChecked(BITMAP_LIGHT, vPos, vAngle, vLight, 5, fRandom);
                 }
             }
         }
@@ -9026,7 +9034,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             vSourcePos[1] += ((float)((rand() % 60 - 30)));
             vSourcePos[2] += (80.0f + ((float)((rand() % 180 - 100))));
             Vector(1.0f, 0.2f, 0.2f, vLight);
-            CreateParticle(BITMAP_LIGHT + 2, vSourcePos, pSourceObj->Angle, vLight, 7, 1.8f);
+            CreateParticleFpsChecked(BITMAP_LIGHT + 2, vSourcePos, pSourceObj->Angle, vLight, 7, 1.8f);
         }
 
         if (o->LifeTime <= 60)
@@ -9038,7 +9046,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 vTargetPos[1] += ((float)((rand() % 60 - 30)));
                 vTargetPos[2] += (80.0f + ((float)((rand() % 180 - 100))));
                 Vector(1.0f, 0.2f, 0.2f, vLight);
-                CreateParticle(BITMAP_LIGHT + 2, vTargetPos, pTargetObj->Angle, vLight, 7, 1.8f);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 2, vTargetPos, pTargetObj->Angle, vLight, 7, 1.8f);
             }
         }
 
@@ -9091,7 +9099,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 vTargetPos[2] += 100.f + (float)(((rand() % 10 - 5)) * 4);		// 80~120
 
                 Vector(0.8f, 0.1f, 0.2f, vLight);
-                CreateJoint(BITMAP_DRAIN_LIFE_GHOST, vSourcePos, vTargetPos, o->Angle, 0, pSourceObj, 40.f, 0, 0, 0, -1, vLight);
+                CreateJointFpsChecked(BITMAP_DRAIN_LIFE_GHOST, vSourcePos, vTargetPos, o->Angle, 0, pSourceObj, 40.f, 0, 0, 0, -1, vLight);
             }
         }
 
@@ -9115,7 +9123,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorCopy(pSourceObj->Position, vSourcePos);
                     vSourcePos[2] += 80.0f;
                     Vector(1.0f, 0.0f, 0.1f, vLight);
-                    CreateJoint(BITMAP_JOINT_ENERGY, vTargetPos, vSourcePos, pTargetObj->Angle, 45, pSourceObj, 10.0f, -1, 0, 0, -1, vLight);
+                    CreateJointFpsChecked(BITMAP_JOINT_ENERGY, vTargetPos, vSourcePos, pTargetObj->Angle, 45, pSourceObj, 10.0f, -1, 0, 0, -1, vLight);
                 }
             }
         }
@@ -9238,11 +9246,11 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 if (o->SubType == 0 || o->SubType == 2)
                 {
-                    CreateJoint(BITMAP_JOINT_HEALING, vWorldPos, o->Position, vAngle, 15, o, 5.f, 0, 0, 0, 0, vLight);
+                    CreateJointFpsChecked(BITMAP_JOINT_HEALING, vWorldPos, o->Position, vAngle, 15, o, 5.f, 0, 0, 0, 0, vLight);
                 }
                 else if (o->SubType == 1)
                 {
-                    CreateJoint(BITMAP_JOINT_HEALING, vWorldPos, o->Position, vAngle, 16, o, 5.f, 0, 0, 0, 0, vLight);
+                    CreateJointFpsChecked(BITMAP_JOINT_HEALING, vWorldPos, o->Position, vAngle, 16, o, 5.f, 0, 0, 0, 0, vLight);
                 }
             }
         }
@@ -9270,19 +9278,19 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     if (o->SubType == 3)
                     {
-                        CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, o->Light, 6, o->Scale);
+                        CreateParticleFpsChecked(BITMAP_LIGHT + 2, vWorldPos, o->Angle, o->Light, 6, o->Scale);
                         iBone = rand() % pModel->NumBones;
                         pModel->TransformPosition(o->Owner->BoneTransform[iBone], vRelativePos, vWorldPos, false);
                         VectorScale(vWorldPos, pModel->BodyScale, vWorldPos);
                         VectorAdd(vWorldPos, o->Owner->Position, vWorldPos);
-                        CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, o->Light, 6, o->Scale);
+                        CreateParticleFpsChecked(BITMAP_LIGHT + 2, vWorldPos, o->Angle, o->Light, 6, o->Scale);
                     }
                     else if (o->SubType == 4)
                     {
                         if (rand_fps_check(2))
                         {
                             vWorldPos[2] -= 20.f;
-                            CreateParticle(BITMAP_TWINTAIL_WATER, vWorldPos, o->Angle, o->Light, 2);
+                            CreateParticleFpsChecked(BITMAP_TWINTAIL_WATER, vWorldPos, o->Angle, o->Light, 2);
                         }
                     }
                 }
@@ -9325,7 +9333,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             CreateSprite(BITMAP_PIN_LIGHT, o->Position, 2.0f * fScale, vLight, o, (float)(rand() % 360));
 
             Vector(1.0f, 0.3f, 0.3f, vLight);
-            CreateParticle(BITMAP_MAGIC, o->Position, o->Angle, vLight, 0, 1.f * fScale);
+            CreateParticleFpsChecked(BITMAP_MAGIC, o->Position, o->Angle, vLight, 0, 1.f * fScale);
 
             vec3_t vPos, vLightFlare, vRelative;
             Vector(1.0f, 0.7f, 0.4f, vLight);
@@ -9337,7 +9345,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     o->Position[2] + (rand() % 70 - 35) * 1.0f, vPos);
                 CreateSprite(BITMAP_LIGHT, vPos, 2.2f, vLightFlare, pObject);
                 if (rand() % 3 > 0) continue;
-                CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, pObject->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, pObject->Angle, vLight, 0, fScale);
             }
 
             Vector(1.0f, 0.5f, 0.4f, vLight);
@@ -9348,13 +9356,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 int iBone = rand() % 41;
                 Vector((rand() % 30 - 15) * 1.0f, (rand() % 30 - 15) * 1.0f, (rand() % 30 - 15) * 1.0f, vRelative);
                 pOwnerModel->TransformByObjectBone(vPos, pOwner, iBone, vRelative);
-                CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, pObject->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, pObject->Angle, vLight, 0, fScale);
             }
 
             float Height = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < Height)
             {
-                CreateEffect(MODEL_LIGHTNING_SHOCK, o->Position, o->Angle, o->Light, 1, o);
+                CreateEffectFpsChecked(MODEL_LIGHTNING_SHOCK, o->Position, o->Angle, o->Light, 1, o);
                 EffectDestructor(o);
             }
         }
@@ -9371,7 +9379,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 fScale = (float)(rand() % 80 + 32) * 0.01f * 1.0f;
                 Vector(o->Position[0] + (rand() % 70 - 35) * 1.0f, o->Position[1] + (rand() % 70 - 35) * 1.0f,
                     o->Position[2] + (rand() % 70 - 35) * 1.0f, vPos);
-                CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, pObject->Angle, vLight, 0, fScale);	// 전기
+                CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, pObject->Angle, vLight, 0, fScale);	// 전기
             }
 
             vec34_t Matrix;
@@ -9390,7 +9398,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorAdd(vPosition, o->Position, vPosition);
                 vPosition[2] = RequestTerrainHeight(vPosition[0], vPosition[1]) + 20;
 
-                CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPosition, pObject->Angle, vLight, 0, fScale);	// 전기
+                CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPosition, pObject->Angle, vLight, 0, fScale);	// 전기
             }
 
             VectorCopy(o->Position, vPosition);
@@ -9399,15 +9407,15 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(1.0f, 0.0f, 0.0f, vLight);
 
             for (int i = 0; i < 2; i++)
-                CreateParticle(BITMAP_SMOKE, vPosition, o->Angle, vLight, 58);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPosition, o->Angle, vLight, 58);
 
             if (rand_fps_check(2))
             {
                 Vector(1.0f, 0.0f, 0.0f, vLight);
-                CreateParticle(BITMAP_SMOKE, vPosition, o->Angle, vLight, 54, 2.8f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, vPosition, o->Angle, vLight, 54, 2.8f);
             }
 
-            CreateEffect(MODEL_STONE1 + rand() % 2, vPosition, o->Angle, vLight, 13, o);
+            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, vPosition, o->Angle, vLight, 13, o);
         }
         else if (o->SubType == 2)
         {
@@ -9427,24 +9435,24 @@ void MoveEffect(OBJECT* o, int iIndex)
                     if (rand_fps_check(60))
                     {
                         fRandom = 5.0f + ((float)(rand() % 20 - 10) * 0.1f);
-                        CreateParticle(BITMAP_LIGHT, vPos, vAngle, vLight, 5, fRandom);
+                        CreateParticleFpsChecked(BITMAP_LIGHT, vPos, vAngle, vLight, 5, fRandom);
                     }
                     Vector(1.0f, 0.8f, 0.4f, vLight);
                     if (rand_fps_check(5))
                     {
                         fRandom = (float)(rand() % 70 + 22) * 0.01f * 1.0f;
-                        CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, vAngle, vLight, 0, fRandom);
+                        CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, vAngle, vLight, 0, fRandom);
                     }
                 }
 
                 Vector(1.0f, 0.0f, 0.0f, vLight);
                 //for(i=0; i<2; i++)
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 58);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 58);
 
                 if (rand_fps_check(4))
                 {
                     Vector(1.0f, 0.0f, 0.0f, vLight);
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 54, 2.8f);
                 }
             }
         }
@@ -9474,12 +9482,12 @@ void MoveEffect(OBJECT* o, int iIndex)
             //o->Direction[2] -= .35f;
             o->Direction[2] -= .01f * FPS_ANIMATION_FACTOR;
             //VectorScale( o->Light, 0.9f, o->Light);
-            CreateParticle(BITMAP_LIGHT, o->Position, o->Angle, o->Light, 1, o->Scale);
+            CreateParticleFpsChecked(BITMAP_LIGHT, o->Position, o->Angle, o->Light, 1, o->Scale);
             if (o->Direction[2] < -2.f)
             {
                 o->LifeTime = 0;
                 /*vec3_t Light = { 1.f, 1.f, 1.f};
-                CreateParticle(BITMAP_EXPLOTION,o->Position,o->Angle,o->Light);*/
+                CreateParticleFpsChecked(BITMAP_EXPLOTION,o->Position,o->Angle,o->Light);*/
             }
         }
         else if (o->SubType == 1)
@@ -9501,10 +9509,10 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             Index = rand() % 7;
             Luminosity = g_byUpperBoneLocation[Index];
-            CreateParticle(BITMAP_LIGHT, o->Position, Angle, Light, 4, Luminosity, o->Owner);
+            CreateParticleFpsChecked(BITMAP_LIGHT, o->Position, Angle, Light, 4, Luminosity, o->Owner);
 
             Luminosity = g_byUpperBoneLocation[6 - Index];
-            CreateParticle(BITMAP_LIGHT, o->Position, Angle, Light, 4, Luminosity, o->Owner);
+            CreateParticleFpsChecked(BITMAP_LIGHT, o->Position, Angle, Light, 4, Luminosity, o->Owner);
         }
         else if (o->SubType == 2)
         {
@@ -9529,7 +9537,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     o->Position[1] = o->Owner->Position[1] + cosf(o->Angle[2] * 0.1f) * 80.f;
                     o->Position[2] = o->Owner->Position[2] + 50;
 
-                    CreateJoint(BITMAP_JOINT_HEALING, o->Position, o->Position, o->Angle, 9, o->Owner, 15.f);
+                    CreateJointFpsChecked(BITMAP_JOINT_HEALING, o->Position, o->Position, o->Angle, 9, o->Owner, 15.f);
                 }
             }
         }
@@ -9549,7 +9557,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     o->Position[1] = o->Owner->Position[1] + cosf(o->Angle[2] * 0.1f) * 50.f;
                     o->Position[2] = o->Owner->Position[2] + 20;
 
-                    CreateJoint(BITMAP_JOINT_HEALING, o->Position, o->Position, o->Angle, 9, o->Owner, 10.f);
+                    CreateJointFpsChecked(BITMAP_JOINT_HEALING, o->Position, o->Position, o->Angle, 9, o->Owner, 10.f);
                 }
             }
         }
@@ -9566,11 +9574,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (rand_fps_check(1))
                 {
-                    CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+                    CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
                 }
             }
-            CreateParticle(BITMAP_SHINY + 4, Position, o->Angle, Light);
-            CreateParticle(BITMAP_EXPLOTION, Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_SHINY + 4, Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_EXPLOTION, Position, o->Angle, Light);
             if (o->Owner == &Hero->Object)
                 AttackCharacterRange(o->Skill, o->Position, 150.f, o->Weapon, o->PKKey);
             o->Live = false;
@@ -9715,14 +9723,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                 {
                     if (rand_fps_check(1))
                     {
-                        CreateEffect(MODEL_METEO1 + rand() % 2, o->Position, o->Angle, o->Light, 0);
+                        CreateEffectFpsChecked(MODEL_METEO1 + rand() % 2, o->Position, o->Angle, o->Light, 0);
                     }
                 }
             }
         }
         VectorAddScaled(o->Position, o->Direction, o->Position, FPS_ANIMATION_FACTOR);
         o->Angle[0] += (10.f / o->Scale) * FPS_ANIMATION_FACTOR;
-        CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
+        CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
         //CreateParticle(BITMAP_ENERGY,o->Position,o->Angle,Light);
         //CreateParticle(BITMAP_SPARK+1,o->Position,o->Angle,Light,0,4.f);
         return;
@@ -9757,7 +9765,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->BlendMeshLight = o->LifeTime * 0.1f;
         break;
     case MODEL_SKILL_WHEEL1:
-        CreateEffect(MODEL_SKILL_WHEEL2, o->Position, o->Angle, o->Light, 4 - o->LifeTime, o->Owner, o->PKKey, o->Skill, o->Kind);
+        CreateEffectFpsChecked(MODEL_SKILL_WHEEL2, o->Position, o->Angle, o->Light, 4 - o->LifeTime, o->Owner, o->PKKey, o->Skill, o->Kind);
         break;
     case MODEL_SKILL_WHEEL2:
         switch (o->SubType)
@@ -9782,7 +9790,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->Angle[2] -= 18 * FPS_ANIMATION_FACTOR;
 
         if (rand_fps_check(1)) {
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
             Vector(Luminosity * 0.3f, Luminosity * 0.3f, Luminosity * 0.3f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
         }
@@ -9799,7 +9807,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[1] += rand() % 20 - 10;
             Position[2] += 120.f;
             Vector(0.5f, 0.5f, 0.5f, Light);
-            CreateParticle(BITMAP_WATERFALL_5, Position, Angle, Light, 3);
+            CreateParticleFpsChecked(BITMAP_WATERFALL_5, Position, Angle, Light, 3);
         }
         else
         {
@@ -9812,8 +9820,8 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorCopy(o->Position, Position);
                     Position[0] += rand() % 20 - 10;
                     Position[1] += rand() % 20 - 10;
-                    CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
-                    if (rand_fps_check(4)) CreateParticle(BITMAP_SPARK, Position, Angle, Light);
+                    CreateJointFpsChecked(BITMAP_JOINT_SPARK, Position, Position, Angle);
+                    if (rand_fps_check(4)) CreateParticleFpsChecked(BITMAP_SPARK, Position, Angle, Light);
                 }
             }
         }
@@ -9847,14 +9855,14 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 Position[0] += rand() % 600 - 200;
                 Position[1] += rand() % 600 - 400;
-                CreateJoint(BITMAP_FLARE, Position, Position, Angle, 24, NULL, 90);
+                CreateJointFpsChecked(BITMAP_FLARE, Position, Position, Angle, 24, NULL, 90);
             }
         }
         else if ((int)o->LifeTime == 2)
         {
             Vector(0.f, 0.f, rand() % 360, Angle);
-            CreateEffect(MODEL_FISSURE, o->Position, Angle, o->Light, 0, o);
-            CreateEffect(MODEL_FISSURE_LIGHT, o->Position, Angle, o->Light, 0, o);
+            CreateEffectFpsChecked(MODEL_FISSURE, o->Position, Angle, o->Light, 0, o);
+            CreateEffectFpsChecked(MODEL_FISSURE_LIGHT, o->Position, Angle, o->Light, 0, o);
             o->Live = false;
         }
     }
@@ -9875,7 +9883,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorRotate(p, Matrix, Position);
             VectorAdd(Position, o->Position, Position);
 
-            CreateEffect(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 0);
+            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 0);
         }
 
         BMD* pModel = &Models[o->Type];
@@ -9886,8 +9894,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 Vector(0.f, 0.f, 0.f, p);
                 pModel->TransformPosition(BoneTransform[i], p, Position, true);
-                CreateParticle(BITMAP_TRUE_FIRE, Position, o->Angle, Light, 3, 4.f, o);
-                CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 21, 1.f);
+                CreateParticleFpsChecked(BITMAP_TRUE_FIRE, Position, o->Angle, Light, 3, 4.f, o);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 21, 1.f);
             }
         }
     }
@@ -9936,7 +9944,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->StartPosition[2] = RequestTerrainHeight(o->StartPosition[0], o->StartPosition[1]) + AddHeight;
             AddHeight = 3.f;
 
-            CreateParticle(BITMAP_EXPLOTION, o->StartPosition, Angle, light, 0, 0.5f);
+            CreateParticleFpsChecked(BITMAP_EXPLOTION, o->StartPosition, Angle, light, 0, 0.5f);
 
             if (o->Kind == 0)
             {
@@ -9949,15 +9957,15 @@ void MoveEffect(OBJECT* o, int iIndex)
                         VectorCopy(o->StartPosition, Position);
                         Position[0] += rand() % 20 - 10;
                         Position[1] += rand() % 20 - 10;
-                        CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
-                        if (rand_fps_check(8)) CreateParticle(BITMAP_SPARK, Position, Angle, Light);
+                        CreateJointFpsChecked(BITMAP_JOINT_SPARK, Position, Position, Angle);
+                        if (rand_fps_check(8)) CreateParticleFpsChecked(BITMAP_SPARK, Position, Angle, Light);
                     }
                 }
             }
             Vector(0.f, 0.f, 0.f, Angle);
 
             if (o->Kind == 0)
-                CreateEffect(MODEL_WAVE, o->StartPosition, Angle, o->Light);
+                CreateEffectFpsChecked(MODEL_WAVE, o->StartPosition, Angle, o->Light);
 
             o->StartPosition[2] -= 27; //* FPS_ANIMATION_FACTOR;
 
@@ -9965,9 +9973,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (o->Owner->Type != MODEL_WEREWOLF_HERO)
                 {
-                    CreateEffect(MODEL_SKILL_FURY_STRIKE + 3, o->StartPosition, Angle, o->Light, 0, o, scale);
-                    CreateEffect(MODEL_SKILL_FURY_STRIKE + 1, o->StartPosition, Angle, o->Light, 0, o, scale);
-                    CreateEffect(MODEL_SKILL_FURY_STRIKE + 2, o->StartPosition, Angle, o->Light, 0, o, scale);
+                    CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE + 3, o->StartPosition, Angle, o->Light, 0, o, scale);
+                    CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE + 1, o->StartPosition, Angle, o->Light, 0, o, scale);
+                    CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE + 2, o->StartPosition, Angle, o->Light, 0, o, scale);
                 }
             }
 
@@ -9997,8 +10005,8 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                     Position[2] = RequestTerrainHeight(Position[0], Position[1]) + AddHeight;
 
-                    CreateEffect(MODEL_SKILL_FURY_STRIKE + 4, Position, Angle, o->Light, 0, o->Owner, scale);
-                    CreateEffect(MODEL_SKILL_FURY_STRIKE + 5, Position, Angle, o->Light, 0, o->Owner, scale);
+                    CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE + 4, Position, Angle, o->Light, 0, o->Owner, scale);
+                    CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE + 5, Position, Angle, o->Light, 0, o->Owner, scale);
                 }
             }
         }
@@ -10044,8 +10052,8 @@ void MoveEffect(OBJECT* o, int iIndex)
                             Pos[i][2] = RequestTerrainHeight(Pos[i][0], Pos[i][1]) + 3;
                         Angle[2] += 270.f;
 
-                        CreateEffect(MODEL_SKILL_FURY_STRIKE + 7, Pos[i], Angle, o->Light, 0, o->Owner, 100);
-                        CreateEffect(MODEL_SKILL_FURY_STRIKE + 8, Pos[i], Angle, o->Light, 0, o->Owner, 100);
+                        CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE + 7, Pos[i], Angle, o->Light, 0, o->Owner, 100);
+                        CreateEffectFpsChecked(MODEL_SKILL_FURY_STRIKE + 8, Pos[i], Angle, o->Light, 0, o->Owner, 100);
                     }
                 }
 
@@ -10084,7 +10092,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     {
                         position[0] = pos[0]; position[1] = pos[1];
                         position[2] = pos[2] - (i * 50);
-                        CreateEffect(MODEL_TAIL, position, Angle, o->Light);
+                        CreateEffectFpsChecked(MODEL_TAIL, position, Angle, o->Light);
                     }
                     pos[0] += rand() % 30 + 20;
                     pos[2] += rand() % 500 - 250;
@@ -10093,7 +10101,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     {
                         position[0] = pos[0]; position[1] = pos[1];
                         position[2] = pos[2] - (i * 30);
-                        CreateEffect(MODEL_TAIL, position, Angle, o->Light);
+                        CreateEffectFpsChecked(MODEL_TAIL, position, Angle, o->Light);
                     }
                     PlayBuffer(SOUND_FURY_STRIKE2);
                 }
@@ -10163,7 +10171,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorRotate(p, Matrix, Position);
                 VectorAdd(Position, o->Position, Position);
 
-                CreateEffect(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 0);
+                CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 0);
             }
         }
 
@@ -10215,7 +10223,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorRotate(p, Matrix, Position);
                 VectorAdd(Position, o->Position, Position);
 
-                CreateEffect(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 0);
+                CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 0);
             }
         }
 
@@ -10310,7 +10318,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Loc[2] = o->Position[2] - 200;
             if (o->SubType == 0 || o->SubType == 2)
             {
-                CreateJoint(BITMAP_FLARE, Loc, Loc, o->Angle, 50, NULL, 40);
+                CreateJointFpsChecked(BITMAP_FLARE, Loc, Loc, o->Angle, 50, NULL, 40);
             }
             //				else
             //				if(o->SubType == 1)
@@ -10318,7 +10326,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                                 //CreateJoint(BITMAP_FLARE,Loc,Loc,o->Angle,51,NULL,30);
 
             if (o->LifeTime > 40)
-                CreateEffect(BITMAP_MAGIC, o->Position, o->Angle, Light, 4, o, 4.0f);
+                CreateEffectFpsChecked(BITMAP_MAGIC, o->Position, o->Angle, Light, 4, o, 4.0f);
         }
         if (o->LifeTime <= 1 && o->SubType == 0)
             SetPlayerStop(Hero);
@@ -10341,16 +10349,16 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if ((int)o->LifeTime == 100)
             {
-                CreateEffect(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 1, o);
+                CreateEffectFpsChecked(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 1, o);
             }
             else
                 if ((int)o->LifeTime == 70)
                 {
-                    CreateEffect(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 2, o);
+                    CreateEffectFpsChecked(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 2, o);
                 }
             if ((int)o->LifeTime == 40)
             {
-                CreateEffect(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 3, o);
+                CreateEffectFpsChecked(MODEL_CHANGE_UP_NASA, o->Position, o->Angle, o->Light, 3, o);
             }
         }
         if (o->SubType >= 1 && o->SubType <= 3)
@@ -10406,7 +10414,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         for (int j = 0; j < 6; j++)
         {
             if (rand_fps_check(1))
-                CreateParticle(BITMAP_SMOKE, Position, Angle, o->Light, 25);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, Angle, o->Light, 25);
         }
         Vector(Luminosity * 0.3f, Luminosity * 0.6f, Luminosity, Light);
         AddTerrainLight(Position[0], Position[1], Light, 3, PrimaryTerrainLight);
@@ -10420,7 +10428,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         for (int j = 0; j < 4; j++)
             if (rand_fps_check(1))
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
 
         Vector(Luminosity * 0.3f, Luminosity * 0.6f, Luminosity, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
@@ -10433,7 +10441,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorCopy(o->Position, Position);
             Angle[2] += rand() % 10 - 5;
             if (rand_fps_check(1))
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.015f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.015f);
 
             Vector(1.f, 1.f, 1.f, Light2);
             Position[2] += 50.f;
@@ -10450,21 +10458,21 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->BlendMeshLight = o->LifeTime * 0.1f;
             o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.1f;
             //VectorAdd(o->Position,o->Direction,o->Position);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 3);
             Vector(90.f, 0.f, o->Angle[2], Angle);
             if (rand_fps_check(2))
             {
                 Vector(o->Position[0] - 200.f, o->Position[1], o->Position[2] + 700.f, Position);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 10.f);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 10.f);
             }
             if (rand_fps_check(2))
             {
                 Vector(o->Position[0] + 200.f, o->Position[1], o->Position[2] + 700.f, Position);
-                CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 10.f);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 10.f);
             }
             o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (rand_fps_check(4))
-                CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
+                CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
             Vector(-Luminosity * 0.4f, -Luminosity * 0.3f, -Luminosity * 0.2f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 5, PrimaryTerrainLight);
 
@@ -10491,8 +10499,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             VectorCopy(o->Position, Position);
             Position[2] += 100.f;
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light, 3);
-            CreateParticle(BITMAP_BUBBLE, Position, o->Angle, o->Light, 3, 0.1f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, o->Light, 3);
+            CreateParticleFpsChecked(BITMAP_BUBBLE, Position, o->Angle, o->Light, 3, 0.1f);
 
             Vector(-Luminosity * 0.1f, -Luminosity * 0.3f, -Luminosity * 1.f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], o->Light, 5, PrimaryTerrainLight);
@@ -10506,8 +10514,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             VectorCopy(o->Position, Position);
             Position[2] += 100.f;
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light, 3);
-            CreateParticle(BITMAP_BUBBLE, Position, o->Angle, o->Light, 3, 0.1f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, o->Light, 3);
+            CreateParticleFpsChecked(BITMAP_BUBBLE, Position, o->Angle, o->Light, 3, 0.1f);
 
             Vector(-Luminosity * 0.1f, -Luminosity * 0.3f, -Luminosity * 1.f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], o->Light, 5, PrimaryTerrainLight);
@@ -10518,11 +10526,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         case 6:
         case 7:
             EarthQuake = (float)(rand() % 8 - 4) * 0.1f;
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 28);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 29);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 30);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 28);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 29);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 30);
             if (rand_fps_check(2))
-                CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
+                CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
             break;
         case 8:
         {
@@ -10583,7 +10591,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorAdd(Position, o->Position, Position);
 
                 Vector(0.3f, 0.5f, 0.6f, Light);
-                CreateParticle(BITMAP_CLUD64, Position, o->Angle, Light, 1, 1.0f);
+                CreateParticleFpsChecked(BITMAP_CLUD64, Position, o->Angle, Light, 1, 1.0f);
             }
 
             Vector(90.f, 0.f, 0.0f, Angle);
@@ -10596,12 +10604,12 @@ void MoveEffect(OBJECT* o, int iIndex)
             Pos2[1] = Pos1[1] + rand() % 100 - 50.0f;
             Pos2[2] = Pos1[2];
 
-            CreateJoint(BITMAP_JOINT_THUNDER, Pos1, Pos2, Angle, 20, o, 20.f);
+            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Pos1, Pos2, Angle, 20, o, 20.f);
 
             Pos2[0] = Pos1[0] + rand() % 100 - 50.0f;
             Pos2[1] = Pos1[1] + rand() % 100 - 50.0f;
             Pos2[2] = Pos1[2];
-            CreateEffect(MODEL_STONE1 + rand() % 2, Pos2, o->Angle, Light, 2);
+            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, Pos2, o->Angle, Light, 2);
 
             o->Angle[2] += (o->Gravity) * FPS_ANIMATION_FACTOR;
             o->Light[0] *= pow(1.0f / (1.02f), FPS_ANIMATION_FACTOR);
@@ -10624,7 +10632,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Light[2] *= pow(1.0f / (1.01f), FPS_ANIMATION_FACTOR);
             }
 
-            CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
+            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light, 2);
         }
     }
     break;
@@ -10653,7 +10661,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Pos2[0] = Pos1[1] + rand() % 200 - 100.0f;
                 Pos2[1] = Pos1[1] + rand() % 200 - 100.0f;
 
-                CreateJoint(BITMAP_JOINT_THUNDER, Pos1, Pos2, Angle, 20, o, 20.f);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Pos1, Pos2, Angle, 20, o, 20.f);
             }
         }
     }
@@ -10694,7 +10702,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             Vector(0.0f, 0.6f, 1.f, Light);
             Vector(0.f, 0.f, 0.f, Angle);
-            CreateEffect(MODEL_SKILL_INFERNO, o->Position, Angle, Light, 2, o, 30, 0);
+            CreateEffectFpsChecked(MODEL_SKILL_INFERNO, o->Position, Angle, Light, 2, o, 30, 0);
 
             for (int i = 0; i < smokeNum; ++i)
             {
@@ -10703,13 +10711,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Position[2] = o->Position[2] + 50;
 
                 Vector(0.3f, 0.5f, 1.0f, Light);
-                CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
             }
 
             for (int j = 0; j < 6; j++)
-                CreateEffect(MODEL_MAYASTONE4 + rand() % 2, o->Position, o->Angle, Light);
+                CreateEffectFpsChecked(MODEL_MAYASTONE4 + rand() % 2, o->Position, o->Angle, Light);
 
-            CreateParticle(BITMAP_EXPLOTION, Position, o->Angle, Light, 0, 4.0f);
+            CreateParticleFpsChecked(BITMAP_EXPLOTION, Position, o->Angle, Light, 0, 4.0f);
 
             o->Live = false;
         }
@@ -10734,7 +10742,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Angle[0] -= (o->Scale * 32.f) * FPS_ANIMATION_FACTOR;
 
         if (rand_fps_check(10))
-            CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 15);
+            CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, o->Light, 15);
     }
     break;
     case MODEL_MAYASTONEFIRE:
@@ -10757,14 +10765,14 @@ void MoveEffect(OBJECT* o, int iIndex)
             vec3_t vPos;
             VectorCopy(o->Position, vPos);
             vPos[2] += 100.f;
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->StartPosition, 17, 10.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->StartPosition, 17, 10.0f);
 
             vec3_t Direction;
             Vector(0.0f, (-80.0f - rand() % 30) * o->Scale, 0.0f, Direction);
             AngleMatrix(o->Angle, Matrix);
             VectorRotate(Direction, Matrix, Position);
             VectorAdd(Position, o->Position, o->Position);
-            CreateEffect(MODEL_MAYAHANDSKILL, o->Position, o->Angle, o->StartPosition, 1, NULL, -1, 0, 0, 0, o->Scale + 0.2f);
+            CreateEffectFpsChecked(MODEL_MAYAHANDSKILL, o->Position, o->Angle, o->StartPosition, 1, NULL, -1, 0, 0, 0, o->Scale + 0.2f);
 
             if (o->Light[0] <= 0.05f)
                 o->Live = false;
@@ -10778,7 +10786,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             vec3_t vPos;
             VectorCopy(o->Position, vPos);
             vPos[2] += 100.f;
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, o->StartPosition, 17, 10.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, o->StartPosition, 17, 10.0f);
         }
     }
     break;
@@ -10798,12 +10806,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                     vec3_t Position;
                     VectorCopy(o->Position, Position);
                     Position[2] += 100.f;
-                    CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 6, o, 60.f, 0, 0);
+                    CreateJointFpsChecked(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 6, o, 60.f, 0, 0);
 
                     if ((int)o->LifeTime == (44 - o->Owner->m_bySkillCount + 1))
                     {
                         Angle[2] = i * 10.f;
-                        CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 7, o, 60.f, 0, 0);
+                        CreateJointFpsChecked(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 7, o, 60.f, 0, 0);
                     }
                 }
             }
@@ -10843,8 +10851,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     VectorCopy(o->Position, Position);
                     Position[2] += 100.f;
-                    CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 22, o, 2.0f, 0, 0);
-                    CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 23, o, 1.75f, 0, 0);
+                    CreateJointFpsChecked(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 22, o, 2.0f, 0, 0);
+                    CreateJointFpsChecked(BITMAP_JOINT_SPIRIT, Position, Position, Angle, 23, o, 1.75f, 0, 0);
                 }
             }
         }
@@ -10871,7 +10879,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 AngleMatrix(Angle, Matrix);
                 VectorRotate(p, Matrix, Position);
                 VectorAdd(Position, o->Position, Position);
-                CreateEffect(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 1);
+                CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 1);
             }
             Vector(Luminosity * 1.f, Luminosity * 0.8f, Luminosity * 0.2f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 4, PrimaryTerrainLight);
@@ -10898,12 +10906,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorRotate(p, Matrix, Position);
                 VectorAdd(Position, o->Position, Position);
 
-                CreateParticle(BITMAP_FLARE_BLUE, Position, o->Angle, o->Light, 0);
+                CreateParticleFpsChecked(BITMAP_FLARE_BLUE, Position, o->Angle, o->Light, 0);
                 if (o->LifeTime > 40)
                 {
                     Position[2] += 600.f;
                     Angle[2] = 45.f;
-                    CreateJoint(BITMAP_FLARE_BLUE, Position, Position, Angle, 19, NULL, 40);
+                    CreateJointFpsChecked(BITMAP_FLARE_BLUE, Position, Position, Angle, 19, NULL, 40);
                 }
             }
             Vector(o->BlendMeshLight, o->BlendMeshLight, o->BlendMeshLight, Light);
@@ -10931,10 +10939,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorRotate(p, Matrix, Position);
                 VectorAdd(Position, o->Position, Position);
 
-                CreateParticle(BITMAP_FLARE_BLUE, Position, o->Angle, o->Light, 0);
+                CreateParticleFpsChecked(BITMAP_FLARE_BLUE, Position, o->Angle, o->Light, 0);
                 Position[2] += 600.f;
                 Angle[2] = 45.f;
-                CreateJoint(BITMAP_FLARE_BLUE, Position, Position, Angle, 19, NULL, 40);
+                CreateJointFpsChecked(BITMAP_FLARE_BLUE, Position, Position, Angle, 19, NULL, 40);
             }
             Vector(o->BlendMeshLight, o->BlendMeshLight, o->BlendMeshLight, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 4, PrimaryTerrainLight);
@@ -11042,10 +11050,10 @@ void MoveEffect(OBJECT* o, int iIndex)
             if ((o->SubType == 0 || o->SubType == 12 || o->SubType == 13) && rand_fps_check(10))
             {
                 if (o->Type == MODEL_ICE_SMALL || o->Type == MODEL_METEO1 || o->Type == MODEL_METEO2)
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light);
                 else if (o->Type == MODEL_STONE1 || o->Type == MODEL_STONE2)
                 {
-                    CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 1 + rand() % 3);
+                    CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, o->Light, 1 + rand() % 3);
                 }
             }
         }
@@ -11097,7 +11105,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             }
 
             if (rand_fps_check(30))
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light);
         }
         else if (o->SubType == 1)
         {
@@ -11121,7 +11129,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(0.0f, 0.6f, 1.f, Light);
                 Vector(0.f, 0.f, 0.f, Angle);
 
-                CreateEffect(MODEL_SKILL_INFERNO, o->Position, Angle, Light, 2, o);
+                CreateEffectFpsChecked(MODEL_SKILL_INFERNO, o->Position, Angle, Light, 2, o);
 
                 Vector(0.2f, 0.4f, 0.8f, Light);
                 for (int i = 0; i < 8; ++i)
@@ -11130,19 +11138,19 @@ void MoveEffect(OBJECT* o, int iIndex)
                     vPos[1] = o->Position[1] + (rand() % 80 - 40);
                     vPos[2] = o->Position[2] + 50;
 
-                    CreateParticle(BITMAP_SMOKE, vPos, o->Angle, Light, 11, (float)(rand() % 40 + 60) * 0.025f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, Light, 11, (float)(rand() % 40 + 60) * 0.025f);
                 }
 
                 for (int j = 0; j < 6; j++)
                 {
-                    CreateEffect(MODEL_EFFECT_BROKEN_ICE0 + rand() % 3, vPos, o->Angle, Light, 0);
+                    CreateEffectFpsChecked(MODEL_EFFECT_BROKEN_ICE0 + rand() % 3, vPos, o->Angle, Light, 0);
                 }
 
                 Vector(0.6f, 0.6f, 1.f, Light);
                 vPos[0] = o->Position[0];
                 vPos[1] = o->Position[1];
                 vPos[2] = o->Position[2] + 100;
-                CreateParticle(BITMAP_EXPLOTION_MONO, vPos, o->Angle, Light, 1, 1.5f);
+                CreateParticleFpsChecked(BITMAP_EXPLOTION_MONO, vPos, o->Angle, Light, 1, 1.5f);
 
                 o->Live = false;
             }
@@ -11154,7 +11162,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             float fHeight = RequestTerrainHeight(o->Position[0], o->Position[1]);
             if (o->Position[2] < fHeight)
             {
-                CreateEffect(o->Type, o->Position, o->Angle, o->Light, 0);
+                CreateEffectFpsChecked(o->Type, o->Position, o->Angle, o->Light, 0);
 
                 o->Live = false;
             }
@@ -11239,7 +11247,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
             }
 
-            CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 5, 1.2f);
+            CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light, 5, 1.2f);
 
             Vector(Luminosity, Luminosity * 0.3f, Luminosity * 0.1f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 4, PrimaryTerrainLight);
@@ -11297,14 +11305,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                             Position[2] -= 30.f;
                             VectorCopy(o->Angle, Angle);
                             Angle[2] += rand() % 180;
-                            CreateParticle(BITMAP_WATERFALL_5, Position, Angle, Light, 2);
+                            CreateParticleFpsChecked(BITMAP_WATERFALL_5, Position, Angle, Light, 2);
                         }
                     }
                     VectorCopy(o->Position, Position);
                     Position[0] += rand() % 40 - 20;
                     Position[1] += rand() % 40 - 20;
                     Position[2] -= 50.f;
-                    CreateParticle(BITMAP_BUBBLE, Position, o->Angle, o->Light, 4);
+                    CreateParticleFpsChecked(BITMAP_BUBBLE, Position, o->Angle, o->Light, 4);
 
                     o->Direction[0] = 0;
                     o->Direction[1] = 0;
@@ -11353,14 +11361,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                         VectorCopy(o->Position, Position);
                         //Position[2] += 100.f;
                         if (rand_fps_check(2))
-                            CreateJoint(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 8, NULL, 50.f, 0, 0);
+                            CreateJointFpsChecked(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 8, NULL, 50.f, 0, 0);
                     }
 
                     if (rand_fps_check(3))
                     {
                         vec3_t Light;
                         Vector(0.5f, 0.5f, 0.5f, Light);
-                        CreateParticle(BITMAP_SMOKE + 3, o->Position, o->Angle, Light, 2, (float)(rand() % 32 + 48) * 0.02f);
+                        CreateParticleFpsChecked(BITMAP_SMOKE + 3, o->Position, o->Angle, Light, 2, (float)(rand() % 32 + 48) * 0.02f);
                     }
                 }
             }
@@ -11627,7 +11635,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         for (int j = 0; j < 4; j++)
         {
-            CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 1);
+            CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, Light, 1);
         }
 
         AddTerrainLight(o->Position[0], o->Position[1], Light, 3, PrimaryTerrainLight);
@@ -11639,11 +11647,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             VectorCopy(o->Position, Position);
             Position[2] += 80;
-            CreateParticle(BITMAP_EXPLOTION, Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_EXPLOTION, Position, o->Angle, Light);
 
             for (int j = 0; j < 6; j++)
             {
-                CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+                CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
             }
             o->Live = false;
         }
@@ -11670,7 +11678,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             Vector(1.f, 1.f, 1.f, Light);
 
-            CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 3, NULL, 20.f, 7); //  전기
+            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 3, NULL, 20.f, 7); //  전기
             CreateSprite(BITMAP_SHINY + 1, o->Position, (float)(rand() % 8 + 8) * 0.2f, Light, o, (float)(rand() % 360));
         }
 
@@ -11690,10 +11698,10 @@ void MoveEffect(OBJECT* o, int iIndex)
     case MODEL_PIERCING + 1:
         if (rand_fps_check(2))
         {
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 0);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 0);
         }
-        CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 5);
-        CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 5);
+        CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light, 5);
+        CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light, 5);
 
         Vector(Luminosity * 0.6f, Luminosity * 0.8f, Luminosity * 0.8f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
@@ -11734,7 +11742,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Angle[1] += (60.f) * FPS_ANIMATION_FACTOR;
 
             if ((int)o->LifeTime == 13)
-                CreateEffect(MODEL_PIERCING, o->Position, o->Angle, o->Light, 3, o);
+                CreateEffectFpsChecked(MODEL_PIERCING, o->Position, o->Angle, o->Light, 3, o);
             CheckClientArrow(o);
 
             Vector(Luminosity * 0.9f, Luminosity * 0.4f, Luminosity * 0.6f, Light);
@@ -11751,7 +11759,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if ((int)o->LifeTime == 13)
                 {
-                    CreateEffect(MODEL_PIERCING, o->Position, o->Angle, o->Light, 0, o);
+                    CreateEffectFpsChecked(MODEL_PIERCING, o->Position, o->Angle, o->Light, 0, o);
                 }
                 else if ((int)o->LifeTime == 30)
                 {
@@ -11790,17 +11798,17 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(0.f, 0.f, 0.f, o->Direction);
                 }
             }
-            CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 5);
+            CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light, 5);
         }
         else if (o->SubType == 5)
         {
             Vector(Luminosity * 0.1f, Luminosity * 0.6f, Luminosity * 0.3f, Light);
-            CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light);
             CheckClientArrow(o);
         }
         else
         {
-            CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light);
             CheckClientArrow(o);
         }
         break;
@@ -11832,7 +11840,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         VectorAdd(Position, o->Position, Position);
 
                         Vector(0.4f, 1.f, 0.2f, Light);
-                        CreateParticle(BITMAP_FLARE, Position, o->Angle, Light, 5, 0.2f);
+                        CreateParticleFpsChecked(BITMAP_FLARE, Position, o->Angle, Light, 5, 0.2f);
                     }
                 }
             }
@@ -11844,7 +11852,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 {
                     Vector((float)(rand() % 32 - 16), (float)(rand() % 64 - 32), (float)(rand() % 32 - 16), Position);
                     VectorAdd(Position, o->Position, Position);
-                    CreateParticle(BITMAP_FLOWER01 + rand() % 3, Position, o->Angle, o->Light);
+                    CreateParticleFpsChecked(BITMAP_FLOWER01 + rand() % 3, Position, o->Angle, o->Light);
                     //CreateParticle(BITMAP_BUBBLE,Position,o->Angle,o->Light);
                 }
                 o->Angle[1] += (30.f) * FPS_ANIMATION_FACTOR;
@@ -11865,11 +11873,11 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorAdd(Position, o->Position, Position);
 
                     Vector(0.4f, 0.2f, 1.f, Light);
-                    CreateParticle(BITMAP_FLARE, Position, o->Angle, Light, 5, 0.2f);
+                    CreateParticleFpsChecked(BITMAP_FLARE, Position, o->Angle, Light, 5, 0.2f);
                 }
             }
             VectorCopy(o->Position, o->EyeLeft);
-            CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 3, NULL, 0);
+            CreateEffectFpsChecked(MODEL_WAVES, o->Position, o->Angle, o->Light, 3, NULL, 0);
 
             Vector(Luminosity * 0.6f, Luminosity * 0.2f, Luminosity * 0.8f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
@@ -11882,9 +11890,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 Vector((float)(rand() % 16 - 8), (float)(rand() % 16 - 8), (float)(rand() % 16 - 8), Position);
                 VectorAdd(Position, o->Position, Position);
-                CreateParticle(BITMAP_BUBBLE, Position, o->Angle, o->Light, 1);
+                CreateParticleFpsChecked(BITMAP_BUBBLE, Position, o->Angle, o->Light, 1);
             }
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 0);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 0);
 
             Vector(Luminosity * 0.6f, Luminosity * 0.8f, Luminosity * 0.8f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
@@ -11909,7 +11917,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]) + 3.f;
 
-        CreateParticle(BITMAP_FLAME, o->Position, o->Angle, o->Light, 8, (o->Scale - 0.4f) * 3.5f);
+        CreateParticleFpsChecked(BITMAP_FLAME, o->Position, o->Angle, o->Light, 8, (o->Scale - 0.4f) * 3.5f);
         if (o->Type == MODEL_DARK_SCREAM)
         {
             CheckClientArrow(o);
@@ -11970,7 +11978,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         effbmd->SetBodyLight(o->Light);
         effbmd->PlayAnimation(&o->AnimationFrame, &o->PriorAnimationFrame, &o->PriorAction, o->Velocity / 3.f, o->Position, o->Angle);
 
-        CreateEffect(BITMAP_SHOCK_WAVE, o->Owner->Position, o->Angle, o->Light, 10, o->Owner);
+        CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Owner->Position, o->Angle, o->Light, 10, o->Owner);
     }
     break;
     case MODEL_CURSEDTEMPLE_RESTRAINT_SKILL:
@@ -12007,7 +12015,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     {
         VectorCopy(o->Position, o->EyeLeft);
         Vector(0.0f, 1.0f, 0.1f, o->Light);
-        CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 4, NULL, 0);
+        CreateEffectFpsChecked(MODEL_WAVES, o->Position, o->Angle, o->Light, 4, NULL, 0);
 
         Vector(Luminosity * 0.6f, Luminosity * 0.2f, Luminosity * 0.8f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
@@ -12031,7 +12039,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             Vector((float)(rand() % 16 - 8), (float)(rand() % 16 - 8), (float)(rand() % 16 - 8), Position);
             VectorAdd(Position, o->Position, Position);
-            CreateParticle(BITMAP_BUBBLE, Position, o->Angle, o->Light, 1);
+            CreateParticleFpsChecked(BITMAP_BUBBLE, Position, o->Angle, o->Light, 1);
         }
         MoveJump(o);
         if ((int)o->LifeTime == 1)
@@ -12079,8 +12087,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             pModel->TransformByObjectBone(vPos, o, 1);
             for (int i = 0; i < iNumCreateFeather; i++)
             {
-                CreateEffect(MODEL_FEATHER, vPos, o->Angle, Light, 0, NULL, -1, 0, 0, 0, 0.6f);
-                CreateEffect(MODEL_FEATHER, vPos, o->Angle, Light, 1, NULL, -1, 0, 0, 0, 0.6f);
+                CreateEffectFpsChecked(MODEL_FEATHER, vPos, o->Angle, Light, 0, NULL, -1, 0, 0, 0, 0.6f);
+                CreateEffectFpsChecked(MODEL_FEATHER, vPos, o->Angle, Light, 1, NULL, -1, 0, 0, 0, 0.6f);
             }
         }
 
@@ -12088,7 +12096,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             pModel->TransformByObjectBone(vPos, o, 1);
             Vector(0.4f, 0.4f, 0.9f, Light);
-            CreateJoint(BITMAP_FLARE + 1, vPos, vPos, o->Angle, 18, o, 90.f, 40, 0, 0, -1, Light);
+            CreateJointFpsChecked(BITMAP_FLARE + 1, vPos, vPos, o->Angle, 18, o, 90.f, 40, 0, 0, -1, Light);
         }
     }
     break;
@@ -12104,11 +12112,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector((float)(rand() % 32 - 16), (float)(rand() % 64 - 32), (float)(rand() % 32 - 16), Position);
             VectorAdd(Position, o->Position, Position);
 
-            CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, vLight, 30, 1.f);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, o->Angle, vLight, 30, 1.f);
         }
 
         VectorCopy(o->Position, o->EyeLeft);
-        CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 24, 1.0f);
+        CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 24, 1.0f);
 
         Vector(Luminosity * 0.2f, Luminosity * 0.8f, Luminosity * 0.5f, vLight);
         AddTerrainLight(o->Position[0], o->Position[1], vLight, 2, PrimaryTerrainLight);
@@ -12159,7 +12167,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(o->Position[0] + (float)(rand() % 64 - 32),
                         o->Position[1] + (float)(rand() % 64 - 32),
                         o->Position[2] + (float)(rand() % 128 + 32), Position);
-                    CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, o->Light);
                 }
                 //AttackRange(o->Position,200.f,10);
                 o->Alpha -= (0.05f) * FPS_ANIMATION_FACTOR;
@@ -12229,7 +12237,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     Position[2] += o->Gravity;
                     Vector(1.f, 1.f, 1.f, Light);
-                    CreateParticle(BITMAP_FIRE + 2, Position, o->Angle, Light, 10, 2.f);
+                    CreateParticleFpsChecked(BITMAP_FIRE + 2, Position, o->Angle, Light, 10, 2.f);
                 }
             }
             else
@@ -12328,7 +12336,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     Vector(0.f, 0.5f, 0.f, Light);
                     Vector(0.f, 0.f, 0.f, Angle);
-                    CreateEffect(MODEL_SKILL_INFERNO, o->Position, Angle, Light, 2, o, 30, 0);
+                    CreateEffectFpsChecked(MODEL_SKILL_INFERNO, o->Position, Angle, Light, 2, o, 30, 0);
 
                     if (o->SubType == 7)
                     {
@@ -12346,14 +12354,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                         Position[2] = o->Position[2] + 50;
 
                         Vector(0.1f, 0.5f, 0.1f, Light);
-                        CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
+                        CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
                     }
 
                     if (o->SubType != 7 && o->SubType != 8)
                     {
                         for (int j = 0; j < 6; j++)
                         {
-                            CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, Light);
+                            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, Light);
                         }
                     }
                     PlayBuffer(SOUND_DEATH_POISON2);
@@ -12362,10 +12370,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                 {
                     for (int j = 0; j < 6; j++)
                     {
-                        CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+                        CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
                     }
                 }
-                CreateParticle(BITMAP_EXPLOTION, Position, o->Angle, Light);
+                CreateParticleFpsChecked(BITMAP_EXPLOTION, Position, o->Angle, Light);
 
                 o->Live = false;
             }
@@ -12396,18 +12404,18 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(0.f, 0.f, 0.f, o->Direction);
                 vec3_t Position;
                 Vector(o->Position[0], o->Position[1], o->Position[2] + 80.f, Position);
-                CreateParticle(BITMAP_EXPLOTION, Position, o->Angle, Light);
+                CreateParticleFpsChecked(BITMAP_EXPLOTION, Position, o->Angle, Light);
                 for (int j = 0; j < 6; j++)
                 {
-                    CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+                    CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
                 }
                 o->Live = false;
             }
         }
         else if (o->SubType == 9)
         {
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Direction, 36, 1.0f + o->Scale, o);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Direction, 37, 2.0f + o->Scale, o);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Direction, 36, 1.0f + o->Scale, o);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Direction, 37, 2.0f + o->Scale, o);
             Vector(1.0f, 0.2f, 0.2f, o->Light);
             AddTerrainLight(o->Position[0], o->Position[1], o->Light, 4, PrimaryTerrainLight);
 
@@ -12428,7 +12436,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
             if ((rand() % 5) != 0)
             {
-                CreateParticle(BITMAP_POUNDING_BALL, o->Position, o->Angle, Light);
+                CreateParticleFpsChecked(BITMAP_POUNDING_BALL, o->Position, o->Angle, Light);
             }
         }
         else
@@ -12461,12 +12469,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Position[0] = o->Position[0] + rand() % 50 - 25;
                     Position[1] = o->Position[1];
                     Position[2] = o->Position[2];
-                    CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, 5);
+                    CreateParticleFpsChecked(BITMAP_FIRE, Position, o->Angle, Light, 5);
                 }
             }
             else if (o->SubType != 3)
             {
-                CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 5);
+                CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light, 5);
             }
             else
             {
@@ -12479,10 +12487,10 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 Vector(0.0f, 0.0f, 0.0f, Angle);
                 Vector(1.0f, 1.0f, 1.0f, Light);
-                CreateParticle(BITMAP_FIRE, Pos, Angle, Light, 8, o->Scale * 2.5f);
+                CreateParticleFpsChecked(BITMAP_FIRE, Pos, Angle, Light, 8, o->Scale * 2.5f);
                 CreateSprite(BITMAP_SHINY + 1, Pos, o->Scale * 3.0f, Light, NULL, (float)(rand() % 360));
             }
-            //                CreateParticle(BITMAP_SMOKE,o->Position,o->Angle,Light, 5);
+            //                CreateParticleFpsChecked(BITMAP_SMOKE,o->Position,o->Angle,Light, 5);
             if (o->SubType == 1)
             {
                 CheckTargetRange(o);
@@ -12495,7 +12503,7 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_FIRECRACKERRISE:
         if (0 == ((int)o->LifeTime % 5) && (0 == (rand() % 3)))
         {
-            CreateEffect(BITMAP_FIRECRACKER, o->Position, o->Angle, o->Light);
+            CreateEffectFpsChecked(BITMAP_FIRECRACKER, o->Position, o->Angle, o->Light);
         }
         break;
     case BITMAP_FIRECRACKER:
@@ -12507,11 +12515,11 @@ void MoveEffect(OBJECT* o, int iIndex)
             //for ( int j = 0; j < 200; ++j)
             for (int j = 0; j < 80 * FPS_ANIMATION_FACTOR; ++j)
             {
-                CreateParticle(BITMAP_FIRECRACKER, o->Position, o->Angle, Light, iSubType);
+                CreateParticleFpsChecked(BITMAP_FIRECRACKER, o->Position, o->Angle, Light, iSubType);
             }
             PlayBuffer(SOUND_FIRECRACKER2, o);
         }
-        CreateParticle(BITMAP_FIRECRACKER, o->Position, o->Angle, o->Light, -1);
+        CreateParticleFpsChecked(BITMAP_FIRECRACKER, o->Position, o->Angle, o->Light, -1);
         Vector(Luminosity * .4f, Luminosity * 0.3f, Luminosity * 0.2f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 1, PrimaryTerrainLight);
         break;
@@ -12522,7 +12530,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             Vector(o->Position[0] + (rand() % 200 - 100), o->Position[1] + (rand() % 200 - 100),
                 o->Position[2], Position);
-            CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, o->Angle, 25, o, 1.f, -1, o->SubType);
+            CreateJointFpsChecked(BITMAP_JOINT_SPIRIT, Position, Position, o->Angle, 25, o, 1.f, -1, o->SubType);
         }
     }
     break;
@@ -12535,7 +12543,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(o->Position[0] + (rand() % 300 - 150), o->Position[1] + (rand() % 300 - 150),
                 o->Position[2], Position);
             float fScale = 0.5f + (rand() % 5) * 0.1f;
-            CreateEffect(BITMAP_FIRECRACKER0003, Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, fScale);
+            CreateEffectFpsChecked(BITMAP_FIRECRACKER0003, Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, fScale);
         }
     }
     break;
@@ -12573,13 +12581,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 vec3_t Light;
                 Vector(1.f, 1.f, 1.f, Light);
-                CreateJoint(BITMAP_JOINT_FORCE, Position, Position, o->HeadAngle, 10, o->Owner, 150.f, o->PKKey, o->Skill, 0, -1, Light);
+                CreateJointFpsChecked(BITMAP_JOINT_FORCE, Position, Position, o->HeadAngle, 10, o->Owner, 150.f, o->PKKey, o->Skill, 0, -1, Light);
             }
             else
                 if (o->SubType == 0)
-                    CreateJoint(BITMAP_JOINT_FORCE, Position, Position, o->HeadAngle, 0, o->Owner, 150.f, o->PKKey, o->Skill);
+                    CreateJointFpsChecked(BITMAP_JOINT_FORCE, Position, Position, o->HeadAngle, 0, o->Owner, 150.f, o->PKKey, o->Skill);
                 else
-                    CreateJoint(BITMAP_JOINT_FORCE, Position, Position, o->HeadAngle, 8, o->Owner, 150.f, o->PKKey, o->Skill);
+                    CreateJointFpsChecked(BITMAP_JOINT_FORCE, Position, Position, o->HeadAngle, 8, o->Owner, 150.f, o->PKKey, o->Skill);
         }
         break;
 
@@ -12595,7 +12603,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 o->StartPosition[0] -= (10.f) * FPS_ANIMATION_FACTOR;
 
-                CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
+                CreateParticleFpsChecked(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
 
                 o->Light[0] += (0.1f) * FPS_ANIMATION_FACTOR;
                 o->Light[1] = o->Light[0];
@@ -12612,7 +12620,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 o->StartPosition[0] -= (10.f) * FPS_ANIMATION_FACTOR;
 
-                CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 11, o->Scale);
+                CreateParticleFpsChecked(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 11, o->Scale);
 
                 o->Light[0] += (0.1f) * FPS_ANIMATION_FACTOR;
                 o->Light[1] = o->Light[0];
@@ -12626,10 +12634,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(0.24f, 0.28f, 0.8f, Light);
                     VectorCopy(o->Position, Position);
                     Position[2] += 50.f;
-                    CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
 
                     if (rand_fps_check(5))
-                        CreateEffect(MODEL_ICE_SMALL, Position, o->Angle, o->Light);
+                        CreateEffectFpsChecked(MODEL_ICE_SMALL, Position, o->Angle, o->Light);
                 }
             }
         }
@@ -12649,12 +12657,12 @@ void MoveEffect(OBJECT* o, int iIndex)
         Vector(0.f, 20.f, 0.f, p);
         VectorRotate(p, Matrix, Position);
         VectorAdd(o->Position, Position, o->StartPosition);
-        CreateParticle(BITMAP_FIRE + 2, o->StartPosition, o->Angle, Light, 10, o->Scale);
+        CreateParticleFpsChecked(BITMAP_FIRE + 2, o->StartPosition, o->Angle, Light, 10, o->Scale);
 
         Vector(0.f, -20.f, 0.f, p);
         VectorRotate(p, Matrix, Position);
         VectorAdd(o->Position, Position, o->StartPosition);
-        CreateParticle(BITMAP_FIRE + 2, o->StartPosition, o->Angle, Light, 10, o->Scale);
+        CreateParticleFpsChecked(BITMAP_FIRE + 2, o->StartPosition, o->Angle, Light, 10, o->Scale);
 
         if ((int)o->LifeTime == 1)
         {
@@ -12688,7 +12696,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (rand_fps_check(10))
         {
-            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, Light);
         }
         break;
 
@@ -12718,7 +12726,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         o->Alpha = o->LifeTime / 10.f;
         if (rand_fps_check(10))
         {
-            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, Light);
         }
         break;
     case MODEL_SHINE:
@@ -12731,7 +12739,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[2] += 360.f;
 
             float Scale = (rand() % 30 + 50) / 100.f;
-            CreateParticle(BITMAP_SHINY, Position, o->Angle, o->Light, 2, Scale);
+            CreateParticleFpsChecked(BITMAP_SHINY, Position, o->Angle, o->Light, 2, Scale);
         }
         break;
     case MODEL_BLIZZARD:
@@ -12744,14 +12752,14 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             o->StartPosition[0] -= (10.f) * FPS_ANIMATION_FACTOR;
 
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 0, 1.5f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 0, 1.5f);
             if (rand_fps_check(2))
             {
-                CreateParticle(BITMAP_ENERGY, o->Position, o->Angle, Light, 1, 0.5f);
+                CreateParticleFpsChecked(BITMAP_ENERGY, o->Position, o->Angle, Light, 1, 0.5f);
             }
             else
             {
-                CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
+                CreateParticleFpsChecked(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
             }
 
             o->Light[0] += (0.1f) * FPS_ANIMATION_FACTOR;
@@ -12766,14 +12774,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(0.24f, 0.28f, 0.8f, Light);
                 VectorCopy(o->Position, Position);
                 Position[2] += 50.f;
-                CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 11, (float)(rand() % 32 + 80) * 0.025f);
 
                 if (rand_fps_check(5))
                 {
-                    CreateEffect(MODEL_ICE_SMALL, Position, o->Angle, o->Light);
+                    CreateEffectFpsChecked(MODEL_ICE_SMALL, Position, o->Angle, o->Light);
                 }
 
-                CreateEffect(MODEL_BLIZZARD, Position, o->Angle, o->Light, 1, NULL, o->PKKey);
+                CreateEffectFpsChecked(MODEL_BLIZZARD, Position, o->Angle, o->Light, 1, NULL, o->PKKey);
 
                 o->Live = false;
             }
@@ -12799,7 +12807,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (rand_fps_check(2))
                 {
-                    CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
+                    CreateParticleFpsChecked(BITMAP_FIRE + 2, o->Position, o->Angle, Light, 7, o->Scale);
                 }
 
                 o->Light[0] += (0.1f) * FPS_ANIMATION_FACTOR;
@@ -12816,9 +12824,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             o->Angle[1] += (30.f) * FPS_ANIMATION_FACTOR;
 
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 13);
 
             if ((int)o->LifeTime == 1)
             {
@@ -12941,7 +12949,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->SubType == 1) {
             if (o->LifeTime > 1) {
                 o->BlendMeshLight *= pow(1.0f / (1.6f), FPS_ANIMATION_FACTOR);
-                CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
+                CreateEffectFpsChecked(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
             }
         }
         else
@@ -12951,13 +12959,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 if (o->LifeTime > 1)
                 {
                     o->BlendMeshLight *= pow(1.0f / (1.6f), FPS_ANIMATION_FACTOR);
-                    CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
+                    CreateEffectFpsChecked(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
                 }
             }
             else {
                 if (o->LifeTime > 5) {
                     o->BlendMeshLight *= pow(1.0f / (1.6f), FPS_ANIMATION_FACTOR);
-                    CreateEffect(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
+                    CreateEffectFpsChecked(MODEL_WAVES, o->Position, o->Angle, o->Light, 2, NULL, o->LifeTime);
                 }
             }
         break;
@@ -13079,13 +13087,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                                 float	fRandDistance = (float)(rand() % 100) + 100;
                                 Vector(0.0f, fRandDistance, 0.0f, vRandomDir);
 
-                                CreateParticle(BITMAP_FIRE + 2, vPosition, o->Angle, o->Light, 17, 1.35f);
+                                CreateParticleFpsChecked(BITMAP_FIRE + 2, vPosition, o->Angle, o->Light, 17, 1.35f);
 
                                 Vector((float)(rand() % 360), 0.f, (float)(rand() % 360), vAngle);
                                 AngleMatrix(vAngle, matRandomRotation);
                                 VectorRotate(vRandomDir, matRandomRotation, vRandomDirPosition);
                                 VectorAdd(vPosition, vRandomDirPosition, vResultRandomPosition);
-                                CreateJoint(BITMAP_JOINT_THUNDER, vResultRandomPosition, vPosition, vAngle, 3, NULL, 10.f, 10, 10);
+                                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vResultRandomPosition, vPosition, vAngle, 3, NULL, 10.f, 10, 10);
                             }
                         }
                         delete[] arrEachBonePos;
@@ -13120,14 +13128,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                     if (o->LifeTime < 10)
                     {
                         o->Velocity += (0.1f) * FPS_ANIMATION_FACTOR;
-                        CreateEffect(BITMAP_MAGIC + 1, Position, o->Angle, o->Light, 1, o);
+                        CreateEffectFpsChecked(BITMAP_MAGIC + 1, Position, o->Angle, o->Light, 1, o);
                     }
 
                     AngleMatrix(o->Angle, Matrix);
                     VectorRotate(o->Direction, Matrix, Position);
                     VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
-                    CreateEffect(MODEL_TAIL, o->Position, o->Angle, o->Light, 0, o);
+                    CreateEffectFpsChecked(MODEL_TAIL, o->Position, o->Angle, o->Light, 0, o);
                 }
                 if (Distance < 40 && (int)o->LifeTime == 5)
                 {
@@ -13178,7 +13186,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorRotate(o->Direction, Matrix, Position);
                     VectorAddScaled(o->Position, Position, o->Position, FPS_ANIMATION_FACTOR);
 
-                    CreateEffect(MODEL_PIER_PART, o->Position, o->Angle, o->Light, 1, o);
+                    CreateEffectFpsChecked(MODEL_PIER_PART, o->Position, o->Angle, o->Light, 1, o);
                 }
                 if (Distance < 40 && (int)o->LifeTime == 5)
                 {
@@ -13206,7 +13214,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 if ((int)o->LifeTime % 3 == 0)
                 {
                     Vector(-90.f, 0.f, o->Angle[2], Angle);
-                    CreateJoint(BITMAP_JOINT_FORCE, o->Position, o->Position, Angle, 2, NULL, 150.f);
+                    CreateJointFpsChecked(BITMAP_JOINT_FORCE, o->Position, o->Position, Angle, 2, NULL, 150.f);
                 }
             }
         }
@@ -13261,8 +13269,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[2] = o->Position[2] + 50.f;
 
             Vector(1.f, 0.8f, 0.6f, Light);
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 11, 2.f, o);
-            CreateEffect(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 10);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 11, 2.f, o);
+            CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 10);
         }
         //        o->BlendMeshTexCoordU = -(int)WorldTime%2000 * 0.0005f;
 
@@ -13353,7 +13361,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if (((int)o->LifeTime % 8) == 0)
             {
-                CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, o->Light, 5);
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Position, o->Angle, o->Light, 5);
             }
             break;
         }
@@ -13461,31 +13469,31 @@ void MoveEffect(OBJECT* o, int iIndex)
     case BITMAP_FLARE:
         if (o->SubType == 1)
         {
-            CreateParticle(BITMAP_FLARE, o->Position, o->Angle, Light, 11, 1.0f);
+            CreateParticleFpsChecked(BITMAP_FLARE, o->Position, o->Angle, Light, 11, 1.0f);
         }
         else if (o->SubType == 2)
         {
-            CreateParticle(BITMAP_FLARE_BLUE, o->Position, o->Angle, Light, 1, 1.0f);
+            CreateParticleFpsChecked(BITMAP_FLARE_BLUE, o->Position, o->Angle, Light, 1, 1.0f);
         }
         else
             if (o->SubType == 3)
             {
                 Vector(0.9f, 0.4f, 0.1f, Light);
                 float fRandom = 3.5f + ((float)(rand() % 20 - 10) * 0.1f);
-                CreateParticle(BITMAP_LIGHT, o->Position, o->Angle, Light, 5, fRandom);
+                CreateParticleFpsChecked(BITMAP_LIGHT, o->Position, o->Angle, Light, 5, fRandom);
             }
             else
                 if ((int)o->LifeTime % 2 == 0)
                 {
                     VectorCopy(o->Position, Position);
                     Position[2] += 100.f;
-                    CreateJoint(BITMAP_FLARE_BLUE, Position, Position, o->Angle, 14, o, 40.f);
-                    CreateJoint(BITMAP_FLARE_BLUE, Position, Position, o->Angle, 15, o, 40.f);
+                    CreateJointFpsChecked(BITMAP_FLARE_BLUE, Position, Position, o->Angle, 14, o, 40.f);
+                    CreateJointFpsChecked(BITMAP_FLARE_BLUE, Position, Position, o->Angle, 15, o, 40.f);
 
                     if (rand_fps_check(2) && o->LifeTime > 5 && o->LifeTime < 15)
                     {
                         Vector(o->Position[0] - 200.f, o->Position[1], o->Position[2] + 700.f, Position);
-                        CreateJoint(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 20.f);
+                        CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, o->Position, Angle, 0, o, 20.f);
                     }
                 }
         break;
@@ -13497,7 +13505,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[0] += rand() % 64 - 32.f;
             Position[1] += rand() % 64 - 32.f;
 
-            CreateJoint(BITMAP_JOINT_THUNDER + 1, Position, Position, o->Angle, 5, NULL, 50.f + rand() % 10);
+            CreateJointFpsChecked(BITMAP_JOINT_THUNDER + 1, Position, Position, o->Angle, 5, NULL, 50.f + rand() % 10);
         }
         break;
 
@@ -13514,7 +13522,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (rand_fps_check(2))
             {
                 Angle[2] = (float)(rand() % 24 * 30);
-                CreateJoint(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 14, NULL, 100.f, 0, 0);
+                CreateJointFpsChecked(BITMAP_JOINT_SPIRIT2, Position, Position, Angle, 14, NULL, 100.f, 0, 0);
             }
         }
         break;
@@ -13547,7 +13555,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[2] += rand() % 60;
             Vector(1, 1, 1, Light);
             for (int i = 0; i < 3; ++i)
-                CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 20, 10.f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 20, 10.f);
         }
         else
         {
@@ -13566,7 +13574,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[1] += rand() % 1200 - 600;
             vec3_t Angle;
             Vector(0.f, 0.f, rand() % 10 * 20.f, Angle);
-            CreateEffect(MODEL_FIRE, Position, Angle, Light, 0, NULL, 0);
+            CreateEffectFpsChecked(MODEL_FIRE, Position, Angle, Light, 0, NULL, 0);
 
             o->Scale += (0.02f) * FPS_ANIMATION_FACTOR;
             //				o->Position[2] -= 0.5f;
@@ -13582,7 +13590,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 {
                     vec3_t Angle;
                     Vector(0, 0, o->Angle[2] + 320 + i * 8, Angle);
-                    CreateEffect(MODEL_CUNDUN_PHOENIX, o->Position, Angle, o->Light, 0);
+                    CreateEffectFpsChecked(MODEL_CUNDUN_PHOENIX, o->Position, Angle, o->Light, 0);
                 }
             }
         }
@@ -13596,13 +13604,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 for (int i = 0; i < 20; ++i)
                 {
                     Angle[2] = (float)(o->PKKey * 30);
-                    CreateEffect(MODEL_CUNDUN_DRAGON_HEAD, o->Position, Angle, o->Light);
+                    CreateEffectFpsChecked(MODEL_CUNDUN_DRAGON_HEAD, o->Position, Angle, o->Light);
                 }
             }
             if (o->PKKey > 5 && o->PKKey < 10)
             {
                 Angle[2] = (float)(o->PKKey * 30);
-                CreateEffect(MODEL_CUNDUN_DRAGON_HEAD, o->Position, Angle, o->Light);
+                CreateEffectFpsChecked(MODEL_CUNDUN_DRAGON_HEAD, o->Position, Angle, o->Light);
             }
             ++o->PKKey;
         }
@@ -13630,7 +13638,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 Position[0] += rand() % 100 - 50.f;
                 Position[1] -= rand() % 30 + 15.f;
-                CreateEffect(MODEL_FLY_BIG_STONE1, Position, o->Angle, o->Light, 2);
+                CreateEffectFpsChecked(MODEL_FLY_BIG_STONE1, Position, o->Angle, o->Light, 2);
             }
         }
         if (o->LifeTime < 5)
@@ -13649,13 +13657,13 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             Vector(0.0f, 0.0f, -30.0f, o->Direction);
             Vector(1.f, 0.6f, 0.2f, Light);
-            CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light);
 
             if (o->HiddenMesh != 99)
             {
                 CreateInferno(o->Position, 1);
                 VectorCopy(o->Position, o->StartPosition);
-                CreateEffect(BITMAP_CRATER, o->Position, o->Angle, o->Light);
+                CreateEffectFpsChecked(BITMAP_CRATER, o->Position, o->Angle, o->Light);
             }
 
             EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
@@ -13680,10 +13688,10 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(1.0f, 1.0f, 1.0f, o->Light);
             Vector(0.0f, 1.5f, 0.0f, p1);
             b->TransformPosition(BoneTransform[2], p1, p2);
-            CreateParticle(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 8, o->Scale - 0.4f, o);
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 38, o->Scale, o);
+            CreateParticleFpsChecked(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 8, o->Scale - 0.4f, o);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 38, o->Scale, o);
             Vector(1.0f, 0.4f, 0.0f, o->Light);
-            CreateParticle(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 9, o->Scale - 0.4f, o);
+            CreateParticleFpsChecked(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 9, o->Scale - 0.4f, o);
         }
 
         if (o->HiddenMesh == 99)
@@ -13731,7 +13739,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if ((int)o->LifeTime % 3 == 0)
             {
                 Vector(1.f, 0.6f, 0.2f, Light);
-                CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light, 1, 0.2f);
+                CreateParticleFpsChecked(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light, 1, 0.2f);
             }
         }
         else
@@ -13751,7 +13759,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 {
                     o->HiddenMesh = -1;
                     Vector(Luminosity * 1.f, Luminosity * 0.5f, Luminosity * 0.1f, Light);
-                    CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 5, 2.f);
+                    CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light, 5, 2.f);
                 }
 
                 o->Velocity -= (0.45f) * FPS_ANIMATION_FACTOR;
@@ -13788,8 +13796,8 @@ void MoveEffect(OBJECT* o, int iIndex)
                 if (o->LifeTime > o->DamageTime)
                 {
                     Vector(1.f, 0.6f, 0.2f, Light);
-                    CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light);
-                    CreateParticle(BITMAP_FIRE, o->Position, o->Angle, Light, 2, 2.f);
+                    CreateParticleFpsChecked(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light);
+                    CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, Light, 2, 2.f);
 
                     if (o->SubType == 88 && o->Owner != NULL)
                     {
@@ -13828,7 +13836,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     }
                     if (o->HiddenMesh != 99 && o->Visible)
                     {
-                        CreateEffect(BITMAP_CRATER, o->Position, o->Angle, o->Light);
+                        CreateEffectFpsChecked(BITMAP_CRATER, o->Position, o->Angle, o->Light);
                         PlayBuffer(SOUND_BC_CATAPULT_HIT, o);
 
                         battleCastle::CollisionEffectToObject(o, 350.f, 250.f, true);
@@ -13840,7 +13848,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         else if (o->SubType == 99 || (o->SubType == 88 && o->Owner != NULL))
                         {
                             Vector(1.f, 0.3f, 0.1f, Light);
-                            CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, Light, 7);
+                            CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Position, o->Angle, Light, 7);
                         }
                     }
                     o->HiddenMesh = 99;
@@ -13904,7 +13912,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 if (rand_fps_check(2))
                 {
-                    CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light, 1, 2.f);
+                    CreateParticleFpsChecked(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, Light, 1, 2.f);
                 }
             }
 
@@ -13942,7 +13950,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if (o->LifeTime > o->DamageTime)
             {
-                CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, o->Light);
+                CreateParticleFpsChecked(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, o->Light);
 
                 if (o->SubType == 88 && o->Owner != NULL)
                 {
@@ -13981,7 +13989,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 }
                 if (o->HiddenMesh != 99 && o->Visible)
                 {
-                    CreateEffect(BITMAP_CRATER, o->Position, o->Angle, o->Light);
+                    CreateEffectFpsChecked(BITMAP_CRATER, o->Position, o->Angle, o->Light);
                     PlayBuffer(SOUND_BC_CATAPULT_HIT, o);
 
                     if (o->SubType == 88 && o->Owner == NULL)
@@ -13991,7 +13999,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     else if (o->SubType == 99 || (o->SubType == 88 && o->Owner != NULL))
                     {
                         Vector(1.f, 0.3f, 0.1f, Light);
-                        CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, Light, 7);
+                        CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Position, o->Angle, Light, 7);
                     }
                 }
                 o->HiddenMesh = 99;
@@ -14036,12 +14044,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->HiddenMesh = 0;
 
                 if (rand_fps_check(10))
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 24, 1.25f * o->Scale);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 24, 1.25f * o->Scale);
             }
             else
             {
                 if (rand_fps_check(2))
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 24, 0.2f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 24, 0.2f);
             }
             break;
         }
@@ -14075,11 +14083,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Type == MODEL_GOLEM_STONE)
         {
             if (rand_fps_check(4)) {
-                CreateParticle(BITMAP_TRUE_FIRE, o->Position, o->Angle, Light, 5, 2.8f);
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 21, 1.8f);
+                CreateParticleFpsChecked(BITMAP_TRUE_FIRE, o->Position, o->Angle, Light, 5, 2.8f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 21, 1.8f);
             }
             if (rand_fps_check(10)) {
-                CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
+                CreateParticleFpsChecked(BITMAP_SMOKE + 1, o->Position, o->Angle, Light);
             }
         }
         else if (o->Type == MODEL_BIG_STONE_PART1 && o->SubType == 2)
@@ -14087,7 +14095,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (rand_fps_check(10)) {
                 Vector(0.2f, 0.5f, 0.35f, Light);
                 o->Position[2] = Height;
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 11, 2.f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 11, 2.f);
             }
         }
         break;
@@ -14118,7 +14126,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (rand_fps_check(10))
         {
-            CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, Light);
         }
         break;
 
@@ -14228,13 +14236,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 vec3_t vLight;
                 Vector(0.5f, 0.5f, 0.5f, vLight);
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, vLight, 11, (float)(rand() % 20 + 30) * 0.020f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, vLight, 11, (float)(rand() % 20 + 30) * 0.020f);
 
                 int iRand = rand() % 2 + 2;
                 for (int i = 0; i < iRand; ++i)
                 {
                     float fScale = 0.03f + (rand() % 10) / 40.0f + o->Scale * 0.3f;
-                    CreateEffect(MODEL_FALL_STONE_EFFECT, o->Position, o->Angle, o->Light, 3, NULL, -1, 0, 0, 0, fScale);
+                    CreateEffectFpsChecked(MODEL_FALL_STONE_EFFECT, o->Position, o->Angle, o->Light, 3, NULL, -1, 0, 0, 0, fScale);
                 }
 
                 o->Live = false;
@@ -14413,7 +14421,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Position[2] = Height;
                 if (o->ExtState == 0)
                 {
-                    CreateEffect(BITMAP_CRATER, o->Position, o->Angle, o->Light, 1);
+                    CreateEffectFpsChecked(BITMAP_CRATER, o->Position, o->Angle, o->Light, 1);
                     o->ExtState = 1;
                 }
             }
@@ -14426,7 +14434,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 if ((int)o->LifeTime % 3 == 0)
                 {
-                    CreateParticle(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, o->Light, 1, 1.f);
+                    CreateParticleFpsChecked(BITMAP_ADV_SMOKE + 1, o->Position, o->Angle, o->Light, 1, 1.f);
                 }
             }
             o->Light[0] = o->LifeTime / 10.f;
@@ -14438,7 +14446,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         {
             if ((int)o->LifeTime % 3 == 0)
             {
-                CreateEffect(MODEL_STUN_STONE, o->Position, o->Angle, o->Light);
+                CreateEffectFpsChecked(MODEL_STUN_STONE, o->Position, o->Angle, o->Light);
             }
             AddTerrainLight(o->Position[0], o->Position[1], o->Light, 1, PrimaryTerrainLight);
         }
@@ -14486,7 +14494,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     o->Scale = 1.f;
                     o->Gravity = 0.01f;
 
-                    CreateEffect(MODEL_MANA_RUNE, o->Position, o->Angle, o->Light, 1);
+                    CreateEffectFpsChecked(MODEL_MANA_RUNE, o->Position, o->Angle, o->Light, 1);
                 }
             }
             else if (o->LifeTime < 15)
@@ -14533,12 +14541,12 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     if ((int)o->LifeTime % 3 == 0)
                     {
-                        CreateParticle(BITMAP_POUNDING_BALL, o->Position, o->Angle, o->Light, 1);
+                        CreateParticleFpsChecked(BITMAP_POUNDING_BALL, o->Position, o->Angle, o->Light, 1);
                     }
                 }
                 else
                 {
-                    CreateParticle(BITMAP_POUNDING_BALL, o->Position, o->Angle, o->Light, 1);
+                    CreateParticleFpsChecked(BITMAP_POUNDING_BALL, o->Position, o->Angle, o->Light, 1);
                 }
             }
             o->Velocity += (1.5f) * FPS_ANIMATION_FACTOR;
@@ -14592,8 +14600,8 @@ void MoveEffect(OBJECT* o, int iIndex)
             Position[0] += rand() % 100 - 50.f;
             Position[1] += rand() % 100 - 50.f;
             Position[2] += 1200.f;
-            CreateJoint(BITMAP_FLASH, Position, Position, o->Angle, 2, o, 50.f);
-            CreateJoint(BITMAP_FLASH, Position, Position, o->Angle, 3, o, 50.f);
+            CreateJointFpsChecked(BITMAP_FLASH, Position, Position, o->Angle, 2, o, 50.f);
+            CreateJointFpsChecked(BITMAP_FLASH, Position, Position, o->Angle, 3, o, 50.f);
         }
         else if (o->SubType == 1)
         {
@@ -14613,7 +14621,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorAdd(o->StartPosition, Position, Position);
 
                 Position[2] += rand() % 400 + 700.f;
-                CreateJoint(BITMAP_FLASH, Position, Position, o->Angle, 5, o, 110.f);
+                CreateJointFpsChecked(BITMAP_FLASH, Position, Position, o->Angle, 5, o, 110.f);
             }
         }
         else if (o->SubType == 1)
@@ -14627,8 +14635,8 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorAdd(o->StartPosition, Position, Position);
 
                 Position[2] += 100.f;
-                CreateJoint(BITMAP_JOINT_THUNDER + 1, Position, Position, o->Angle, 6, o, 80.f);
-                CreateJoint(BITMAP_JOINT_THUNDER + 1, Position, Position, o->Angle, 6, o, 80.f);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER + 1, Position, Position, o->Angle, 6, o, 80.f);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER + 1, Position, Position, o->Angle, 6, o, 80.f);
             }
         }
 
@@ -14642,10 +14650,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                 o->Direction[1] -= (2.f) * FPS_ANIMATION_FACTOR;
                 if (o->SubType == 2)
                 {
-                    CreateEffect(MODEL_SWORD_FORCE, o->Position, o->Angle, o->Light, 3, o);
+                    CreateEffectFpsChecked(MODEL_SWORD_FORCE, o->Position, o->Angle, o->Light, 3, o);
                 }
                 else
-                    CreateEffect(MODEL_SWORD_FORCE, o->Position, o->Angle, o->Light, 1, o);
+                    CreateEffectFpsChecked(MODEL_SWORD_FORCE, o->Position, o->Angle, o->Light, 1, o);
             }
             else
             {
@@ -14665,13 +14673,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                 for (int i = 0; i < 4; i++)
                 {
                     Vector((float)(rand() % 60 + 60 + 90), 0.f, o->Angle[2], Angle);
-                    CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
+                    CreateJointFpsChecked(BITMAP_JOINT_SPARK, Position, Position, Angle);
                     if (o->SubType == 2)
                     {
-                        CreateParticle(BITMAP_FIRE, Position, Angle, o->Light, 18, 1.5f);
+                        CreateParticleFpsChecked(BITMAP_FIRE, Position, Angle, o->Light, 18, 1.5f);
                     }
                     else
-                        CreateParticle(BITMAP_FIRE, Position, Angle, o->Light, 2, 1.5f);
+                        CreateParticleFpsChecked(BITMAP_FIRE, Position, Angle, o->Light, 2, 1.5f);
                 }
             }
             Vector(1.f, 0.8f, 0.6f, Light);
@@ -14701,7 +14709,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->LifeTime < 125 && o->LifeTime > 120)
             {
                 for (int i = 0; i < 5; ++i)
-                    CreateParticle(BITMAP_SPARK, o->Position, o->Angle, o->Light, 6, 1.5f, o);
+                    CreateParticleFpsChecked(BITMAP_SPARK, o->Position, o->Angle, o->Light, 6, 1.5f, o);
             }
         }
         else if (o->LifeTime > 95)
@@ -14738,7 +14746,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     o->Position[1] + (rand() % 26 - 13) * cosf(fAngle),
                     //o->Position[2] + 45+(10-o->LifeTime)*1.5f+rand()%5, p);
                     o->Position[2] + 48 - o->LifeTime + (rand() % 5), p);
-                CreateParticle(BITMAP_SPARK, p, o->Angle, o->Light, 5, 2.0f, o);
+                CreateParticleFpsChecked(BITMAP_SPARK, p, o->Angle, o->Light, 5, 2.0f, o);
             }
         }
     }
@@ -14756,12 +14764,12 @@ void MoveEffect(OBJECT* o, int iIndex)
             vPos[2] += 110.f;
 
             {
-                CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 24, 1.0f, o);
+                CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 24, 1.0f, o);
             }
 
             if ((int)o->LifeTime % 15 == 0)
             {
-                CreateEffect(BITMAP_TARGET_POSITION_EFFECT1, o->Position, vAngle, vLight, 0);//, NULL, -1, 0, 0, 0, fScale );
+                CreateEffectFpsChecked(BITMAP_TARGET_POSITION_EFFECT1, o->Position, vAngle, vLight, 0);//, NULL, -1, 0, 0, 0, fScale );
             }
 
             if (o->LifeTime <= 10)
@@ -14832,7 +14840,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Position[0] += ((float)((rand() % 120) - 60)) * FPS_ANIMATION_FACTOR;
             o->Position[1] += ((float)((rand() % 120) - 60)) * FPS_ANIMATION_FACTOR;
 
-            CreateEffect(MODEL_EFFECT_SAPITRES_ATTACK_1, o->Position, o->Angle, o->Light, 0, o->Owner);
+            CreateEffectFpsChecked(MODEL_EFFECT_SAPITRES_ATTACK_1, o->Position, o->Angle, o->Light, 0, o->Owner);
         }
     }
     break;
@@ -14854,7 +14862,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    CreateEffect(MODEL_EFFECT_SAPITRES_ATTACK_2, o->Position, o->Angle, vLight, 0);
+                    CreateEffectFpsChecked(MODEL_EFFECT_SAPITRES_ATTACK_2, o->Position, o->Angle, vLight, 0);
                 }
             }
         }
@@ -14874,7 +14882,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 vPos[0] += (3.0f * ((float)(rand() % 40) - 20));
                 vPos[1] += (3.0f * ((float)(rand() % 40) - 20));
                 vPos[2] += (3.0f * ((float)(rand() % 40) - 20));
-                CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, o->Angle, vLight, 0, o->Scale);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, o->Angle, vLight, 0, o->Scale);
             }
             CreateSprite(BITMAP_LIGHT, o->Position, 8.0f, vLightFlare, o);
             CreateSprite(BITMAP_LIGHT, o->Position, 8.0f, vLightFlare, o);
@@ -14897,7 +14905,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 vPos[0] += (3.0f * ((float)(rand() % 40) - 20));
                 vPos[1] += (3.0f * ((float)(rand() % 40) - 20));
                 vPos[2] += (3.0f * ((float)(rand() % 40) - 20));
-                CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, o->Angle, vLight, 0, o->Scale);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, o->Angle, vLight, 0, o->Scale);
             }
 
             VectorCopy(o->Position, vPos);
@@ -14932,8 +14940,8 @@ void MoveEffect(OBJECT* o, int iIndex)
                 CreateSprite(BITMAP_SHINY + 1, vtaWorldPos, 1.8f, o->Light, o, +WorldTime * 0.08f);
                 for (int i = 0; i < 7; ++i)
                 {
-                    CreateParticle(BITMAP_SHINY + 1, vtaWorldPos, o->Angle, o->Light, 5, 0.8f, o);
-                    CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 7 == 3 ? vLight2 : vLight1, 0, 0.5f);
+                    CreateParticleFpsChecked(BITMAP_SHINY + 1, vtaWorldPos, o->Angle, o->Light, 5, 0.8f, o);
+                    CreateParticleFpsChecked(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 7 == 3 ? vLight2 : vLight1, 0, 0.5f);
                 }
 
                 b->TransformPosition(BoneTransform[2], vRelativePos, vtaWorldPos, false);
@@ -14941,8 +14949,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 for (int i = 0; i < 7; ++i)
                 {
-                    CreateParticle(BITMAP_SHINY + 1, vtaWorldPos, o->Angle, o->Light, 5, 0.8f, o);
-                    CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 7 == 3 ? vLight2 : vLight1, 0, 0.5f);
+                    CreateParticleFpsChecked(BITMAP_SHINY + 1, vtaWorldPos, o->Angle, o->Light, 5, 0.8f, o);
+                    CreateParticleFpsChecked(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 7 == 3 ? vLight2 : vLight1, 0, 0.5f);
                 }
 
                 if ((int)o->LifeTime == 30 || (int)o->LifeTime == 15 || (int)o->LifeTime == 4)
@@ -14971,14 +14979,14 @@ void MoveEffect(OBJECT* o, int iIndex)
                     for (int k = 0; k < 70; ++k)
                     {
                         if (rand_fps_check(3)) {
-                            CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 7 == 3 ? vLight2 : vLight1, 0, 0.4f);
+                            CreateParticleFpsChecked(BITMAP_CHERRYBLOSSOM_EVENT_PETAL, vtaWorldPos, o->Angle, rand() % 7 == 3 ? vLight2 : vLight1, 0, 0.4f);
                         }
-                        CreateParticle(BITMAP_CHERRYBLOSSOM_EVENT_FLOWER, vtaWorldPos, o->Angle, rand() % 4 == 3 ? vLight2 : vLight1, 0, 0.4f);
+                        CreateParticleFpsChecked(BITMAP_CHERRYBLOSSOM_EVENT_FLOWER, vtaWorldPos, o->Angle, rand() % 4 == 3 ? vLight2 : vLight1, 0, 0.4f);
                     }
 
                     Vector(0.f, 1.f, 0.f, vAngle);
                     Vector(1.f, 0.6f, 0.8f, vLight2);
-                    CreateParticle(BITMAP_SHOCK_WAVE, vtaWorldPos, vAngle, vLight2, 4, 0.005f);
+                    CreateParticleFpsChecked(BITMAP_SHOCK_WAVE, vtaWorldPos, vAngle, vLight2, 4, 0.005f);
 
                     characterBMD->Animation(o->Owner->BoneTransform, o->Owner->AnimationFrame,
                         o->Owner->PriorAnimationFrame, o->Owner->PriorAction, o->Owner->Angle, o->Owner->HeadAngle);
@@ -15016,9 +15024,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                 if ((int)o->LifeTime == 23)
                 {
                     Vector(0.3f, 0.3f, 1.0f, vLight);
-                    CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o);
-                    CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o);
-                    CreateEffect(MODEL_KNIGHT_PLANCRACK_A, o->Position, o->Angle, vLight, 0, o, 0, 0, 0, 0, 1.2f);
+                    CreateEffectFpsChecked(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o);
+                    CreateEffectFpsChecked(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o);
+                    CreateEffectFpsChecked(MODEL_KNIGHT_PLANCRACK_A, o->Position, o->Angle, vLight, 0, o, 0, 0, 0, 0, 1.2f);
 
                     vec3_t vDir, vPos, vAngle;
                     VectorSubtract(o->StartPosition, o->Position, vDir);
@@ -15038,7 +15046,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         {
                             vAngle[2] -= (rand() % 20 + 10);
                         }
-                        CreateEffect(MODEL_KNIGHT_PLANCRACK_B, vPos, vAngle, vLight, 0, o, 0, 0, 0, 0, 1.0f);
+                        CreateEffectFpsChecked(MODEL_KNIGHT_PLANCRACK_B, vPos, vAngle, vLight, 0, o, 0, 0, 0, 0, 1.0f);
                     }
                 }
 
@@ -15063,11 +15071,11 @@ void MoveEffect(OBJECT* o, int iIndex)
                         float fScale = 1.6f + rand() % 10 * 0.1f;
                         Vector(0.5f, 0.5f, 1.0f, vLight);
                         int index = (rand_fps_check(2)) ? BITMAP_WATERFALL_5 : BITMAP_WATERFALL_3;
-                        CreateParticle(index, vPos, o->Angle, vLight, 8, fScale);
+                        CreateParticleFpsChecked(index, vPos, o->Angle, vLight, 8, fScale);
                         Vector(1.0f, 1.0f, 1.0f, vLight);
                         if (rand_fps_check(2))
                         {
-                            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 55, 1.f);
+                            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 55, 1.f);
                         }
                     }
                 }
@@ -15078,9 +15086,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(0.5f, 0.5f, 1.f, vLight);
 
                     Vector(0.3f, 0.3f, 1.0f, vLight);
-                    CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, 2.f);
-                    CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, 1.f);
-                    CreateEffect(MODEL_RAKLION_BOSS_CRACKEFFECT, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, 0.2f);
+                    CreateEffectFpsChecked(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, 2.f);
+                    CreateEffectFpsChecked(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, 1.f);
+                    CreateEffectFpsChecked(MODEL_RAKLION_BOSS_CRACKEFFECT, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, 0.2f);
 
                     vec3_t vPos, vResult;
                     vec3_t vAngle;
@@ -15093,7 +15101,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         VectorRotate(vPos, Matrix, vResult);
                         VectorAdd(vResult, o->Position, vResult);
 
-                        CreateEffect(MODEL_STONE1 + rand() % 2, vResult, o->Angle, o->Light, 13);
+                        CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, vResult, o->Angle, o->Light, 13);
                     }
                 }
 
@@ -15125,10 +15133,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorAdd(o->Position, vPos, vPos);
                 VectorCopy(o->Owner->Angle, vAngle);
                 vAngle[2] += (rand() % 40 + 140);
-                CreateEffect(MODEL_DRAGON_LOWER_DUMMY, vPos, vAngle, vLight, 0, o, 0, 0, 0, 0, 0.8f);
+                CreateEffectFpsChecked(MODEL_DRAGON_LOWER_DUMMY, vPos, vAngle, vLight, 0, o, 0, 0, 0, 0, 0.8f);
 
                 Vector(1.0f, 1.0f, 1.0f, vLight);
-                CreateEffect(BITMAP_LIGHT_RED, vPos, vAngle, vLight, 4, o, -1, 0, 0, 0, 3.0f);
+                CreateEffectFpsChecked(BITMAP_LIGHT_RED, vPos, vAngle, vLight, 4, o, -1, 0, 0, 0, 3.0f);
             }
         }
     }
@@ -15258,9 +15266,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(0.4f, 0.3f, 0.9f, vLight);
             if ((int)o->LifeTime == 45 || (int)o->LifeTime == 35 || (int)o->LifeTime == 25)
             {
-                CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 14, o, -1, 0, 0, 0, 5.0f);
-                CreateEffect(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 14, o, -1, 0, 0, 0, 5.0f);
-                CreateEffect(BITMAP_TWLIGHT, o->Position, o->Angle, vLight, 3, o, -1, 0, 0, 0, 6.0f);
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 14, o, -1, 0, 0, 0, 5.0f);
+                CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->Position, o->Angle, vLight, 14, o, -1, 0, 0, 0, 5.0f);
+                CreateEffectFpsChecked(BITMAP_TWLIGHT, o->Position, o->Angle, vLight, 3, o, -1, 0, 0, 0, 6.0f);
             }
 
             Vector(0.7f, 0.3f, 0.9f, vLight);
@@ -15281,9 +15289,9 @@ void MoveEffect(OBJECT* o, int iIndex)
             if ((int)o->LifeTime == 45)
             {
                 pModel->TransformByObjectBone(vPos, o->Owner, 28);
-                CreateEffect(MODEL_ARROWSRE06, vPos, o->Angle, vLight, 1, o->Owner, 28);
+                CreateEffectFpsChecked(MODEL_ARROWSRE06, vPos, o->Angle, vLight, 1, o->Owner, 28);
                 pModel->TransformByObjectBone(vPos, o->Owner, 37);
-                CreateEffect(MODEL_ARROWSRE06, vPos, o->Angle, vLight, 1, o->Owner, 37);
+                CreateEffectFpsChecked(MODEL_ARROWSRE06, vPos, o->Angle, vLight, 1, o->Owner, 37);
             }
 
             if (o->LifeTime >= 30)
@@ -15291,7 +15299,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(0.3f, 0.2f, 0.9f, vLight);
                 for (int i = 0; i < 2; i++)
                 {
-                    CreateJoint(BITMAP_2LINE_GHOST, o->Position, o->Position, o->Angle, 1, o, 20.0f + rand() % 10, -1, 0, 0, -1, vLight);
+                    CreateJointFpsChecked(BITMAP_2LINE_GHOST, o->Position, o->Position, o->Angle, 1, o, 20.0f + rand() % 10, -1, 0, 0, -1, vLight);
                 }
             }
         }
@@ -15399,10 +15407,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                 Vector(0.2f, 0.2f, 0.9f, vLight);
 
                 // Bip01 R Hand
-                CreateEffect(MODEL_ARROWSRE06, o->Position, o->Angle, vLight, 1, o->Owner, 28);
+                CreateEffectFpsChecked(MODEL_ARROWSRE06, o->Position, o->Angle, vLight, 1, o->Owner, 28);
 
                 // Bip01 L Hand
-                CreateEffect(MODEL_ARROWSRE06, o->Position, o->Angle, vLight, 1, o->Owner, 37);
+                CreateEffectFpsChecked(MODEL_ARROWSRE06, o->Position, o->Angle, vLight, 1, o->Owner, 37);
 
                 o->Timer = WorldTime;
             }
@@ -15523,7 +15531,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                     v3Light_[0] = 0.5f; v3Light_[1] = 0.6f; v3Light_[2] = 0.94f;
 
-                    CreateParticle(BITMAP_RAKLION_CLOUDS, v3ResultPos, v3ResultAngle, v3Light_, 1, fResultScale);
+                    CreateParticleFpsChecked(BITMAP_RAKLION_CLOUDS, v3ResultPos, v3ResultAngle, v3Light_, 1, fResultScale);
                 }
             }
         }
@@ -15533,9 +15541,9 @@ void MoveEffect(OBJECT* o, int iIndex)
         vec3_t	v3Pos;
         VectorCopy(o->Position, v3Pos);
 
-        CreateParticle(BITMAP_WATERFALL_3, v3Pos, o->Angle, o->Light, 11, 0.6f);
+        CreateParticleFpsChecked(BITMAP_WATERFALL_3, v3Pos, o->Angle, o->Light, 11, 0.6f);
         // 연기
-        CreateParticle(BITMAP_SMOKE, v3Pos, o->Angle, o->Light, 52, 0.6f);
+        CreateParticleFpsChecked(BITMAP_SMOKE, v3Pos, o->Angle, o->Light, 52, 0.6f);
 
         if (15 == o->LifeTime)
         {
@@ -15553,7 +15561,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorCopy(o->Position, vPos);
             //vPos[2] += 100.f;
 
-            CreateEffect(MODEL_MOONHARVEST_MOON, vPos, vDir_, o->Light,
+            CreateEffectFpsChecked(MODEL_MOONHARVEST_MOON, vPos, vDir_, o->Light,
                 1,
                 NULL, -1, 0, 0, 0, 0.3f);
         }
@@ -15605,11 +15613,11 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorAdd(o->Position, vLook, vPosition);
         if (o->Type == MODEL_PKFIELD_ASSASSIN_EFFECT_GREEN_HEAD)
         {
-            CreateEffect(BITMAP_FIRE_CURSEDLICH, vPosition, o->Angle, vLight, 4, o);
+            CreateEffectFpsChecked(BITMAP_FIRE_CURSEDLICH, vPosition, o->Angle, vLight, 4, o);
         }
         else
         {
-            CreateEffect(BITMAP_FIRE_CURSEDLICH, vPosition, o->Angle, vLight, 3, o);
+            CreateEffectFpsChecked(BITMAP_FIRE_CURSEDLICH, vPosition, o->Angle, vLight, 3, o);
         }
     }
     break;
@@ -15716,7 +15724,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorRotate(p, Matrix, Position);
                 VectorAdd(Position, o->Position, Position);
 
-                CreateEffect(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 0);
+                CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, Position, o->Angle, o->Light, 0);
             }
         }
         else
@@ -15735,7 +15743,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
         if (rand_fps_check(3))
         {
-            CreateParticle(BITMAP_SMOKE + 1, o->Position, o->Angle, o->Light, 6);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 1, o->Position, o->Angle, o->Light, 6);
         }
     }
     break;
@@ -15999,13 +16007,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                                     float	fRandDistance = (float)(rand() % 100) + 100;
                                     Vector(0.0f, fRandDistance, 0.0f, vRandomDir);
 
-                                    CreateParticle(BITMAP_FIRE, vPosition, o->Angle, o->Light, 5, 1.35f);
+                                    CreateParticleFpsChecked(BITMAP_FIRE, vPosition, o->Angle, o->Light, 5, 1.35f);
 
                                     Vector((float)(rand() % 360), 0.f, (float)(rand() % 360), vAngle);
                                     AngleMatrix(vAngle, matRandomRotation);
                                     VectorRotate(vRandomDir, matRandomRotation, vRandomDirPosition);
                                     VectorAdd(vPosition, vRandomDirPosition, vResultRandomPosition);
-                                    CreateJoint(BITMAP_JOINT_THUNDER, vResultRandomPosition, vPosition, vAngle, 3, NULL, 10.f, 10, 10);
+                                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vResultRandomPosition, vPosition, vAngle, 3, NULL, 10.f, 10, 10);
                                 }
                             }
                         }
@@ -16049,13 +16057,13 @@ void MoveEffect(OBJECT* o, int iIndex)
                                     float	fRandDistance = (float)(rand() % 100) + 100;
                                     Vector(0.0f, fRandDistance, 0.0f, vRandomDir);
 
-                                    CreateParticle(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
+                                    CreateParticleFpsChecked(BITMAP_FIRE, vPosition, o->Angle, o->Light, 0);
 
                                     Vector((float)(rand() % 360), 0.f, (float)(rand() % 360), vAngle);
                                     AngleMatrix(vAngle, matRandomRotation);
                                     VectorRotate(vRandomDir, matRandomRotation, vRandomDirPosition);
                                     VectorAdd(vPosition, vRandomDirPosition, vResultRandomPosition);
-                                    CreateJoint(BITMAP_JOINT_THUNDER, vResultRandomPosition, vPosition, vAngle, 3, NULL, 10.f, 10, 10);
+                                    CreateJointFpsChecked(BITMAP_JOINT_THUNDER, vResultRandomPosition, vPosition, vAngle, 3, NULL, 10.f, 10, 10);
                                 }
                             }
                         }
@@ -16093,7 +16101,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (fCurrentRate > fRateShadowStart && fCurrentRate < fRateShadowEnd)
                 {
-                    CreateEffect(o->Type, o->Position, o->Angle, o->Light, 20, o, -1, 0, 0, 0, o->Scale);
+                    CreateEffectFpsChecked(o->Type, o->Position, o->Angle, o->Light, 20, o, -1, 0, 0, 0, o->Scale);
                 }
             }
 
@@ -16101,7 +16109,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if (fCurrentRate > fRateJointStart && fCurrentRate < fRateJointEnd)
                 {
-                    CreateJoint(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 20, o, 160.f, 40);
+                    CreateJointFpsChecked(BITMAP_FLARE + 1, o->Position, o->Position, o->Angle, 20, o, 160.f, 40);
                 }
             }
 
@@ -16184,7 +16192,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         {
                             if (rand_fps_check(20))
                             {
-                                CreateEffect(BITMAP_FIRE_CURSEDLICH, arrEachBonePos[j], vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale);
+                                CreateEffectFpsChecked(BITMAP_FIRE_CURSEDLICH, arrEachBonePos[j], vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale);
                             }
                         }
                     }
@@ -16217,7 +16225,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         v3PosModify[2] = arrEachBonePos[i][2] + (float)((rand() % 80) - 40);
                         if (rand_fps_check(10))
                         {
-                            CreateEffect(BITMAP_FIRE_CURSEDLICH, v3PosModify, vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale * 1.5f);
+                            CreateEffectFpsChecked(BITMAP_FIRE_CURSEDLICH, v3PosModify, vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale * 1.5f);
                         }
                     }
 
@@ -16238,7 +16246,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if ((int)o->LifeTime == 5)
                 {
-                    CreateEffect(o->Type, o->Position, o->Angle, o->Light, 11, o->Owner, -1, 0, 0, 0, o->Scale);
+                    CreateEffectFpsChecked(o->Type, o->Position, o->Angle, o->Light, 11, o->Owner, -1, 0, 0, 0, o->Scale);
                 }
             }
             break;
@@ -16247,7 +16255,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if ((int)o->LifeTime == 3)
                 {
-                    CreateEffect(o->Type, o->Position, o->Angle, o->Light, 11, o->Owner, -1, 0, 0, 0, o->Scale);
+                    CreateEffectFpsChecked(o->Type, o->Position, o->Angle, o->Light, 11, o->Owner, -1, 0, 0, 0, o->Scale);
                 }
             }
             break;
@@ -16255,7 +16263,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if ((int)o->LifeTime == 10)
                 {
-                    CreateEffect(MODEL_SWORDMAIN01_EMPIREGUARDIAN_BOSS_GAION_,
+                    CreateEffectFpsChecked(MODEL_SWORDMAIN01_EMPIREGUARDIAN_BOSS_GAION_,
                         o->Position, o->Angle, o->Light, 11, o->Owner, -1, 0, 0, 0, o->Scale);
                 }
             }
@@ -16264,7 +16272,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 if ((int)o->LifeTime == 1)
                 {
-                    CreateEffect(MODEL_EMPIREGUARDIANBOSS_FRAMESTRIKE,
+                    CreateEffectFpsChecked(MODEL_EMPIREGUARDIANBOSS_FRAMESTRIKE,
                         o->Position, o->Angle, o->Light, 1,
                         o->Owner, -1, 0, 0, 0, o->Scale);
                 }
@@ -16355,7 +16363,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(0.0f, 0.0f, 0.0f, v3RelativePos);
                     Vector(0.0f, 0.0f, 0.0f, v3OwnerBonePos);
 
-                    CreateEffect(o->Type, oHighHier->Position, oHighHier->Angle, oHighHier->Light,
+                    CreateEffectFpsChecked(o->Type, oHighHier->Position, oHighHier->Angle, oHighHier->Light,
                         11, o->Owner, -1, 0, 0, 0, o->Scale);
                 }
 
@@ -16383,16 +16391,16 @@ void MoveEffect(OBJECT* o, int iIndex)
                         VectorRotate(vDirection, Matrix, vPosition);
                         VectorAdd(vPosition, o->Light, vPosition);
 
-                        CreateEffect(BITMAP_JOINT_THUNDER, vPosition, o->Angle, vLight, 1);
+                        CreateEffectFpsChecked(BITMAP_JOINT_THUNDER, vPosition, o->Angle, vLight, 1);
                     }
 
                     Vector(1.f, 1.f, 1.f, vLight);
                     VectorCopy(o->Light, vPosition);
 
-                    CreateEffect(BITMAP_CRATER, vPosition, o->Angle, vLight, 2, NULL, -1, 0, 0, 0, 1.5f);
+                    CreateEffectFpsChecked(BITMAP_CRATER, vPosition, o->Angle, vLight, 2, NULL, -1, 0, 0, 0, 1.5f);
                     for (int iu = 0; iu < 20; iu++)
                     {
-                        CreateEffect(MODEL_STONE2, vPosition, o->Angle, vLight);
+                        CreateEffectFpsChecked(MODEL_STONE2, vPosition, o->Angle, vLight);
                     }
 
                     vec3_t	v3Pos;
@@ -16403,40 +16411,40 @@ void MoveEffect(OBJECT* o, int iIndex)
                     v3Pos[0] = vPosition[0] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[1] = vPosition[1] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[2] = vPosition[2] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
-                    CreateParticle(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
+                    CreateParticleFpsChecked(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
 
                     v3Pos[0] = vPosition[0] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[1] = vPosition[1] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[2] = vPosition[2] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
-                    CreateParticle(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
+                    CreateParticleFpsChecked(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
 
                     v3Pos[0] = vPosition[0] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[1] = vPosition[1] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[2] = vPosition[2] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
-                    CreateParticle(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
+                    CreateParticleFpsChecked(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
 
                     v3Pos[0] = vPosition[0] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[1] = vPosition[1] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[2] = vPosition[2] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
-                    CreateParticle(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
+                    CreateParticleFpsChecked(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
 
                     v3Pos[0] = vPosition[0] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[1] = vPosition[1] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[2] = vPosition[2] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
-                    CreateParticle(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
+                    CreateParticleFpsChecked(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
 
                     v3Pos[0] = vPosition[0] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[1] = vPosition[1] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
                     v3Pos[2] = vPosition[2] + ((rand() % iLimitPos) - (iLimitPos * 0.5f));
-                    CreateParticle(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
+                    CreateParticleFpsChecked(BITMAP_CLUD64, v3Pos, o->Angle, vLight, 7, 2.0f);
 
                     Vector(0.3f, 0.2f, 1.f, vLight);
-                    CreateEffect(BITMAP_SHOCK_WAVE, vPosition, o->Angle, vLight, 11);
-                    CreateEffect(BITMAP_SHOCK_WAVE, vPosition, o->Angle, vLight, 11);
+                    CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, vPosition, o->Angle, vLight, 11);
+                    CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, vPosition, o->Angle, vLight, 11);
 
                     vPosition[2] += 100.0f;
                     Vector(0.0f, 0.2f, 1.0f, vLight);
-                    CreateEffect(MODEL_EFFECT_THUNDER_NAPIN_ATTACK_1, vPosition, o->Angle, vLight, 1, NULL, -1, 0, 0, 0, 1.0f);
+                    CreateEffectFpsChecked(MODEL_EFFECT_THUNDER_NAPIN_ATTACK_1, vPosition, o->Angle, vLight, 1, NULL, -1, 0, 0, 0, 1.0f);
                 }
             }
             break;
@@ -16444,7 +16452,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if ((int)o->LifeTime == 15)
             {
-                CreateEffect(o->Type, o->Position, o->Angle, o->Light, 12, o->Owner, -1, 0, 0, 0, o->Scale);
+                CreateEffectFpsChecked(o->Type, o->Position, o->Angle, o->Light, 12, o->Owner, -1, 0, 0, 0, o->Scale);
             }
 
             int	iSwordOnTheLand = (o->ExtState / 2) + 5;
@@ -16519,7 +16527,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         Vector(1.0f, 1.0f, 1.0f, v3LightModify);
                         if (rand_fps_check(2))
                         {
-                            CreateParticle(BITMAP_POUNDING_BALL, arrEachBonePos[j], o->Angle, v3LightModify, 3, 1.3f);
+                            CreateParticleFpsChecked(BITMAP_POUNDING_BALL, arrEachBonePos[j], o->Angle, v3LightModify, 3, 1.3f);
                         }
                     }
                 }
@@ -16533,7 +16541,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     {
                         if (rand_fps_check(2))
                         {
-                            CreateParticle(BITMAP_FIRE_HIK1_MONO, arrEachBonePos[j], o->Angle, v3LightModify, 10, o->Scale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, arrEachBonePos[j], o->Angle, v3LightModify, 10, o->Scale);
                         }
                     }
                 }
@@ -16546,7 +16554,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     {
                         if (rand_fps_check(20))
                         {
-                            CreateEffect(BITMAP_FIRE_CURSEDLICH, arrEachBonePos[j], vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale);
+                            CreateEffectFpsChecked(BITMAP_FIRE_CURSEDLICH, arrEachBonePos[j], vAngle, v3LightModify, 12, o, -1, 0, 0, 0, o->Scale);
                         }
                     }
                 }
@@ -16618,7 +16626,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     {
                         if (rand_fps_check(2))
                         {
-                            CreateParticle(BITMAP_FIRE_HIK1_MONO, arrEachBonePos[j], o->Angle, v3LightModify, 10, o->Scale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, arrEachBonePos[j], o->Angle, v3LightModify, 10, o->Scale);
                         }
                     }
                 }
@@ -16690,10 +16698,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                     //CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o);
                     //CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o);
 
-                    CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, o->PKKey, o->Kind, o->Skill, o->m_bySkillSerialNum, o->Scale * 1.0f);
-                    CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, o->PKKey, o->Kind, o->Skill, o->m_bySkillSerialNum, o->Scale * 1.0f);
+                    CreateEffectFpsChecked(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, o->PKKey, o->Kind, o->Skill, o->m_bySkillSerialNum, o->Scale * 1.0f);
+                    CreateEffectFpsChecked(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, o->PKKey, o->Kind, o->Skill, o->m_bySkillSerialNum, o->Scale * 1.0f);
 
-                    CreateEffect(MODEL_KNIGHT_PLANCRACK_A, o->Position, o->Angle, vLight, 0, o, 0, 0, 0, 0, o->Scale * 0.2f);
+                    CreateEffectFpsChecked(MODEL_KNIGHT_PLANCRACK_A, o->Position, o->Angle, vLight, 0, o, 0, 0, 0, 0, o->Scale * 0.2f);
 
                     vec3_t vDir, vPos, vAngle;
                     VectorSubtract(o->StartPosition, o->Position, vDir);
@@ -16713,7 +16721,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         {
                             vAngle[2] -= (rand() % 20 + 10);
                         }
-                        CreateEffect(MODEL_KNIGHT_PLANCRACK_B,
+                        CreateEffectFpsChecked(MODEL_KNIGHT_PLANCRACK_B,
                             vPos, vAngle, vLight, 0, o, 0, 0, 0, 0, o->Scale);
                     }
                 }
@@ -16739,11 +16747,11 @@ void MoveEffect(OBJECT* o, int iIndex)
                         float fScale = (o->Scale * 1.6f) + rand() % 10 * 0.1f;
                         Vector(0.3f, 0.3f, 1.0f, vLight);
                         int index = (rand_fps_check(2)) ? BITMAP_WATERFALL_5 : BITMAP_WATERFALL_3;
-                        CreateParticle(index, vPos, o->Angle, vLight, 8, fScale);
+                        CreateParticleFpsChecked(index, vPos, o->Angle, vLight, 8, fScale);
                         Vector(1.0f, 1.0f, 1.0f, vLight);
                         if (rand_fps_check(2))
                         {
-                            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 55, o->Scale * 0.9f);
+                            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 55, o->Scale * 0.9f);
                         }
                     }
                 }
@@ -16754,9 +16762,9 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(0.5f, 0.5f, 1.f, vLight);
 
                     Vector(0.3f, 0.3f, 1.0f, vLight);
-                    CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, o->Scale * 1.1f);
-                    CreateEffect(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, o->Scale * 1.2f);
-                    CreateEffect(MODEL_RAKLION_BOSS_CRACKEFFECT, o->Position, o->Angle, vLight,
+                    CreateEffectFpsChecked(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, o->Scale * 1.1f);
+                    CreateEffectFpsChecked(MODEL_NIGHTWATER_01, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, o->Scale * 1.2f);
+                    CreateEffectFpsChecked(MODEL_RAKLION_BOSS_CRACKEFFECT, o->Position, o->Angle, vLight,
                         0, o, -1, 0, 0, 0, o->Scale * 0.4f);
 
                     vec3_t vPos, vResult;
@@ -16770,7 +16778,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                         VectorRotate(vPos, Matrix, vResult);
                         VectorAdd(vResult, o->Position, vResult);
 
-                        CreateEffect(MODEL_STONE1 + rand() % 2, vResult, o->Angle, o->Light, 13);
+                        CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, vResult, o->Angle, o->Light, 13);
                     }
                 }
 
@@ -16805,7 +16813,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 vec3_t vLight;
                 Vector(1.0f, 0.2f, 0.5f, vLight);
-                CreateEffect(BITMAP_RING_OF_GRADATION, o->Owner->Position, o->Angle, vLight, 0, o->Owner, 0, 0, 0, 0, 1.2f);
+                CreateEffectFpsChecked(BITMAP_RING_OF_GRADATION, o->Owner->Position, o->Angle, vLight, 0, o->Owner, 0, 0, 0, 0, 1.2f);
             }
         }
     }break;
@@ -16835,7 +16843,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             o->Scale *= pow(1.1f, FPS_ANIMATION_FACTOR);
         }
         CreateSprite(BITMAP_SHOCK_WAVE, o->Position, o->Scale, o->Light, o->Owner);
-        CreateParticle(BITMAP_FIRE + 2, o->Position, o->Angle, o->Light, 16, 2.5f);
+        CreateParticleFpsChecked(BITMAP_FIRE + 2, o->Position, o->Angle, o->Light, 16, 2.5f);
     }break;
     case MODEL_EFFECT_SD_AURA:
     {
@@ -16920,10 +16928,10 @@ void MoveEffect(OBJECT* o, int iIndex)
                     Vector(0.2f, 0.3f, 1.0f, Light);
                     p[1] += rand() % 20 - 10;
                     p[2] += rand() % 28 + 6;
-                    CreateJoint(BITMAP_PIN_LIGHT, p, p, o->Owner->Angle, 0, o->Owner, 5.0f);
+                    CreateJointFpsChecked(BITMAP_PIN_LIGHT, p, p, o->Owner->Angle, 0, o->Owner, 5.0f);
                 }
-                CreateEffect(MODEL_WOLF_HEAD_EFFECT, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 1, o->Owner);
-                CreateEffect(MODEL_WOLF_HEAD_EFFECT, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 2, o->Owner);
+                CreateEffectFpsChecked(MODEL_WOLF_HEAD_EFFECT, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 1, o->Owner);
+                CreateEffectFpsChecked(MODEL_WOLF_HEAD_EFFECT, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 2, o->Owner);
                 o->Owner->Angle[2] = Angle[2];
                 o->Owner->Angle[0] = Angle[0];
             }
@@ -16950,7 +16958,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorCopy(CharactersClient[o->Owner->m_sTargetIndex].Object.Position, vPosition);
             Vector(vPosition[0] + rand() % 80 - 40, vPosition[1] + rand() % 80 - 40, vPosition[2] + rand() % 120 + 30, vPosition);
             float Scale = 1.5f + (rand() % 10 * 0.02f);
-            CreateParticle(BITMAP_SBUMB, vPosition, o->Angle, vLight, 0, Scale * o->Scale, o->Owner);
+            CreateParticleFpsChecked(BITMAP_SBUMB, vPosition, o->Angle, vLight, 0, Scale * o->Scale, o->Owner);
         }
         if ((int)o->LifeTime == 15 || (int)o->LifeTime == 9 || (int)o->LifeTime == 6)
         {
@@ -16981,7 +16989,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             vec3_t _StartPos, _EndPos;
             pModel->TransformByObjectBone(_StartPos, o, 0);
-            CreateJoint(BITMAP_FORCEPILLAR, _StartPos, _StartPos, o->Angle, 0, o, 50.0f);
+            CreateJointFpsChecked(BITMAP_FORCEPILLAR, _StartPos, _StartPos, o->Angle, 0, o, 50.0f);
 
             VectorCopy(o->Owner->Angle, o->Angle);
             VectorCopy(o->Owner->Position, o->Position);
@@ -17007,7 +17015,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             if (o->AnimationFrame >= 6.0f || !o->Owner->Live)
             {
                 o->Live = false;
-                CreateEffect(MODEL_DOWN_ATTACK_DUMMY_L, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 0, o->Owner);
+                CreateEffectFpsChecked(MODEL_DOWN_ATTACK_DUMMY_L, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 0, o->Owner);
             }
 
             if (o->AnimationFrame >= 3.0f && o->LifeTime > 50)
@@ -17022,7 +17030,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             vec3_t _StartPos, _EndPos;
             pModel->TransformByObjectBone(_StartPos, o, 0);
-            CreateJoint(BITMAP_FORCEPILLAR, _StartPos, _StartPos, o->Angle, 1, o, 50.0f);
+            CreateJointFpsChecked(BITMAP_FORCEPILLAR, _StartPos, _StartPos, o->Angle, 1, o, 50.0f);
 
             VectorCopy(o->Owner->Angle, o->Angle);
             VectorCopy(o->Owner->Position, o->Position);
@@ -17047,7 +17055,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         vec3_t _StartPos, _EndPos;
         b->TransformByObjectBone(_StartPos, o->Owner, 5);
         b->TransformByObjectBone(_EndPos, o->Owner, 4);
-        CreateJoint(BITMAP_SWORDEFF, _StartPos, _EndPos, o->Owner->Angle, 0, o->Owner, 100.0f);
+        CreateJointFpsChecked(BITMAP_SWORDEFF, _StartPos, _EndPos, o->Owner->Angle, 0, o->Owner, 100.0f);
 
         if (o->Owner->AnimationFrame > 6 && o->LifeTime > 50)
         {
@@ -17060,13 +17068,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             b->TransformByObjectBone(position, o->Owner, 0, Relative);
 
             Vector(60.0f, 0.0f, Angle[2] - 180, Angle);
-            CreateEffect(MODEL_SHOCKWAVE01, position, Angle, Light, 0, o->Owner, -1, 0, 0, 0, 1.0f);
-            CreateEffect(MODEL_WOLF_HEAD_EFFECT2, o->Position, o->Angle, o->Light, 3, o->Owner);
+            CreateEffectFpsChecked(MODEL_SHOCKWAVE01, position, Angle, Light, 0, o->Owner, -1, 0, 0, 0, 1.0f);
+            CreateEffectFpsChecked(MODEL_WOLF_HEAD_EFFECT2, o->Position, o->Angle, o->Light, 3, o->Owner);
 
             if (o->Owner->m_sTargetIndex < 0)
                 break;
 
-            CreateEffect(BITMAP_DAMAGE1, CharactersClient[o->Owner->m_sTargetIndex].Object.Position, Angle, Light, 0, o->Owner, -1, 0, 0, 0, 1.4f);
+            CreateEffectFpsChecked(BITMAP_DAMAGE1, CharactersClient[o->Owner->m_sTargetIndex].Object.Position, Angle, Light, 0, o->Owner, -1, 0, 0, 0, 1.4f);
             StopBuffer(SOUND_RAGESKILL_GIANTSWING_ATTACK, true);
             PlayBuffer(SOUND_RAGESKILL_GIANTSWING_ATTACK);
             o->LifeTime = 45;
@@ -17081,21 +17089,21 @@ void MoveEffect(OBJECT* o, int iIndex)
             Vector(-80.0f, 120.0f, 0.0f, Relative);
             b->TransformByObjectBone(position, o->Owner, 4, Relative);
             Vector(90.f, 0.0f, Angle[2] - 180, Angle);
-            CreateEffect(MODEL_SHOCKWAVE02, position, Angle, Light, 0, o->Owner, -1, 0, 0, 0, 0.5f);
-            CreateEffect(MODEL_WOLF_HEAD_EFFECT2, o->Position, o->Angle, o->Light, 5, o->Owner);
+            CreateEffectFpsChecked(MODEL_SHOCKWAVE02, position, Angle, Light, 0, o->Owner, -1, 0, 0, 0, 0.5f);
+            CreateEffectFpsChecked(MODEL_WOLF_HEAD_EFFECT2, o->Position, o->Angle, o->Light, 5, o->Owner);
 
             Vector(1.0f, 1.0f, 1.0f, Light);
             Vector(-80.0f, 20.0f, 0.0f, vPosition);
             b->TransformByObjectBone(vPosition, o->Owner, 4, vPosition);
             Vector(90.0f, Angle[1], Angle[2], Angle);
-            CreateEffect(MODEL_SHOCKWAVE_SPIN01, vPosition, Angle, Light, 0, o->Owner, -1, 0, 0, 0, 0.5f);
-            CreateEffect(MODEL_SHOCKWAVE_SPIN01, vPosition, Angle, Light, 1, o->Owner, -1, 0, 0, 0, 0.9f);
+            CreateEffectFpsChecked(MODEL_SHOCKWAVE_SPIN01, vPosition, Angle, Light, 0, o->Owner, -1, 0, 0, 0, 0.5f);
+            CreateEffectFpsChecked(MODEL_SHOCKWAVE_SPIN01, vPosition, Angle, Light, 1, o->Owner, -1, 0, 0, 0, 0.9f);
 
             if (o->Owner->m_sTargetIndex < 0)
                 break;
 
             VectorCopy(CharactersClient[o->Owner->m_sTargetIndex].Object.Position, vPosition);
-            CreateEffect(BITMAP_SHINY + 4, vPosition, o->Angle, Light, 0, o->Owner, -1, 0, 0, 0, 1.9f);
+            CreateEffectFpsChecked(BITMAP_SHINY + 4, vPosition, o->Angle, Light, 0, o->Owner, -1, 0, 0, 0, 1.9f);
             StopBuffer(SOUND_RAGESKILL_GIANTSWING_ATTACK, true);
             PlayBuffer(SOUND_RAGESKILL_GIANTSWING_ATTACK);
             o->LifeTime = 20;
@@ -17183,7 +17191,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             VectorCopy(CharactersClient[o->Owner->m_sTargetIndex].Object.Position, vPosition);
             Vector(vPosition[0] + rand() % 90 - 40, vPosition[1] + rand() % 90 - 40, vPosition[2] + rand() % 100 + 50, vPosition);
             float Scale = 1.5f + (rand() % 5 * 0.01f);
-            CreateParticle(BITMAP_DAMAGE1, vPosition, o->Angle, vLight, 0, Scale * o->Scale, o->Owner);
+            CreateParticleFpsChecked(BITMAP_DAMAGE1, vPosition, o->Angle, vLight, 0, Scale * o->Scale, o->Owner);
         }
     }
     break;
@@ -17251,7 +17259,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                 {
                     Vector(1.0f, 0.2f, 0.0f, vLight);
                 }
-                CreateEffect(MODEL_WINDFOCE, o->Position, o->Angle, vLight, 3, o, -1, 0, 0, 0, 1.0f);
+                CreateEffectFpsChecked(MODEL_WINDFOCE, o->Position, o->Angle, vLight, 3, o, -1, 0, 0, 0, 1.0f);
             }
         }
         else if (o->SubType == 1)		//지속적인거
@@ -17292,7 +17300,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 vec3_t vLight;
                 Vector(1.0f, 0.5f, 0.0f, vLight);
-                CreateEffect(MODEL_WINDFOCE, o->Position, o->Angle, vLight, 3, o, -1, 0, 0, 0, 1.0f);
+                CreateEffectFpsChecked(MODEL_WINDFOCE, o->Position, o->Angle, vLight, 3, o, -1, 0, 0, 0, 1.0f);
             }
         }
         else if (o->SubType == 3)
@@ -17314,7 +17322,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorCopy(o->Position, vPosition);
         VectorCopy(o->Light, Light);
         Vector(vPosition[0] + rand() % 100 - 40, vPosition[1] + rand() % 100 - 40, vPosition[2] + rand() % 100 + 50, vPosition);
-        CreateParticle(BITMAP_SHINY + 4, vPosition, o->Angle, Light, 2, o->Scale);
+        CreateParticleFpsChecked(BITMAP_SHINY + 4, vPosition, o->Angle, Light, 2, o->Scale);
     }
     break;
     case BITMAP_LIGHT_RED:
@@ -17334,7 +17342,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     {
                         vec3_t vLight;
                         Vector(0.6f, 0.6f, 1.0f, vLight);
-                        CreateEffect(MODEL_WINDFOCE_MIRROR, o->Owner->Position, o->Angle, vLight, 0, o->Owner, -1, 0, 0, 0, 1.0f);
+                        CreateEffectFpsChecked(MODEL_WINDFOCE_MIRROR, o->Owner->Position, o->Angle, vLight, 0, o->Owner, -1, 0, 0, 0, 1.0f);
                     }
                 }
             }
@@ -17373,7 +17381,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     VectorCopy(o->Position, Position);
                     Vector(1.0f, 0.12f, 0.0f, Light);
                     b->TransformByObjectBone(Position, o->Owner, (rand_fps_check(2)) ? 26 : 35);
-                    CreateParticle(BITMAP_SMOKELINE1, Position, o->Angle, Light, 5, 0.005f, o->Owner);
+                    CreateParticleFpsChecked(BITMAP_SMOKELINE1, Position, o->Angle, Light, 5, 0.005f, o->Owner);
                 }
             }
         }
@@ -17404,7 +17412,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         VectorCopy(o->Light, vLight);
         VectorScale(vLight, 0.1f, vLight);
         if ((int)o->LifeTime % 3 != 0)
-            CreateParticle(BITMAP_SWORD_EFFECT_MONO, o->Position, o->Angle, o->Light, 0, o->Scale, o);
+            CreateParticleFpsChecked(BITMAP_SWORD_EFFECT_MONO, o->Position, o->Angle, o->Light, 0, o->Scale, o);
 
         if ((int)o->LifeTime == 14)
         {
@@ -17421,7 +17429,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 Vector(1.0f, 0.12f, 0.0f, vLight);
             }
-            CreateEffect(MODEL_SHOCKWAVE01, o->Position, o->Angle, vLight, 2, o->Owner, -1, 0, 0, 0, 1.0f);
+            CreateEffectFpsChecked(MODEL_SHOCKWAVE01, o->Position, o->Angle, vLight, 2, o->Owner, -1, 0, 0, 0, 1.0f);
         }
     }
     break;
@@ -17465,8 +17473,8 @@ void MoveEffect(OBJECT* o, int iIndex)
 
                 VectorCopy(pos, o->Position);
 
-                CreateEffect(MODEL_WOLF_HEAD_EFFECT2, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 4, o->Owner);
-                CreateEffect(MODEL_WOLF_HEAD_EFFECT2, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 6, o->Owner);
+                CreateEffectFpsChecked(MODEL_WOLF_HEAD_EFFECT2, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 4, o->Owner);
+                CreateEffectFpsChecked(MODEL_WOLF_HEAD_EFFECT2, o->Owner->Position, o->Owner->Angle, o->Owner->Light, 6, o->Owner);
                 o->Owner->Angle[2] = Angle[2];
                 o->Owner->Angle[0] = Angle[0];
             }
@@ -17536,7 +17544,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     pModel->TransformByObjectBone(_StartPos, o, 1);
                     pModel->TransformByObjectBone(_EndPos, o, 2);
 
-                    CreateJoint(BITMAP_GROUND_WIND, _StartPos, _EndPos, o->Angle, i, o, 150.0f);
+                    CreateJointFpsChecked(BITMAP_GROUND_WIND, _StartPos, _EndPos, o->Angle, i, o, 150.0f);
                     fAnimationFrame += fSpeedPerFrame;
                 }
             }
@@ -17556,15 +17564,15 @@ void MoveEffect(OBJECT* o, int iIndex)
                     float fScale = ((float)(rand() % 40 + 50) * 0.01f * 1.5f) * o->Scale * 1.8f;
                     for (int i = 0; i < 4; ++i)
                     {
-                        CreateParticle(BITMAP_ENERGY, vPos, o->Angle, o->Light, 7, fScale);
-                        CreateParticle(BITMAP_LIGHTNING_MEGA1, vPos, o->Angle, o->Light, 0, fScale * 0.9f);
+                        CreateParticleFpsChecked(BITMAP_ENERGY, vPos, o->Angle, o->Light, 7, fScale);
+                        CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1, vPos, o->Angle, o->Light, 0, fScale * 0.9f);
 
-                        CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, o->Light, 3, 1.0f + (fLuminosity * 0.05f));
-                        CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, o->Light, 8, 1.0f + (fLuminosity * 0.05f));
+                        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, o->Light, 3, 1.0f + (fLuminosity * 0.05f));
+                        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, o->Light, 8, 1.0f + (fLuminosity * 0.05f));
 
                         if (i % 2)
                         {
-                            CreateParticle(BITMAP_SPARK, vPos, o->Angle, o->Light, 13);
+                            CreateParticleFpsChecked(BITMAP_SPARK, vPos, o->Angle, o->Light, 13);
                         }
 
                         if (i % 2)
@@ -17623,8 +17631,8 @@ void MoveEffect(OBJECT* o, int iIndex)
                 pModel->TransformByObjectBone(_StartPos, o->Owner, 36);
                 pModel->TransformByObjectBone(_EndPos, o->Owner, 28);
 
-                CreateJoint(BITMAP_LAVA, _StartPos, _StartPos, o->Owner->Angle, i, o->Owner, 20.0f);
-                CreateJoint(BITMAP_LAVA, _EndPos, _EndPos, o->Owner->Angle, 7 + i, o->Owner, 20.0f);
+                CreateJointFpsChecked(BITMAP_LAVA, _StartPos, _StartPos, o->Owner->Angle, i, o->Owner, 20.0f);
+                CreateJointFpsChecked(BITMAP_LAVA, _EndPos, _EndPos, o->Owner->Angle, 7 + i, o->Owner, 20.0f);
                 fAnimationFrame += fSpeedPerFrame;
             }
         }
@@ -17635,14 +17643,14 @@ void MoveEffect(OBJECT* o, int iIndex)
         if (o->Owner->AnimationFrame > 5 && o->LifeTime > 100)
         {
             Vector(1.0f, 0.12f, 0.0f, vLight);
-            CreateEffect(MODEL_SHOCKWAVE01, o->Owner->Position, vAngle, vLight, 1, o->Owner, -1, 0, 0, 0, 1.0f);
+            CreateEffectFpsChecked(MODEL_SHOCKWAVE01, o->Owner->Position, vAngle, vLight, 1, o->Owner, -1, 0, 0, 0, 1.0f);
             o->LifeTime = 95;
         }
 
         if (o->Owner->AnimationFrame > 5 && o->LifeTime > 80)
         {
             Vector(1.0f, 0.1f, 0.0f, vLight);
-            CreateEffect(MODEL_SHOCKWAVE_GROUND01, o->Position, o->Angle, vLight, 1, o, -1, 0, 0, 0, 1.0f);
+            CreateEffectFpsChecked(MODEL_SHOCKWAVE_GROUND01, o->Position, o->Angle, vLight, 1, o, -1, 0, 0, 0, 1.0f);
             o->LifeTime = 80;
         }
 
@@ -17656,13 +17664,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             switch (rand() % 3)
             {
             case 0:
-                CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 0, fScale);
                 break;
             case 1:
-                CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 4, fScale);
                 break;
             case 2:
-                CreateParticle(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 0, fScale);
                 break;
             }
 
@@ -17681,12 +17689,12 @@ void MoveEffect(OBJECT* o, int iIndex)
                 VectorRotate(PosL, Matrix, outPos);
                 VectorAdd(vPos, outPos, vPos);
                 vPos[2] = tempPos[2];
-                CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 5, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 5, fScale);
 
                 vec3_t TempPos;
                 VectorCopy(vPos, TempPos);
                 TempPos[2] = 250.0f;
-                CreateParticle(BITMAP_SPARK, TempPos, o->Angle, o->Light, 12, 1.5f);
+                CreateParticleFpsChecked(BITMAP_SPARK, TempPos, o->Angle, o->Light, 12, 1.5f);
             }
         }
     }
@@ -17702,14 +17710,14 @@ void MoveEffect(OBJECT* o, int iIndex)
             vec3_t temp;
             VectorCopy(o->Position, temp);
             temp[2] = 250.0f;
-            CreateParticle(BITMAP_SPARK, temp, o->Angle, o->Light, 12, 1.5f);
+            CreateParticleFpsChecked(BITMAP_SPARK, temp, o->Angle, o->Light, 12, 1.5f);
         }
 
         if (o->AnimationFrame > 1 && o->LifeTime > 80)
         {
             vec3_t vLight;
             Vector(1.0f, 1.0f, 1.0f, vLight);
-            CreateEffect(BITMAP_LIGHT_RED, o->Position, o->Angle, vLight, 1, o, -1, 0, 0, 0, 15.0f);
+            CreateEffectFpsChecked(BITMAP_LIGHT_RED, o->Position, o->Angle, vLight, 1, o, -1, 0, 0, 0, 15.0f);
             o->LifeTime = 80;
         }
         o->Alpha *= pow(0.96f, FPS_ANIMATION_FACTOR);
@@ -17742,13 +17750,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             switch (rand() % 3)
             {
             case 0:
-                CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, fScale);
                 break;
             case 1:
-                CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, fScale);
                 break;
             case 2:
-                CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, fScale);
                 break;
             }
         }
@@ -17771,13 +17779,13 @@ void MoveEffect(OBJECT* o, int iIndex)
             switch (rand() % 3)
             {
             case 0:
-                CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 6, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 6, fScale);
                 break;
             case 1:
-                CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 9, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 9, fScale);
                 break;
             case 2:
-                CreateParticle(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 6, fScale);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 6, fScale);
                 break;
             }
 
@@ -17785,12 +17793,12 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 for (int i = 0; i < 4; ++i)
                 {
-                    CreateEffect(MODEL_VOLCANO_STONE, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, 1.0f);
+                    CreateEffectFpsChecked(MODEL_VOLCANO_STONE, o->Position, o->Angle, vLight, 0, o, -1, 0, 0, 0, 1.0f);
                 }
 
                 VectorCopy(o->Position, vPos);
                 Vector(1.0f, 0.1f, 0.0f, vLight);
-                CreateEffect(MODEL_SHOCKWAVE_GROUND01, vPos, o->Angle, vLight, 2, o, -1, 0, 0, 0, 1.0f);
+                CreateEffectFpsChecked(MODEL_SHOCKWAVE_GROUND01, vPos, o->Angle, vLight, 2, o, -1, 0, 0, 0, 1.0f);
                 Vector(1.0f, 1.0f, 1.0f, vLight);
             }
             if (o->LifeTime < 20)
@@ -17818,7 +17826,7 @@ void MoveEffect(OBJECT* o, int iIndex)
 
             if ((int)o->LifeTime == 2)
             {
-                CreateEffect(MODEL_VOLCANO_OF_MONK, o->Position, o->Angle, o->Light, 1, o, -1, 0, 0, 0, 1.0f);
+                CreateEffectFpsChecked(MODEL_VOLCANO_OF_MONK, o->Position, o->Angle, o->Light, 1, o, -1, 0, 0, 0, 1.0f);
                 o->LifeTime = 0;
                 o->Live = false;
             }
@@ -17858,13 +17866,13 @@ void MoveEffect(OBJECT* o, int iIndex)
         switch (rand() % 3)
         {
         case 0:
-            CreateParticle(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, fScale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, o->Position, o->Angle, vLight, 0, fScale);
             break;
         case 1:
-            CreateParticle(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, fScale);
+            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, o->Position, o->Angle, vLight, 4, fScale);
             break;
         case 2:
-            CreateParticle(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, fScale);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, o->Position, o->Angle, vLight, 0, fScale);
             break;
         }
     }

--- a/Source Main 5.2/source/ZzzEffect.h
+++ b/Source Main 5.2/source/ZzzEffect.h
@@ -31,6 +31,8 @@ void AnimationFlag();
 void RenderFlag(OBJECT* o, vec3_t Light, int Tex1, int Tex2);
 
 int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType = 0, float Scale = 1.f, OBJECT* Owner = NULL);
+int CreateParticleFpsChecked(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType = 0, float Scale = 1.f, OBJECT* Owner = NULL);
+
 void RenderParticles(BYTE byRenderOneMore = 0);
 void MoveParticles();
 bool DeleteParticle(int iType);
@@ -58,6 +60,8 @@ void CheckClientArrow(OBJECT* o);
 void RenderEffects(bool bRenderBlendMesh = false);
 void RenderAfterEffects(bool bRenderBlendMesh = false);
 void RenderEffectShadows();
+void CreateEffectFpsChecked(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType = 0, OBJECT* Target = NULL, short PKKey = -1,
+    WORD SkillIndex = 0, WORD Skill = 0, WORD SkillSerialNum = 0, float Scale = 0.0f, short int sTargetIndex = -1);
 void CreateEffect(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType = 0, OBJECT* Target = NULL, short PKKey = -1,
     WORD SkillIndex = 0, WORD Skill = 0, WORD SkillSerialNum = 0, float Scale = 0.0f, short int sTargetIndex = -1);
 void MoveEffects();

--- a/Source Main 5.2/source/ZzzEffectJoint.cpp
+++ b/Source Main 5.2/source/ZzzEffectJoint.cpp
@@ -18,6 +18,15 @@
 
 extern float g_fBoneSave[10][3][4];
 
+void CreateJointFpsChecked(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle, int SubType, OBJECT* Target, float Scale, short PKKey,
+    WORD SkillIndex, WORD SkillSerialNum, int iChaIndex, const float* vPriorColor, short int sTargetindex)
+{
+    if (rand_fps_check(1))
+    {
+        CreateJoint(Type, Position, TargetPosition, Angle, SubType, Target, Scale, PKKey, SkillIndex, SkillSerialNum, iChaIndex, vPriorColor, sTargetindex);
+    }
+}
+
 void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle, int SubType, OBJECT* Target, float Scale, short PKKey,
     WORD SkillIndex, WORD SkillSerialNum, int iChaIndex, const float* vPriorColor, short int sTargetindex)
 {
@@ -3144,20 +3153,20 @@ void MoveJoint(JOINT* o, int iIndex)
                 Luminosity = sinf(WorldTime * 0.002f) * 0.3f + 0.8f;
                 Vector(Luminosity * 0.5f, Luminosity * 0.1f, Luminosity, Light);
                 VectorMul(Light, o->Light, Light);
-                CreateParticle(BITMAP_LIGHTNING + 1, o->Position, o->Angle, Light);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING + 1, o->Position, o->Angle, Light);
                 break;
             case 14:
             case 15:
                 Luminosity = sinf(WorldTime * 0.002f) * 0.3f + 0.8f;
                 Vector(Luminosity, Luminosity * 0.1f, Luminosity * 0.1f, Light);
-                CreateParticle(BITMAP_LIGHTNING + 1, o->Position, o->Angle, Light, 4);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING + 1, o->Position, o->Angle, Light, 4);
                 break;
             case 22:
             case 23:
                 Luminosity = sinf(WorldTime * 0.002f) * 0.2f + 0.8f;
                 Vector(Luminosity, Luminosity, Luminosity, Light);
                 VectorMul(Light, o->Light, Light);
-                CreateParticle(BITMAP_LIGHTNING + 1, o->Position, o->Angle, Light, 4);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING + 1, o->Position, o->Angle, Light, 4);
                 break;
             case 24:
             case 25:
@@ -3307,7 +3316,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 if (Distance <= 35.f)
                 {
                     o->Live = false;
-                    CreateParticle(BITMAP_LIGHTNING + 1, o->Position, o->Angle, o->Light, 1);
+                    CreateParticleFpsChecked(BITMAP_LIGHTNING + 1, o->Position, o->Angle, o->Light, 1);
                     PlayBuffer(SOUND_GET_ENERGY);
                 }
                 else if (Distance <= 70.0f && fabs(fOldAngle - o->Angle[2]) > 20.0f)
@@ -3322,7 +3331,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->SubType == 6 || o->SubType == 9)
             {
-                CreateParticle(BITMAP_LIGHTNING + 1, o->Position, o->Angle, o->Light, 3, 0.05f);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING + 1, o->Position, o->Angle, o->Light, 3, 0.05f);
             }
             else if (o->SubType == 12 || o->SubType == 13)
             {
@@ -3337,12 +3346,12 @@ void MoveJoint(JOINT* o, int iIndex)
             else if (o->SubType == 16)
             {
                 Vector(0.4f, 0.8f, 1.0f, Light);
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 31, 0.8f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 31, 0.8f);
             }
             else if (o->SubType == 46)
             {
                 Vector(0.4f, 1.0f, 0.4f, Light);
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 31, 0.8f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 31, 0.8f);
             }
             else if (o->SubType == 45)
             {
@@ -3351,7 +3360,7 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             else
             {
-                CreateParticle(BITMAP_LIGHTNING + 1, o->Position, o->Angle, o->Light);
+                CreateParticleFpsChecked(BITMAP_LIGHTNING + 1, o->Position, o->Angle, o->Light);
             }
         }
         break;
@@ -3394,7 +3403,7 @@ void MoveJoint(JOINT* o, int iIndex)
             Vector(Luminosity * 0.4f, Luminosity, Luminosity * 0.8f, Light);
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
 
-            CreateParticle(BITMAP_LIGHTNING + 1, o->Position, o->Angle, o->Light, 5, 0.12f);
+            CreateParticleFpsChecked(BITMAP_LIGHTNING + 1, o->Position, o->Angle, o->Light, 5, 0.12f);
         }
         break;
         case 43:
@@ -3441,7 +3450,7 @@ void MoveJoint(JOINT* o, int iIndex)
             CreateSprite(BITMAP_LIGHT, vPos, 2.0f, vLight, NULL, -(WorldTime * 0.1f));
             CreateSprite(BITMAP_LIGHT, vPos, 2.0f, vLight, NULL, (WorldTime * 0.12f));
             Vector(1.0f, 0.6f, 0.4f, vLight);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 31, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 31, 1.0f);
         }
         break;
         }
@@ -3660,7 +3669,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 o->m_sTargetIndex = -10;
                 o->Angle[2] += (o->m_sTargetIndex) * FPS_ANIMATION_FACTOR;
             }
-            CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 59, 1.0f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 59, 1.0f);
         }
         else if (o->SubType == 1)
         {
@@ -3927,7 +3936,7 @@ void MoveJoint(JOINT* o, int iIndex)
             VectorCopy(o->Position, Position);
 
             o->Angle[0] = (float)o->LifeTime;	// 임시로 -_-
-            CreateParticle(BITMAP_FIRE + 1, Position, o->Angle, Light, 5, 0.9f);
+            CreateParticleFpsChecked(BITMAP_FIRE + 1, Position, o->Angle, Light, 5, 0.9f);
             if (rand_fps_check(200))
             {
                 CreateJoint(BITMAP_JOINT_SPIRIT, Position, Position, o->Angle, 12, NULL, 0.9f);
@@ -3944,10 +3953,10 @@ void MoveJoint(JOINT* o, int iIndex)
 
             Vector(1.0f, 0.2f, 0.1f, Light);
             //if (rand()%2 == 1)
-            CreateParticle(BITMAP_SMOKE + 3, Position, o->Angle, Light, 0, (float)(rand() % 32 + 48) * 0.01f);
+            CreateParticleFpsChecked(BITMAP_SMOKE + 3, Position, o->Angle, Light, 0, (float)(rand() % 32 + 48) * 0.01f);
 
             Vector(1, 1, 1, Light);
-            CreateParticle(BITMAP_FIRE + 1, Position, o->Angle, Light, 6, 0.6f);
+            CreateParticleFpsChecked(BITMAP_FIRE + 1, Position, o->Angle, Light, 6, 0.6f);
         }
         else if (o->SubType == 14)
         {
@@ -3958,11 +3967,11 @@ void MoveJoint(JOINT* o, int iIndex)
             o->Angle[0] -= (2.0f) * FPS_ANIMATION_FACTOR;
             int r = rand() % 5;
             if (r == 0)
-                CreateParticle(BITMAP_WATERFALL_3, o->Position, o->Angle, o->Light, 2);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_3, o->Position, o->Angle, o->Light, 2);
             else if (r <= 2)
-                CreateParticle(BITMAP_WATERFALL_4, o->Position, o->Angle, o->Light, 2);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_4, o->Position, o->Angle, o->Light, 2);
             else
-                CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, o->Light, 4);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, o->Light, 4);
         }
         else if (o->SubType == 15)
         {
@@ -3973,7 +3982,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if (o->LifeTime < 35)
             {
-                CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, 7, 1.0f);
+                CreateParticleFpsChecked(BITMAP_FIRE, Position, o->Angle, Light, 7, 1.0f);
 
                 if (rand_fps_check(2))//if ((int)o->LifeTime % 2 == 0)
                 {
@@ -4017,7 +4026,7 @@ void MoveJoint(JOINT* o, int iIndex)
             VectorCopy(o->Position, Position);
 
             o->Angle[0] = (float)o->LifeTime;
-            CreateParticle(BITMAP_WATERFALL_5, o->Position, o->Angle, o->Light, 4);
+            CreateParticleFpsChecked(BITMAP_WATERFALL_5, o->Position, o->Angle, o->Light, 4);
             o->Position[0] += (cosf(o->Angle[2]) * 30.0f) * FPS_ANIMATION_FACTOR;
             o->Position[1] += (sinf(o->Angle[2]) * 30.0f) * FPS_ANIMATION_FACTOR;
         }
@@ -4032,7 +4041,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 for (int i = 0; i < 120; ++i)
                 {
                     Vector(0.f, 0.f, i * 3.f, Angle);
-                    CreateJoint(BITMAP_JOINT_SPIRIT, Position, o->Position, Angle, 16, NULL, 0.9f);
+                    CreateJointFpsChecked(BITMAP_JOINT_SPIRIT, Position, o->Position, Angle, 16, NULL, 0.9f);
                 }
             }
         }
@@ -4059,7 +4068,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             VectorCopy(o->Position, Position);
             Vector(1, 1, 1, Light);
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle, Light, 19, 7.f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, Light, 19, 7.f);
         }
         else if (o->SubType == 20)
         {
@@ -4136,7 +4145,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if ((int)o->LifeTime == 10)
             {
-                CreateEffect(BITMAP_FIRECRACKER0002, o->Position, o->Angle, o->Light, o->Skill);
+                CreateEffectFpsChecked(BITMAP_FIRECRACKER0002, o->Position, o->Angle, o->Light, o->Skill);
             }
         }
         break;
@@ -4309,7 +4318,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     if (o->Weapon == 40 && o->SubType <= 6)
                     {
-                        CreateEffect(BITMAP_SHOCK_WAVE, o->StartPosition, o->Angle, o->Light, 3);
+                        CreateEffectFpsChecked(BITMAP_SHOCK_WAVE, o->StartPosition, o->Angle, o->Light, 3);
                     }
                     o->Weapon += FPS_ANIMATION_FACTOR;
 
@@ -4584,13 +4593,13 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 if (o->Scale == 50.f)
                 {
-                    CreateParticle(BITMAP_ENERGY, o->Position, o->Angle, o->Light);
+                    CreateParticleFpsChecked(BITMAP_ENERGY, o->Position, o->Angle, o->Light);
                     vec3_t Position;
                     if (rand_fps_check(8))
                     {
                         Vector((float)(rand() % 64 - 32), (float)(rand() % 64 - 32), (float)(rand() % 64 - 32), Position);
                         VectorAdd(Position, o->TargetPosition, Position);
-                        CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light);
+                        CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light);
                     }
                 }
                 break;
@@ -4641,7 +4650,7 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     Vector((float)(rand() % 64 - 32), (float)(rand() % 64 - 32), (float)(rand() % 64 - 32), Position);
                     VectorAdd(Position, o->TargetPosition, Position);
-                    CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light);
+                    CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, o->Light);
                 }
                 //CreateParticle(BITMAP_ENERGY,o->Position,o->Angle,o->Light);
                 /*o->TargetCharacter->TargetCharacter = o->OwnerCharacter;
@@ -4910,7 +4919,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 if (o->Scale == 50.f)
                 {
-                    CreateParticle(BITMAP_ENERGY, o->Position, o->Angle, o->Light);
+                    CreateParticleFpsChecked(BITMAP_ENERGY, o->Position, o->Angle, o->Light);
                     vec3_t Position;
                     if (rand_fps_check(8))
                     {
@@ -4964,9 +4973,9 @@ void MoveJoint(JOINT* o, int iIndex)
 
         else if (o->SubType == 15 && ((int)o->LifeTime % 2) == 0)
         {
-            CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->StartPosition, o->Angle, 0, NULL, 50.f);
-            CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->StartPosition, o->Angle, 0, NULL, 10.f);
-            CreateParticle(BITMAP_ENERGY, o->Position, o->Angle, Light);
+            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, o->Position, o->StartPosition, o->Angle, 0, NULL, 50.f);
+            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, o->Position, o->StartPosition, o->Angle, 0, NULL, 10.f);
+            CreateParticleFpsChecked(BITMAP_ENERGY, o->Position, o->Angle, Light);
 
             vec3_t Angle;
             VectorCopy(o->StartPosition, Position);
@@ -4986,8 +4995,8 @@ void MoveJoint(JOINT* o, int iIndex)
                         o->TargetPosition[2] += 100.f;
                         Angle[2] = CreateAngle2D(o->Position, o->TargetPosition);
 
-                        CreateJoint(BITMAP_JOINT_THUNDER, Position, o->TargetPosition, Angle, 0, NULL, 50.f);
-                        CreateJoint(BITMAP_JOINT_THUNDER, Position, o->TargetPosition, Angle, 0, NULL, 10.f);
+                        CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, o->TargetPosition, Angle, 0, NULL, 50.f);
+                        CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Position, o->TargetPosition, Angle, 0, NULL, 10.f);
 
                         VectorCopy(o->TargetPosition, Position);
                     }
@@ -5090,7 +5099,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
                 CreateSprite(BITMAP_SHINY + 1, o->TargetPosition, 1.5f, Light, NULL, (float)((rand() % 360)));
                 CreateSprite(BITMAP_SHINY + 1, o->TargetPosition, 1.5f, Light, NULL, (float)((rand() % 360)));
-                CreateParticle(BITMAP_TRUE_BLUE, o->TargetPosition, o->Angle, Light);
+                CreateParticleFpsChecked(BITMAP_TRUE_BLUE, o->TargetPosition, o->Angle, Light);
             }
             else if (o->SubType == 3)
             {
@@ -5101,7 +5110,7 @@ void MoveJoint(JOINT* o, int iIndex)
             else if (o->SubType == 6)
             {
                 o->TargetPosition[2] = RequestTerrainHeight(o->TargetPosition[0], o->TargetPosition[1]) + 30.f;
-                CreateParticle(BITMAP_TRUE_BLUE, o->TargetPosition, o->Angle, Light, 0, 2.0f);
+                CreateParticleFpsChecked(BITMAP_TRUE_BLUE, o->TargetPosition, o->Angle, Light, 0, 2.0f);
             }
         }
         else if (o->SubType == 4)
@@ -5669,8 +5678,8 @@ void MoveJoint(JOINT* o, int iIndex)
             }
             if (o->SubType == 45 && o->LifeTime <= 1)
             {
-                CreateEffect(MODEL_CHANGE_UP_EFF, o->Target->Position, o->Target->Angle, o->Target->Light, 1, o->Target);
-                CreateEffect(MODEL_CHANGE_UP_CYLINDER, o->Target->Position, o->Target->Angle, o->Target->Light, 1, o->Target);
+                CreateEffectFpsChecked(MODEL_CHANGE_UP_EFF, o->Target->Position, o->Target->Angle, o->Target->Light, 1, o->Target);
+                CreateEffectFpsChecked(MODEL_CHANGE_UP_CYLINDER, o->Target->Position, o->Target->Angle, o->Target->Light, 1, o->Target);
             }
             {
                 if (o->SubType != 47)
@@ -5685,7 +5694,7 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 vec3_t Angle = { 0.0f, 0.0f, 0.0f };
                 vec3_t Light = { 1.f, 1.f, 1.f };
-                CreateParticle(BITMAP_EXPLOTION, o->Position, Angle, Light, 1, 0.6f);
+                CreateParticleFpsChecked(BITMAP_EXPLOTION, o->Position, Angle, Light, 1, 0.6f);
             }
         }
         else if (o->SubType == 8)
@@ -6048,17 +6057,17 @@ void MoveJoint(JOINT* o, int iIndex)
                 {
                     CreateSprite(BITMAP_SPARK + 1, o->Position, 5.0f, o->Light, NULL);
 
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 34, 1.0f);
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 35, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 34, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 35, 1.0f);
                     //CreateParticle(BITMAP_SPARK+1, o->Position, o->Angle, o->Light, 12, 1.0f);
                     Vector(0.7f, 0.3f, 0.3f, o->Light);
-                    CreateParticle(BITMAP_SPARK + 1, o->Position, o->Angle, o->Light, 10, 4.0f);
+                    CreateParticleFpsChecked(BITMAP_SPARK + 1, o->Position, o->Angle, o->Light, 10, 4.0f);
                     Vector(1.0f, 1.0f, 0.2f, o->Light);
                 }
                 else if (o->SubType == 15 && o->Live == true)
                 {
-                    CreateParticle(BITMAP_SHINY, o->Position, o->Angle, o->Light, 3, 0.5f);
-                    CreateParticle(BITMAP_SHINY, o->Position, o->Angle, o->Light, 3, 0.5f);
+                    CreateParticleFpsChecked(BITMAP_SHINY, o->Position, o->Angle, o->Light, 3, 0.5f);
+                    CreateParticleFpsChecked(BITMAP_SHINY, o->Position, o->Angle, o->Light, 3, 0.5f);
                 }
 
                 if (o->LifeTime < 15)
@@ -6202,17 +6211,17 @@ void MoveJoint(JOINT* o, int iIndex)
                     {
                         if (rand_fps_check(2))
                         {
-                            CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 0);
+                            CreateParticleFpsChecked(BITMAP_FIRE, o->Position, o->Angle, o->Light, 0);
                         }
 
-                        CreateJoint(BITMAP_JOINT_THUNDER, Light, o->Position, o->Angle, 3, NULL, rand() % 10 + 5.f, 5, 10);
-                        CreateJoint(BITMAP_JOINT_THUNDER, Light, o->Position, o->Angle, 3, NULL, rand() % 8 + 4.f, 5, 10);
+                        CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Light, o->Position, o->Angle, 3, NULL, rand() % 10 + 5.f, 5, 10);
+                        CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Light, o->Position, o->Angle, 3, NULL, rand() % 8 + 4.f, 5, 10);
                     }
                     else
                         if (o->SubType == 8)
                         {
-                            CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 3, NULL, rand() % 10 + 5.f, 5, 10);
-                            CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 3, NULL, rand() % 8 + 4.f, 5, 10);
+                            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 3, NULL, rand() % 10 + 5.f, 5, 10);
+                            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 3, NULL, rand() % 8 + 4.f, 5, 10);
                         }
                 }
                 if (o->SubType == 10)
@@ -6281,8 +6290,8 @@ void MoveJoint(JOINT* o, int iIndex)
                                 CreateParticle(BITMAP_FIRE, o->Position, o->Angle, o->Light, 0);
                             }
 
-                            CreateJoint(BITMAP_JOINT_THUNDER, Light, o->Position, o->Angle, 3, NULL, rand() % 10 + 5.f, 5, 10); //  전기
-                            CreateJoint(BITMAP_JOINT_THUNDER, Light, o->Position, o->Angle, 3, NULL, rand() % 8 + 4.f, 5, 10); //  전기
+                            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Light, o->Position, o->Angle, 3, NULL, rand() % 10 + 5.f, 5, 10); //  전기
+                            CreateJointFpsChecked(BITMAP_JOINT_THUNDER, Light, o->Position, o->Angle, 3, NULL, rand() % 8 + 4.f, 5, 10); //  전기
                         }
                     }
                     if (o->SubType == 0)
@@ -6356,13 +6365,13 @@ void MoveJoint(JOINT* o, int iIndex)
                 }
                 if ((int)o->LifeTime % 5 == 0 && o->SubType == 2)
                 {
-                    CreateEffect(MODEL_SKILL_INFERNO, o->StartPosition, o->HeadAngle, o->Light, 6, NULL, 20, 0);
+                    CreateEffectFpsChecked(MODEL_SKILL_INFERNO, o->StartPosition, o->HeadAngle, o->Light, 6, NULL, 20, 0);
                 }
                 else if (o->SubType == 4)
                 {
                     Vector(0.1f, 0.6f, 1.f, Light);
 
-                    CreateJoint(BITMAP_FLARE_BLUE, o->Position, o->Position, o->Angle, 6, NULL, 30.0f);
+                    CreateJointFpsChecked(BITMAP_FLARE_BLUE, o->Position, o->Position, o->Angle, 6, NULL, 30.0f);
                     CreateSprite(BITMAP_LIGHT, o->Position, 1.6f, Light, NULL);
                     CreateSprite(BITMAP_SHINY + 1, o->Position, 1.5f, Light, NULL, WorldTime * 0.1f);
                 }
@@ -6729,7 +6738,7 @@ void MoveJoint(JOINT* o, int iIndex)
 
             if ((o->Weapon - o->LifeTime) < 10)
             {
-                CreateParticle(BITMAP_EXPLOTION + 1, o->StartPosition, o->Angle, o->Light, 0, 3.f);
+                CreateParticleFpsChecked(BITMAP_EXPLOTION + 1, o->StartPosition, o->Angle, o->Light, 0, 3.f);
                 o->Scale = 100.f;
             }
             else
@@ -6742,13 +6751,13 @@ void MoveJoint(JOINT* o, int iIndex)
             {
                 vec3_t tPos;
                 VectorCopy(o->Position, tPos);
-                CreateJoint(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 4, NULL, 60.f);
+                CreateJointFpsChecked(BITMAP_JOINT_THUNDER, o->Position, o->Position, o->Angle, 4, NULL, 60.f);
                 Vector(1.f, 1.f, 1.f, Light);
                 if (o->Direction[2] <= 0) o->Direction[2] = sinf(o->Velocity) * 20.f;
                 o->Position[2] = height + 5.f;
 
                 tPos[2] = o->Position[2] + 30.f;
-                CreateParticle(BITMAP_ADV_SMOKE + 1, tPos, o->Angle, o->Light, 2, 3.f);
+                CreateParticleFpsChecked(BITMAP_ADV_SMOKE + 1, tPos, o->Angle, o->Light, 2, 3.f);
             }
 
             CreateTailAxis(o, Matrix, 1);

--- a/Source Main 5.2/source/ZzzEffectNoUse.cpp
+++ b/Source Main 5.2/source/ZzzEffectNoUse.cpp
@@ -569,18 +569,18 @@ void RenderBackLight(OBJECT* o, vec3_t Position, vec3_t Light1, vec3_t Light2)
         position[1] = Position[1] + rand() % 80 - 40;
         position[2] = Position[2] + 10;
 
-        if (rand() % 2)
+        if (rand_fps_check(2))
         {
             CreateParticle(BITMAP_ENERGY, position, o->Angle, Light1, 1, 0.05f);
         }
-        else
+        else if (rand_fps_check(2))
         {
             CreateParticle(BITMAP_ENERGY, position, o->Angle, Light2, 1, 0.05f);
         }
 
         Vector(Light1[0] * light + Light2[0] * (1.f - light), Light1[1] * light + Light2[1] * (1.f - light), Light1[2] * light + Light2[2] * (1.f - light), Light);
 
-        CreateParticle(BITMAP_FLARE, position, o->Angle, Light1, 1, 0.2f);
+        CreateParticleFpsChecked(BITMAP_FLARE, position, o->Angle, Light1, 1, 0.2f);
     }
     g_aniBackLight = true;
 }

--- a/Source Main 5.2/source/ZzzEffectParticle.cpp
+++ b/Source Main 5.2/source/ZzzEffectParticle.cpp
@@ -40,6 +40,18 @@ void HandPosition(PARTICLE* o)
     b->TransformPosition(Owner->BoneTransform[Hero->Weapon[o->SubType % 2].LinkBone], p, o->Position, true);
 }
 
+int CreateParticleFpsChecked(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType, float Scale, OBJECT* Owner)
+{
+    if (rand_fps_check(1))
+    {
+        return CreateParticle(Type, Position, Angle, Light, SubType, Scale, Owner);
+    }
+    else
+    {
+        return false;
+    }
+}
+
 int CreateParticle(int Type, vec3_t Position, vec3_t Angle, vec3_t Light, int SubType, float Scale, OBJECT* Owner)
 {
     if (!g_pOption->GetRenderAllEffects())
@@ -8747,7 +8759,7 @@ void MoveParticles()
                 {
                     vec3_t Light;
                     Vector(0.8f, 0.3f, 0.3f, Light);
-                    if (rand() % 2 == 1)
+                    if (rand_fps_check(2))
                         CreateParticle(BITMAP_CURSEDTEMPLE_EFFECT_MASKER, o->StartPosition, o->Angle, Light, 1, 1.3f);
                 }
             }
@@ -8855,11 +8867,11 @@ void MoveParticles()
                 {
                     float _Scale = (rand() % 20 + 20.0f) / 50.0f;
                     if (o->SubType == 0)
-                        CreateParticle(BITMAP_AG_ADDITION_EFFECT, Temp_Pos, o->Angle, o->Light, 0, 1.0f, o->Target);
+                        CreateParticleFpsChecked(BITMAP_AG_ADDITION_EFFECT, Temp_Pos, o->Angle, o->Light, 0, 1.0f, o->Target);
                     else if (o->SubType == 1)
-                        CreateParticle(BITMAP_AG_ADDITION_EFFECT, Temp_Pos, o->Angle, o->Light, 1, 1.0f, o->Target);
+                        CreateParticleFpsChecked(BITMAP_AG_ADDITION_EFFECT, Temp_Pos, o->Angle, o->Light, 1, 1.0f, o->Target);
                     else if (o->SubType == 2)
-                        CreateParticle(BITMAP_AG_ADDITION_EFFECT, Temp_Pos, o->Angle, o->Light, 2, 1.0f, o->Target);
+                        CreateParticleFpsChecked(BITMAP_AG_ADDITION_EFFECT, Temp_Pos, o->Angle, o->Light, 2, 1.0f, o->Target);
                 }
             }
             break;

--- a/Source Main 5.2/source/ZzzObject.cpp
+++ b/Source Main 5.2/source/ZzzObject.cpp
@@ -138,7 +138,7 @@ void ActionObject(OBJECT* o)
                                 {
                                     Position[0] = o->Position[0] + (rand() % 300 - 150.f);
                                     Position[1] = o->Position[1] - (rand() % 20 + 600.f);
-                                    CreateParticle(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
+                                    CreateParticleFpsChecked(BITMAP_SMOKE + 1, Position, o->Angle, o->Light);
                                 }
                             }
                         }
@@ -624,7 +624,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                 CreateSprite(BITMAP_LIGHT, o->Position, 3.f, Light, o, 0.0f, 0);	// flare01.jpg
                 Vector(0.9f, 0.6f, 0.6f, Light);
                 CreateSprite(BITMAP_POUNDING_BALL, o->Position, 0.9f + fLuminosity, Light, NULL, (WorldTime / 10.0f));
-                CreateParticle(BITMAP_POUNDING_BALL, o->Position, o->Angle, Light, 2, 0.1f, o);
+                CreateParticleFpsChecked(BITMAP_POUNDING_BALL, o->Position, o->Angle, Light, 2, 0.1f, o);
 
                 b->RenderBody(RENDER_TEXTURE, o->Alpha, o->BlendMesh, o->BlendMeshLight, o->BlendMeshTexCoordU, o->BlendMeshTexCoordV, 0);
                 b->RenderMesh(0, RENDER_TEXTURE, 0.7f, 0, o->BlendMeshLight * 3.f, o->BlendMeshTexCoordU, -WorldTime * 0.004f);
@@ -690,7 +690,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                         Vector(0.f, 0.f, 0.f, vRelativePos);
                         b->TransformPosition(BoneTransform[20], vRelativePos, vPos);
                         Vector(1.f, 1.f, 1.f, vLight);
-                        CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight);
+                        CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight);
                     }
                 }
                 else if (o->Type == 67)
@@ -812,7 +812,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                         Vector(1.0f, 0.0f, 0.0f, vLight);
                         Vector((float)(rand() % 10 - 10) * 0.5f, 0.f, (float)(rand() % 40 - 20) * 0.5f, vPos);
                         b->TransformPosition(BoneTransform[14], vPos, vPosition, false);
-                        CreateParticle(BITMAP_SPARK + 1, vPosition, o->Angle, vLight, 15, 0.7f + (fLuminosity * 0.05f));
+                        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPosition, o->Angle, vLight, 15, 0.7f + (fLuminosity * 0.05f));
                     }
 
                     b->StreamMesh = -1;
@@ -838,7 +838,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                         Vector(1.0f, 0.0f, 0.0f, vLight);
                         Vector((float)(rand() % 10 - 10) * 0.5f, 0.f, (float)(rand() % 40 - 20) * 0.5f, vPos);
                         b->TransformPosition(BoneTransform[14], vPos, vPosition, false);	// 턱
-                        CreateParticle(BITMAP_SPARK + 1, vPosition, o->Angle, vLight, 15, 0.7f + (fLuminosity * 0.05f));
+                        CreateParticleFpsChecked(BITMAP_SPARK + 1, vPosition, o->Angle, vLight, 15, 0.7f + (fLuminosity * 0.05f));
                     }
                     b->StreamMesh = -1;
                 }
@@ -1167,13 +1167,13 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                                         Position[0] += 40.f;
                                         Position[1] += 30.f;
                                         Position[2] -= 90.f;
-                                        CreateParticle(BITMAP_SMOKE, Position, Angle, Light, 11, 0.4f);
+                                        CreateParticleFpsChecked(BITMAP_SMOKE, Position, Angle, Light, 11, 0.4f);
 
                                         VectorCopy(o->Position, Position);
                                         Position[0] -= 40.f;
                                         Position[1] -= 30.f;
                                         Position[2] -= 90.f;
-                                        CreateParticle(BITMAP_SMOKE, Position, Angle, Light, 11, 0.4f);
+                                        CreateParticleFpsChecked(BITMAP_SMOKE, Position, Angle, Light, 11, 0.4f);
                                         b->EndRender();
                                     }
                                     else
@@ -1608,9 +1608,9 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                                                         if (o->LifeTime > 15)
                                                         {
                                                             b->TransformPosition(BoneTransform[1], p1, p2);
-                                                            CreateParticle(BITMAP_LIGHT + 1, p2, o->Angle, Light, 5, 0.6f);
+                                                            CreateParticleFpsChecked(BITMAP_LIGHT + 1, p2, o->Angle, Light, 5, 0.6f);
                                                             b->TransformPosition(BoneTransform[3], p1, p2);
-                                                            CreateParticle(BITMAP_LIGHT + 1, p2, o->Angle, Light, 5, 0.8f);
+                                                            CreateParticleFpsChecked(BITMAP_LIGHT + 1, p2, o->Angle, Light, 5, 0.8f);
                                                         }
                                                     }
                                                     else if (o->Type == MODEL_INFINITY_ARROW)
@@ -1622,7 +1622,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                                                         {
                                                             if (idx == 5) continue;
                                                             b->TransformPosition(BoneTransform[idx], p1, p2);
-                                                            CreateJoint(BITMAP_FLARE + 1, p2, o->Position, o->Angle, 16, o, 20.f);
+                                                            CreateJointFpsChecked(BITMAP_FLARE + 1, p2, o->Position, o->Angle, 16, o, 20.f);
                                                         }
                                                     }
                                                     else if (o->Type >= MODEL_INFINITY_ARROW && o->Type <= MODEL_INFINITY_ARROW4)
@@ -1662,14 +1662,14 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                                                         float fLumi = (sinf(WorldTime * 0.004f) + 1.0f) * 0.05f;
                                                         Vector(0.8f + fLumi, 0.8f + fLumi, 0.3f + fLumi, o->Light);
                                                         CreateSprite(BITMAP_LIGHT, vPos, 0.4f, o->Light, o, 0.5f);
-                                                        if (rand() % 15 == 8)
+                                                        if (rand_fps_check(15))
                                                         {
                                                             CreateParticle(BITMAP_SHINY, vPos, o->Angle, vLight, 5, 0.5f);
                                                         }
                                                         Vector(-18.f, 0.f, 6.f, vRelativePos);
                                                         b->TransformPosition(BoneTransform[0], vRelativePos, vPos, true);
                                                         CreateSprite(BITMAP_LIGHT, vPos, 0.4f, o->Light, o, 0.5f);
-                                                        if (rand() % 15 == 11)
+                                                        if (rand_fps_check(15))
                                                         {
                                                             CreateParticle(BITMAP_SHINY, vPos, o->Angle, vLight, 5, 0.5f);
                                                         }
@@ -1871,7 +1871,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                         CreateSprite(BITMAP_LIGHT, vWorldPos, 4.0f, Light, o);
 
                         b->TransformPosition(o->BoneTransform[34], vRelativePos, vWorldPos, true);
-                        CreateParticle(BITMAP_SHINY, vWorldPos, o->Angle, Light, 7);
+                        CreateParticleFpsChecked(BITMAP_SHINY, vWorldPos, o->Angle, Light, 7);
                         Vector(1.0f, 0.8f, 0.2f, Light);
                         CreateSprite(BITMAP_LIGHT, vWorldPos, 2.0f, Light, o);
 
@@ -1880,7 +1880,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                             vRelativePos[0] = o->Position[0] + sinf(((rand() % 360) * 6.12)) * 40.0f;
                             vRelativePos[1] = o->Position[1] + sinf(((rand() % 360) * 6.12)) * 40.0f;
                             vRelativePos[2] = o->Position[2];
-                            CreateParticle(BITMAP_SMOKE, vRelativePos, o->Angle, o->Light);
+                            CreateParticleFpsChecked(BITMAP_SMOKE, vRelativePos, o->Angle, o->Light);
                         }
 
                         b->RenderMesh(0, RENDER_TEXTURE, o->Alpha, o->BlendMesh, o->BlendMeshLight, o->BlendMeshTexCoordU, o->BlendMeshTexCoordV, o->HiddenMesh);
@@ -1936,7 +1936,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                     CreateSprite(BITMAP_LIGHT, vWorldPos, 4.0f, Light, o);
 
                     b->TransformPosition(o->BoneTransform[34], vRelativePos, vWorldPos, true);
-                    CreateParticle(BITMAP_SHINY, vWorldPos, o->Angle, Light, 7);
+                    CreateParticleFpsChecked(BITMAP_SHINY, vWorldPos, o->Angle, Light, 7);
                     Vector(1.0f, 0.8f, 0.2f, Light);
                     CreateSprite(BITMAP_LIGHT, vWorldPos, 2.0f, Light, o);
 
@@ -2003,10 +2003,10 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
 
                         Vector((rand() % 90 + 10) * 0.01f, (rand() % 90 + 10) * 0.01f, (rand() % 90 + 10) * 0.01f, Light);
                         fScale = (rand() % 5 + 5) * 0.1f;
-                        CreateParticle(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 13, fScale, o);
-                        CreateParticle(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 13, fScale, o);
-                        CreateParticle(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 13, fScale, o);
-                        CreateParticle(BITMAP_SHINY, vWorldPos, o->Angle, Light, 7);
+                        CreateParticleFpsChecked(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 13, fScale, o);
+                        CreateParticleFpsChecked(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 13, fScale, o);
+                        CreateParticleFpsChecked(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 13, fScale, o);
+                        CreateParticleFpsChecked(BITMAP_SHINY, vWorldPos, o->Angle, Light, 7);
 
                         Vector(1.0f, 0.8f, 0.2f, Light);
                         Vector(0.f, 0.f, 0.f, vRelativePos);
@@ -2024,7 +2024,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                             o->AI = 1;
                             CreateSprite(BITMAP_LIGHT, vWorldPos, 0.5f, Light, o);
                             CreateSprite(BITMAP_DS_SHOCK, vWorldPos, 0.15f, Light, o);
-                            CreateEffect(BITMAP_FIRECRACKER0002, vWorldPos, o->Angle, Light, o->Skill);
+                            CreateEffectFpsChecked(BITMAP_FIRECRACKER0002, vWorldPos, o->Angle, Light, o->Skill);
                         }
                         break;
                     }
@@ -2053,12 +2053,12 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                                 Vector(0.7f, 0.3f, 0.0f, vLight);
                                 for (int i = 0; i < 30; i++)
                                 {
-                                    CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 27);
+                                    CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 27);
                                 }
 
                                 for (int i = 0; i < 20; i++)
                                 {
-                                    CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 28);
+                                    CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 28);
                                 }
 
                                 Vector(vPos[0] + (rand() % 100 - 50), vPos[1] + (rand() % 100 - 50),
@@ -2068,16 +2068,16 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                                 for (int i = 0; i < 60; i++)
                                 {
                                     Vector(0.3f + (rand() % 700) * 0.001f, 0.3f + (rand() % 700) * 0.001f, 0.3f + (rand() % 700) * 0.001f, vLight);
-                                    CreateParticle(BITMAP_SHINY, vPos, o->Angle, vLight, 9);
+                                    CreateParticleFpsChecked(BITMAP_SHINY, vPos, o->Angle, vLight, 9);
                                 }
 
                                 vPos[2] += 50;
 
                                 for (int i = 0; i < 3; ++i)
                                 {
-                                    CreateEffect(MODEL_HALLOWEEN_CANDY_STAR, vPos, o->Angle, vLight, 1);
-                                    CreateEffect(rand() % 4 + MODEL_XMAS_EVENT_BOX, vPos, o->Angle, vLight, 0, o);
-                                    CreateEffect(rand() % 4 + MODEL_XMAS_EVENT_BOX, vPos, o->Angle, vLight, 0, o);
+                                    CreateEffectFpsChecked(MODEL_HALLOWEEN_CANDY_STAR, vPos, o->Angle, vLight, 1);
+                                    CreateEffectFpsChecked(rand() % 4 + MODEL_XMAS_EVENT_BOX, vPos, o->Angle, vLight, 0, o);
+                                    CreateEffectFpsChecked(rand() % 4 + MODEL_XMAS_EVENT_BOX, vPos, o->Angle, vLight, 0, o);
                                 }
                             }
 
@@ -2252,13 +2252,13 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                         switch (rand() % 3)
                         {
                         case 0:
-                            CreateParticle(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 3, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK1, vPos, o->Angle, vLight, 3, fScale);
                             break;
                         case 1:
-                            CreateParticle(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 7, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_CURSEDLICH, vPos, o->Angle, vLight, 7, fScale);
                             break;
                         case 2:
-                            CreateParticle(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 3, fScale);
+                            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, vPos, o->Angle, vLight, 3, fScale);
                             break;
                         }
                     }
@@ -2273,8 +2273,8 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                     Vector(0.f, 0.f, 0.f, vRelativePos);
                     Vector(0.8f, 0.8f, 0.8f, Light);
                     b->TransformPosition(o->BoneTransform[41], vRelativePos, vWorldPos, true);
-                    CreateParticle(BITMAP_SMOKELINE1 + rand() % 3, vWorldPos, o->Angle, Light, 1, 0.6f, o);
-                    CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 6, 0.6f, o);
+                    CreateParticleFpsChecked(BITMAP_SMOKELINE1 + rand() % 3, vWorldPos, o->Angle, Light, 1, 0.6f, o);
+                    CreateParticleFpsChecked(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 6, 0.6f, o);
 
                     Vector(0.5f, 0.5f, 0.5f, Light);
                     b->TransformPosition(o->BoneTransform[55], vRelativePos, vWorldPos, true);
@@ -2326,9 +2326,9 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                             vPos[1] = o->Position[1] + rand() % 120 - 60;
                             vPos[2] = o->Position[2];
                             Vector(0.3f, 0.3f, 0.3f, vLight);
-                            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 54, 2.0f);
+                            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 54, 2.0f);
                             Vector(0.3f, 0.3f, 0.3f, vLight);
-                            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 66, 2.0f, o);
+                            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 66, 2.0f, o);
                         }
 
                         if (rand_fps_check(2))
@@ -2344,8 +2344,8 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                         }
 
                         Vector(0.9f, 0.7f, 0.0f, vLight);
-                        CreateParticle(BITMAP_SHINY, vPos, o->Angle, vLight, 3, 0.5f, o);
-                        CreateParticle(BITMAP_SHINY, vPos, o->Angle, vLight, 3, 0.5f, o);
+                        CreateParticleFpsChecked(BITMAP_SHINY, vPos, o->Angle, vLight, 3, 0.5f, o);
+                        CreateParticleFpsChecked(BITMAP_SHINY, vPos, o->Angle, vLight, 3, 0.5f, o);
 
                         vPos[0] = o->Position[0];
                         vPos[1] = o->Position[1];
@@ -2629,7 +2629,7 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                     CreateSprite(BITMAP_SHINY + 1, Position, (float)(sinf(WorldTime * 0.002f) * 0.3f + 1.3f), Light, o, (float)(rand() % 360));
                     CreateSprite(BITMAP_LIGHT, Position, 1.5f, Light, o, 90.f);
                     CreateSprite(BITMAP_SHINY + 1, Position, (float)(sinf(WorldTime * 0.002f) * 0.3f + 1.3f), Light, o, (float)(rand() % 360));
-                    CreateParticle(BITMAP_SPARK, Position, o->Angle, Light);
+                    CreateParticleFpsChecked(BITMAP_SPARK, Position, o->Angle, Light);
                 }
                 if (o->Type == MODEL_ARROW_TANKER_HIT || o->Type == MODEL_ARROW_TANKER)
                 {
@@ -2645,11 +2645,11 @@ void Draw_RenderObject(OBJECT* o, bool Translate, int Select, int ExtraMon)
                     Vector(1.0f, 1.0f, 1.0f, o->Light);
                     Vector(0.0f, 1.5f, 0.0f, p1);
                     b->TransformPosition(BoneTransform[2], p1, p2);
-                    CreateParticle(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 8, o->Scale - 0.4f, o);
-                    CreateParticle(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 8, o->Scale - 0.4f, o);
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 38, o->Scale, o);
+                    CreateParticleFpsChecked(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 8, o->Scale - 0.4f, o);
+                    CreateParticleFpsChecked(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 8, o->Scale - 0.4f, o);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 38, o->Scale, o);
                     Vector(1.0f, 0.4f, 0.0f, o->Light);
-                    CreateParticle(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 9, o->Scale - 0.4f, o);
+                    CreateParticleFpsChecked(BITMAP_FIRE + 1, o->Position, o->Angle, o->Light, 9, o->Scale - 0.4f, o);
 
                     for (int i = 0; i < 10; i++)
                     {
@@ -2973,7 +2973,7 @@ void RenderObjectVisual(OBJECT* o)
             {
                 for (int i = 0; i < 20; ++i)
                 {
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 6, o->Scale);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 6, o->Scale);
                 }
             }
             o->HiddenMesh = -2;
@@ -3010,7 +3010,7 @@ void RenderObjectVisual(OBJECT* o)
 
                 if (((int)WorldTime % 5000) > 4500) Smoke = true;
                 if (Smoke)
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 4, o->Scale);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 4, o->Scale);
             }
             break;
         case 83:
@@ -3025,14 +3025,14 @@ void RenderObjectVisual(OBJECT* o)
                 {
                     Vector(1.f, 1.f, 1.f, Light);
 
-                    CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 8, o->Scale);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 8, o->Scale);
                     if (rand_fps_check(3))
                     {
                         Position[0] = o->Position[0] + (rand() % 128 - 64);
                         Position[1] = o->Position[1] + (rand() % 128 - 64);
                         Position[2] = o->Position[2];
-                        CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light, 4, o->Scale * 0.5f);
-                        CreateEffect(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
+                        CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle, o->Light, 4, o->Scale * 0.5f);
+                        CreateEffectFpsChecked(MODEL_STONE1 + rand() % 2, o->Position, o->Angle, o->Light);
                     }
                 }
             }
@@ -3057,7 +3057,7 @@ void RenderObjectVisual(OBJECT* o)
             }
             Vector(-15.f, 0.f, 0.f, p);
             b->TransformPosition(BoneTransform[23], p, Position);
-            CreateParticle(BITMAP_RAIN_CIRCLE + 1, Position, o->Angle, Light);
+            CreateParticleFpsChecked(BITMAP_RAIN_CIRCLE + 1, Position, o->Angle, Light);
             break;
         }
         break;
@@ -3071,7 +3071,7 @@ void RenderObjectVisual(OBJECT* o)
                 Vector(0.1f, 0.1f, 0.1f, Light);
                 for (int i = 0; i < 20; ++i)
                 {
-                    CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 0, o->Scale, o);
+                    CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 0, o->Scale, o);
                 }
             }
             o->HiddenMesh = -2;
@@ -3084,7 +3084,7 @@ void RenderObjectVisual(OBJECT* o)
                 Vector(0.1f, 0.1f, 0.1f, Light);
                 for (int i = 0; i < 20; ++i)
                 {
-                    CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 1, o->Scale, o);
+                    CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 1, o->Scale, o);
                 }
             }
             o->HiddenMesh = -2;
@@ -3097,7 +3097,7 @@ void RenderObjectVisual(OBJECT* o)
                 Vector(0.1f, 0.1f, 0.1f, Light);
                 for (int i = 0; i < 20; ++i)
                 {
-                    CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 2, o->Scale, o);
+                    CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 2, o->Scale, o);
                 }
             }
             o->HiddenMesh = -2;
@@ -3110,7 +3110,7 @@ void RenderObjectVisual(OBJECT* o)
                 Vector(0.1f, 0.1f, 0.1f, Light);
                 for (int i = 0; i < 10; ++i)
                 {
-                    CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 3, o->Scale, o);
+                    CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 3, o->Scale, o);
                 }
             }
             o->HiddenMesh = -2;
@@ -3123,7 +3123,7 @@ void RenderObjectVisual(OBJECT* o)
                 Vector(0.1f, 0.1f, 0.1f, Light);
                 for (int i = 0; i < 10; ++i)
                 {
-                    CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 4, o->Scale, o);
+                    CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 4, o->Scale, o);
                 }
             }
             o->HiddenMesh = -2;
@@ -3136,7 +3136,7 @@ void RenderObjectVisual(OBJECT* o)
                 Vector(0.1f, 0.1f, 0.1f, Light);
                 for (int i = 0; i < 10; ++i)
                 {
-                    CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 5, o->Scale, o);
+                    CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 5, o->Scale, o);
                 }
             }
             o->HiddenMesh = -2;
@@ -3148,7 +3148,7 @@ void RenderObjectVisual(OBJECT* o)
             b->TransformPosition(BoneTransform[3], p, Position);
 
             Vector(1.f, 1.f, 1.f, Light);
-            CreateParticle(BITMAP_LIGHT, Position, o->Angle, Light, 0, 1.f);
+            CreateParticleFpsChecked(BITMAP_LIGHT, Position, o->Angle, Light, 0, 1.f);
         }
         case    6:
         case    7:
@@ -3239,7 +3239,7 @@ void RenderObjectVisual(OBJECT* o)
                     o->Position[1] + (rand() % 2048 - 1024) * FPS_ANIMATION_FACTOR,
                     o->Position[2] + (3000 + rand() % 600) * FPS_ANIMATION_FACTOR,
                     Position);
-                CreateEffect(MODEL_FIRE, Position, o->Angle, o->Light, 9);
+                CreateEffectFpsChecked(MODEL_FIRE, Position, o->Angle, o->Light, 9);
             }
         }
         break;
@@ -3970,9 +3970,9 @@ void MoveObject(OBJECT* o)
             Position[0] = o->Position[0];
             Position[1] = o->Position[1];
             Position[2] = o->Position[2] + 160.f;
-            CreateParticle(BITMAP_TRUE_FIRE, Position, o->Angle,
+            CreateParticleFpsChecked(BITMAP_TRUE_FIRE, Position, o->Angle,
                 o->Light, 0, o->Scale);
-            CreateParticle(BITMAP_SMOKE, Position, o->Angle,
+            CreateParticleFpsChecked(BITMAP_SMOKE, Position, o->Angle,
                 o->Light, 21, 0.5f + ((rand() % 9) * 0.1f));
         }
         break;
@@ -4032,7 +4032,7 @@ void MoveObject(OBJECT* o)
             vec3_t Position;
             Vector(o->Position[0], o->Position[1] - 50.f, o->Position[2] + 350.f, Position);
             Vector(0.5f, 0.5f, 0.5f, Light);
-            CreateParticle(BITMAP_SPARK + 1, Position, o->Angle, Light, 9, 1.4f);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, Position, o->Angle, Light, 9, 1.4f);
             break;
         case 18:
             o->BlendMeshTexCoordV = (int)WorldTime % 1000 * 0.001f;
@@ -4122,7 +4122,7 @@ void MoveObject(OBJECT* o)
             if (o->Timer > 10.f)
                 o->Timer = 0.f;
             if (o->Timer > 5.f)
-                CreateParticle(BITMAP_BUBBLE, o->Position, o->Angle, o->Light);
+                CreateParticleFpsChecked(BITMAP_BUBBLE, o->Position, o->Angle, o->Light);
             break;
         case 23:
             o->BlendMesh = 0;
@@ -8357,7 +8357,7 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
         {
             CreateParticle(BITMAP_TRUE_FIRE, vPos, o->Angle, vLight, 8, 0.5f, o);
         }
-        CreateParticle(BITMAP_TRUE_FIRE, vPos, o->Angle, vLight, 9, 0.5f, o);
+        CreateParticleFpsChecked(BITMAP_TRUE_FIRE, vPos, o->Angle, vLight, 9, 0.5f, o);
 
         vPos[2] -= 5.0f;
         float fLumi;
@@ -8385,8 +8385,8 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
             {
                 Vector(1.f, 1.f, 1.f, vLight);
                 vPos[2] -= 20.f;
-                CreateParticle(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 0, 0.6f);
-                CreateParticle(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 0, 0.6f);
+                CreateParticleFpsChecked(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 0, 0.6f);
+                CreateParticleFpsChecked(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 0, 0.6f);
                 for (int i = 0; i < 20; ++i)
                 {
                     fLumi = (float)(rand() % 100) * 0.01f;
@@ -8395,7 +8395,7 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
                     vLight[1] = fLumi;
                     fLumi = (float)(rand() % 100) * 0.01f;
                     vLight[2] = fLumi;
-                    CreateParticle(BITMAP_SHINY, vPos, o->Angle, vLight, 4, 0.8f);
+                    CreateParticleFpsChecked(BITMAP_SHINY, vPos, o->Angle, vLight, 4, 0.8f);
                 }
                 o->m_iAnimation++;
             }
@@ -8405,7 +8405,7 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
                 Vector(1.f, 1.f, 1.f, vLight);
                 CreateEffect(MODEL_HALLOWEEN_EX, vPos, o->Angle, vLight, 0);
                 vPos[2] -= 40.f;
-                CreateParticle(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 1);
+                CreateParticleFpsChecked(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 1);
                 SetAction(o, PLAYER_SHOCK);
                 SendRequestAction(*o, PLAYER_SHOCK);
                 o->m_iAnimation = 0;
@@ -8435,8 +8435,8 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
             {
                 Vector(1.f, 1.f, 1.f, vLight);
                 vPos[2] -= 20.f;
-                CreateParticle(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 0, 0.6f);
-                CreateParticle(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 0, 0.6f);
+                CreateParticleFpsChecked(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 0, 0.6f);
+                CreateParticleFpsChecked(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 0, 0.6f);
                 for (int i = 0; i < 20; ++i)
                 {
                     fLumi = (float)(rand() % 100) * 0.01f;
@@ -8445,7 +8445,7 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
                     vLight[1] = fLumi;
                     fLumi = (float)(rand() % 100) * 0.01f;
                     vLight[2] = fLumi;
-                    CreateParticle(BITMAP_SHINY, vPos, o->Angle, vLight, 4, 0.8f);
+                    CreateParticleFpsChecked(BITMAP_SHINY, vPos, o->Angle, vLight, 4, 0.8f);
                 }
                 o->m_iAnimation++;
             }
@@ -8455,7 +8455,7 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
                 Vector(1.f, 1.f, 1.f, vLight);
                 CreateEffect(MODEL_HALLOWEEN_EX, vPos, o->Angle, vLight, 0);
                 vPos[2] -= 40.f;
-                CreateParticle(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 1);
+                CreateParticleFpsChecked(BITMAP_SPARK + 2, vPos, o->Angle, vLight, 1);
                 SetAction(o, PLAYER_SHOCK);
                 SendRequestAction(*o, PLAYER_SHOCK);
                 o->m_iAnimation = 0;
@@ -8541,12 +8541,12 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
                 vPos[2] += 230.f;
                 for (int i = 0; i < 2; ++i)
                 {
-                    CreateEffect(iEffectType, vPos, o->Angle, o->Light);
-                    CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, o->Light, 20, 1.f);
+                    CreateEffectFpsChecked(iEffectType, vPos, o->Angle, o->Light);
+                    CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, o->Light, 20, 1.f);
                 }
                 for (int i = 0; i < 5; ++i)
                 {
-                    CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 20, 1.f);
+                    CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 20, 1.f);
                 }
             }
             if (iAnimationFrame >= 19 && iPriorAnimationFrame != iAnimationFrame)
@@ -8560,8 +8560,8 @@ void RenderPartObjectBody(BMD* b, OBJECT* o, int Type, float Alpha, int RenderTy
             VectorCopy(o->Position, vPos);
             vPos[2] += 230;
             Vector(1.f, 1.f, 1.f, vLight);
-            CreateParticle(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 20, 1.f);
-            CreateParticle(BITMAP_SMOKE, vPos, o->Angle, vLight, 4, 2.0f);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, vPos, o->Angle, vLight, 20, 1.f);
+            CreateParticleFpsChecked(BITMAP_SMOKE, vPos, o->Angle, vLight, 4, 2.0f);
             if (rand_fps_check(6))
             {
                 CreateParticle(BITMAP_SNOW_EFFECT_1, vPos, o->Angle, vLight, 0, 0.3f);
@@ -9365,7 +9365,7 @@ void NextGradeObjectRender(CHARACTER* c)
 
             Vector(1.0f, 0.2f, 0.0f, vLight);
             fScale = (float)(rand() % 80 + 10) * 0.01f * 1.0f;
-            CreateParticle(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, c->Object.Angle, vLight, 0, fScale);
+            CreateParticleFpsChecked(BITMAP_LIGHTNING_MEGA1 + rand() % 3, vPos, c->Object.Angle, vLight, 0, fScale);
         }break;
         }//switch
     } //for

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -1146,8 +1146,8 @@ bool NewRenderCharacterScene(HDC hDC)
 
         float Rotation = (int)WorldTime % 3600 / (float)10.f;
         Vector(0.15f, 0.15f, 0.15f, o->Light);
-        CreateParticle(BITMAP_EFFECT, o->Position, o->Angle, o->Light, 4);
-        CreateParticle(BITMAP_EFFECT, o->Position, o->Angle, o->Light, 5);
+        CreateParticleFpsChecked(BITMAP_EFFECT, o->Position, o->Angle, o->Light, 4);
+        CreateParticleFpsChecked(BITMAP_EFFECT, o->Position, o->Angle, o->Light, 5);
 
         g_csMapServer.SetHeroID((wchar_t*)CharactersClient[SelectedHero].ID);
     }

--- a/Source Main 5.2/source/w_CharacterInfo.cpp
+++ b/Source Main 5.2/source/w_CharacterInfo.cpp
@@ -49,6 +49,7 @@ void CHARACTER::Initialize()
     PK = 0;
     AttackFlag = 0;
     AttackTime = 0;
+    LastAttackEffectTime = -1;
     TargetAngle = 0;
     Dead = 0;
     Run = 0;

--- a/Source Main 5.2/source/w_CharacterInfo.h
+++ b/Source Main 5.2/source/w_CharacterInfo.h
@@ -199,6 +199,7 @@ public:
     int         PositionX;
     int         PositionY;
     int			m_iFenrirSkillTarget;
+    int         LastAttackEffectTime;
 
     float       m_iDeleteTime;
     float       LastCritDamageEffect;
@@ -249,6 +250,14 @@ public:
 #ifdef PBG_MOD_STRIFE_GENSMARKRENDER
     BYTE		GensContributionPoints;
 #endif //PBG_MOD_STRIFE_GENSMARKRENDER
+    bool CheckAttackTime(int timeNumber) const
+    {
+        return static_cast<int>(AttackTime) == timeNumber && LastAttackEffectTime != timeNumber;
+    }
+    void SetLastAttackEffectTime()
+    {
+        LastAttackEffectTime = static_cast<int>(AttackTime);
+    }
 };
 
 #endif // !defined(AFX_W_CHARACTERINFO_H__95647591_5047_48A4_81AE_E88B5F17EE94__INCLUDED_)

--- a/Source Main 5.2/source/w_CursedTemple.cpp
+++ b/Source Main 5.2/source/w_CursedTemple.cpp
@@ -309,7 +309,7 @@ bool CursedTemple::AttackEffectMonster(CHARACTER* c, OBJECT* o, BMD* b)
                 Vector(0.4f, 0.6f, 1.f, Light);
 
                 for (int i = 0; i < 5; i++)
-                    CreateParticle(BITMAP_SMOKE, to->Position, o->Angle, Light, 1);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, to->Position, o->Angle, Light, 1);
 
                 PlayBuffer(SOUND_HEART);
             }
@@ -558,8 +558,8 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             float Rotation = (int)WorldTime % 3600 / (float)10.f;
 
             Vector(0.15f, 0.15f, 0.15f, o->Light);
-            CreateParticle(BITMAP_EFFECT, position, o->Angle, o->Light);
-            CreateParticle(BITMAP_EFFECT, position, o->Angle, o->Light, 3);
+            CreateParticleFpsChecked(BITMAP_EFFECT, position, o->Angle, o->Light);
+            CreateParticleFpsChecked(BITMAP_EFFECT, position, o->Angle, o->Light, 3);
         }
         break;
         case 70:
@@ -568,7 +568,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             {
                 float fLumi = (rand() % 10) * 0.007f + 0.03f;
                 Vector(54.f / 256.f * fLumi, 177.f / 256.f * fLumi, 150.f / 256.f * fLumi, Light);
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
             }
         }
         return true;
@@ -578,7 +578,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             {
                 float fLumi = (rand() % 10) * 0.007f + 0.03f;
                 Vector(221.f / 256.f * fLumi, 121.f / 256.f * fLumi, 201.f / 256.f * fLumi, Light);
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
             }
         }
         return true;
@@ -588,9 +588,9 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             {
                 float fLumi = (rand() % 10) * 0.007f + 0.03f;
                 Vector(54.f / 256.f * fLumi, 177.f / 256.f * fLumi, 150.f / 256.f * fLumi, Light);
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
                 Vector(221.f / 256.f * fLumi, 121.f / 256.f * fLumi, 201.f / 256.f * fLumi, Light);
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
             }
         }
         return true;
@@ -600,7 +600,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             {
                 float fLumi = (rand() % 10) * 0.002f + 0.03f;
                 Vector(1.2f * fLumi, 1.2f * fLumi, 1.2f * fLumi, Light);
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 15, o->Scale, o);
             }
         }
         return true;
@@ -609,7 +609,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             if (rand_fps_check(2))
             {
                 Vector(0.f, 0.f, 0.f, Light);
-                CreateParticle(BITMAP_CLOUD, o->Position, o->Angle, Light, 16, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_CLOUD, o->Position, o->Angle, Light, 16, o->Scale, o);
             }
         }
         return true;
@@ -619,7 +619,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             {
                 float fLumi = (rand() % 10) * 0.05f + 0.03f;
                 Vector(256.f / 256.f * fLumi, 256.f / 256.f * fLumi, 256.f / 256.f * fLumi, Light);
-                CreateParticle(BITMAP_GHOST_CLOUD1, o->Position, o->Angle, Light, 0, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_GHOST_CLOUD1, o->Position, o->Angle, Light, 0, o->Scale, o);
             }
         }
         return true;
@@ -632,7 +632,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             VectorCopy(o->Position, vPos);
             for (int i = 0; i < 1; ++i)
             {
-                CreateParticle(BITMAP_TORCH_FIRE, vPos, o->Angle, Light, 0, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_TORCH_FIRE, vPos, o->Angle, Light, 0, o->Scale, o);
             }
             VectorCopy(o->Position, vPos);
             vPos[2] += 20.f;
@@ -648,7 +648,7 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
             VectorCopy(o->Position, vPos);
             for (int i = 0; i < 1; ++i)
             {
-                CreateParticle(BITMAP_TORCH_FIRE, vPos, o->Angle, Light, 0, o->Scale, o);
+                CreateParticleFpsChecked(BITMAP_TORCH_FIRE, vPos, o->Angle, Light, 0, o->Scale, o);
             }
             VectorCopy(o->Position, vPos);
             vPos[2] += 20.f;
@@ -664,17 +664,17 @@ bool CursedTemple::RenderObjectVisual(OBJECT* o, BMD* b)
                 Vector(1.f, 0.8f, 0.8f, Light);
                 for (int i = 0; i < 4; ++i)
                 {
-                    CreateEffect(MODEL_FALL_STONE_EFFECT, o->Position, o->Angle, Light);
+                    CreateEffectFpsChecked(MODEL_FALL_STONE_EFFECT, o->Position, o->Angle, Light);
                 }
-                CreateEffect(MODEL_FALL_STONE_EFFECT, o->Position, o->Angle, Light, 1);
+                CreateEffectFpsChecked(MODEL_FALL_STONE_EFFECT, o->Position, o->Angle, Light, 1);
                 Vector(0.7f, 0.7f, 0.8f, Light);
                 vec3_t vPos;
                 VectorCopy(o->Position, vPos);
                 vPos[0] += (float)(rand() % 80 - 40);
                 vPos[1] += (float)(rand() % 80 - 40);
-                CreateParticle(BITMAP_WATERFALL_3 + (rand() % 2), vPos, o->Angle, Light, 2);
+                CreateParticleFpsChecked(BITMAP_WATERFALL_3 + (rand() % 2), vPos, o->Angle, Light, 2);
                 Vector(0.9f, 0.0f, 0.0f, Light);
-                CreateParticle(BITMAP_SMOKE, o->Position, o->Angle, Light, 0, 1.5f);
+                CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, Light, 0, 1.5f);
             }
         }
         return true;
@@ -763,7 +763,7 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             }
 
             b->TransformPosition(o->BoneTransform[1], vRelativePos, vWorldPos, true);
-            CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 0, 0.7f);
+            CreateParticleFpsChecked(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 0, 0.7f);
         }
     }
     break;
@@ -781,19 +781,19 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 b->TransformPosition(o->BoneTransform[22], vRelativePos, vWorldPos, true);
 
                 Vector(0.8f, 0.8f, 1.0f, Light);
-                CreateParticle(BITMAP_LIGHT + 2, vWorldPos, o->Angle, Light, 2, 0.7f);
+                CreateParticleFpsChecked(BITMAP_LIGHT + 2, vWorldPos, o->Angle, Light, 2, 0.7f);
 
                 Light[0] = static_cast<float>((rand() % 100) * 0.01f);
                 Light[1] = static_cast<float>((rand() % 100) * 0.01f);
                 Light[2] = static_cast<float>((rand() % 100) * 0.01f);
 
-                CreateParticle(BITMAP_SHINY, vWorldPos, o->Angle, Light, 3, 0.8f);
+                CreateParticleFpsChecked(BITMAP_SHINY, vWorldPos, o->Angle, Light, 3, 0.8f);
             }
 
             if (o->AnimationFrame > 7.3f && o->AnimationFrame < (7.5f + fActionSpeed))
             {
                 Vector(0.7f, 0.7f, 1.0f, Light);
-                CreateParticle(BITMAP_GM_AURORA, vWorldPos, o->Angle, Light, 3, 0.7f);
+                CreateParticleFpsChecked(BITMAP_GM_AURORA, vWorldPos, o->Angle, Light, 3, 0.7f);
             }
         }
     }
@@ -810,7 +810,7 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             for (int i = 0; i < 6; ++i)
             {
                 b->TransformPosition(o->BoneTransform[boneindex[i]], vRelativePos, vWorldPos, true);
-                CreateParticle(BITMAP_SMOKE + 3, vWorldPos, o->Angle, Light, 3, 0.5f);
+                CreateParticleFpsChecked(BITMAP_SMOKE + 3, vWorldPos, o->Angle, Light, 3, 0.5f);
             }
         }
     }
@@ -834,14 +834,14 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(0.f, 0.f, 0.f, vRelativePos);
             b->TransformPosition(o->BoneTransform[17], vRelativePos, vWorldPos, true);
             CreateSprite(BITMAP_LIGHT, vWorldPos, 3.f, Light, o, 0.f);
-            CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 4, 0.8f);
-            CreateParticle(BITMAP_SPARK + 1, vWorldPos, o->Angle, Light, 15, 0.7f + (fLuminosity * 0.05f));
+            CreateParticleFpsChecked(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 4, 0.8f);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, vWorldPos, o->Angle, Light, 15, 0.7f + (fLuminosity * 0.05f));
 
             Vector(0.f, 0.f, 0.f, vRelativePos);
             b->TransformPosition(o->BoneTransform[41], vRelativePos, vWorldPos, true);
             CreateSprite(BITMAP_LIGHT, vWorldPos, 3.f, Light, o, 0.f);
-            CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 4, 0.8f);
-            CreateParticle(BITMAP_SPARK + 1, vWorldPos, o->Angle, Light, 15, 0.7f + (fLuminosity * 0.05f));
+            CreateParticleFpsChecked(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 4, 0.8f);
+            CreateParticleFpsChecked(BITMAP_SPARK + 1, vWorldPos, o->Angle, Light, 15, 0.7f + (fLuminosity * 0.05f));
         }
         else if (o->CurrentAction == MONSTER01_DIE)
         {
@@ -850,7 +850,7 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             for (int i = 0; i < 4; ++i)
             {
                 b->TransformPosition(o->BoneTransform[boneindex[i]], vRelativePos, vWorldPos, true);
-                CreateParticle(BITMAP_SMOKE + 3, vWorldPos, o->Angle, Light, 3, 0.5f);
+                CreateParticleFpsChecked(BITMAP_SMOKE + 3, vWorldPos, o->Angle, Light, 3, 0.5f);
             }
         }
     }
@@ -871,18 +871,18 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
         {
             Vector(0.6f, 0.0f, 0.0f, Light);
             b->TransformPosition(o->BoneTransform[17], vRelativePos, vWorldPos, true);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
-            CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 4, 1.f);
+            CreateEffectFpsChecked(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
+            CreateEffectFpsChecked(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
+            CreateEffectFpsChecked(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
+            CreateParticleFpsChecked(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 4, 1.f);
             CreateSprite(BITMAP_LIGHT, vWorldPos, 3.f, Light, o, 0.f);
 
             b->TransformPosition(o->BoneTransform[41], vRelativePos, vWorldPos, true);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
-            CreateEffect(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
-            CreateParticle(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 4, 1.f);
+            CreateEffectFpsChecked(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
+            CreateEffectFpsChecked(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
+            CreateEffectFpsChecked(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
+            CreateEffectFpsChecked(MODEL_FENRIR_THUNDER, vWorldPos, o->Angle, Light, 2, o);
+            CreateParticleFpsChecked(BITMAP_CLUD64, vWorldPos, o->Angle, Light, 4, 1.f);
             CreateSprite(BITMAP_LIGHT, vWorldPos, 3.f, Light, o, 0.f);
         }
         else if (o->CurrentAction == MONSTER01_DIE)
@@ -892,7 +892,7 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             for (int i = 0; i < 6; ++i)
             {
                 b->TransformPosition(o->BoneTransform[boneindex[i]], vRelativePos, vWorldPos, true);
-                CreateParticle(BITMAP_SMOKE + 3, vWorldPos, o->Angle, Light, 3, 0.5f);
+                CreateParticleFpsChecked(BITMAP_SMOKE + 3, vWorldPos, o->Angle, Light, 3, 0.5f);
             }
         }
     }
@@ -912,13 +912,13 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                 o->PKKey = 1;
                 EarthQuake = (float)(rand() % 16 - 8) * 0.1f;
                 vWorldPos[2] = vRelativePos[2] + 250;
-                CreateEffect(MODEL_CURSEDTEMPLE_STATUE_PART2, vWorldPos, o->Angle, Light, 0, o, 0, 0);
+                CreateEffectFpsChecked(MODEL_CURSEDTEMPLE_STATUE_PART2, vWorldPos, o->Angle, Light, 0, o, 0, 0);
                 for (int i = 0; i < 60; ++i)
                 {
                     vWorldPos[0] = vRelativePos[0] + rand() % 80 - 40;
                     vWorldPos[1] = vRelativePos[1] + rand() % 80 - 40;
                     vWorldPos[2] = vRelativePos[2] + (rand() % 250);
-                    CreateEffect(MODEL_CURSEDTEMPLE_STATUE_PART1, vWorldPos, o->Angle, Light, 0, o, 0, 0);
+                    CreateEffectFpsChecked(MODEL_CURSEDTEMPLE_STATUE_PART1, vWorldPos, o->Angle, Light, 0, o, 0, 0);
                 }
                 Vector(0.5f, 0.5f, 0.5f, Light);
 
@@ -927,7 +927,7 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
                     vWorldPos[0] = vRelativePos[0] + rand() % 140 - 70;
                     vWorldPos[1] = vRelativePos[1] + rand() % 140 - 70;
                     vWorldPos[2] = vRelativePos[2] + (rand() % 400) - 100;
-                    CreateParticle(BITMAP_SMOKE, vWorldPos, o->Angle, Light, 48, 1.0f);
+                    CreateParticleFpsChecked(BITMAP_SMOKE, vWorldPos, o->Angle, Light, 48, 1.0f);
                 }
             }
         }
@@ -937,14 +937,14 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(0.2f, 0.3f, 0.4f + (rand() % 3) * 0.1f, Light);
             Vector(0.f, 0.f, 0.f, vRelativePos);
             b->TransformPosition(o->BoneTransform[13], vRelativePos, vWorldPos, true);
-            CreateParticle(BITMAP_FLARE + 1, vWorldPos, o->Angle, Light, 0, 0.15f);
+            CreateParticleFpsChecked(BITMAP_FLARE + 1, vWorldPos, o->Angle, Light, 0, 0.15f);
             vWorldPos[2] += 30;
-            CreateParticle(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 1, 8.0f);
+            CreateParticleFpsChecked(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 1, 8.0f);
 
             vWorldPos[2] += 160;
             Vector(0.2f, 0.1f, 0.0f, Light);
             b->TransformPosition(o->BoneTransform[14], vRelativePos, vWorldPos, true);
-            CreateParticle(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 1, 4.0f);
+            CreateParticleFpsChecked(BITMAP_LIGHT, vWorldPos, o->Angle, Light, 1, 4.0f);
         }
         return true;
     case MODEL_CURSEDTEMPLE_ALLIED_BASKET:
@@ -955,10 +955,10 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(1.0f, 1.0f, 0.5f, Light);
             Vector(0.f, 0.f, 0.f, vRelativePos);
             b->TransformPosition(o->BoneTransform[5], vRelativePos, vWorldPos, true);
-            CreateEffect(BITMAP_FLARE, vWorldPos, o->Angle, Light, 1);
+            CreateEffectFpsChecked(BITMAP_FLARE, vWorldPos, o->Angle, Light, 1);
 
             Vector(0.9f, 0.7f, 0.4f, Light);
-            CreateEffect(BITMAP_MAGIC, o->Position, o->Angle, Light, 8);
+            CreateEffectFpsChecked(BITMAP_MAGIC, o->Position, o->Angle, Light, 8);
 
             m_ShowAlliedPointEffect = false;
         }
@@ -972,10 +972,10 @@ bool CursedTemple::RenderMonsterVisual(CHARACTER* c, OBJECT* o, BMD* b)
             Vector(0.5f, 1.0f, 1.0f, Light);
             Vector(0.f, 0.f, 0.f, vRelativePos);
             b->TransformPosition(o->BoneTransform[3], vRelativePos, vWorldPos, true);
-            CreateEffect(BITMAP_FLARE, vWorldPos, o->Angle, Light, 2);
+            CreateEffectFpsChecked(BITMAP_FLARE, vWorldPos, o->Angle, Light, 2);
 
             Vector(0.7f, 0.8f, 0.9f, Light);
-            CreateEffect(BITMAP_MAGIC, o->Position, o->Angle, Light, 8);
+            CreateEffectFpsChecked(BITMAP_MAGIC, o->Position, o->Angle, Light, 8);
 
             m_ShowIllusionPointEffect = false;
         }

--- a/Source Main 5.2/source/w_PetActionCollecter.cpp
+++ b/Source Main 5.2/source/w_PetActionCollecter.cpp
@@ -238,7 +238,7 @@ bool PetActionCollecter::Effect(OBJECT* obj, CHARACTER* Owner, int targetKey, do
     Vector(1.0f, 0.8f, 0.2f, Light);
     VectorCopy(obj->Position, Position);
     Position[2] += 30.0f;
-    CreateParticle(BITMAP_SHINY, Position, obj->Angle, Light, 7);
+    CreateParticleFpsChecked(BITMAP_SHINY, Position, obj->Angle, Light, 7);
 
     switch (m_state)
     {

--- a/Source Main 5.2/source/w_PetActionCollecter_Add.cpp
+++ b/Source Main 5.2/source/w_PetActionCollecter_Add.cpp
@@ -573,13 +573,13 @@ bool PetActionCollecterSkeleton::Effect(OBJECT* obj, CHARACTER* Owner, int targe
             switch (rand() % 3)
             {
             case 0:
-                CreateParticle(BITMAP_FIRE_HIK1_MONO, vPosition, vAngle, vLight, 4, obj->Scale, obj);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK1_MONO, vPosition, vAngle, vLight, 4, obj->Scale, obj);
                 break;
             case 1:
-                CreateParticle(BITMAP_FIRE_HIK2_MONO, vPosition, vAngle, vLight, 8, obj->Scale, obj);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK2_MONO, vPosition, vAngle, vLight, 8, obj->Scale, obj);
                 break;
             case 2:
-                CreateParticle(BITMAP_FIRE_HIK3_MONO, vPosition, vAngle, vLight, 5, obj->Scale, obj);
+                CreateParticleFpsChecked(BITMAP_FIRE_HIK3_MONO, vPosition, vAngle, vLight, 5, obj->Scale, obj);
                 break;
             }
         }

--- a/Source Main 5.2/source/w_PetActionDemon.cpp
+++ b/Source Main 5.2/source/w_PetActionDemon.cpp
@@ -102,7 +102,7 @@ bool PetActionDemon::Effect(OBJECT* obj, CHARACTER* Owner, int targetKey, double
         case 3:
         case 4:
         case 5:
-            CreateParticle(BITMAP_CLUD64, Position, obj->Angle, Light, 11, 0.5f);
+            CreateParticleFpsChecked(BITMAP_CLUD64, Position, obj->Angle, Light, 11, 0.5f);
             break;
 
         case 6:
@@ -111,7 +111,7 @@ bool PetActionDemon::Effect(OBJECT* obj, CHARACTER* Owner, int targetKey, double
             break;
 
         case 8:
-            CreateParticle(BITMAP_FIRE_HIK3, Position, obj->Angle, Light, 1, 0.4f);
+            CreateParticleFpsChecked(BITMAP_FIRE_HIK3, Position, obj->Angle, Light, 1, 0.4f);
             CreateSprite(BITMAP_FLARE, Position, 1.5f, Light, obj);
             CreateSprite(BITMAP_FLARE, Position, 0.5f, Light2, obj);
             break;

--- a/Source Main 5.2/source/w_PetActionUnicorn.cpp
+++ b/Source Main 5.2/source/w_PetActionUnicorn.cpp
@@ -275,9 +275,9 @@ bool PetActionUnicorn::Effect(OBJECT* obj, CHARACTER* Owner, int targetKey, doub
 
     Vector(0.7f, 0.7f, 1.0f, Light);
     b->TransformPosition(BoneTransform[4], vRelativePos, Position, false);
-    CreateParticle(BITMAP_SMOKELINE1, Position, obj->Angle, Light, 4, 0.6f, obj);
-    CreateParticle(BITMAP_SMOKELINE2, Position, obj->Angle, Light, 4, 0.6f, obj);
-    CreateParticle(BITMAP_SMOKELINE3, Position, obj->Angle, Light, 4, 0.6f, obj);
+    CreateParticleFpsChecked(BITMAP_SMOKELINE1, Position, obj->Angle, Light, 4, 0.6f, obj);
+    CreateParticleFpsChecked(BITMAP_SMOKELINE2, Position, obj->Angle, Light, 4, 0.6f, obj);
+    CreateParticleFpsChecked(BITMAP_SMOKELINE3, Position, obj->Angle, Light, 4, 0.6f, obj);
 
     return TRUE;
 }


### PR DESCRIPTION
First, there are some checks for AttackTime:
Before we went over 25fps, 1 AttackTime meant 1 frame. Now attack time is increased by the fps_animation_factor (below 1 for over 25fps). In the code are a lot of checks if (int)AttackTime == x, which don't work as intended anymore. Effects are started multiple times. To restore the previous behavior, I added a simple mechanism.

Additionally, a lot of places in code create new effects and particles for each frame. These last longer than just this frame, so a lot of them get accumulated and drag down the overall fps. So when the fps is higher than 25, we now reduce the number of effects spawned per frame. The number of effects created should now correlate with the time being spent.