### PR TITLE
Refactor DSplaysound to use modern C++ standard library and improve resource management

### DIFF
--- a/Source Main 5.2/source/DSplaysound.cpp
+++ b/Source Main 5.2/source/DSplaysound.cpp
@@ -508,7 +508,7 @@ HRESULT DirectSoundManager::CreateStaticBuffer(SoundBufferEntry& entry, ESound b
         return E_FAIL;
     }
 
-    std::unique_ptr<waveIO> waveFile = std::make_unique<waveIO>(INPUT);
+    std::unique_ptr<waveIO> waveFile = std::make_unique<waveIO>(waveIO::Mode::Input);
     if (!waveFile->LoadWaveHeader(filename))
     {
         g_ErrorReport.Write(L"CreateStaticBuffer - Failed to load %ls\r\n", filename);

--- a/Source Main 5.2/source/DSwaveIO.cpp
+++ b/Source Main 5.2/source/DSwaveIO.cpp
@@ -25,7 +25,7 @@ bool waveIO::CloseWaveFile()
     return true;
 }
 
-bool waveIO::LoadWaveHeader(wchar_t* szFilename)
+bool waveIO::LoadWaveHeader(const wchar_t* szFilename)
 {
     MMCKINFO		ckOutRIFF;          // chunk info. for output RIFF chunk
     MMCKINFO		ckOut;              // info. for a chunk in output file

--- a/Source Main 5.2/source/DSwaveIO.cpp
+++ b/Source Main 5.2/source/DSwaveIO.cpp
@@ -34,7 +34,7 @@ bool waveIO::LoadWaveHeader(const wchar_t* szFilename)
         return false;
 
     // Open the wave file for reading using buffered I/O.
-    m_hmmio = mmioOpen(szFilename, nullptr, MMIO_ALLOCBUF | MMIO_READ);
+    m_hmmio = mmioOpen(const_cast<wchar_t*>(szFilename), nullptr, MMIO_ALLOCBUF | MMIO_READ);
     if (m_hmmio == nullptr)
     {
         wprintf(L"Cannot find file %s\n", szFilename);

--- a/Source Main 5.2/source/DSwaveIO.h
+++ b/Source Main 5.2/source/DSwaveIO.h
@@ -15,7 +15,7 @@ class waveIO
 public:
     waveIO(bool IO);
     virtual ~waveIO();
-    bool LoadWaveHeader(wchar_t* szFilename);
+    bool LoadWaveHeader(const wchar_t* szFilename);
     bool WriteWaveHeader(wchar_t* szFilename, PCMWAVEFORMAT wf, int nWaveDateSize);
     bool CloseWaveFile();
     WAVEFORMATEX GetWaveFormatEx() { return m_wfex; }

--- a/Source Main 5.2/source/DSwaveIO.h
+++ b/Source Main 5.2/source/DSwaveIO.h
@@ -1,34 +1,43 @@
-// waveIO.h: interface for the waveIO class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_WAVEIO_H__A0449D63_0097_11D4_A092_A64970C5F176__INCLUDED_)
-#define AFX_WAVEIO_H__A0449D63_0097_11D4_A092_A64970C5F176__INCLUDED_
-
 #pragma once
 
-#define INPUT	0
-#define OUTPUT	1
+#include <windows.h>
+#include <mmsystem.h>
+#include <cstdint>
 
 class waveIO
 {
 public:
-    waveIO(bool IO);
-    virtual ~waveIO();
-    bool LoadWaveHeader(const wchar_t* szFilename);
-    bool WriteWaveHeader(wchar_t* szFilename, PCMWAVEFORMAT wf, int nWaveDateSize);
-    bool CloseWaveFile();
-    WAVEFORMATEX GetWaveFormatEx() { return m_wfex; }
-    bool ReadWaveData(char* buffer, int nSizeOfBuffer);
-    bool WriteWaveData(char* buffer, int nSizeOfBuffer);
-    int GetDataSize() { return m_DataSize; }
-private:
-    HMMIO			m_hmmio;	// Handle to WAVE file
-    WAVEFORMATEX	m_wfex;		// WAVEFORMATEX structure
-    int				m_DataSize;	// Stores size of wave data
-    int				m_DataLeft;
-    int				m_SilentSample;
-    bool			m_IO;
-};
+    enum class Mode : std::uint8_t
+    {
+        Input = 0,
+        Output = 1
+    };
 
-#endif // !defined(AFX_WAVEIO_H__A0449D63_0097_11D4_A092_A64970C5F176__INCLUDED_)
+    explicit waveIO(Mode mode);
+    waveIO();
+    explicit waveIO(bool legacyMode);
+    ~waveIO();
+
+    waveIO(const waveIO&) = delete;
+    waveIO& operator=(const waveIO&) = delete;
+
+    bool LoadWaveHeader(const wchar_t* filename);
+    bool WriteWaveHeader(const wchar_t* filename, const PCMWAVEFORMAT& format, int waveDataSize);
+    bool CloseWaveFile();
+
+    WAVEFORMATEX GetWaveFormatEx() const { return m_wfex; }
+    bool ReadWaveData(char* buffer, int bufferSize);
+    bool WriteWaveData(const char* buffer, int bufferSize);
+    int GetDataSize() const { return m_DataSize; }
+
+private:
+    bool IsInputMode() const noexcept;
+    bool IsOutputMode() const noexcept;
+
+    HMMIO        m_hmmio;
+    WAVEFORMATEX m_wfex;
+    int          m_DataSize;
+    int          m_DataLeft;
+    int          m_SilentSample;
+    Mode         m_mode;
+};


### PR DESCRIPTION
Replaced raw COM pointers with std::unique_ptr with custom ComReleaser deleter (ComPtr alias). Replaced raw arrays with std::array (BufferName, BufferChannel, MaxBufferChannel, Enable3DSound, Object3DSound). Replaced global variables with DirectSoundManager singleton class encapsulating DirectSound state. Replaced manual memory management (new/delete) with RAII patterns.