### PR TITLE
Add packet handling for base stat setting

### DIFF
--- a/Source Main 5.2/source/WSclient.cpp
+++ b/Source Main 5.2/source/WSclient.cpp
@@ -6628,6 +6628,18 @@ void ReceiveAddPointExtended(const BYTE* ReceiveBuffer)
     CharacterMachine->CalculateAll();
 }
 
+void ReceiveSetPointsExtended(const BYTE* ReceiveBuffer)
+{
+    auto Data = (LPPRECEIVE_SET_POINTS_EXTENDED)ReceiveBuffer;
+    CharacterAttribute->Strength = Data->Strength;
+    CharacterAttribute->Dexterity = Data->Dexterity;
+    CharacterAttribute->Vitality = Data->Vitality;
+    CharacterAttribute->Energy = Data->Energy;
+    CharacterAttribute->Charisma = Data->Charisma;
+
+    CharacterMachine->CalculateAll();
+}
+
 void ReceiveStatsExtended(const BYTE* ReceiveBuffer)
 {
     auto Data = (LPPRECEIVE_STATS_EXTENDED)ReceiveBuffer;
@@ -13271,6 +13283,9 @@ static void ProcessPacket(const BYTE* ReceiveBuffer, int32_t Size)
             break;
         case 0x30:
             ReceiveOption(ReceiveBuffer);
+            break;
+        case 0x32:
+            ReceiveSetPointsExtended(ReceiveBuffer);
             break;
         case 0x40:
             ReceiveServerCommand(ReceiveBuffer);

--- a/Source Main 5.2/source/WSclient.h
+++ b/Source Main 5.2/source/WSclient.h
@@ -842,6 +842,16 @@ typedef struct {
 
 typedef struct {
     PBMSG_HEADER Header;
+    BYTE         SubCode;       // 3
+    DWORD        Strength;      // 4
+    DWORD        Dexterity;     // 8
+    DWORD		 Vitality;      // 12
+    DWORD		 Energy;        // 16
+    DWORD		 Charisma;      // 20
+} PRECEIVE_SET_POINTS_EXTENDED, * LPPRECEIVE_SET_POINTS_EXTENDED;
+
+typedef struct {
+    PBMSG_HEADER Header;
     BYTE         KeyH;
     BYTE         KeyL;
     BYTE         PositionX;


### PR DESCRIPTION
This new packet handler will set the base stats and calculate related stats accordingly.
This will allow handling of stats setters, which will allow the "set stats" command, resetting without logout, etc.