### PR TITLE
Fix invalid LangSelection entry in the registry

### DIFF
--- a/Source Main 5.2/source/Winmain.cpp
+++ b/Source Main 5.2/source/Winmain.cpp
@@ -1036,7 +1036,7 @@ BOOL OpenInitFile()
             g_bUseWindowMode = FALSE;
         }
 
-        dwSize = MAX_LANGUAGE_NAME_LENGTH;
+        dwSize = MAX_LANGUAGE_NAME_LENGTH * sizeof(wchar_t);
         if (RegQueryValueEx(hKey, L"LangSelection", 0, NULL, (LPBYTE)g_aszMLSelection, &dwSize) != ERROR_SUCCESS)
         {
             wcscpy(g_aszMLSelection, L"Eng");


### PR DESCRIPTION
Currently, reading the LangSelection entry in the registry does not take effect and always defaults to "Eng" because the REG_SZ length is not calculated correctly.