### PR TITLE
Fix RandomInt distribution initialization

### DIFF
--- a/Source Main 5.2/source/ZzzEffectFireLeave.cpp
+++ b/Source Main 5.2/source/ZzzEffectFireLeave.cpp
@@ -32,19 +32,16 @@ std::mt19937& RandomEngine()
     return engine;
 }
 
-static std::uniform_int_distribution<int> g_uniformIntDistribution;
-static std::uniform_real_distribution<float> g_uniformFloatDistribution;
-
 int RandomInt(int minInclusive, int maxInclusive)
 {
-    using Dist = std::uniform_int_distribution<int>;
-    return g_uniformIntDistribution(RandomEngine(), Dist::param_type{minInclusive, maxInclusive});
+    std::uniform_int_distribution<int> dist(minInclusive, maxInclusive);
+    return dist(RandomEngine());
 }
 
 float RandomFloat(float minInclusive, float maxInclusive)
 {
-    using Dist = std::uniform_real_distribution<float>;
-    return g_uniformFloatDistribution(RandomEngine(), Dist::param_type{minInclusive, maxInclusive});
+    std::uniform_real_distribution<float> dist(minInclusive, maxInclusive);
+    return dist(RandomEngine());
 }
 } // namespace
 

--- a/Source Main 5.2/source/ZzzEffectPointer.cpp
+++ b/Source Main 5.2/source/ZzzEffectPointer.cpp
@@ -26,9 +26,8 @@ std::mt19937& RandomEngine()
 
 int RandomInt(int minInclusive, int maxInclusive)
 {
-    static std::uniform_int_distribution<int> dist;
-    using Dist = std::uniform_int_distribution<int>;
-    return dist(RandomEngine(), Dist::param_type{minInclusive, maxInclusive});
+    std::uniform_int_distribution<int> dist(minInclusive, maxInclusive);
+    return dist(RandomEngine());
 }
 } // namespace
 


### PR DESCRIPTION
Refactors RandomInt to create distributions with parameters directly instead of using a static distribution with param_type, fixing incorrect behavior across calls.

Follow-up to #202.