### PR TITLE
Customizable number of messages processed per cycle

### DIFF
--- a/Source Main 5.2/Main.vcxproj
+++ b/Source Main 5.2/Main.vcxproj
@@ -664,6 +664,7 @@
     <ClCompile Include="source\UISenatus.cpp" />
     <ClCompile Include="source\UIWindows.cpp" />
     <ClCompile Include="source\UsefulDef.cpp" />
+    <ClCompile Include="source\Utilities\CpuUsage.cpp" />
     <ClCompile Include="source\Utilities\Log\ErrorReport.cpp" />
     <ClCompile Include="source\Utilities\Log\muConsoleDebug.cpp" />
     <ClCompile Include="source\Utilities\Log\WindowsConsole.cpp" />
@@ -1071,6 +1072,7 @@
     <ClInclude Include="source\UISenatus.h" />
     <ClInclude Include="source\UIWindows.h" />
     <ClInclude Include="source\UsefulDef.h" />
+    <ClInclude Include="source\Utilities\CpuUsage.h" />
     <ClInclude Include="source\Utilities\Log\ErrorReport.h" />
     <ClInclude Include="source\Utilities\Log\muConsoleDebug.h" />
     <ClInclude Include="source\Utilities\Log\WindowsConsole.h" />

--- a/Source Main 5.2/Main.vcxproj.filters
+++ b/Source Main 5.2/Main.vcxproj.filters
@@ -1198,6 +1198,9 @@
     <ClCompile Include="source\MUHelper\MuHelperData.cpp">
       <Filter>MU\Client\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="source\Utilities\CpuUsage.cpp">
+      <Filter>MU\Client\Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\BlackWin.h">
@@ -2284,6 +2287,9 @@
       <Filter>MU\MUHelper</Filter>
     </ClInclude>
     <ClInclude Include="source\MUHelper\MuHelperData.h">
+      <Filter>MU\Client\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="source\Utilities\CpuUsage.h">
       <Filter>MU\Client\Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Source Main 5.2/source/Utilities/CpuUsage.cpp
+++ b/Source Main 5.2/source/Utilities/CpuUsage.cpp
@@ -1,58 +1,70 @@
 #include "stdafx.h"
-#include "CpuUsage.h"
+#include <chrono>
 #include <windows.h>
 #include <stdexcept>
+#include "CpuUsage.h"
 
 // Implementation for Windows
 class CpuUsage::Impl 
 {
 public:
-    Impl() : m_lastSystemTime(0), m_lastProcessTime(0) {}
+    Impl()
+    {
+        SYSTEM_INFO sysInfo;
+        GetSystemInfo(&sysInfo);
+        m_numProcessors = sysInfo.dwNumberOfProcessors;
+        m_lastCheckTime = std::chrono::steady_clock::now();
+    }
 
     double GetUsage() 
     {
-        FILETIME now, creationTime, exitTime, kernelTime, userTime;
-        ULONGLONG systemTimeElapsed, processTimeElapsed;
-
-        // Get the system time and the process times
-        GetSystemTimeAsFileTime(&now);
+        // Get the current process times
+        FILETIME creationTime, exitTime, kernelTime, userTime;
         if (!GetProcessTimes(GetCurrentProcess(), &creationTime, &exitTime, &kernelTime, &userTime))
         {
-            return -1.0; // Error
+            return 0.0; // Error
         }
 
-        // Convert FILETIME to ULONGLONG
-        ULONGLONG currentSystemTime = FileTimeToULL(now);
+        // Convert process times to ULONGLONG
         ULONGLONG currentKernelTime = FileTimeToULL(kernelTime);
         ULONGLONG currentUserTime = FileTimeToULL(userTime);
+        ULONGLONG currentProcessTime = currentKernelTime + currentUserTime;
 
-        // Check if this is the first call
-        if (m_lastSystemTime == 0 || m_lastProcessTime == 0) 
+        // Get the current wall-clock time using std::chrono
+        auto now = std::chrono::steady_clock::now();
+        auto elapsedWallTime = std::chrono::duration_cast<std::chrono::microseconds>(now - m_lastCheckTime).count();
+
+        // First call: Initialize
+        if (m_lastSystemTime == 0 || m_lastProcessTime == 0)
         {
-            m_lastSystemTime = currentSystemTime;
-            m_lastProcessTime = currentKernelTime + currentUserTime;
-            return 0.0; // First call, no valid data to calculate usage
+            m_lastSystemTime = elapsedWallTime;
+            m_lastProcessTime = currentProcessTime;
+            m_lastCheckTime = now;
+            return 0.0; // Not enough data to calculate usage
         }
 
         // Calculate elapsed times
-        systemTimeElapsed = currentSystemTime - m_lastSystemTime;
-        processTimeElapsed = (currentKernelTime + currentUserTime) - m_lastProcessTime;
+        ULONGLONG systemTimeElapsed = elapsedWallTime;
+        ULONGLONG processTimeElapsed = currentProcessTime - m_lastProcessTime;
 
-        // Store the current times for the next call
-        m_lastSystemTime = currentSystemTime;
-        m_lastProcessTime = currentKernelTime + currentUserTime;
+        // Update last recorded times
+        m_lastSystemTime = elapsedWallTime;
+        m_lastProcessTime = currentProcessTime;
+        m_lastCheckTime = now;
 
         // Avoid division by zero
-        if (systemTimeElapsed == 0)
+        if (systemTimeElapsed == 0 || m_numProcessors == 0)
             return 0.0;
 
-        // CPU usage as a percentage
-        return (100.0 * processTimeElapsed) / systemTimeElapsed;
+        // Calculate CPU usage as a percentage
+        return (100.0 * processTimeElapsed) / (systemTimeElapsed * m_numProcessors);
     }
 
 private:
     ULONGLONG m_lastSystemTime;
     ULONGLONG m_lastProcessTime;
+    DWORD m_numProcessors;
+    std::chrono::steady_clock::time_point m_lastCheckTime;
 
     ULONGLONG FileTimeToULL(const FILETIME& ft)
     {

--- a/Source Main 5.2/source/Utilities/CpuUsage.cpp
+++ b/Source Main 5.2/source/Utilities/CpuUsage.cpp
@@ -1,0 +1,79 @@
+#include "stdafx.h"
+#include "CpuUsage.h"
+#include <windows.h>
+#include <stdexcept>
+
+// Implementation for Windows
+class CpuUsage::Impl 
+{
+public:
+    Impl() : m_lastSystemTime(0), m_lastProcessTime(0) {}
+
+    double GetUsage() 
+    {
+        FILETIME now, creationTime, exitTime, kernelTime, userTime;
+        ULONGLONG systemTimeElapsed, processTimeElapsed;
+
+        // Get the system time and the process times
+        GetSystemTimeAsFileTime(&now);
+        if (!GetProcessTimes(GetCurrentProcess(), &creationTime, &exitTime, &kernelTime, &userTime))
+        {
+            return -1.0; // Error
+        }
+
+        // Convert FILETIME to ULONGLONG
+        ULONGLONG currentSystemTime = FileTimeToULL(now);
+        ULONGLONG currentKernelTime = FileTimeToULL(kernelTime);
+        ULONGLONG currentUserTime = FileTimeToULL(userTime);
+
+        // Check if this is the first call
+        if (m_lastSystemTime == 0 || m_lastProcessTime == 0) 
+        {
+            m_lastSystemTime = currentSystemTime;
+            m_lastProcessTime = currentKernelTime + currentUserTime;
+            return 0.0; // First call, no valid data to calculate usage
+        }
+
+        // Calculate elapsed times
+        systemTimeElapsed = currentSystemTime - m_lastSystemTime;
+        processTimeElapsed = (currentKernelTime + currentUserTime) - m_lastProcessTime;
+
+        // Store the current times for the next call
+        m_lastSystemTime = currentSystemTime;
+        m_lastProcessTime = currentKernelTime + currentUserTime;
+
+        // Avoid division by zero
+        if (systemTimeElapsed == 0)
+            return 0.0;
+
+        // CPU usage as a percentage
+        return (100.0 * processTimeElapsed) / systemTimeElapsed;
+    }
+
+private:
+    ULONGLONG m_lastSystemTime;
+    ULONGLONG m_lastProcessTime;
+
+    ULONGLONG FileTimeToULL(const FILETIME& ft)
+    {
+        return (static_cast<ULONGLONG>(ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+    }
+};
+
+CpuUsage* CpuUsage::Instance() 
+{
+    static CpuUsage instance;
+    return &instance;
+}
+
+// Constructor
+CpuUsage::CpuUsage() : pImpl(std::make_unique<Impl>()) {}
+
+// Destructor
+CpuUsage::~CpuUsage() = default;
+
+// Public methods
+double CpuUsage::GetUsage()
+{
+    return pImpl->GetUsage();
+}

--- a/Source Main 5.2/source/Utilities/CpuUsage.cpp
+++ b/Source Main 5.2/source/Utilities/CpuUsage.cpp
@@ -14,6 +14,8 @@ public:
         GetSystemInfo(&sysInfo);
         m_numProcessors = sysInfo.dwNumberOfProcessors;
         m_lastCheckTime = std::chrono::steady_clock::now();
+        m_lastProcessTime = 0;
+        m_lastSystemTime = 0;
     }
 
     double GetUsage() 
@@ -57,7 +59,7 @@ public:
             return 0.0;
 
         // Calculate CPU usage as a percentage
-        return (100.0 * processTimeElapsed) / (systemTimeElapsed * m_numProcessors);
+        return max(0.0, (100.0 * processTimeElapsed) / (systemTimeElapsed * m_numProcessors));
     }
 
 private:

--- a/Source Main 5.2/source/Utilities/CpuUsage.h
+++ b/Source Main 5.2/source/Utilities/CpuUsage.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+
+class CpuUsage {
+public:
+    static CpuUsage* Instance();
+
+    double GetUsage();
+
+private:
+    CpuUsage();
+    ~CpuUsage();
+
+    class Impl;                  // Forward declaration of the implementation
+    std::unique_ptr<Impl> pImpl; // Pointer to implementation
+};

--- a/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
+++ b/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
@@ -89,6 +89,14 @@ bool CmuConsoleDebug::CheckCommand(const std::wstring& strCommand)
         return true;
     }
 
+    if (strCommand._Starts_with(L"$winmsg"))
+    {
+        auto str_limit = strCommand.substr(8);
+        auto message_limit = std::stof(str_limit);
+        SetMaxMessagePerCycle(message_limit);
+        return true;
+    }
+
 #ifdef CSK_LH_DEBUG_CONSOLE
     if (!m_bInit)
         return false;

--- a/Source Main 5.2/source/Winmain.cpp
+++ b/Source Main 5.2/source/Winmain.cpp
@@ -1259,6 +1259,13 @@ bool ExceptionCallback(_EXCEPTION_POINTERS* pExceptionInfo)
     return true;
 }
 
+int g_MaxMessagePerCycle = 10;
+
+void SetMaxMessagePerCycle(int messages)
+{
+    g_MaxMessagePerCycle = messages;
+}
+
 MSG MainLoop()
 {
     MSG msg;
@@ -1268,12 +1275,11 @@ MSG MainLoop()
 
     while (1)
     {
-        const int MaxMessagePerCycle = 10;
         int messageProcessed = 0;
 
-        while (PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE) && messageProcessed < MaxMessagePerCycle)
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
         {
-            if (!GetMessage(&msg, NULL, 0, 0))
+            if (msg.message == WM_QUIT)
             {
                 return msg;
             }
@@ -1281,6 +1287,11 @@ MSG MainLoop()
             TranslateMessage(&msg);
             DispatchMessage(&msg);
             ++messageProcessed;
+
+            if (g_MaxMessagePerCycle > 0 && messageProcessed >= g_MaxMessagePerCycle)
+            {
+                break;
+            }
         }
 
         if (CheckRenderNextFrame())

--- a/Source Main 5.2/source/Winmain.cpp
+++ b/Source Main 5.2/source/Winmain.cpp
@@ -1379,13 +1379,13 @@ MSG MainLoop()
         {
             if (!PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE))
             {
-                WaitForNextActivity(precise != TIMERR_NOERROR);
+                WaitForNextActivity(precise == TIMERR_NOERROR);
             }
         }
 
     } // while( 1 )
 
-    if (precise != TIMERR_NOERROR)
+    if (precise == TIMERR_NOERROR)
     {
         timeEndPeriod(target_resolution);
     }

--- a/Source Main 5.2/source/Winmain.cpp
+++ b/Source Main 5.2/source/Winmain.cpp
@@ -1268,7 +1268,7 @@ MSG MainLoop()
 
     while (1)
     {
-        const int MaxMessagePerCycle = 5;
+        const int MaxMessagePerCycle = 10;
         int messageProcessed = 0;
 
         while (PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE) && messageProcessed < MaxMessagePerCycle)

--- a/Source Main 5.2/source/Winmain.h
+++ b/Source Main 5.2/source/Winmain.h
@@ -79,6 +79,7 @@ extern int  m_Resolution;
 extern int m_nColorDepth;
 extern int m_RememberMe;
 extern int g_MaxMessagePerCycle;
+extern double CPU_AVG;
 
 extern void SetMaxMessagePerCycle(int messages);
 extern void CheckHack(void);

--- a/Source Main 5.2/source/Winmain.h
+++ b/Source Main 5.2/source/Winmain.h
@@ -78,7 +78,9 @@ extern int  m_MusicOnOff;
 extern int  m_Resolution;
 extern int m_nColorDepth;
 extern int m_RememberMe;
+extern int g_MaxMessagePerCycle;
 
+extern void SetMaxMessagePerCycle(int messages);
 extern void CheckHack(void);
 extern DWORD GetCheckSum(WORD wKey);
 extern void StopMp3(char* Name, BOOL bEnforce = false);

--- a/Source Main 5.2/source/ZzzOpenglUtil.cpp
+++ b/Source Main 5.2/source/ZzzOpenglUtil.cpp
@@ -768,6 +768,11 @@ void DisableVSync()
     _isVSyncEnabled = false;
 }
 
+int GetFPSLimit()
+{
+    return GetDeviceCaps(g_hDC, VREFRESH);
+}
+
 #ifdef LDS_ADD_MULTISAMPLEANTIALIASING
 BOOL InitGLMultisample(HINSTANCE hInstance, HWND hWnd, PIXELFORMATDESCRIPTOR pfd, int iRequestMSAAValue, int& OutiPixelFormat)
 {

--- a/Source Main 5.2/source/ZzzOpenglUtil.h
+++ b/Source Main 5.2/source/ZzzOpenglUtil.h
@@ -87,6 +87,7 @@ bool IsVSyncAvailable();
 bool IsVSyncEnabled();
 void EnableVSync();
 void DisableVSync();
+int GetFPSLimit();
 
 void UpdateMousePositionn();
 extern inline void TEXCOORD(float* c, float u, float v);

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -2441,7 +2441,7 @@ void MainScene(HDC hDC)
 #ifndef  defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
         BeginBitmap();
         wchar_t szDebugText[128];
-        swprintf(szDebugText, L"FPS : %.1f Connected: %d", FPS_AVG, g_bGameServerConnected);
+        swprintf(szDebugText, L"FPS : %.1f WinMsg : %d Connected: %d", FPS_AVG, g_MaxMessagePerCycle, g_bGameServerConnected);
         wchar_t szMousePos[128];
         swprintf(szMousePos, L"MousePos : %d %d %d", MouseX, MouseY, MouseLButtonPush);
         wchar_t szCamera3D[128];

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -2266,7 +2266,7 @@ double ms_per_frame = 1000.0 / target_fps;
 
 void SetTargetFps(double targetFps)
 {
-    if (targetFps < 0 || targetFps >= GetFPSLimit())
+    if (IsVSyncEnabled() && targetFps >= GetFPSLimit())
     {
         targetFps = -1;
     }
@@ -2775,7 +2775,7 @@ void WaitForNextActivity(bool usePreciseSleep)
         if (rest_ms - sleep_duration_offset_ms > sleep_threshold_ms)
         {
             const auto sleep_ms = min(rest_ms - sleep_duration_offset_ms, max_sleep_ms);
-            std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<long>(final_sleep_ms)));
+            std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<long>(sleep_ms)));
         }
         else
         {

--- a/Source Main 5.2/source/ZzzScene.h
+++ b/Source Main 5.2/source/ZzzScene.h
@@ -26,7 +26,7 @@ extern void LoadingScene(HDC hDC);
 extern void RenderScene(HDC Hdc);
 extern bool CheckName();
 void    StartGame();
-void SetTargetFps(float targetFps);
+void SetTargetFps(double targetFps);
 
 BOOL	ShowCheckBox(int num, int index, int message = MESSAGE_TRADE_CHECK);
 


### PR DESCRIPTION
- Let's user set the max events processed per cycle using `$winmsg` command
  - -1 is same as the old behavior where all events are processed first before rendering
  - adjust as needed (recommended: "`$winmsg 10`")
- Added average CPU usage info in the debug text next to FPS info
- Setting `$fps` to a value >= refresh rate when vsync is On sets the `target_fps` global variable back to -1