### PR TITLE
Refactor credit window to use modern C++ standard library and improve resource management

### DIFF
--- a/Source Main 5.2/source/CreditWin.cpp
+++ b/Source Main 5.2/source/CreditWin.cpp
@@ -91,6 +91,8 @@ CCreditWin::CCreditWin()
     , m_font(nullptr, &FontDeleter)
     , m_nNowIndex(0)
     , m_nNameCount(0)
+    , m_anTextIndex{}
+    , m_aeTextState{}
     , m_textElapsed(DurationMs::zero())
 {
 }
@@ -246,7 +248,7 @@ void CCreditWin::RenderControls()
 	case 2:
 		nTextBoxWidth = lScreenWidth / 4 / g_fScreenRate_x;
 		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]], 160, 72, nTextBoxWidth);
-		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]], 320, 72, nTextBoxWidth);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME1]], 320, 72, nTextBoxWidth);
 		break;
 	case 3:
 		nTextBoxWidth = lScreenWidth / 3 / g_fScreenRate_x;
@@ -376,7 +378,15 @@ void CCreditWin::LoadText()
 	}
 
 	const std::size_t nSize = sizeof(SCreditItem) * CRW_ITEM_MAX;
-	std::fread(m_aCredit, nSize, 1, file.get());
+	if (std::fread(m_aCredit, nSize, 1, file.get()) != 1)
+	{
+		wchar_t szMessage[256];
+		std::swprintf(szMessage, std::size(szMessage), L"Failed to read %hs file or file is corrupt.\r\n", kCreditDataPath.data());
+		g_ErrorReport.Write(szMessage);
+		::MessageBox(g_hWnd, szMessage, NULL, MB_OK);
+		::PostMessage(g_hWnd, WM_DESTROY, 0, 0);
+		return;
+	}
 	::BuxConvert(reinterpret_cast<BYTE*>(m_aCredit), static_cast<int>(nSize));
 }
 

--- a/Source Main 5.2/source/CreditWin.cpp
+++ b/Source Main 5.2/source/CreditWin.cpp
@@ -16,18 +16,82 @@
 
 #include "UIControls.h"
 
-#define	CRW_ILLUST_FADE_TIME	2000.0 
-#define	CRW_ILLUST_SHOW_TIME	22000.0
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cwchar>
+#include <memory>
+#include <string_view>
 
-#define	CRW_TEXT_FADE_TIME		1000.0
-#define	CRW_NAME_SHOW_TIME		2300.0
+namespace
+{
+    using DurationMs = std::chrono::duration<double, std::milli>;
 
-#define	CRW_DATA_FILE		"Data\\Local\\credit.bmd"
+    constexpr DurationMs kIllustFadeDuration{2000.0};
+    constexpr DurationMs kIllustShowDuration{22000.0};
+    constexpr DurationMs kTextFadeDuration{1000.0};
+    constexpr DurationMs kNameShowDuration{2300.0};
+    constexpr std::string_view kCreditDataPath = "Data\\Local\\credit.bmd";
+
+    constexpr std::array<std::array<const wchar_t*, 2>, CRW_ILLUST_MAX> kIllustPaths = {{
+        {L"Interface\\im1_1.jpg", L"Interface\\im1_2.jpg"},
+        {L"Interface\\im2_1.jpg", L"Interface\\im2_2.jpg"},
+        {L"Interface\\im3_1.jpg", L"Interface\\im3_2.jpg"},
+        {L"Interface\\im4_1.jpg", L"Interface\\im4_2.jpg"},
+        {L"Interface\\im5_1.jpg", L"Interface\\im5_2.jpg"},
+        {L"Interface\\im6_1.jpg", L"Interface\\im6_2.jpg"},
+        {L"Interface\\im7_1.jpg", L"Interface\\im7_2.jpg"},
+        {L"Interface\\im8_1.jpg", L"Interface\\im8_2.jpg"},
+    }};
+
+    template<typename T>
+    short IncreaseAlpha(short alpha, T ratio)
+    {
+        const double delta = 255.0 * std::clamp(static_cast<double>(ratio), 0.0, 1.0);
+        return static_cast<short>(std::min(255.0, static_cast<double>(alpha) + delta));
+    }
+
+    template<typename T>
+    short DecreaseAlpha(short alpha, T ratio)
+    {
+        const double delta = 255.0 * std::clamp(static_cast<double>(ratio), 0.0, 1.0);
+        return static_cast<short>(std::max(0.0, static_cast<double>(alpha) - delta));
+    }
+
+    template<std::size_t N>
+    void CopyNameToWide(const char* source, wchar_t (&destination)[N])
+    {
+        if (source == nullptr)
+        {
+            destination[0] = L'\0';
+            return;
+        }
+
+        std::mbstowcs(destination, source, N);
+        destination[N - 1] = L'\0';
+    }
+
+    void FontDeleter(HFONT font)
+    {
+        if (font != nullptr)
+        {
+            ::DeleteObject(font);
+        }
+    }
+}
 
 
 
 
-CCreditWin::CCreditWin() : m_hFont(NULL)
+CCreditWin::CCreditWin()
+    : m_eIllustState(HIDE)
+    , m_illustElapsed(DurationMs::zero())
+    , m_byIllust(0)
+    , m_illustPaths(kIllustPaths)
+    , m_font(nullptr, &FontDeleter)
+    , m_nNowIndex(0)
+    , m_nNameCount(0)
+    , m_textElapsed(DurationMs::zero())
 {
 }
 
@@ -60,24 +124,6 @@ void CCreditWin::Create()
 	m_btnClose.Create(54, 30, BITMAP_BUTTON + 2, 3, 2, 1);
 	CWin::RegisterButton(&m_btnClose);
 
-	m_eIllustState = HIDE;
-	m_apszIllustPath[0][0] = L"Interface\\im1_1.jpg";
-	m_apszIllustPath[0][1] = L"Interface\\im1_2.jpg";
-	m_apszIllustPath[1][0] = L"Interface\\im2_1.jpg";
-	m_apszIllustPath[1][1] = L"Interface\\im2_2.jpg";
-	m_apszIllustPath[2][0] = L"Interface\\im3_1.jpg";
-	m_apszIllustPath[2][1] = L"Interface\\im3_2.jpg";
-	m_apszIllustPath[3][0] = L"Interface\\im4_1.jpg";
-	m_apszIllustPath[3][1] = L"Interface\\im4_2.jpg";
-	m_apszIllustPath[4][0] = L"Interface\\im5_1.jpg";
-	m_apszIllustPath[4][1] = L"Interface\\im5_2.jpg";
-	m_apszIllustPath[5][0] = L"Interface\\im6_1.jpg";
-	m_apszIllustPath[5][1] = L"Interface\\im6_2.jpg";
-	m_apszIllustPath[6][0] = L"Interface\\im7_1.jpg";
-	m_apszIllustPath[6][1] = L"Interface\\im7_2.jpg";
-	m_apszIllustPath[7][0] = L"Interface\\im8_1.jpg";
-	m_apszIllustPath[7][1] = L"Interface\\im8_2.jpg";
-
 	int nFontSize = 10;
 	switch (rInput.GetScreenWidth())
 	{
@@ -85,7 +131,8 @@ void CCreditWin::Create()
 	case 1024:	nFontSize = 18;	break;
 	case 1280:	nFontSize = 24;	break;
 	}
-	m_hFont = CreateFont(nFontSize, 0, 0, 0, FW_BOLD, 0, 0, 0, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, NONANTIALIASED_QUALITY, DEFAULT_PITCH | FF_DONTCARE, GlobalText[0][0] ? GlobalText[0] : NULL);
+	HFONT fontHandle = CreateFont(nFontSize, 0, 0, 0, FW_BOLD, 0, 0, 0, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, NONANTIALIASED_QUALITY, DEFAULT_PITCH | FF_DONTCARE, GlobalText[0][0] ? GlobalText[0] : NULL);
+	m_font.reset(fontHandle);
 
 	LoadText();
 	SetPosition();
@@ -95,12 +142,7 @@ void CCreditWin::PreRelease()
 {
 	for (int i = 0; i < CRW_SPR_MAX; ++i)
 		m_aSpr[i].Release();
-
-	if (m_hFont)
-	{
-		::DeleteObject((HGDIOBJ)m_hFont);
-		m_hFont = NULL;
-	}
+	m_font.reset();
 }
 
 void CCreditWin::SetPosition()
@@ -151,8 +193,10 @@ bool CCreditWin::CursorInWin(int nArea)
 	return CWin::CursorInWin(nArea);
 }
 
-void CCreditWin::UpdateWhileActive(double dDeltaTick)
+void CCreditWin::UpdateWhileActive(double deltaMilliseconds)
 {
+	const DurationMs deltaTime{ deltaMilliseconds };
+
 	if (m_btnClose.IsClick())
 		CloseWin();
 	else if (CInput::Instance().IsKeyDown(VK_ESCAPE))
@@ -163,8 +207,8 @@ void CCreditWin::UpdateWhileActive(double dDeltaTick)
 	}
 
 	for (int i = 0; i <= CRW_INDEX_NAME; ++i)
-		AnimationText(i, dDeltaTick);
-	AnimationIllust(dDeltaTick);
+		AnimationText(i, deltaTime);
+	AnimationIllust(deltaTime);
 }
 
 void CCreditWin::RenderControls()
@@ -177,54 +221,46 @@ void CCreditWin::RenderControls()
 	long lScreenWidth = CInput::Instance().GetScreenWidth();
 	int nTextBoxWidth;
 
-	g_pRenderText->SetFont(m_hFont);
+	g_pRenderText->SetFont(m_font.get());
 	g_pRenderText->SetTextColor(CLRDW_BR_GRAY);
 	g_pRenderText->SetBgColor(0);
 	nTextBoxWidth = lScreenWidth / g_fScreenRate_x;
-	
-	wchar_t wtext[CRW_NAME_MAX];
 
-	mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_DEPARTMENT]].szName, CRW_NAME_MAX);
-	g_pRenderText->RenderText(0, 20, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
+	auto renderCentered = [&](const SCreditItem& item, int x, int y, int width)
+	{
+		wchar_t buffer[CRW_NAME_MAX]{};
+		CopyNameToWide(item.szName, buffer);
+		g_pRenderText->RenderText(x, y, buffer, width, 0, RT3_SORT_CENTER);
+	};
 
-	mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_TEAM]].szName, CRW_NAME_MAX);
-	g_pRenderText->RenderText(0, 46, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
+	renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_DEPARTMENT]], 0, 20, nTextBoxWidth);
+	renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_TEAM]], 0, 46, nTextBoxWidth);
 
 	g_pRenderText->SetTextColor(CLRDW_BR_YELLOW);
 
 	switch (m_nNameCount)
 	{
 	case 1:
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(0, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]], 0, 72, nTextBoxWidth);
 		break;
 	case 2:
 		nTextBoxWidth = lScreenWidth / 4 / g_fScreenRate_x;
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(160, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(320, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]], 160, 72, nTextBoxWidth);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]], 320, 72, nTextBoxWidth);
 		break;
 	case 3:
 		nTextBoxWidth = lScreenWidth / 3 / g_fScreenRate_x;
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(0, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME1]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(213, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME2]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(426, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]], 0, 72, nTextBoxWidth);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME1]], 213, 72, nTextBoxWidth);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME2]], 426, 72, nTextBoxWidth);
 		break;
 	case 4:
 		nTextBoxWidth = lScreenWidth / 4 / g_fScreenRate_x;
 
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(0, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME1]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(160, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME2]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(320, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
-		mbstowcs(wtext, m_aCredit[m_anTextIndex[CRW_INDEX_NAME3]].szName, CRW_NAME_MAX);
-		g_pRenderText->RenderText(480, 72, wtext, nTextBoxWidth, 0, RT3_SORT_CENTER);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME0]], 0, 72, nTextBoxWidth);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME1]], 160, 72, nTextBoxWidth);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME2]], 320, 72, nTextBoxWidth);
+		renderCentered(m_aCredit[m_anTextIndex[CRW_INDEX_NAME3]], 480, 72, nTextBoxWidth);
 		break;
 	}
 
@@ -249,13 +285,13 @@ void CCreditWin::CloseWin()
 void CCreditWin::Init()
 {
 	m_eIllustState = FADEIN;
-	m_dIllustDeltaTickSum = 0.0;
+	m_illustElapsed = DurationMs::zero();
 	m_byIllust = 0;
 	LoadIllust();
 
 	for (int i = 0; i <= CRW_INDEX_NAME; ++i)
 		m_aeTextState[i] = FADEIN;
-	m_dTextDeltaTickSum = 0.0;
+	m_textElapsed = DurationMs::zero();
 	m_nNowIndex = 0;
 	m_nNameCount = 0;
 	SetTextIndex();
@@ -269,7 +305,8 @@ void CCreditWin::LoadIllust()
 
 	for (int i = 0; i < 2; ++i)
 	{
-		LoadBitmap(m_apszIllustPath[m_byIllust][i], BITMAP_TEMP + i, GL_LINEAR);
+		const auto& illustPath = m_illustPaths[m_byIllust][i];
+		LoadBitmap(illustPath, BITMAP_TEMP + i, GL_LINEAR);
 
 		m_aSpr[i].Create(400, 400, BITMAP_TEMP + i, 0, NULL, 0, 0,
 			false, SPR_SIZING_DATUMS_LT, fScaleX, fScaleY);
@@ -282,14 +319,14 @@ void CCreditWin::LoadIllust()
 }
 
 
-void CCreditWin::AnimationIllust(double dDeltaTick)
+void CCreditWin::AnimationIllust(DurationMs deltaTime)
 {
 	short nAlpha;
 	switch (m_eIllustState)
 	{
 	case FADEIN:
 		nAlpha = short(m_aSpr[CRW_SPR_PIC_L].GetAlpha());
-		nAlpha += short(255.0 * dDeltaTick / CRW_ILLUST_FADE_TIME);
+		nAlpha = IncreaseAlpha(nAlpha, deltaTime / kIllustFadeDuration);
 		if (255 <= nAlpha)
 		{
 			m_eIllustState = SHOW;
@@ -300,17 +337,17 @@ void CCreditWin::AnimationIllust(double dDeltaTick)
 		break;
 
 	case SHOW:
-		m_dIllustDeltaTickSum += dDeltaTick;
-		if (m_dIllustDeltaTickSum > CRW_ILLUST_SHOW_TIME)
+		m_illustElapsed += deltaTime;
+		if (m_illustElapsed > kIllustShowDuration)
 		{
 			m_eIllustState = FADEOUT;
-			m_dIllustDeltaTickSum = 0.0;
+			m_illustElapsed = DurationMs::zero();
 		}
 		break;
 
 	case FADEOUT:
 		nAlpha = short(m_aSpr[CRW_SPR_PIC_L].GetAlpha());
-		nAlpha -= short(255.0 * dDeltaTick / CRW_ILLUST_FADE_TIME);
+		nAlpha = DecreaseAlpha(nAlpha, deltaTime / kIllustFadeDuration);
 		if (0 >= nAlpha)
 		{
 			m_eIllustState = FADEIN;
@@ -327,22 +364,20 @@ void CCreditWin::AnimationIllust(double dDeltaTick)
 
 void CCreditWin::LoadText()
 {
-	FILE* fp = ::fopen(CRW_DATA_FILE, "rb");
-	if (fp == NULL)
+	std::unique_ptr<FILE, decltype(&std::fclose)> file(std::fopen(kCreditDataPath.data(), "rb"), &std::fclose);
+	if (!file)
 	{
 		wchar_t szMessage[256];
-		::wsprintf(szMessage, L"%s file not found.\r\n", CRW_DATA_FILE);
+		std::swprintf(szMessage, std::size(szMessage), L"%hs file not found.\r\n", kCreditDataPath.data());
 		g_ErrorReport.Write(szMessage);
 		::MessageBox(g_hWnd, szMessage, NULL, MB_OK);
 		::PostMessage(g_hWnd, WM_DESTROY, 0, 0);
 		return;
 	}
 
-	int nSize = sizeof(SCreditItem) * CRW_ITEM_MAX;
-	::fread(m_aCredit, nSize, 1, fp);
-	::BuxConvert((BYTE*)m_aCredit, nSize);
-
-	::fclose(fp);
+	const std::size_t nSize = sizeof(SCreditItem) * CRW_ITEM_MAX;
+	std::fread(m_aCredit, nSize, 1, file.get());
+	::BuxConvert(reinterpret_cast<BYTE*>(m_aCredit), static_cast<int>(nSize));
 }
 
 void CCreditWin::SetTextIndex()
@@ -379,7 +414,7 @@ void CCreditWin::SetTextIndex()
 	m_nNameCount = iNameCnt;
 }
 
-void CCreditWin::AnimationText(int nClass, double dDeltaTick)
+void CCreditWin::AnimationText(int nClass, DurationMs deltaTime)
 {
 	SHOW_STATE* peTextState = &m_aeTextState[nClass];
 	short nAlpha;
@@ -390,7 +425,7 @@ void CCreditWin::AnimationText(int nClass, double dDeltaTick)
 	{
 	case FADEIN:
 		nAlpha = short(psprHide->GetAlpha());
-		nAlpha -= short(255.0 * dDeltaTick / CRW_TEXT_FADE_TIME);
+		nAlpha = DecreaseAlpha(nAlpha, deltaTime / kTextFadeDuration);
 		if (0 >= nAlpha)
 		{
 			*peTextState = SHOW;
@@ -403,11 +438,11 @@ void CCreditWin::AnimationText(int nClass, double dDeltaTick)
 		if (nClass != CRW_INDEX_NAME)
 			break;
 
-		m_dTextDeltaTickSum += dDeltaTick;
-		if (m_dTextDeltaTickSum > CRW_NAME_SHOW_TIME)
+		m_textElapsed += deltaTime;
+		if (m_textElapsed > kNameShowDuration)
 		{
 			m_aeTextState[CRW_INDEX_NAME] = FADEOUT;
-			m_dTextDeltaTickSum = 0.0;
+			m_textElapsed = DurationMs::zero();
 
 			if (3 != m_aCredit[m_nNowIndex].byClass)
 			{
@@ -420,7 +455,7 @@ void CCreditWin::AnimationText(int nClass, double dDeltaTick)
 
 	case FADEOUT:
 		nAlpha = short(psprHide->GetAlpha());
-		nAlpha += short(255.0 * dDeltaTick / CRW_TEXT_FADE_TIME);
+		nAlpha = IncreaseAlpha(nAlpha, deltaTime / kTextFadeDuration);
 		if (255 <= nAlpha)
 		{
 			*peTextState = FADEIN;

--- a/Source Main 5.2/source/CreditWin.cpp
+++ b/Source Main 5.2/source/CreditWin.cpp
@@ -48,14 +48,14 @@ namespace
     short IncreaseAlpha(short alpha, T ratio)
     {
         const double delta = 255.0 * std::clamp(static_cast<double>(ratio), 0.0, 1.0);
-        return static_cast<short>(std::min(255.0, static_cast<double>(alpha) + delta));
+        return static_cast<short>(std::min<double>(255.0, static_cast<double>(alpha) + delta));
     }
 
     template<typename T>
     short DecreaseAlpha(short alpha, T ratio)
     {
         const double delta = 255.0 * std::clamp(static_cast<double>(ratio), 0.0, 1.0);
-        return static_cast<short>(std::max(0.0, static_cast<double>(alpha) - delta));
+        return static_cast<short>(std::max<double>(0.0, static_cast<double>(alpha) - delta));
     }
 
     template<std::size_t N>

--- a/Source Main 5.2/source/CreditWin.h
+++ b/Source Main 5.2/source/CreditWin.h
@@ -7,6 +7,11 @@
 
 #pragma once
 
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+
 #include "Win.h"
 #include "Button.h"
 
@@ -36,28 +41,30 @@ class CCreditWin : public CWin
 {
 	enum SHOW_STATE { HIDE, FADEIN, SHOW, FADEOUT };
 
+	using DurationMs = std::chrono::duration<double, std::milli>;
+
 	struct SCreditItem
 	{
-		BYTE	byClass;
-		char	szName[CRW_NAME_MAX];
+		std::uint8_t    byClass;
+		char            szName[CRW_NAME_MAX];
 	};
 
 protected:
 	CSprite		m_aSpr[CRW_SPR_MAX];
 	CButton		m_btnClose;
 
-	SHOW_STATE	m_eIllustState;
-	double		m_dIllustDeltaTickSum;
-	BYTE		m_byIllust;
-	wchar_t* m_apszIllustPath[CRW_ILLUST_MAX][2];
+	SHOW_STATE  m_eIllustState;
+	DurationMs  m_illustElapsed;
+	std::uint8_t        m_byIllust;
+	std::array<std::array<const wchar_t*, 2>, CRW_ILLUST_MAX> m_illustPaths;
 
-	HFONT		m_hFont;
+	std::unique_ptr<std::remove_pointer_t<HFONT>, void(*)(HFONT)>	m_font;
 	SCreditItem	m_aCredit[CRW_ITEM_MAX];
 	int			m_nNowIndex;
 	int			m_nNameCount;
 	int			m_anTextIndex[CRW_INDEX_MAX];
 	SHOW_STATE	m_aeTextState[CRW_INDEX_NAME + 1];
-	double		m_dTextDeltaTickSum;
+	DurationMs	m_textElapsed;
 
 public:
 	CCreditWin();
@@ -76,10 +83,10 @@ protected:
 	void CloseWin();
 	void Init();
 	void LoadIllust();
-	void AnimationIllust(double dDeltaTick);
+	void AnimationIllust(DurationMs deltaTime);
 	void LoadText();
 	void SetTextIndex();
-	void AnimationText(int nClass, double dDeltaTick);
+	void AnimationText(int nClass, DurationMs deltaTime);
 };
 
 #endif // !defined(AFX_CREDITWIN_H__9D392798_811A_46FE_918B_7753E6BA35D0__INCLUDED_)


### PR DESCRIPTION
Replaced magic numbers with constexpr constants using std::chrono::duration (kIllustFadeDuration, kIllustShowDuration, kTextFadeDuration, kNameShowDuration) and std::string_view (kCreditDataPath). Replaced raw HFONT pointer with std::unique_ptr with custom deleter (FontDeleter). Changed raw array m_apszIllustPath to std::array constant kIllustPaths initialized at compile time.