### PR TITLE
Refactor bone manager to use modern C++ standard library and improve memory management

### DIFF
--- a/Source Main 5.2/source/BoneManager.cpp
+++ b/Source Main 5.2/source/BoneManager.cpp
@@ -77,19 +77,11 @@ void CBoneManager::UnregisterBone(CHARACTER* pCharacter, const std::wstring& nam
 }
 void CBoneManager::UnregisterBone(CHARACTER* pCharacter)
 {
-    auto iter = m_listBone.begin();
-    while (iter != m_listBone.end())
-    {
-        const auto& boneInfo = *iter;
-        if (boneInfo && boneInfo->pCharacter == pCharacter)
+    m_listBone.remove_if(
+        [pCharacter](const std::unique_ptr<BONEINFO>& boneInfo)
         {
-            iter = m_listBone.erase(iter);
-        }
-        else
-        {
-            ++iter;
-        }
-    }
+            return boneInfo && boneInfo->pCharacter == pCharacter;
+        });
 }
 void CBoneManager::UnregisterAll()
 {
@@ -160,9 +152,7 @@ CBoneManager::t_bone_list::iterator CBoneManager::FindBoneIterator(OBJECT* pObje
         m_listBone.end(),
         [pObject, &name](const std::unique_ptr<BONEINFO>& boneInfo)
         {
-            return boneInfo != nullptr &&
-                boneInfo->pCharacter != nullptr &&
-                (&boneInfo->pCharacter->Object == pObject) &&
+            return (&boneInfo->pCharacter->Object == pObject) &&
                 (boneInfo->name == name);
         });
 }
@@ -174,9 +164,7 @@ CBoneManager::t_bone_list::const_iterator CBoneManager::FindBoneIterator(OBJECT*
         m_listBone.cend(),
         [pObject, &name](const std::unique_ptr<BONEINFO>& boneInfo)
         {
-            return boneInfo != nullptr &&
-                boneInfo->pCharacter != nullptr &&
-                (&boneInfo->pCharacter->Object == pObject) &&
+            return (&boneInfo->pCharacter->Object == pObject) &&
                 (boneInfo->name == name);
         });
 }

--- a/Source Main 5.2/source/BoneManager.h
+++ b/Source Main 5.2/source/BoneManager.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
-#include "zzzinfomation.h"
+#include <list>
+#include <memory>
+#include <string>
+
+#include "ZzzInfomation.h"
 #include "ZzzBMD.h"
 #include "ZzzObject.h"
 #include "ZzzCharacter.h"
@@ -21,17 +25,17 @@ namespace BoneManager {
 }
 
 class CBoneManager {
-    typedef struct __BONEINFO
+    struct BONEINFO
     {
-        std::wstring	name;	// bone name
+        std::wstring name; // bone name
+        CHARACTER* pCharacter{ nullptr };
+        BMD* pModel{ nullptr };
+        int nBone{ -1 };
+    };
+    using LPBONEINFO = BONEINFO*;
+    using t_bone_list = std::list<std::unique_ptr<BONEINFO>>;
 
-        CHARACTER* pCharacter;
-        BMD* pModel;
-        int			nBone;
-    } BONEINFO, * LPBONEINFO;
-
-    typedef std::list<LPBONEINFO> t_bone_list;
-    t_bone_list	m_listBone;
+    t_bone_list m_listBone;
 
 public:
     ~CBoneManager();
@@ -52,6 +56,8 @@ protected:
     CBoneManager();		//. ban create instance
 
     LPBONEINFO FindBone(OBJECT* pObject, const std::wstring& name);
+    t_bone_list::iterator FindBoneIterator(OBJECT* pObject, const std::wstring& name);
+    t_bone_list::const_iterator FindBoneIterator(OBJECT* pObject, const std::wstring& name) const;
 };
 
 #endif // _BONEMANAGER_H_


### PR DESCRIPTION
Replaced raw pointers with std::unique_ptr for BONEINFO members in bone list. Changed manual memory management (new/delete) to std::make_unique for automatic cleanup. Replaced manual list iteration with std::find_if algorithm and lambda predicates. Added FindBoneIterator helper methods with const and non-const overloads. Simplified UnregisterAll to rely on automatic cleanup.