### PR TITLE
Fix for running Client on Linux with Proton

### DIFF
--- a/Source Main 5.2/source/Utilities/Log/ErrorReport.cpp
+++ b/Source Main 5.2/source/Utilities/Log/ErrorReport.cpp
@@ -129,7 +129,7 @@ void CErrorReport::Write(const wchar_t* lpszFormat, ...)
     wchar_t lpszBuffer[1024] = { 0, };
     va_list va;
     va_start(va, lpszFormat);
-    wvsprintf(lpszBuffer, lpszFormat, va);
+    vswprintf(lpszBuffer, 1024, lpszFormat, va);
     va_end(va);
 
     WriteDebugInfoStr(lpszBuffer);

--- a/Source Main 5.2/source/Utilities/Log/ErrorReport.cpp
+++ b/Source Main 5.2/source/Utilities/Log/ErrorReport.cpp
@@ -129,7 +129,7 @@ void CErrorReport::Write(const wchar_t* lpszFormat, ...)
     wchar_t lpszBuffer[1024] = { 0, };
     va_list va;
     va_start(va, lpszFormat);
-    vswprintf(lpszBuffer, lpszFormat, va);
+    wvsprintf(lpszBuffer, lpszFormat, va);
     va_end(va);
 
     WriteDebugInfoStr(lpszBuffer);

--- a/Source Main 5.2/source/Utilities/Log/WindowsConsole.cpp
+++ b/Source Main 5.2/source/Utilities/Log/WindowsConsole.cpp
@@ -79,9 +79,11 @@ CConsoleWindow::~CConsoleWindow() {}
 bool CConsoleWindow::Open(const std::wstring& title)
 {
     Close();
+    if (m_started)
+        return true;
+    m_started = true;
 
-    if (FALSE == ::AllocConsole())
-        return false;
+    assert(::AllocConsole());
 
     freopen("CONIN$", "r", stdin);
     freopen("CONOUT$", "w", stdout);
@@ -101,11 +103,6 @@ bool CConsoleWindow::Open(const std::wstring& title)
             break;
         ::Sleep(500);
     }
-    if (GetWndHandle() == NULL || false == SetTitle(title))
-    {
-        Close();
-        return false;
-    }
 
     m_bActiveCloseButton = true;
 
@@ -120,6 +117,7 @@ void CConsoleWindow::Close()
     FreeConsole();
 
     m_hWnd = NULL;
+    m_started = false;
 }
 
 bool CConsoleWindow::SetTitle(const std::wstring& title)
@@ -139,7 +137,7 @@ const std::wstring& CConsoleWindow::GetTitle()
 
 HWND CConsoleWindow::GetWndHandle() { return m_hWnd; }
 
-bool CConsoleWindow::IsVisible() { return ::IsWindowVisible(GetWndHandle()) ? true : false; }
+bool CConsoleWindow::IsVisible() { return GetWndHandle() && ::IsWindowVisible(GetWndHandle()) ? true : false; }
 void CConsoleWindow::Show(bool bShow)
 {
     if (m_hWnd)
@@ -219,7 +217,7 @@ void CConsoleWindow::ActivateCloseButton(bool bActive)
         ::DrawMenuBar(m_hWnd);
         m_bActiveCloseButton = true;
     }
-    else
+    else if (m_hWnd != NULL)
     {
         // disable the [x] button if we found our console
         HMENU hMenu = ::GetSystemMenu(m_hWnd, FALSE);

--- a/Source Main 5.2/source/Utilities/Log/WindowsConsole.cpp
+++ b/Source Main 5.2/source/Utilities/Log/WindowsConsole.cpp
@@ -83,7 +83,8 @@ bool CConsoleWindow::Open(const std::wstring& title)
         return true;
     m_started = true;
 
-    assert(::AllocConsole());
+    if (FALSE == ::AllocConsole())
+        return false;
 
     freopen("CONIN$", "r", stdin);
     freopen("CONOUT$", "w", stdout);

--- a/Source Main 5.2/source/Utilities/Log/WindowsConsole.cpp
+++ b/Source Main 5.2/source/Utilities/Log/WindowsConsole.cpp
@@ -71,6 +71,7 @@ CConsoleWindow::CConsoleWindow()
 {
     m_hWnd = NULL;
     m_bActiveCloseButton = false;
+    m_started = false;
 
     m_LimitTimer.SetTimer(12000);	//. 12√ 
 }

--- a/Source Main 5.2/source/Utilities/Log/WindowsConsole.h
+++ b/Source Main 5.2/source/Utilities/Log/WindowsConsole.h
@@ -62,6 +62,7 @@ namespace leaf {
         CTimer2	m_LimitTimer;
         HWND	m_hWnd;
         bool	m_bActiveCloseButton;
+        bool    m_started;
 
     public:
         ~CConsoleWindow();

--- a/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
+++ b/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
@@ -22,14 +22,12 @@
 CmuConsoleDebug::CmuConsoleDebug() : m_bInit(false)
 {
 #ifdef CSK_LH_DEBUG_CONSOLE
-    if (leaf::OpenConsoleWindow(L"Mu Debug Console Window"))
-    {
-        leaf::ActivateCloseButton(false);
-        leaf::ShowConsole(true);
-        m_bInit = true;
+    assert(leaf::OpenConsoleWindow(L"Mu Debug Console Window"));
+    leaf::ActivateCloseButton(false);
+    leaf::ShowConsole(true);
+    m_bInit = true;
 
-        g_ErrorReport.Write(L"Mu Debug Console Window Init - completed(Handle:0x%00000008X)\r\n", leaf::GetConsoleWndHandle());
-    }
+    g_ErrorReport.Write(L"Mu Debug Console Window Init - completed(Handle:0x%00000008X)\r\n", leaf::GetConsoleWndHandle());
 #endif
 }
 

--- a/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
+++ b/Source Main 5.2/source/Utilities/Log/muConsoleDebug.cpp
@@ -22,12 +22,14 @@
 CmuConsoleDebug::CmuConsoleDebug() : m_bInit(false)
 {
 #ifdef CSK_LH_DEBUG_CONSOLE
-    assert(leaf::OpenConsoleWindow(L"Mu Debug Console Window"));
-    leaf::ActivateCloseButton(false);
-    leaf::ShowConsole(true);
-    m_bInit = true;
+    if (leaf::OpenConsoleWindow(L"Mu Debug Console Window"))
+    {
+        leaf::ActivateCloseButton(false);
+        leaf::ShowConsole(true);
+        m_bInit = true;
 
-    g_ErrorReport.Write(L"Mu Debug Console Window Init - completed(Handle:0x%00000008X)\r\n", leaf::GetConsoleWndHandle());
+        g_ErrorReport.Write(L"Mu Debug Console Window Init - completed(Handle:0x%00000008X)\r\n", leaf::GetConsoleWndHandle());
+    }
 #endif
 }
 

--- a/Source Main 5.2/source/ZzzScene.cpp
+++ b/Source Main 5.2/source/ZzzScene.cpp
@@ -2126,7 +2126,7 @@ void MainScene(HDC hDC)
 
         g_PhysicsManager.Render();
 
-#ifndef  defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
+#if defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
         BeginBitmap();
         wchar_t szDebugText[128];
         swprintf(szDebugText, L"FPS: %.1f Vsync: %d CPU: %.1f%%", FPS_AVG, IsVSyncEnabled(), CPU_AVG);


### PR DESCRIPTION
This fix two crashes that occurs when trying to run the game on Linux with Proton (specially with Steam Deck)

The first one is related to the game in general, where the `vswprintf` crashes whenever the game is started with no error message. This was fixed by changing it with its cousin `wvsprintf`

The second one is only related when building using the Debug profile (Or enabling the Debug Console). This was because of Handle being null and no child was enumerated while starting the Debug Console. This was fixed by removing that dependency and just checking if the Handle is null when needed. The side effect, at least on Linux, is that in some times there could be more than one console, yet I'm not sure if this is a error of the workaround or if this was made by proton itself.

This fix was tested in both Windows 11 and in Steam Deck with Proton 10 (Beta), both OS using Debug and Release profiles.