### PR TITLE
Apply personal store data for own store to inventory

### DIFF
--- a/Source Main 5.2/source/NewUIMyShopInventory.cpp
+++ b/Source Main 5.2/source/NewUIMyShopInventory.cpp
@@ -159,6 +159,11 @@ void SEASON3B::CNewUIMyShopInventory::GetTitle(wchar_t* titletext)
      m_EditBox->GetText(titletext, iMAX_SHOPTITLE_MULTI);
 }
 
+void SEASON3B::CNewUIMyShopInventory::SetTitle(wchar_t* titletext)
+{
+    m_EditBox->SetText(titletext);
+}
+
 bool SEASON3B::CNewUIMyShopInventory::InsertItem(int iIndex, std::span<const BYTE> pbyItemPacket)
 {
     if (m_pNewInventoryCtrl)
@@ -233,7 +238,7 @@ void SEASON3B::CNewUIMyShopInventory::OpenButtonUnLock()
     m_Button[MYSHOPINVENTORY_OPEN].ChangeImgColor(BUTTON_STATE_UP, RGBA(255, 255, 255, 255));
     m_Button[MYSHOPINVENTORY_OPEN].ChangeTextColor(RGBA(255, 255, 255, 255));
     m_Button[MYSHOPINVENTORY_OPEN].UnLock();
-    m_Button[MYSHOPINVENTORY_OPEN].ChangeToolTipText(GlobalText[1107], true);
+    m_Button[MYSHOPINVENTORY_OPEN].ChangeToolTipText(GlobalText[1106], true);
 }
 
 const bool SEASON3B::CNewUIMyShopInventory::IsEnablePersonalShop() const
@@ -250,7 +255,6 @@ void SEASON3B::CNewUIMyShopInventory::ChangeEditBox(const UISTATES type)
         m_EditBox->GiveFocus();
     }
 
-    m_EditBox->SetText(NULL);
 }
 
 bool SEASON3B::CNewUIMyShopInventory::UpdateKeyEvent()
@@ -414,7 +418,7 @@ bool SEASON3B::CNewUIMyShopInventory::UpdateMouseEvent()
             return false;
             case 1:
             {
-                wchar_t shopTitle[MAX_SHOPTITLE]{};
+                wchar_t shopTitle[MAX_SHOPTITLE + 1]{};
                 g_pMyShopInventory->GetTitle(shopTitle);
                 if (IsExistUndecidedPrice() == false && wcslen(shopTitle) > 0)
                 {

--- a/Source Main 5.2/source/NewUIMyShopInventory.cpp
+++ b/Source Main 5.2/source/NewUIMyShopInventory.cpp
@@ -88,7 +88,7 @@ bool SEASON3B::CNewUIMyShopInventory::Create(CNewUIManager* pNewUIMng, int x, in
     m_EditBox->SetBackColor(0, 0, 0, 25);
     m_EditBox->SetFont(g_hFont);
 
-    ChangeEditBox(UISTATE_HIDE);
+    ChangeEditBox(UISTATE_NORMAL);
     ChangePersonal(m_EnablePersonalShop);
 
     Show(false);

--- a/Source Main 5.2/source/NewUIMyShopInventory.h
+++ b/Source Main 5.2/source/NewUIMyShopInventory.h
@@ -80,8 +80,9 @@ namespace SEASON3B
         ITEM* FindItem(int iLinealPos);
         int GetItemInventoryIndex(ITEM* pItem);
         void ChangeEditBox(const UISTATES type);
-        void ChangeTitle(std::wstring& titletext);
+        void ChangeTitle(wchar_t* titletext);
         void GetTitle(wchar_t* titletext);
+        void SetTitle(wchar_t* titletext);
         void ChangePersonal(bool state);
         const bool IsEnablePersonalShop() const;
         void OpenButtonLock();
@@ -118,9 +119,9 @@ namespace SEASON3B
     };
 
     inline
-        void CNewUIMyShopInventory::ChangeTitle(std::wstring& titletext)
+        void CNewUIMyShopInventory::ChangeTitle(wchar_t* titletext)
     {
-        m_EditBox->SetText(titletext.c_str());
+        m_EditBox->SetText(titletext);
     }
 
     inline

--- a/Source Main 5.2/source/NewUISystem.cpp
+++ b/Source Main 5.2/source/NewUISystem.cpp
@@ -826,7 +826,7 @@ void CNewUISystem::Show(DWORD dwKey)
         {
             g_pMyShopInventory->OpenButtonLock();
         }
-        else
+        else if (!g_pMyShopInventory->IsEnablePersonalShop())
         {
             g_pMyShopInventory->OpenButtonUnLock();
         }

--- a/Source Main 5.2/source/PersonalShopTitleImp.cpp
+++ b/Source Main 5.2/source/PersonalShopTitleImp.cpp
@@ -260,27 +260,19 @@ void CPersonalShopTitleImp::Draw()
         UpdatePosition();
         RevisionPosition();
 
-        if (m_iHighlightFrame > 6)
-        {
-            m_iHighlightFrame = 0;
-        }
-        else
-        {
-            m_iHighlightFrame++;
-        }
+        auto isHighlightTime = static_cast<INT64>(WorldTime / 265) % 2 == 0;
 
         auto mi = m_listShopTitleDrawObj.begin();
         for (; mi != m_listShopTitleDrawObj.end(); ++mi)
         {
-            CShopTitleDrawObj* pDrawObj = (*mi).second;
+            CShopTitleDrawObj* pDrawObj = mi->second;
             if (SelectedCharacter != -1
-                && m_iHighlightFrame < 3
+                && isHighlightTime
                 && g_pNewUISystem->IsVisible(SEASON3B::INTERFACE_COMMAND)
-                && g_pCommandWindow->GetCurCommandType() == COMMAND_PURCHASE
-                )
+                && g_pCommandWindow->GetCurCommandType() == COMMAND_PURCHASE)
             {
-                CHARACTER* pSeletedPlayer = &CharactersClient[SelectedCharacter];
-                if ((*mi).first == pSeletedPlayer)
+                CHARACTER* selectedPlayer = &CharactersClient[SelectedCharacter];
+                if (mi->first == selectedPlayer)
                 {
                     pDrawObj->EnableHighlight();
                 }
@@ -292,7 +284,7 @@ void CPersonalShopTitleImp::Draw()
 
             if (pDrawObj->IsVisible() && IsShowShopTitles())
             {
-                pDrawObj->Draw((*mi).first->PK);
+                pDrawObj->Draw(mi->first->PK);
             }
         }
     }

--- a/Source Main 5.2/source/UIControls.cpp
+++ b/Source Main 5.2/source/UIControls.cpp
@@ -3472,14 +3472,17 @@ void CUITextInputBox::WriteText(int iOffset, int iWidth, int iHeight)
 }
 void CUITextInputBox::Render()
 {
+    m_bIsReady = TRUE;
+    if (m_hEditWnd == nullptr || !IsWindowVisible(m_hEditWnd))
+    {
+        return;
+    }
+
     if (m_bSetText)
     {
         SetWindowTextW(m_hEditWnd, m_sTextToSet.c_str());
         m_bSetText = false;
     }
-
-    m_bIsReady = TRUE;
-    if (m_hEditWnd == nullptr || IsWindowVisible(m_hEditWnd) == FALSE) return;
 
     POINT RealWndPos = { (int)(m_iPos_x * g_fScreenRate_x), (int)(m_iPos_y * g_fScreenRate_y) };
     SIZE RealWndSize = { (int)(m_iWidth * g_fScreenRate_x), (int)(m_iHeight * g_fScreenRate_y) };
@@ -3507,26 +3510,23 @@ void CUITextInputBox::Render()
     const int LIMIT_WIDTH = 256, LIMIT_HEIGHT = 32;
     SIZE RealTextLine = { 0, 0 };
 
-    if (m_bUseMultiLine == FALSE)
+    if (!m_bUseMultiLine)
     {
-        wchar_t TextCheck[MAX_TEXT_LENGTH + 1] = { 0, };
-        GetText(TextCheck);
-        wchar_t TextCheckUTF16[MAX_TEXT_LENGTH + 1] = { '\0' };
+        wchar_t TextCheckUTF16[MAX_TEXT_LENGTH + 1] = { };
         GetText(TextCheckUTF16);
         SIZE TextSize;
 
-        if (IsPassword() == FALSE)
+        if (!IsPassword())
         {
             GetTextExtentPoint32(m_hMemDC, TextCheckUTF16, wcslen(TextCheckUTF16), &TextSize);
         }
         else
         {
-            wchar_t szPasswd[MAX_TEXT_LENGTH + 1];
+            wchar_t szPasswd[MAX_TEXT_LENGTH + 1] = { };
             memset(szPasswd, '*', MAX_TEXT_LENGTH);
-            szPasswd[MAX_TEXT_LENGTH] = '\0';
             g_pRenderText->SetFont(g_hFontBold);
 
-            GetTextExtentPoint32(m_hMemDC, szPasswd, wcslen(TextCheck), &TextSize);
+            GetTextExtentPoint32(m_hMemDC, szPasswd, wcslen(TextCheckUTF16), &TextSize);
             g_pRenderText->SetFont(g_hFont);
         }
         RealTextLine.cx = TextSize.cx + m_fCaretWidth;

--- a/Source Main 5.2/source/ZzzInventory.cpp
+++ b/Source Main 5.2/source/ZzzInventory.cpp
@@ -85,7 +85,7 @@ bool g_bEnablePersonalShop = false;
 int g_iPShopWndType = PSHOPWNDTYPE_NONE;
 POINT g_ptPersonalShop = { 0, 0 };
 int g_iPersonalShopMsgType = 0;
-wchar_t g_szPersonalShopTitle[64] = { 0, };
+wchar_t g_szPersonalShopTitle[MAX_SHOPTITLE + 1] = { 0, };
 
 CHARACTER g_PersonalShopSeller;
 bool g_bIsTooltipOn = false;

--- a/Source Main 5.2/source/ZzzInventory.h
+++ b/Source Main 5.2/source/ZzzInventory.h
@@ -106,7 +106,7 @@ extern bool g_bEnablePersonalShop;
 extern int g_iPShopWndType;
 extern POINT g_ptPersonalShop;
 extern int g_iPersonalShopMsgType;
-extern wchar_t g_szPersonalShopTitle[64];
+extern wchar_t g_szPersonalShopTitle[MAX_SHOPTITLE + 1];
 extern CHARACTER g_PersonalShopSeller;
 
 extern bool EnableRenderInventory;


### PR DESCRIPTION
This opens up the possibility for the server to restore previous personal store state after entering the game.
That means all item prices and the open state of the store doesn't need to be repeated by the player anymore after login.

Helpful for https://github.com/MUnique/OpenMU/issues/577 and https://github.com/MUnique/OpenMU/pull/579