### PR TITLE
Refactor button UI control to use modern C++ containers and safer text/color handling

### DIFF
--- a/Source Main 5.2/source/Button.cpp
+++ b/Source Main 5.2/source/Button.cpp
@@ -311,5 +311,5 @@ int CButton::ResolveColorIndex(int requestedIndex) const
     }
 
     const int clamped = ClampStateIndex(requestedIndex);
-    return std::min(clamped, static_cast<int>(m_textColorCount - 1));
+    return std::min<int>(clamped, static_cast<int>(m_textColorCount - 1));
 }

--- a/Source Main 5.2/source/Button.h
+++ b/Source Main 5.2/source/Button.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
+#include <string>
+
 #include "Sprite.h"
 
 #define	BTN_UP				0
@@ -22,12 +26,12 @@ protected:
     bool	m_bClick;
     bool	m_bCheck;
 
-    int		m_anImgMap[BTN_IMG_MAX];
-
-    wchar_t* m_szText;
-    DWORD* m_adwTextColorMap;
-    DWORD	m_dwTextColor;
-    float	m_fTextAddYPos;
+    std::array<int, BTN_IMG_MAX> m_imageFrames{};
+    std::wstring m_text;
+    std::array<DWORD, BTN_IMG_MAX> m_textColors{};
+    std::size_t m_textColorCount{0};
+    DWORD	m_textColor{0};
+    float	m_fTextAddYPos{0.0f};
 
 public:
     CButton();
@@ -46,8 +50,12 @@ public:
     void SetCheck(bool bCheck = true) { m_bCheck = bCheck; }
     bool IsCheck() { return m_bCheck; }
     void SetText(const wchar_t* pszText, DWORD* adwColor);
-    wchar_t* GetText() const { return m_szText; }
+    wchar_t* GetText() const;
 
 protected:
     void ReleaseText();
+    void ApplyVisualState(int frameIndex);
+    void ApplyTextColorForState(int colorIndex);
+    bool HasCheckVisuals() const;
+    int ResolveColorIndex(int requestedIndex) const;
 };

--- a/Source Main 5.2/source/Button.h
+++ b/Source Main 5.2/source/Button.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <vector>
 
 #include "Sprite.h"
 
@@ -28,6 +29,7 @@ protected:
 
     std::array<int, BTN_IMG_MAX> m_imageFrames{};
     std::wstring m_text;
+    mutable std::vector<wchar_t> m_textBuffer;
     std::array<DWORD, BTN_IMG_MAX> m_textColors{};
     std::size_t m_textColorCount{0};
     DWORD	m_textColor{0};


### PR DESCRIPTION
Replaced raw wchar_t*/DWORD* allocations and SAFE_DELETE_ARRAY cleanup with std::wstring and std::array storage for caption text and per-state text colors. Switched m_anImgMap to std::array<int, BTN_IMG_MAX> and added helper functions (ApplyVisualState, ApplyTextColorForState, ResolveColorIndex) to centralize frame/color selection logic. Normalized Button.cpp to UTF-8 and made GetText() return a stable pointer to the internal std::wstring buffer (or nullptr when empty) for backward compatibility.