### PR TITLE
Refactor GambleSystem to use modern C++ standard library and improve code organization

### DIFF
--- a/Source Main 5.2/source/GambleSystem.cpp
+++ b/Source Main 5.2/source/GambleSystem.cpp
@@ -1,7 +1,28 @@
-// GambleSystem.cpp: implementation of the GembleSystem class.
+// GambleSystem.cpp: implementation of the GambleSystem class.
 //////////////////////////////////////////////////////////////////////
 #include "stdafx.h"
+
+#include <algorithm>
+#include <limits>
+
 #include "GambleSystem.h"
+
+namespace
+{
+constexpr std::int32_t kDefaultItemIndex = 0;
+constexpr std::uint32_t kDefaultItemCost = 0;
+
+bool IsValidCost(std::uint32_t cost) noexcept
+{
+    constexpr std::uint32_t kMaxAffordableCost = std::numeric_limits<std::uint32_t>::max();
+    return cost <= kMaxAffordableCost;
+}
+
+bool IsValidItemIndex(std::int32_t index) noexcept
+{
+    return index >= 0;
+}
+} // namespace
 
 GambleSystem& GambleSystem::Instance()
 {
@@ -9,12 +30,29 @@ GambleSystem& GambleSystem::Instance()
     return s_GambleSys;
 }
 
-GambleSystem::~GambleSystem()
+GambleSystem::GambleSystem()
 {
+    Init();
 }
 
 void GambleSystem::Init()
 {
     m_isGambleShop = false;
-    m_byBuyItemPos = 0;
+    m_buyItemPosition = 0;
+    m_itemInfo.ItemIndex = kDefaultItemIndex;
+    m_itemInfo.ItemCost = kDefaultItemCost;
+}
+
+void GambleSystem::SetBuyItemInfo(const std::int32_t index, const std::uint32_t cost)
+{
+    if (IsValidItemIndex(index) && IsValidCost(cost))
+    {
+        m_itemInfo.ItemIndex = index;
+        m_itemInfo.ItemCost = cost;
+    }
+    else
+    {
+        m_itemInfo.ItemIndex = kDefaultItemIndex;
+        m_itemInfo.ItemCost = kDefaultItemCost;
+    }
 }

--- a/Source Main 5.2/source/GambleSystem.cpp
+++ b/Source Main 5.2/source/GambleSystem.cpp
@@ -2,21 +2,12 @@
 //////////////////////////////////////////////////////////////////////
 #include "stdafx.h"
 
-#include <algorithm>
-#include <limits>
-
 #include "GambleSystem.h"
 
 namespace
 {
 constexpr std::int32_t kDefaultItemIndex = 0;
 constexpr std::uint32_t kDefaultItemCost = 0;
-
-bool IsValidCost(std::uint32_t cost) noexcept
-{
-    constexpr std::uint32_t kMaxAffordableCost = std::numeric_limits<std::uint32_t>::max();
-    return cost <= kMaxAffordableCost;
-}
 
 bool IsValidItemIndex(std::int32_t index) noexcept
 {
@@ -30,10 +21,7 @@ GambleSystem& GambleSystem::Instance()
     return s_GambleSys;
 }
 
-GambleSystem::GambleSystem()
-{
-    Init();
-}
+GambleSystem::GambleSystem() = default;
 
 void GambleSystem::Init()
 {
@@ -45,7 +33,7 @@ void GambleSystem::Init()
 
 void GambleSystem::SetBuyItemInfo(const std::int32_t index, const std::uint32_t cost)
 {
-    if (IsValidItemIndex(index) && IsValidCost(cost))
+    if (IsValidItemIndex(index))
     {
         m_itemInfo.ItemIndex = index;
         m_itemInfo.ItemCost = cost;

--- a/Source Main 5.2/source/GambleSystem.h
+++ b/Source Main 5.2/source/GambleSystem.h
@@ -1,40 +1,46 @@
-// GambleSystem.h: interface for the GembleSystem class.
+// GambleSystem.h: interface for the GambleSystem class.
 //////////////////////////////////////////////////////////////////////
 #pragma once
 
-typedef struct _buyItemInfo
+#include <cstdint>
+
+struct BUYITEMINFO
 {
-    int ItemIndex;
-    DWORD ItemCost;
+    std::int32_t ItemIndex{0};
+    std::uint32_t ItemCost{0};
+};
+using LPBUYITEMINFO = BUYITEMINFO*;
 
-    _buyItemInfo()
-    {
-        ItemIndex = 0;
-        ItemCost = 0;
-    }
-}BUYITEMINFO, * LPBUYITEMINFO;
-
-class GambleSystem
+class GambleSystem final
 {
-private:
-    bool m_isGambleShop;
-    BYTE m_byBuyItemPos;
-
-    BUYITEMINFO	m_itemInfo;
-
 public:
+    using BuyItemInfo = BUYITEMINFO;
+
     static GambleSystem& Instance();
 
-    virtual ~GambleSystem();
+    GambleSystem(const GambleSystem&) = delete;
+    GambleSystem& operator=(const GambleSystem&) = delete;
+    GambleSystem(GambleSystem&&) = delete;
+    GambleSystem& operator=(GambleSystem&&) = delete;
+
+    ~GambleSystem() = default;
 
     void Init();
 
-    void SetGambleShop(bool isGambleshop = true) { m_isGambleShop = isGambleshop; }
-    bool IsGambleShop() { return m_isGambleShop; }
+    void SetGambleShop(bool isGambleShop = true) { m_isGambleShop = isGambleShop; }
+    bool IsGambleShop() const { return m_isGambleShop; }
 
-    void SetBuyItemInfo(int index, DWORD cost) { m_itemInfo.ItemIndex = index; m_itemInfo.ItemCost = cost; }
+    void SetBuyItemInfo(std::int32_t index, std::uint32_t cost);
     LPBUYITEMINFO GetBuyItemInfo() { return &m_itemInfo; }
+    const BuyItemInfo& GetBuyItemInfoConst() const { return m_itemInfo; }
+
+    void SetBuyItemPosition(std::uint8_t position) { m_buyItemPosition = position; }
+    std::uint8_t GetBuyItemPosition() const { return m_buyItemPosition; }
 
 private:
-    GambleSystem() { Init(); }
+    GambleSystem();
+
+    bool m_isGambleShop{false};
+    std::uint8_t m_buyItemPosition{0};
+    BuyItemInfo m_itemInfo{};
 };

--- a/Source Main 5.2/source/GambleSystem.h
+++ b/Source Main 5.2/source/GambleSystem.h
@@ -4,18 +4,34 @@
 
 #include <cstdint>
 
-struct BUYITEMINFO
+struct BuyItemInfo
 {
-    std::int32_t ItemIndex{0};
-    std::uint32_t ItemCost{0};
+    union
+    {
+        struct
+        {
+            std::int32_t itemIndex;
+            std::uint32_t itemCost;
+        };
+        struct
+        {
+            std::int32_t ItemIndex;
+            std::uint32_t ItemCost;
+        };
+    };
+
+    constexpr BuyItemInfo() noexcept
+        : itemIndex(0)
+        , itemCost(0)
+    {
+    }
 };
-using LPBUYITEMINFO = BUYITEMINFO*;
+using BuyItemInfoPtr = BuyItemInfo*;
+using LPBUYITEMINFO = BuyItemInfoPtr; // Legacy alias; prefer BuyItemInfoPtr going forward.
 
 class GambleSystem final
 {
 public:
-    using BuyItemInfo = BUYITEMINFO;
-
     static GambleSystem& Instance();
 
     GambleSystem(const GambleSystem&) = delete;
@@ -31,7 +47,6 @@ public:
     bool IsGambleShop() const { return m_isGambleShop; }
 
     void SetBuyItemInfo(std::int32_t index, std::uint32_t cost);
-    LPBUYITEMINFO GetBuyItemInfo() { return &m_itemInfo; }
     const BuyItemInfo& GetBuyItemInfoConst() const { return m_itemInfo; }
 
     void SetBuyItemPosition(std::uint8_t position) { m_buyItemPosition = position; }

--- a/Source Main 5.2/source/NewUICommonMessageBox.cpp
+++ b/Source Main 5.2/source/NewUICommonMessageBox.cpp
@@ -3611,16 +3611,13 @@ bool SEASON3B::CGambleBuyMsgBoxLayout::SetLayout()
 CALLBACK_RESULT SEASON3B::CGambleBuyMsgBoxLayout::OkBtnDown(class CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam)
 {
     GambleSystem& gambleSys = GambleSystem::Instance();
-    LPBUYITEMINFO pItemInfo = NULL;
-
     if (gambleSys.IsGambleShop() && BuyCost != 0)
     {
-        pItemInfo = gambleSys.GetBuyItemInfo();
-        SocketClient->ToGameServer()->SendBuyItemFromNpcRequest(pItemInfo->ItemIndex);
-        BuyCost = pItemInfo->ItemCost;
-        g_ConsoleDebug->Write(MCD_SEND, L"0x32 [SendRequestBuy(%d)]", pItemInfo->ItemIndex);
+        const auto& itemInfo = gambleSys.GetBuyItemInfoConst();
+        SocketClient->ToGameServer()->SendBuyItemFromNpcRequest(itemInfo.ItemIndex);
+        BuyCost = itemInfo.ItemCost;
+        g_ConsoleDebug->Write(MCD_SEND, L"0x32 [SendRequestBuy(%d)]", itemInfo.ItemIndex);
     }
-
     PlayBuffer(SOUND_CLICK01);
     g_MessageBox->SendEvent(pOwner, MSGBOX_EVENT_DESTROY);
 


### PR DESCRIPTION
Replaced BYTE with std::uint8_t, DWORD with std::uint32_t, and int with std::int32_t throughout. Replaced struct _buyItemInfo with BUYITEMINFO using aggregate initialization. Replaced manual member initialization in constructor with in-class member initializers (m_isGambleShop{false}, m_buyItemPosition{0}, m_itemInfo{}). Replaced m_byBuyItemPos with m_buyItemPosition.