### PR TITLE
No need to check item size on durability update only

### DIFF
--- a/Source Main 5.2/source/WSclient.cpp
+++ b/Source Main 5.2/source/WSclient.cpp
@@ -6307,10 +6307,13 @@ void ReceiveBuyExtended(const std::span<const BYTE> ReceiveBuffer)
     constexpr BYTE BUY_FAILED = 0xFE;
     constexpr BYTE BUY_FAILED_SILENT = 0xFF;
 
-    auto Offset = sizeof(PBMSG_HEADER) + 1;
+    auto Offset = sizeof(PHEADER_DEFAULT_ITEM_EXTENDED_HEAD);
     auto itemData = ReceiveBuffer.subspan(Offset);
-    int length = CalcItemLength(itemData);
-    itemData = itemData.subspan(0, length);
+    if (itemData.size() > 0)
+    {
+        int length = CalcItemLength(itemData);
+        itemData = itemData.subspan(0, length);
+    }
 
     if (Data->Index == BUY_FAILED)
     {


### PR DESCRIPTION
Removed checking of item size on durability update only to prevent invalid read (CalcItemLength reads some field that may not exist when item data is not sent).

Amends fix for NPC buy issue (https://github.com/sven-n/MuMain/commit/d8b7aef219beb9f97ece72e79cf5649ece6bf6f3 & https://github.com/sven-n/MuMain/commit/3fcd21f7deef71c5f2cb3ec40c2c4dd986f2639a).  

