### PR TITLE
Refactor pointer effect system to use modern C++ random number generation

### DIFF
--- a/Source Main 5.2/source/ZzzEffectPointer.cpp
+++ b/Source Main 5.2/source/ZzzEffectPointer.cpp
@@ -9,10 +9,27 @@
 #include "ZzzCharacter.h"
 #include "ZzzLodTerrain.h"
 #include "ZzzTexture.h"
-#include "ZzzAi.h"
+#include "ZzzAI.h"
 #include "ZzzEffect.h"
 #include "DSPlaySound.h"
-#include "WSClient.h"
+#include "WSclient.h"
+
+#include <random>
+
+namespace
+{
+std::mt19937& RandomEngine()
+{
+    static std::mt19937 engine{std::random_device{}()};
+    return engine;
+}
+
+int RandomInt(int minInclusive, int maxInclusive)
+{
+    std::uniform_int_distribution<int> dist(minInclusive, maxInclusive);
+    return dist(RandomEngine());
+}
+} // namespace
 
 PARTICLE  Pointers[MAX_POINTERS];
 
@@ -37,7 +54,7 @@ void CreatePointer(int Type, vec3_t Position, float Angle, vec3_t Light, float S
             case BITMAP_BLOOD:
             case BITMAP_BLOOD + 1:
             case BITMAP_FOOT:
-                o->LifeTime = 50 + rand() % 32;
+                o->LifeTime = 50 + RandomInt(0, 31);
                 break;
             }
             return;

--- a/Source Main 5.2/source/ZzzEffectPointer.cpp
+++ b/Source Main 5.2/source/ZzzEffectPointer.cpp
@@ -26,8 +26,9 @@ std::mt19937& RandomEngine()
 
 int RandomInt(int minInclusive, int maxInclusive)
 {
-    std::uniform_int_distribution<int> dist(minInclusive, maxInclusive);
-    return dist(RandomEngine());
+    static std::uniform_int_distribution<int> dist;
+    using Dist = std::uniform_int_distribution<int>;
+    return dist(RandomEngine(), Dist::param_type{minInclusive, maxInclusive});
 }
 } // namespace
 


### PR DESCRIPTION
Replaced rand() call with std::mt19937-based RandomInt helper function in anonymous namespace. Changed manual range calculation from rand() % 32 to RandomInt(0, 31) with inclusive min/max parameters for lifetime generation.