### PR TITLE
Refactor magic skill effects to use modern C++ random number generation

### DIFF
--- a/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
+++ b/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
@@ -9,11 +9,29 @@
 #include "ZzzCharacter.h"
 #include "ZzzLodTerrain.h"
 #include "ZzzTexture.h"
-#include "ZzzAi.h"
+#include "ZzzAI.h"
 #include "ZzzEffect.h"
 #include "DSPlaySound.h"
-#include "WSClient.h"
+#include "WSclient.h"
 #include "SkillManager.h"
+
+#include <cmath>
+#include <random>
+
+namespace
+{
+std::mt19937& RandomEngine()
+{
+    static std::mt19937 engine{std::random_device{}()};
+    return engine;
+}
+
+float RandomFloat(float minInclusive, float maxInclusive)
+{
+    std::uniform_real_distribution<float> dist(minInclusive, maxInclusive);
+    return dist(RandomEngine());
+}
+} // namespace
 
 void RenderCircle(int Type, vec3_t ObjectPosition, float ScaleBottom, float ScaleTop, float Height, float Rotation, float LightTop, float TextureV)
 {
@@ -309,7 +327,7 @@ void CreateArrows(CHARACTER* c, OBJECT* o, OBJECT* to, WORD SkillIndex, WORD Ski
             vec3_t a;
             for (int i = 0; i < 15; ++i)
             {
-                Vector((float)(rand() % 360), 0.f, 0.f, a);
+                Vector(RandomFloat(0.f, 360.f), 0.f, 0.f, a);
                 if (rand_fps_check(2))
                 {
                     CreateJoint(BITMAP_JOINT_SPARK, Position, Position, a, 3);

--- a/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
+++ b/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
@@ -28,8 +28,9 @@ std::mt19937& RandomEngine()
 
 float RandomFloat(float minInclusive, float maxInclusive)
 {
-    std::uniform_real_distribution<float> dist(minInclusive, maxInclusive);
-    return dist(RandomEngine());
+    static std::uniform_real_distribution<float> dist;
+    using Dist = std::uniform_real_distribution<float>;
+    return dist(RandomEngine(), Dist::param_type{minInclusive, maxInclusive});
 }
 } // namespace
 


### PR DESCRIPTION
Replaced rand() call with std::mt19937-based RandomFloat helper function in anonymous namespace for arrow effect angle generation. Changed manual range calculation from rand() % 360 to RandomFloat(0.f, 360.f) with inclusive min/max parameters.