### PR TITLE
Fix std::min and std::max template type parameters

### DIFF
--- a/Source Main 5.2/source/CameraMove.cpp
+++ b/Source Main 5.2/source/CameraMove.cpp
@@ -46,7 +46,7 @@ namespace
     template <typename T>
     constexpr const T& Clamp(const T& value, const T& minValue, const T& maxValue)
     {
-        return std::max(minValue, std::min(value, maxValue));
+        return std::max<T>(minValue, std::min<T>(value, maxValue));
     }
 
     template <std::size_t Size>
@@ -229,7 +229,7 @@ void CCameraMove::AddWayPoint(int iGridX, int iGridY, float fCameraMoveAccel, fl
 
     waypoint->fCameraMoveAccel = Clamp(fCameraMoveAccel, kMinMoveAccel, kMaxMoveAccel);
     waypoint->fCameraDistanceLevel = Clamp(fCameraDistanceLevel, kMinDistanceLevel, kMaxDistanceLevel);
-    waypoint->iDelay = std::max(iDelay, 0);
+    waypoint->iDelay = std::max<int>(iDelay, 0);
 
     m_listWayPoint.push_back(std::move(waypoint));
 }
@@ -276,7 +276,7 @@ void CCameraMove::SetCameraDistanceLevel(int iTileIndex, float fCameraDistanceLe
 }
 void CCameraMove::SetDelay(int iTileIndex, int iDelay)
 {
-    const int clampedDelay = std::max(iDelay, 0);
+    const int clampedDelay = std::max<int>(iDelay, 0);
     for (auto& waypoint : m_listWayPoint)
     {
         if (waypoint->iIndex == iTileIndex)

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -733,7 +733,7 @@ void CalcFPS()
     frame++;
     WorldTime = g_WorldTime->GetTimeElapsed();
 
-    const double differenceMs = std::max(WorldTime - last, MIN_FRAME_TIME_MS);
+    const double differenceMs = std::max<double>(WorldTime - last, MIN_FRAME_TIME_MS);
     FPS = MILLISECONDS_IN_SECOND / differenceMs;
 
     // animate with no less than REFERENCE_FPS, otherwise some animations don't work correctly

--- a/Source Main 5.2/source/ZzzEffectBlurSpark.cpp
+++ b/Source Main 5.2/source/ZzzEffectBlurSpark.cpp
@@ -120,7 +120,7 @@ void AddBlur(Blur* b, vec3_t p1, vec3_t p2, vec3_t Light, int Type)
     }
     VectorCopy(p1, b->P1[0]);
     VectorCopy(p2, b->P2[0]);
-    b->Number = std::min(b->Number + 1, MAX_BLUR_TAILS - 1);
+    b->Number = std::min<int>(b->Number + 1, MAX_BLUR_TAILS - 1);
 }
 
 void CreateBlur(CHARACTER* Owner, vec3_t p1, vec3_t p2, vec3_t Light, int Type, bool Short, int SubType)
@@ -167,7 +167,7 @@ void MoveBlurs()
         }
 
         blur.LifeTime--;
-        blur.Number = std::max(blur.Number - 1, 0);
+        blur.Number = std::max<int>(blur.Number - 1, 0);
 
         for (int i = blur.Number - 1; i >= 0; --i)
         {
@@ -177,7 +177,7 @@ void MoveBlurs()
 
         if (blur.LifeTime <= 0)
         {
-            blur.Number = std::max(blur.Number - 1, 0);
+            blur.Number = std::max<int>(blur.Number - 1, 0);
             if (blur.Number <= 0)
             {
                 blur.Live = false;
@@ -280,7 +280,7 @@ void AddObjectBlur(ObjectBlur* b, vec3_t p1, vec3_t p2, vec3_t Light, int Type)
     }
     VectorCopy(p1, b->P1[0]);
     VectorCopy(p2, b->P2[0]);
-    b->Number = std::min(b->Number + 1, MAX_OBJECT_BLUR_TAILS - 1);
+    b->Number = std::min<int>(b->Number + 1, MAX_OBJECT_BLUR_TAILS - 1);
 }
 
 void CreateObjectBlur(OBJECT* Owner, vec3_t p1, vec3_t p2, vec3_t Light, int Type, bool Short, int SubType, int iLimitLifeTime)
@@ -337,7 +337,7 @@ void MoveObjectBlurs()
         }
 
         blur.LifeTime--;
-        blur.Number = std::max(blur.Number - 1, 0);
+        blur.Number = std::max<int>(blur.Number - 1, 0);
 
         if (blur.LifeTime <= 0)
         {


### PR DESCRIPTION
Add explicit template type parameters to std::min and std::max calls for improved type safety and consistency