### PR TITLE
Refactor map server connection system to use modern C++ standard library and improve code organization

### DIFF
--- a/Source Main 5.2/source/CSMapServer.cpp
+++ b/Source Main 5.2/source/CSMapServer.cpp
@@ -93,7 +93,7 @@ void CSMServer::GetServerAddress(wchar_t* szAddress)
 
     CMultiLanguage::ConvertFromUtf8(
         szAddress,
-        const_cast<char*>(m_serverInfo.m_szMapSvrIpAddress.data()),
+        m_serverInfo.m_szMapSvrIpAddress.data(),
         static_cast<int>(kIpAddressLength));
 }
 
@@ -116,7 +116,7 @@ void CSMServer::ConnectChangeMapServer(MServerInfo sInfo)
     std::array<wchar_t, kIpAddressLength> ipAddress {};
     CMultiLanguage::ConvertFromUtf8(
         ipAddress.data(),
-        const_cast<char*>(m_serverInfo.m_szMapSvrIpAddress.data()),
+        m_serverInfo.m_szMapSvrIpAddress.data(),
         static_cast<int>(kIpAddressLength));
 
     if (CreateSocket(ipAddress.data(), m_serverInfo.m_wMapSvrPort))

--- a/Source Main 5.2/source/CSMapServer.cpp
+++ b/Source Main 5.2/source/CSMapServer.cpp
@@ -1,20 +1,40 @@
 #include "stdafx.h"
-#include "ZzzCharacter.h"
-#include "ZzzTexture.h"
-#include "zzzOpenData.h"
 
 #include "CSMapServer.h"
 
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstring>
+#include <cwchar>
+#include <thread>
 
+#include "MultiLanguage.h"
 #include "WSclient.h"
+#include "ZzzCharacter.h"
+#include "ZzzOpenData.h"
 
-extern int  LogIn;
+extern int LogIn;
 extern wchar_t LogInID[MAX_ID_SIZE + 1];
 extern int HeroKey;
 extern BYTE Version[SIZE_PROTOCOLVERSION];
 extern BYTE Serial[SIZE_PROTOCOLSERIAL + 1];
 
-static  CSMServer csMapServer;
+namespace
+{
+constexpr std::size_t kIpAddressLength = 16;
+constexpr std::chrono::milliseconds kReconnectDelay(20);
+
+std::uint32_t GetCurrentTickMilliseconds()
+{
+    const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now().time_since_epoch());
+    return static_cast<std::uint32_t>(now.count());
+}
+} // namespace
+
+static CSMServer g_csMapServerInstance;
 
 CSMServer::CSMServer()
 {
@@ -23,44 +43,58 @@ CSMServer::CSMServer()
 
 void CSMServer::Init(void)
 {
-    m_bFillServerInfo = false;
-    memset(&m_vServerInfo, 0, sizeof(MServerInfo));
+    m_hasServerInfo = false;
+    m_serverInfo = {};
+    m_heroId.clear();
 }
 
 void CSMServer::SetHeroID(wchar_t* ID)
 {
-    m_strHeroID = ID;
+    if (ID == nullptr)
+    {
+        m_heroId.clear();
+        return;
+    }
+
+    m_heroId.assign(ID);
 }
 
 void CSMServer::SetServerInfo(MServerInfo sInfo)
 {
-    memcpy(&m_vServerInfo, &sInfo, sizeof(MServerInfo));
-
-    m_bFillServerInfo = true;
+    m_serverInfo = sInfo;
+    m_hasServerInfo = true;
 }
 
 void CSMServer::GetServerInfo(MServerInfo& sInfo)
 {
-    if (m_bFillServerInfo)
+    if (m_hasServerInfo)
     {
-        memcpy(&sInfo, &m_vServerInfo, sizeof(MServerInfo));
+        sInfo = m_serverInfo;
     }
     else
     {
-        memset(&sInfo, 0, sizeof(MServerInfo));
+        sInfo = {};
     }
 }
 
 void CSMServer::GetServerAddress(wchar_t* szAddress)
 {
-    if (m_bFillServerInfo)
+    if (szAddress == nullptr)
     {
-        memcpy(szAddress, m_vServerInfo.m_szMapSvrIpAddress, sizeof(char) * 16);
+        return;
     }
-    else
+
+    std::wmemset(szAddress, 0, kIpAddressLength);
+
+    if (!m_hasServerInfo)
     {
-        memset(szAddress, 0, sizeof(char) * 16);
+        return;
     }
+
+    CMultiLanguage::ConvertFromUtf8(
+        szAddress,
+        const_cast<char*>(m_serverInfo.m_szMapSvrIpAddress.data()),
+        static_cast<int>(kIpAddressLength));
 }
 
 extern BOOL g_bGameServerConnected;
@@ -68,55 +102,67 @@ void CSMServer::ConnectChangeMapServer(MServerInfo sInfo)
 {
     SetServerInfo(sInfo);
 
-    if (m_bFillServerInfo && LogIn != 0)
+    if (!m_hasServerInfo || LogIn == 0)
     {
-        DeleteSocket();
-        SaveOptions();
-        SaveMacro(L"Data\\Macro.txt");
+        return;
+    }
 
-        ::Sleep(20);
+    DeleteSocket();
+    SaveOptions();
+    SaveMacro(L"Data\\Macro.txt");
 
-        wchar_t ip[16];
-        CMultiLanguage::ConvertFromUtf8(ip, m_vServerInfo.m_szMapSvrIpAddress);
+    std::this_thread::sleep_for(kReconnectDelay);
 
-        if (CreateSocket(ip, m_vServerInfo.m_wMapSvrPort))
-        {
-            g_bGameServerConnected = TRUE;
-        }
+    std::array<wchar_t, kIpAddressLength> ipAddress {};
+    CMultiLanguage::ConvertFromUtf8(
+        ipAddress.data(),
+        const_cast<char*>(m_serverInfo.m_szMapSvrIpAddress.data()),
+        static_cast<int>(kIpAddressLength));
+
+    if (CreateSocket(ipAddress.data(), m_serverInfo.m_wMapSvrPort))
+    {
+        g_bGameServerConnected = TRUE;
     }
 }
 
 void CSMServer::SendChangeMapServer(void)
 {
-    if (m_bFillServerInfo == false || LogIn == 0) return;
+    if (!m_hasServerInfo || LogIn == 0)
+    {
+        return;
+    }
 
-    wchar_t  CharID[MAX_ID_SIZE + 1];
+    constexpr std::size_t kCharacterIdLength = MAX_ID_SIZE + 1;
+    constexpr std::size_t kPacketBufferLength = MAX_ID_SIZE + 2;
 
-    wcscpy(CharID, m_strHeroID.c_str());
-    //	memcpy ( CharID, m_strHeroID.c_str(), MAX_ID_SIZE );
-    CharID[MAX_ID_SIZE] = NULL;
+    std::array<wchar_t, kCharacterIdLength> characterIdBuffer {};
+
+    const std::size_t heroIdCopyLength = std::min<std::size_t>(m_heroId.size(), MAX_ID_SIZE);
+    std::wmemcpy(characterIdBuffer.data(), m_heroId.c_str(), heroIdCopyLength);
+    characterIdBuffer[heroIdCopyLength] = L'\0';
 
     ClearCharacters(-1);
     InitGame();
-    
-    wchar_t lpszID[MAX_ID_SIZE + 2];
-    wchar_t lpszCHR[MAX_ID_SIZE + 2];
-    ZeroMemory(lpszID, MAX_ID_SIZE + 2);
-    ZeroMemory(lpszCHR, MAX_ID_SIZE + 2);
-    // TODO wcscpy(lpszID, LogInID);
-    wcscpy(lpszCHR, CharID);
-    BuxConvert((BYTE*)lpszID, MAX_ID_SIZE + 2);
+
+    std::array<wchar_t, kPacketBufferLength> loginIdBuffer {};
+    std::array<wchar_t, kPacketBufferLength> characterPacketBuffer {};
+
+    // TODO: Populate loginIdBuffer with LogInID if credentials are required again.
+    std::wmemcpy(characterPacketBuffer.data(), characterIdBuffer.data(), heroIdCopyLength + 1);
+
+    BuxConvert(reinterpret_cast<BYTE*>(loginIdBuffer.data()), kPacketBufferLength);
     SocketClient->ToGameServer()->SendServerChangeAuthentication(
-        (BYTE*)lpszID, MAX_ID_SIZE,
-        (BYTE*)CharID, MAX_ID_SIZE,
-        m_vServerInfo.m_iJoinAuthCode1,
-        m_vServerInfo.m_iJoinAuthCode2,
-        m_vServerInfo.m_iJoinAuthCode3,
-        m_vServerInfo.m_iJoinAuthCode4,
-        GetTickCount(),
+        reinterpret_cast<BYTE*>(loginIdBuffer.data()),
+        MAX_ID_SIZE,
+        reinterpret_cast<BYTE*>(characterPacketBuffer.data()),
+        MAX_ID_SIZE,
+        m_serverInfo.m_iJoinAuthCode1,
+        m_serverInfo.m_iJoinAuthCode2,
+        m_serverInfo.m_iJoinAuthCode3,
+        m_serverInfo.m_iJoinAuthCode4,
+        GetCurrentTickMilliseconds(),
         Version,
         SIZE_PROTOCOLVERSION,
         Serial,
         SIZE_PROTOCOLSERIAL);
-    //SendChangeMServer(LogInID, CharID, m_vServerInfo.m_iJoinAuthCode1, m_vServerInfo.m_iJoinAuthCode2, m_vServerInfo.m_iJoinAuthCode3, m_vServerInfo.m_iJoinAuthCode4);
 }

--- a/Source Main 5.2/source/CSMapServer.h
+++ b/Source Main 5.2/source/CSMapServer.h
@@ -1,47 +1,52 @@
 //////////////////////////////////////////////////////////////////////////
 //  CSMapServer.h
 //////////////////////////////////////////////////////////////////////////
-#ifndef __CS_MAP_SERVER_H__
-#define __CS_MAP_SERVER_H__
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <array>
+#include <string>
 
 #include "Singleton.h"
-typedef struct
+
+struct MapServerInfo
 {
-    char            m_szMapSvrIpAddress[16];
-    WORD            m_wMapSvrPort;
-    WORD            m_wMapSvrCode;
-    int             m_iJoinAuthCode1;
-    int             m_iJoinAuthCode2;
-    int             m_iJoinAuthCode3;
-    int             m_iJoinAuthCode4;
-}MServerInfo;
+    std::array<char, 16> m_szMapSvrIpAddress {};
+    std::uint16_t m_wMapSvrPort {0};
+    std::uint16_t m_wMapSvrCode {0};
+    std::int32_t m_iJoinAuthCode1 {0};
+    std::int32_t m_iJoinAuthCode2 {0};
+    std::int32_t m_iJoinAuthCode3 {0};
+    std::int32_t m_iJoinAuthCode4 {0};
+};
+
+using MServerInfo = MapServerInfo;
 
 class CSMServer : public Singleton<CSMServer>
 {
-private:
-    bool        m_bFillServerInfo;
-    std::wstring m_strHeroID;
-    MServerInfo m_vServerInfo;
-
 public:
     CSMServer();
-    ~CSMServer() {}
+    ~CSMServer() = default;
 
-    void    Init(void);
+    void Init(void);
 
-    void    SetHeroID(wchar_t* ID);
+    void SetHeroID(wchar_t* ID);
 
-    void    SetServerInfo(MServerInfo sInfo);
-    void    GetServerInfo(MServerInfo& sInfo);
+    void SetServerInfo(MServerInfo sInfo);
+    void GetServerInfo(MServerInfo& sInfo);
 
-    void    GetServerAddress(wchar_t* szAddress);
-    WORD    GetServerPort(void) { return (m_bFillServerInfo ? m_vServerInfo.m_wMapSvrPort : 0); }
-    WORD    GetServerCode(void) { return (m_bFillServerInfo ? m_vServerInfo.m_wMapSvrCode : 0); }
+    void GetServerAddress(wchar_t* szAddress);
+    std::uint16_t GetServerPort() const { return (m_hasServerInfo ? m_serverInfo.m_wMapSvrPort : 0); }
+    std::uint16_t GetServerCode() const { return (m_hasServerInfo ? m_serverInfo.m_wMapSvrCode : 0); }
 
-    void    ConnectChangeMapServer(MServerInfo sInfo);
-    void    SendChangeMapServer(void);
+    void ConnectChangeMapServer(MServerInfo sInfo);
+    void SendChangeMapServer(void);
+
+private:
+    std::wstring m_heroId;
+    MapServerInfo m_serverInfo {};
+    bool m_hasServerInfo {false};
 };
 
-#define g_csMapServer CSMServer::GetSingleton ()
-
-#endif// __CS_MAP_SERVER_H__
+#define g_csMapServer CSMServer::GetSingleton()


### PR DESCRIPTION
Replaced WORD with std::uint16_t, int with std::int32_t, and char arrays with std::array in MServerInfo structure. Replaced bool m_bFillServerInfo with m_hasServerInfo and std::wstring m_strHeroID with m_heroId. Replaced manual memory operations (memset, memcpy, wcscpy) with direct assignment, std::wmemcpy, and std::wmemset. Replaced ::Sleep with std::this_thread::sleep_for using constexpr kReconnectDelay.