### PR TITLE
Refactor CBT message box to use modern C++ standard library and improve positioning logic

### DIFF
--- a/Source Main 5.2/source/CBTMessageBox.cpp
+++ b/Source Main 5.2/source/CBTMessageBox.cpp
@@ -12,7 +12,7 @@ namespace
 {
     int ClampInt(int value, int minValue, int maxValue)
     {
-        return std::min(std::max(value, minValue), maxValue);
+        return std::min<int>(std::max<int>(value, minValue), maxValue);
     }
 
     POINT ComputeCenteredTopLeft(const RECT& parentRect, const RECT& childRect, const RECT& desktopRect)
@@ -29,8 +29,8 @@ namespace
 
         const int desktopRight = static_cast<int>(desktopRect.right);
         const int desktopBottom = static_cast<int>(desktopRect.bottom);
-        const int maxX = std::max(0, desktopRight - width);
-        const int maxY = std::max(0, desktopBottom - height);
+        const int maxX = std::max<int>(0, desktopRight - width);
+        const int maxY = std::max<int>(0, desktopBottom - height);
 
         result.x = ClampInt(result.x, 0, maxX);
         result.y = ClampInt(result.y, 0, maxY);

--- a/Source Main 5.2/source/CBTMessageBox.cpp
+++ b/Source Main 5.2/source/CBTMessageBox.cpp
@@ -40,6 +40,10 @@ namespace
     struct ScopedCbtUnhook
     {
         leaf::CCBTMessageBox* owner{nullptr};
+        ScopedCbtUnhook(const ScopedCbtUnhook&) = delete;
+        ScopedCbtUnhook& operator=(const ScopedCbtUnhook&) = delete;
+        ScopedCbtUnhook(ScopedCbtUnhook&&) = delete;
+        ScopedCbtUnhook& operator=(ScopedCbtUnhook&&) = delete;
         ~ScopedCbtUnhook()
         {
             if (owner)


### PR DESCRIPTION
Replaced NULL with nullptr throughout. Changed manual min/max calculations to std::min/std::max in ClampInt helper function. Extracted centering logic into ComputeCenteredTopLeft helper function in anonymous namespace. Added ScopedCbtUnhook RAII guard to ensure UnhookCBT is called automatically. Simplified OpenMessageBox to use ternary operator for parent window selection and added early return for hook failure.