### PR TITLE
Refactor CSQuest system to use modern C++ standard library and improve code organization

### DIFF
--- a/Source Main 5.2/source/CSQuest.h
+++ b/Source Main 5.2/source/CSQuest.h
@@ -3,16 +3,26 @@
 #ifndef __CSQUEST_H__
 #define __CSQUEST_H__
 
+#include <array>
+#include <cstdint>
+
 #include "Singleton.h"
 #include "_enum.h"
+#include "_struct.h"
 
 class CSQuest : public Singleton<CSQuest>
 {
 private:
-    BYTE getQuestState(int questIndex = -1);
-    BYTE CheckQuestState(BYTE state = 255);
+    using QuestStateList = std::array<std::uint8_t, MAX_QUESTS / 4>;
+    using QuestAttributes = std::array<QUEST_ATTRIBUTE, MAX_QUESTS>;
+    using QuestEventCounters = std::array<std::uint8_t, TYPE_QUEST_END>;
+    using KillTracker = std::array<int, 5>;
+
+private:
+    std::uint8_t getQuestState(int questIndex = -1);
+    std::uint8_t CheckQuestState(std::uint8_t state = 0xFF);
     short FindQuestContext(QUEST_ATTRIBUTE* pQuest, int index);
-    bool CheckRequestCondition(QUEST_ATTRIBUTE* pQuest, bool bLastCheck = 0);
+    bool CheckRequestCondition(QUEST_ATTRIBUTE* pQuest, bool bLastCheck = false);
     bool CheckActCondition(QUEST_ATTRIBUTE* pQuest);
     void RenderDevilSquare(void);
     void RenderBloodCastle(void);
@@ -22,32 +32,32 @@ public:
     ~CSQuest(void);
 
     //  Quest Init Functions
-    bool OpenQuestScript(wchar_t* filename);
+    bool OpenQuestScript(const wchar_t* filename);
     bool IsInit(void);
     void clearQuest(void);
 
     //  Quest Setting.
-    void setQuestLists(BYTE* byList, int num, CLASS_TYPE Class = CLASS_UNDEFINED);
+    void setQuestLists(const std::uint8_t* byList, int num, CLASS_TYPE Class = CLASS_UNDEFINED);
     void setQuestList(int index, int result);
-    BYTE getQuestState2(int questIndex);
+    std::uint8_t getQuestState2(int questIndex);
     void ShowQuestPreviewWindow(int index = -1);
     void ShowQuestNpcWindow(int index = -1);
 
-    BYTE getCurrQuestState(void);
+    std::uint8_t getCurrQuestState(void);
     wchar_t* GetNPCName(BYTE byQuestIndex);
     wchar_t* getQuestTitle();
     wchar_t* getQuestTitle(BYTE byQuestIndex);
     wchar_t* getQuestTitleWindow();
-    void SetEventCount(BYTE type, BYTE count);
-    int GetEventCount(BYTE byType);
-    DWORD GetNeedZen() { return m_dwNeedZen; }
+    void SetEventCount(std::uint8_t type, std::uint8_t count);
+    int GetEventCount(std::uint8_t byType);
+    std::uint32_t GetNeedZen() { return m_dwNeedZen; }
     QUEST_ATTRIBUTE* GetCurQuestAttribute()
     {
         return &m_Quest[m_byCurrQuestIndex];
     }
 
-    BYTE GetCurrQuestIndex() { return m_byCurrQuestIndex; }
-    void SetKillMobInfo(int* anKillMobInfo);
+    std::uint8_t GetCurrQuestIndex() { return m_byCurrQuestIndex; }
+    void SetKillMobInfo(const int* anKillMobInfo);
     bool ProcessNextProgress();
     void ShowDialogText(int iDialogIndex);
     bool BeQuestItem();
@@ -55,28 +65,28 @@ public:
     int GetKillMobCount(int nMobType);
 
 private:
-    BYTE    m_byClass;
+    std::uint8_t    m_byClass;
 
-    BYTE    m_byEventCount[TYPE_QUEST_END];
-    QUEST_ATTRIBUTE m_Quest[MAX_QUESTS];
+    QuestEventCounters m_byEventCount;
+    QuestAttributes    m_Quest;
 
-    BYTE    m_byQuestList[MAX_QUESTS / 4];
-    BYTE    m_byCurrQuestIndex;
-    BYTE    m_byCurrQuestIndexWnd;
+    QuestStateList m_byQuestList;
+    std::uint8_t   m_byCurrQuestIndex;
+    std::uint8_t   m_byCurrQuestIndexWnd;
 
-    BYTE    m_byStartQuestList;
+    std::uint8_t   m_byStartQuestList;
 
-    BYTE    m_byViewQuest;
-    short   m_shCurrPage;
-    BYTE    m_byCurrState;
-    DWORD   m_dwNeedZen;
+    std::uint8_t   m_byViewQuest;
+    short          m_shCurrPage;
+    std::uint8_t   m_byCurrState;
+    std::uint32_t  m_dwNeedZen;
 
-    BYTE    m_byQuestType;
-    bool	m_bOnce;
+    std::uint8_t   m_byQuestType;
+    bool	       m_bOnce;
 
-    int 	m_anKillMobType[5];
-    int		m_anKillMobCount[5];
-    WORD	m_wNPCIndex;
+    KillTracker m_anKillMobType;
+    KillTracker m_anKillMobCount;
+    std::uint16_t m_wNPCIndex;
 
     int     m_iStartX;
     int     m_iStartY;

--- a/Source Main 5.2/source/CSQuest.h
+++ b/Source Main 5.2/source/CSQuest.h
@@ -12,15 +12,21 @@
 
 class CSQuest : public Singleton<CSQuest>
 {
-private:
-    using QuestStateList = std::array<std::uint8_t, MAX_QUESTS / 4>;
-    using QuestAttributes = std::array<QUEST_ATTRIBUTE, MAX_QUESTS>;
-    using QuestEventCounters = std::array<std::uint8_t, TYPE_QUEST_END>;
-    using KillTracker = std::array<int, 5>;
+public:
+    static constexpr std::uint8_t QUEST_STATE_INVALID = 0xFF;
+    static constexpr std::uint8_t QUEST_STATE_MASK = 0x03;
+    static constexpr std::uint8_t QUEST_STATES_PER_ENTRY = 4;
+    static constexpr std::uint8_t QUEST_STATE_BIT_WIDTH = 2;
+    static constexpr int QUEST_MONSTER_SLOT_COUNT = 5;
 
 private:
+    using QuestStateList = std::array<std::uint8_t, (MAX_QUESTS + (QUEST_STATES_PER_ENTRY - 1)) / QUEST_STATES_PER_ENTRY>;
+    using QuestAttributes = std::array<QUEST_ATTRIBUTE, MAX_QUESTS>;
+    using QuestEventCounters = std::array<std::uint8_t, TYPE_QUEST_END>;
+    using KillTracker = std::array<int, QUEST_MONSTER_SLOT_COUNT>;
+
     std::uint8_t getQuestState(int questIndex = -1);
-    std::uint8_t CheckQuestState(std::uint8_t state = 0xFF);
+    std::uint8_t CheckQuestState(std::uint8_t state = QUEST_STATE_INVALID);
     short FindQuestContext(QUEST_ATTRIBUTE* pQuest, int index);
     bool CheckRequestCondition(QUEST_ATTRIBUTE* pQuest, bool bLastCheck = false);
     bool CheckActCondition(QUEST_ATTRIBUTE* pQuest);


### PR DESCRIPTION
Replaced BYTE with std::uint8_t throughout. Replaced raw arrays with std::array (m_byQuestList, m_byEventCount, m_anKillMobType, m_anKillMobCount). Replaced manual file handling (FILE*, fopen, fclose) with std::ifstream and std::filesystem::path. Replaced manual memory operations (memset, memcpy, wcscpy) with std::fill, std::memcpy, wcscpy_s, and array fill(). Replaced NULL with nullptr.