### PR TITLE
Fixed overlap of storage extension and NPC Shop/Mix inventory

### DIFF
--- a/Source Main 5.2/source/NewUIMixInventory.cpp
+++ b/Source Main 5.2/source/NewUIMixInventory.cpp
@@ -175,6 +175,8 @@ void CNewUIMixInventory::SetPos(int x, int y)
 {
     m_Pos.x = x;
     m_Pos.y = y;
+
+    m_pNewInventoryCtrl->SetPos(x + 15, y + 110);
 }
 
 bool CNewUIMixInventory::UpdateMouseEvent()

--- a/Source Main 5.2/source/NewUINPCShop.cpp
+++ b/Source Main 5.2/source/NewUINPCShop.cpp
@@ -86,6 +86,8 @@ void SEASON3B::CNewUINPCShop::SetPos(int x, int y)
 {
     m_Pos.x = x;
     m_Pos.y = y;
+
+    m_pNewInventoryCtrl->SetPos(x + 15, y + 50);
 }
 
 bool SEASON3B::CNewUINPCShop::UpdateMouseEvent()

--- a/Source Main 5.2/source/NewUISystem.cpp
+++ b/Source Main 5.2/source/NewUISystem.cpp
@@ -677,20 +677,25 @@ void CNewUISystem::Show(DWORD dwKey)
                 Hide(INTERFACE_CHARACTER);
             }
         }
-        else if (IsVisible(INTERFACE_MYQUEST))
+        if (IsVisible(INTERFACE_MYQUEST))
         {
             Hide(INTERFACE_MYQUEST);
         }
-        else if (IsVisible(INTERFACE_CHARACTER))
+        if (IsVisible(INTERFACE_CHARACTER))
         {
             Hide(INTERFACE_CHARACTER);
         }
-        else if (IsVisible(INTERFACE_MIXINVENTORY))
+        if (IsVisible(INTERFACE_NPCSHOP))
+        {
+            g_pNPCShop->SetPos(640 - 190 * 3, 0);
+            Hide(INTERFACE_HERO_POSITION_INFO);
+        }
+        if (IsVisible(INTERFACE_MIXINVENTORY))
         {
             g_pMixInventory->SetPos(640 - 190 * 3, 0);
             Hide(INTERFACE_HERO_POSITION_INFO);
         }
-        else if (IsVisible(INTERFACE_TRADE))
+        if (IsVisible(INTERFACE_TRADE))
         {
             g_pTrade->SetPos(640 - 190 * 3, 0);
             Hide(INTERFACE_HERO_POSITION_INFO);
@@ -1143,6 +1148,16 @@ void CNewUISystem::Hide(DWORD dwKey)
         if (IsVisible(INTERFACE_STORAGE))
         {
             g_pStorageInventory->SetPos(secondColumnX, 0);
+        }
+
+        if (IsVisible(INTERFACE_NPCSHOP))
+        {
+            g_pNPCShop->SetPos(secondColumnX, 0);
+        }
+
+        if (IsVisible(INTERFACE_MIXINVENTORY))
+        {
+            g_pMixInventory->SetPos(secondColumnX, 0);
         }
 
         Show(INTERFACE_HERO_POSITION_INFO);


### PR DESCRIPTION
Fixes the problem where opening the Inventory Extension overlaps with NPC w/storage like Elf Lala / Potion Girl / etc, and Goblin Mix. 

Example:
![image](https://github.com/user-attachments/assets/abe11131-e686-436c-b9ee-4d2f3d2efa88)