### PR TITLE
Updated MU Helper skill list layout

### DIFF
--- a/Source Main 5.2/source/NewUIMuHelper.cpp
+++ b/Source Main 5.2/source/NewUIMuHelper.cpp
@@ -1937,20 +1937,27 @@ bool CNewUIMuHelperSkillList::Render()
     float iconOffsetX = (boxWidth - iconWidth) / 2.f;
     float iconOffsetY = (boxHeight - iconHeight) / 2.f;
 
-    // top skills Helper basic
+    // x position relative to the position of mu helper window
     float startX = 640.f - 190.f - 32.f;
-    float startY = m_bFilterByAttackSkills ? 20.f : 260.f;
+    // y position relative to the skill/buff selection in mu helper window
+    float startY = m_bFilterByAttackSkills ? 171.f : 293.f;
 
-    int itemsPerColumn = m_bFilterByAttackSkills ? 10 : 6;
-    int iSkillCount = 0;
+    int itemsPerColumn = m_bFilterByAttackSkills ? 10 : 5;
 
-    for (int iSkillType : m_aiSkillsToRender)
+    for (int i = 0; i < m_aiSkillsToRender.size(); i++)
     {
-        int col = iSkillCount / itemsPerColumn;
-        int row = iSkillCount % itemsPerColumn;
+        int iSkillType = m_aiSkillsToRender[i];
 
-        float x = startX - col * boxWidth;
-        float y = startY + row * boxHeight;
+        int col = i / itemsPerColumn;
+        int rowInColumn = i % itemsPerColumn;
+
+        int offset = (rowInColumn + 1) / 2;
+        bool skillCountEven = (rowInColumn % 2 == 0);
+
+        float x = startX - col * boxWidth; // left to right
+        float y = skillCountEven           // bounce up and down from center
+            ? startY - offset * boxHeight
+            : startY + offset * boxHeight;
 
         RenderImage(IMAGE_SKILLBOX, x, y, boxWidth, boxHeight);
         RenderSkillIcon(iSkillType, x + iconOffsetX, y + iconOffsetY, iconWidth, iconHeight);
@@ -1960,8 +1967,6 @@ bool CNewUIMuHelperSkillList::Render()
             { static_cast<LONG>(x), static_cast<LONG>(y) },
             { static_cast<LONG>(boxWidth), static_cast<LONG>(boxHeight) }
             });
-
-        iSkillCount++;
     }
 
     if (m_bRenderSkillInfo && m_pNewUI3DRenderMng)


### PR DESCRIPTION
I updated the layout to be relative to the skill slots in the mu helper window.  
Also, I restored the behavior where the skills are added top/bottom from the center depending on the number of skills.
![image](https://github.com/user-attachments/assets/7379b97f-e045-44f2-bba9-af38899b9794)
This was the original intention of the old code (but was buggy when the column is more than 1)
