### PR TITLE
Refactor texture loading and JPEG handling to use modern C++ standard library

### DIFF
--- a/Source Main 5.2/source/ZzzTexture.cpp
+++ b/Source Main 5.2/source/ZzzTexture.cpp
@@ -3,6 +3,10 @@
 
 #include "stdafx.h"
 #include <setjmp.h>
+#include <array>
+#include <cstdio>
+#include <string>
+#include <vector>
 #include "ZzzTexture.h"
 
 #include "WSclient.h"
@@ -12,98 +16,139 @@ CGlobalBitmap Bitmaps;
 
 bool WriteJpeg(wchar_t* filename, int Width, int Height, unsigned char* Buffer, int quality)
 {
-    FILE* outfile;
-    if ((outfile = _wfopen(filename, L"wb")) == NULL)
+    auto outfile = _wfopen(filename, L"wb");
+    if (outfile == nullptr)
     {
-        //fprintf(stderr, L"can't open %s\n", filename);
-        //exit(1);
-        return FALSE;
+        return false;
     }
 
     const auto handle = tjInitCompress();
-    unsigned long jpegSize = 0;
-    auto maxSize = tjBufSize(Width, Height, TJSAMP_444);
-    auto outputBuffer = new unsigned char[maxSize];
-    
-    tjCompress2(handle, Buffer, Width, 0, Height, TJPF_RGB, &outputBuffer, &jpegSize, TJSAMP_444, quality, TJFLAG_BOTTOMUP);
-    fwrite(outputBuffer, 1, jpegSize, outfile);
+    if (handle == nullptr)
+    {
+        fclose(outfile);
+        return false;
+    }
+
+    const auto maxSize = tjBufSize(Width, Height, TJSAMP_444);
+    std::vector<unsigned char> outputBuffer(maxSize);
+    unsigned long jpegSize = maxSize;
+    unsigned char* jpegPtr = outputBuffer.data();
+    const int flags = TJFLAG_BOTTOMUP | TJFLAG_NOREALLOC;
+    const auto result = tjCompress2(handle, Buffer, Width, 0, Height, TJPF_RGB, &jpegPtr, &jpegSize, TJSAMP_444, quality, flags);
+
+    bool success = (result == 0);
+    if (success)
+    {
+        fwrite(jpegPtr, 1, jpegSize, outfile);
+    }
+
     fclose(outfile);
     tjDestroy(handle);
-
-    return TRUE;
+    return success;
 }
+
+namespace
+{
+std::wstring NormalizeExtension(const wchar_t* Ext)
+{
+    if (Ext == nullptr || Ext[0] == L'\0')
+    {
+        return {};
+    }
+    std::wstring result = Ext;
+    if (result.front() != L'.')
+    {
+        result.insert(result.begin(), L'.');
+    }
+    return result;
+}
+} // namespace
 
 void SaveImage(int HeaderSize, wchar_t* Ext, wchar_t* filename, BYTE* PakBuffer, int Size)
 {
-    if (PakBuffer == NULL || Size == 0)
+    if (filename == nullptr || Ext == nullptr)
     {
-        wchar_t OpenFileName[256];
-        wcscpy(OpenFileName, L"Data2\\");
-        wcscat(OpenFileName, filename);
-        FILE* fp = _wfopen(OpenFileName, L"rb");
-        if (fp == NULL)
+        return;
+    }
+
+    const bool hasExternalBuffer = (PakBuffer != nullptr && Size > 0);
+    std::vector<unsigned char> localBuffer;
+    if (!hasExternalBuffer)
+    {
+        std::wstring openFileName = L"Data2\\";
+        openFileName += filename;
+        auto fp = _wfopen(openFileName.c_str(), L"rb");
+        if (fp == nullptr)
         {
             return;
         }
         fseek(fp, 0, SEEK_END);
-        Size = ftell(fp);
+        const auto fileSize = ftell(fp);
         fseek(fp, 0, SEEK_SET);
-        PakBuffer = new unsigned char[Size];
-        fread(PakBuffer, 1, Size, fp);
+        if (fileSize <= 0)
+        {
+            fclose(fp);
+            return;
+        }
+        localBuffer.resize(static_cast<size_t>(fileSize));
+        fread(localBuffer.data(), 1, localBuffer.size(), fp);
         fclose(fp);
     }
 
-    wchar_t Header[24];
-    memcpy(Header, PakBuffer, HeaderSize);
-
-    wchar_t NewFileName[256];
-    int iTextcnt = 0;
-    for (int i = 0; i < (int)wcslen(filename); i++)
+    const unsigned char* buffer = hasExternalBuffer ? PakBuffer : localBuffer.data();
+    const size_t bufferSize = hasExternalBuffer ? static_cast<size_t>(Size) : localBuffer.size();
+    if (buffer == nullptr || bufferSize == 0 || bufferSize < static_cast<size_t>(HeaderSize))
     {
-        iTextcnt = i;
-        NewFileName[i] = filename[i];
-        if (filename[i] == '.') break;
+        return;
     }
-    NewFileName[iTextcnt + 1] = NULL;
-    wcscat(NewFileName, Ext);
-    wchar_t SaveFileName[256];
-    wcscpy(SaveFileName, L"Data\\");
-    wcscat(SaveFileName, NewFileName);
-    FILE* fp = _wfopen(SaveFileName, L"wb");
-    if (fp == NULL) return;
-    fwrite(Header, 1, HeaderSize, fp);
-    fwrite(PakBuffer, 1, Size, fp);
+
+    std::vector<unsigned char> header(buffer, buffer + HeaderSize);
+
+    std::wstring newFileName = filename;
+    const auto normalizedExt = NormalizeExtension(Ext);
+    const auto dotPos = newFileName.find_last_of(L'.');
+    if (dotPos != std::wstring::npos)
+    {
+        newFileName = newFileName.substr(0, dotPos);
+    }
+    newFileName += normalizedExt;
+
+    std::wstring saveFileName = L"Data\\";
+    saveFileName += newFileName;
+
+    auto fp = _wfopen(saveFileName.c_str(), L"wb");
+    if (fp == nullptr)
+    {
+        return;
+    }
+
+    fwrite(header.data(), 1, HeaderSize, fp);
+    fwrite(buffer, 1, bufferSize, fp);
     fclose(fp);
-
-    if (PakBuffer == NULL || Size == 0)
-    {
-        SAFE_DELETE_ARRAY(PakBuffer);
-    }
 }
 
 bool OpenJpegBuffer(wchar_t* filename, float* BufferFloat)
 {
-    
-    wchar_t FileName[256];
-
-    wchar_t NewFileName[256];
-    int iTextcnt = 0;
-    for (int i = 0; i < (int)wcslen(filename); i++)
+    if (filename == nullptr || BufferFloat == nullptr)
     {
-        iTextcnt = i;
-        NewFileName[i] = filename[i];
-        if (filename[i] == '.') break;
+        return false;
     }
-    NewFileName[iTextcnt + 1] = NULL;
-    wcscpy(FileName, L"Data\\");
-    wcscat(FileName, NewFileName);
-    wcscat(FileName, L"OZJ");
 
-    auto compressedFile = _wfopen(FileName, L"rb");
+    std::wstring newFileName = filename;
+    const auto dotPos = newFileName.find_last_of(L'.');
+    if (dotPos != std::wstring::npos)
+    {
+        newFileName = newFileName.substr(0, dotPos);
+    }
+    std::wstring fileName = L"Data\\";
+    fileName += newFileName;
+    fileName += L".OZJ";
+
+    auto compressedFile = _wfopen(fileName.c_str(), L"rb");
     if (compressedFile == nullptr)
     {
         wchar_t Text[256];
-        swprintf(Text, L"%s - File not exist.", FileName);
+        swprintf(Text, L"%ls - File not exist.", fileName.c_str());
         g_ErrorReport.Write(Text);
         g_ErrorReport.Write(L"\r\n");
         MessageBox(g_hWnd, Text, NULL, MB_OK);
@@ -115,50 +160,48 @@ bool OpenJpegBuffer(wchar_t* filename, float* BufferFloat)
     const auto fileSize = ftell(compressedFile);
     if (fileSize < 24)
     {
+        fclose(compressedFile);
         return false;
     }
 
-    // Skip first 24 bytes, because these are added by the OZJ format
     fseek(compressedFile, 24, SEEK_SET);
-
     const auto jpegSize = fileSize - 24;
-    int jpegWidth = 0, jpegHeight = 0;
+    std::vector<unsigned char> jpegBuf(static_cast<size_t>(jpegSize));
+    fread(jpegBuf.data(), 1, jpegBuf.size(), compressedFile);
+    fclose(compressedFile);
+
+    int jpegWidth = 0;
+    int jpegHeight = 0;
     int jpegSubsamp = TJSAMP_444;
     int jpegColorspace = TJCS_RGB;
 
     auto tjhandle = tjInitDecompress();
-
-    auto jpegBuf = new BYTE[jpegSize];
-    fread(jpegBuf, 1, jpegSize, compressedFile);
-    fclose(compressedFile);
-
-    // First reading the header with the size information
-    auto result = tjDecompressHeader3(tjhandle, jpegBuf, jpegSize, &jpegWidth, &jpegHeight, &jpegSubsamp, &jpegColorspace);
-    if (result != 0)
+    if (tjhandle == nullptr)
     {
-        delete[] jpegBuf;
         return false;
     }
 
-    // decompress into the buffer
-    const auto bufferSize = jpegWidth * jpegHeight * 3;
-    const auto buffer = new BYTE[bufferSize];
-    result = tjDecompress2(tjhandle, jpegBuf, jpegSize, buffer, jpegWidth, 0, jpegHeight, TJPF_RGB, TJFLAG_BOTTOMUP);
-    delete[] jpegBuf;
-    jpegBuf = nullptr;
+    auto result = tjDecompressHeader3(tjhandle, jpegBuf.data(), jpegBuf.size(), &jpegWidth, &jpegHeight, &jpegSubsamp, &jpegColorspace);
     if (result != 0)
     {
-        delete[] buffer;
+        tjDestroy(tjhandle);
         return false;
     }
 
-    for (int i = 0; i < bufferSize; ++i)
+    const auto bufferSize = static_cast<size_t>(jpegWidth) * static_cast<size_t>(jpegHeight) * 3;
+    std::vector<unsigned char> buffer(bufferSize);
+    result = tjDecompress2(tjhandle, jpegBuf.data(), jpegBuf.size(), buffer.data(), jpegWidth, 0, jpegHeight, TJPF_RGB, TJFLAG_BOTTOMUP);
+    tjDestroy(tjhandle);
+    if (result != 0)
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < bufferSize; ++i)
     {
         BufferFloat[i] = static_cast<float>(buffer[i]) / 255.f;
     }
 
-    delete[] buffer;
-    
     return true;
 }
 
@@ -188,7 +231,7 @@ bool LoadBitmap(const wchar_t* szFileName, GLuint uiTextureIndex, GLuint uiFilte
         if (false == Bitmaps.LoadImage(uiTextureIndex, szFullPath, uiFilter, uiWrapMode))
         {
             wchar_t szErrorMsg[256] = { 0, };
-            swprintf(szErrorMsg, L"LoadBitmap Failed: %s", szFullPath);
+            swprintf(szErrorMsg, L"LoadBitmap Failed: %ls", szFullPath);
 #ifdef FOR_WORK
             PopUpErrorCheckMsgBox(szErrorMsg);
 #else // FOR_WORK


### PR DESCRIPTION
Replaced C-style file I/O and manual memory management with std::vector for automatic cleanup. Added nullptr checks and error handling for file operations and TurboJPEG calls. Extracted extension normalization logic into NormalizeExtension helper function in anonymous namespace. Replaced manual string manipulation with std::wstring operations (find_last_of, substr). Changed TRUE/FALSE to true/false.