### PR TITLE
Add Random module with thread-safe random number generation utilities

### DIFF
--- a/Source Main 5.2/source/Random.cpp
+++ b/Source Main 5.2/source/Random.cpp
@@ -42,8 +42,9 @@ namespace Random
             return minInclusive;
         }
 
-        std::uniform_int_distribution<std::int32_t> dist(minInclusive, maxInclusive);
-        return dist(GetThreadEngine());
+        thread_local static std::uniform_int_distribution<std::int32_t> dist;
+        using param_type = std::uniform_int_distribution<std::int32_t>::param_type;
+        return dist(GetThreadEngine(), param_type(minInclusive, maxInclusive));
     }
 
     float RangeFloat(float minInclusive, float maxInclusive)
@@ -53,19 +54,20 @@ namespace Random
             return minInclusive;
         }
 
-        std::uniform_real_distribution<float> dist(minInclusive, maxInclusive);
-        return dist(GetThreadEngine());
+        thread_local static std::uniform_real_distribution<float> dist;
+        using param_type = std::uniform_real_distribution<float>::param_type;
+        return dist(GetThreadEngine(), param_type(minInclusive, maxInclusive));
     }
 
     float Unit()
     {
-        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        thread_local static std::uniform_real_distribution<float> dist(0.0f, 1.0f);
         return dist(GetThreadEngine());
     }
 
     double UnitDouble()
     {
-        std::uniform_real_distribution<double> dist(0.0, 1.0);
+        thread_local static std::uniform_real_distribution<double> dist(0.0, 1.0);
         return dist(GetThreadEngine());
     }
 

--- a/Source Main 5.2/source/Random.cpp
+++ b/Source Main 5.2/source/Random.cpp
@@ -78,7 +78,7 @@ namespace Random
             return false;
         }
 
-        const double clampedFactor = std::min(1.0, std::max(0.0, animationFactor));
+        const double clampedFactor = std::min<double>(1.0, std::max<double>(0.0, animationFactor));
         
         const double randomValue = UnitDouble();
         

--- a/Source Main 5.2/source/Random.cpp
+++ b/Source Main 5.2/source/Random.cpp
@@ -1,0 +1,90 @@
+///////////////////////////////////////////////////////////////////////////////
+// Random.cpp
+//
+// Implementation of thread-safe random number generation.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "Random.h"
+
+#include <algorithm>
+#include <random>
+
+namespace Random
+{
+    namespace
+    {
+        /// Thread-local Mersenne Twister engine with high-quality seeding.
+        /// Each thread gets its own independent RNG state for thread safety.
+        /// Seeded using multiple calls to std::random_device for better entropy.
+        std::mt19937& GetThreadEngine()
+        {
+            thread_local static std::mt19937 engine{
+                []()
+                {
+                    std::seed_seq seed{
+                        std::random_device{}(),
+                        std::random_device{}(),
+                        std::random_device{}(),
+                        std::random_device{}()
+                    };
+                    return std::mt19937{seed};
+                }()
+            };
+            return engine;
+        }
+
+    } // anonymous namespace
+
+    std::int32_t RangeInt(std::int32_t minInclusive, std::int32_t maxInclusive)
+    {
+        if (minInclusive >= maxInclusive)
+        {
+            return minInclusive;
+        }
+
+        std::uniform_int_distribution<std::int32_t> dist(minInclusive, maxInclusive);
+        return dist(GetThreadEngine());
+    }
+
+    float RangeFloat(float minInclusive, float maxInclusive)
+    {
+        if (minInclusive >= maxInclusive)
+        {
+            return minInclusive;
+        }
+
+        std::uniform_real_distribution<float> dist(minInclusive, maxInclusive);
+        return dist(GetThreadEngine());
+    }
+
+    float Unit()
+    {
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        return dist(GetThreadEngine());
+    }
+
+    double UnitDouble()
+    {
+        std::uniform_real_distribution<double> dist(0.0, 1.0);
+        return dist(GetThreadEngine());
+    }
+
+    bool FpsCheck(std::int32_t referenceFrames, double animationFactor)
+    {
+        if (referenceFrames <= 0)
+        {
+            return false;
+        }
+
+        const double clampedFactor = std::min(1.0, std::max(0.0, animationFactor));
+        
+        const double randomValue = UnitDouble();
+        
+        const double chance = (referenceFrames == 1)
+            ? clampedFactor
+            : (1.0 / static_cast<double>(referenceFrames)) * clampedFactor;
+
+        return randomValue <= chance;
+    }
+
+} // namespace Random

--- a/Source Main 5.2/source/Random.h
+++ b/Source Main 5.2/source/Random.h
@@ -1,0 +1,58 @@
+///////////////////////////////////////////////////////////////////////////////
+// Random.h
+//
+// Thread-safe random number generation module.
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstdint>
+
+namespace Random
+{
+    /// Returns a random integer in the range [minInclusive, maxInclusive].
+    /// Thread-safe. Both bounds are inclusive.
+    /// If min >= max, returns minInclusive.
+    std::int32_t RangeInt(std::int32_t minInclusive, std::int32_t maxInclusive);
+
+    /// Returns a random float in the range [minInclusive, maxInclusive].
+    /// Thread-safe. Both bounds are inclusive.
+    /// If min >= max, returns minInclusive.
+    float RangeFloat(float minInclusive, float maxInclusive);
+
+    /// Returns a random float in the range [0.0, 1.0].
+    /// Thread-safe. Useful for probability checks.
+    float Unit();
+
+    /// Returns a random double in the range [0.0, 1.0].
+    /// Thread-safe. Higher precision than Unit().
+    double UnitDouble();
+
+    /// FPS-aware probability check.
+    /// Returns true with a probability adjusted for current frame rate.
+    /// 
+    /// @param referenceFrames - The reference frame interval (e.g., 10 means "once every 10 frames at reference FPS")
+    /// @param animationFactor - Current FPS scaling factor (typically FPS_ANIMATION_FACTOR from the engine)
+    /// 
+    /// At reference FPS (animationFactor = 1.0):
+    ///   - referenceFrames=1 -> 100% chance per frame
+    ///   - referenceFrames=10 -> 10% chance per frame
+    ///   - referenceFrames=60 -> ~1.67% chance per frame
+    /// 
+    /// At lower FPS (animationFactor < 1.0), probability is scaled proportionally
+    /// to maintain similar event frequency over real time.
+    /// 
+    /// Thread-safe.
+    bool FpsCheck(std::int32_t referenceFrames, double animationFactor);
+
+    /// Simplified FPS check with default animation factor of 1.0.
+    /// Useful for non-FPS-dependent random events.
+    /// Thread-safe.
+    inline bool FpsCheck(std::int32_t referenceFrames)
+    {
+        return FpsCheck(referenceFrames, 1.0);
+    }
+
+} // namespace Random
+
+#endif // Random.h

--- a/Source Main 5.2/source/Random.h
+++ b/Source Main 5.2/source/Random.h
@@ -55,4 +55,3 @@ namespace Random
 
 } // namespace Random
 
-#endif // Random.h

--- a/Source Main 5.2/source/UsefulDef.h
+++ b/Source Main 5.2/source/UsefulDef.h
@@ -5,12 +5,6 @@
 #define SWAP(a, b)			{ (a) ^= (b) ^= (a) ^= (b); }
 #define	ARGB(a,r,g,b)	(((DWORD)(a))<<24 | (DWORD)(r) | ((DWORD)(g))<<8 | ((DWORD)(b))<<16)
 
-
-inline int Random(int nMin, int nMax)
-{
-    return rand() % (nMax - nMin + 1) + nMin;
-}
-
 bool ReduceStringByPixel(LPTSTR lpszDst, int nDstSize, LPCTSTR lpszSrc, int nPixel);
 #if defined KJH_ADD_INGAMESHOP_UI_SYSTEM || defined LJH_MOD_TO_USE_DIVIDESTRINGBYPIXEL_FUNC
 int DivideStringByPixel(wchar_t* alpszDst, int nDstRow, int nDstColumn, const wchar_t* lpszSrc,

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -17,8 +17,8 @@
 #include <cmath>
 #include <limits>
 #include <mutex>
-#include <random>
 
+#include "Random.h"
 #include "ZzzTexture.h"
 #include "ZzzOpenglUtil.h"
 #include "ZzzInterface.h"
@@ -486,8 +486,8 @@ void MoveHead(CHARACTER* c)
         {
             if (rand_fps_check(32))
             {
-                o->HeadTargetAngle[0] = (float)(rand() % 128 - 64);
-                o->HeadTargetAngle[1] = (float)(rand() % 48 - 16);
+                o->HeadTargetAngle[0] = static_cast<float>(Random::RangeInt(-64, 63));
+                o->HeadTargetAngle[1] = static_cast<float>(Random::RangeInt(-16, 31));
                 for (int i = 0; i < 2; i++)
                     if (o->HeadTargetAngle[i] < 0) o->HeadTargetAngle[i] += 360.f;
             }
@@ -525,7 +525,7 @@ void Damage(vec3_t soPosition, CHARACTER* tc, float AttackRange, int AttackPoint
         {
             CreateParticle(BITMAP_SPARK, Position, to->Angle, Light);
             vec3_t Angle;
-            Vector(-(float)(rand() % 60 + 30), 0.f, (float)(rand() % 360), Angle);
+            Vector(-static_cast<float>(Random::RangeInt(30, 89)), 0.f, static_cast<float>(Random::RangeInt(0, 359)), Angle);
             CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
         }
         CreateParticle(BITMAP_SPARK + 1, Position, to->Angle, Light);
@@ -703,20 +703,9 @@ float   FPS_ANIMATION_FACTOR;
 double   FPS_AVG;
 double   WorldTime = 0.0;
 
-std::random_device rd;  // a seed source for the random number engine
-std::mt19937 gen(rd()); // mersenne_twister_engine seeded with rd()
-std::uniform_real_distribution<> distrib(0.0, 1.0);
-
 bool rand_fps_check(int reference_frames)
 {
-    // return rand() % reference_frames == 0;
-    const auto animation_factor = std::min<double>(1.0, static_cast<double>(FPS_ANIMATION_FACTOR));
-    const auto rand_value = distrib(gen);// *1.5;
-    const auto chance = reference_frames == 1
-        ? animation_factor
-        : (1.0 / reference_frames) * animation_factor;
-
-    return rand_value <= chance;
+    return Random::FpsCheck(reference_frames, static_cast<double>(FPS_ANIMATION_FACTOR));
 }
 
 void CalcFPS()

--- a/Source Main 5.2/source/ZzzAI.cpp
+++ b/Source Main 5.2/source/ZzzAI.cpp
@@ -486,8 +486,8 @@ void MoveHead(CHARACTER* c)
         {
             if (rand_fps_check(32))
             {
-                o->HeadTargetAngle[0] = static_cast<float>(Random::RangeInt(-64, 63));
-                o->HeadTargetAngle[1] = static_cast<float>(Random::RangeInt(-16, 31));
+                o->HeadTargetAngle[0] = Random::RangeFloat(-64, 63);
+                o->HeadTargetAngle[1] = Random::RangeFloat(-16, 31);
                 for (int i = 0; i < 2; i++)
                     if (o->HeadTargetAngle[i] < 0) o->HeadTargetAngle[i] += 360.f;
             }
@@ -525,7 +525,7 @@ void Damage(vec3_t soPosition, CHARACTER* tc, float AttackRange, int AttackPoint
         {
             CreateParticle(BITMAP_SPARK, Position, to->Angle, Light);
             vec3_t Angle;
-            Vector(-static_cast<float>(Random::RangeInt(30, 89)), 0.f, static_cast<float>(Random::RangeInt(0, 359)), Angle);
+            Vector(-Random::RangeFloat(30, 89), 0.f, Random::RangeFloat(0, 359), Angle);
             CreateJoint(BITMAP_JOINT_SPARK, Position, Position, Angle);
         }
         CreateParticle(BITMAP_SPARK + 1, Position, to->Angle, Light);

--- a/Source Main 5.2/source/ZzzEffectBlurSpark.cpp
+++ b/Source Main 5.2/source/ZzzEffectBlurSpark.cpp
@@ -13,11 +13,11 @@
 #include "ZzzEffect.h"
 #include "DSPlaySound.h"
 #include "WSclient.h"
+#include "Random.h"
 
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <random>
 
 namespace
 {
@@ -90,23 +90,6 @@ std::array<ObjectBlur, MAX_OBJECT_BLURS> g_objectBlurs{};
 std::array<physics_vertex, FLAG_HEIGHT * FLAG_WIDTH> g_flagVertices{};
 std::array<physics_face, (FLAG_HEIGHT - 1) * (FLAG_WIDTH - 1)> g_flagFaces{};
 
-std::mt19937& RandomEngine()
-{
-    thread_local static std::mt19937 engine{std::random_device{}()};
-    return engine;
-}
-
-int RandomInt(int minInclusive, int maxInclusive)
-{
-    std::uniform_int_distribution<int> dist(minInclusive, maxInclusive);
-    return dist(RandomEngine());
-}
-
-float RandomFloat(float minInclusive, float maxInclusive)
-{
-    std::uniform_real_distribution<float> dist(minInclusive, maxInclusive);
-    return dist(RandomEngine());
-}
 } // namespace
 
 void AddBlur(Blur* b, vec3_t p1, vec3_t p2, vec3_t Light, int Type)
@@ -451,7 +434,7 @@ void CreateSpark(int Type, CHARACTER* tc, vec3_t Position, vec3_t Angle)
     for (int i = 0; i < 20; i++)
     {
         vec3_t a;
-        Vector(RandomFloat(0.f, 360.f), 0.f, RandomFloat(0.f, 360.f), a);
+        Vector(Random::RangeFloat(0.f, 360.f), 0.f, Random::RangeFloat(0.f, 360.f), a);
         VectorAdd(a, Angle, a);
         CreateParticle(BITMAP_SPARK, Position, to->Angle, Light);
     }
@@ -473,10 +456,10 @@ void CreateBlood(OBJECT* o)
             vec3_t p, Position;
             for (int i = 0; i < 2; i++)
             {
-                Vector(RandomFloat(-50.f, 50.f), RandomFloat(-50.f, 50.f), 0.f, p);
+                Vector(Random::RangeFloat(-50.f, 50.f), Random::RangeFloat(-50.f, 50.f), 0.f, p);
                 Models[o->Type].TransformPosition(o->BoneTransform[BoneHead], p, Position, true);
-                const float rotation = RandomFloat(0.f, 360.f);
-                const float scale = RandomFloat(0.8f, 1.2f);
+                const float rotation = Random::RangeFloat(0.f, 360.f);
+                const float scale = Random::RangeFloat(0.8f, 1.2f);
                 CreatePointer(BITMAP_BLOOD, Position, rotation, o->Light, scale);
             }
         }

--- a/Source Main 5.2/source/ZzzEffectFireLeave.cpp
+++ b/Source Main 5.2/source/ZzzEffectFireLeave.cpp
@@ -169,7 +169,7 @@ bool CreateChaosCastleRain(PARTICLE* o, int Index)
 
     o->Type = BITMAP_RAIN;
     o->TurningForce[0] = 1.f;
-    o->TurningForce[1] = 30.f + RandomFloat(0, 9);
+    o->TurningForce[1] = 30.f + Random::RangeFloat(0, 9);
 
     if (Index < 300)
     {

--- a/Source Main 5.2/source/ZzzEffectFireLeave.cpp
+++ b/Source Main 5.2/source/ZzzEffectFireLeave.cpp
@@ -39,7 +39,7 @@ void CreateBonfire(vec3_t Position, vec3_t Angle)
     vec3_t Light;
     Vector(1.f, 1.f, 1.f, Light);
     CreateParticle(BITMAP_FIRE, Position, Angle, Light, Random::RangeInt(0, 3));
-    if (Random::FpsCheck(4))
+    if (rand_fps_check(4))
     {
         CreateParticle(BITMAP_SPARK, Position, Angle, Light);
         vec3_t a;
@@ -69,16 +69,16 @@ void CreateFire(int Type, OBJECT* o, float x, float y, float z)
     case 0:
         Luminosity = Random::RangeFloat(6, 11) * 0.1f;
         Vector(Luminosity, Luminosity * 0.6f, Luminosity * 0.4f, Light);
-        if (Random::FpsCheck(2))
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, Random::RangeInt(0, 3));
         AddTerrainLight(Position[0], Position[1], Light, 4, PrimaryTerrainLight);
         break;
     case 1:
-        if (Random::FpsCheck(2))
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light);
         break;
     case 2:
-        if (Random::FpsCheck(2))
+        if (rand_fps_check(2))
             CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light, 2);
         break;
     }
@@ -145,7 +145,7 @@ bool CreateDevilSquareRain(PARTICLE* o, int Index)
                o->Position);
     }
 
-    if (Random::FpsCheck(2))
+    if (rand_fps_check(2))
     {
         Vector(-Random::RangeFloat(20, 39), 0.f, 0.f, o->Angle);
     }
@@ -191,7 +191,7 @@ bool CreateChaosCastleRain(PARTICLE* o, int Index)
                Hero->Object.Position[2] + randomZ,
                o->Position);
     }
-    if (Random::FpsCheck(2))
+    if (rand_fps_check(2))
     {
         Vector(-Random::RangeFloat(20, 39), 0.f, 0.f, o->Angle);
     }
@@ -270,7 +270,7 @@ bool CreateDeviasSnow(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     o->Scale = 5.f;
-    if (Random::FpsCheck(10))
+    if (rand_fps_check(10))
     {
         o->Type = BITMAP_LEAF2;
         o->Scale = 10.f;
@@ -328,7 +328,7 @@ bool MoveDevilSquareRain(PARTICLE* o)
     {
         o->Live = false;
         o->Position[2] = Height + 10.f;
-        if (Random::FpsCheck(4))
+        if (rand_fps_check(4))
             CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light);
         else
             CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light);
@@ -346,7 +346,7 @@ bool MoveChaosCastleRain(PARTICLE* o)
     {
         o->Live = false;
         o->Position[2] = Height + 10.f;
-        if (Random::FpsCheck(4))
+        if (rand_fps_check(4))
             CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light);
         else
             CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light);

--- a/Source Main 5.2/source/ZzzEffectFireLeave.cpp
+++ b/Source Main 5.2/source/ZzzEffectFireLeave.cpp
@@ -20,30 +20,9 @@
 #include "MapManager.h"
 #include "w_MapHeaders.h"
 #include "NewUISystem.h"
+#include "Random.h"
 
 #include <cmath>
-#include <random>
-
-namespace
-{
-std::mt19937& RandomEngine()
-{
-    static std::mt19937 engine{std::random_device{}()};
-    return engine;
-}
-
-int RandomInt(int minInclusive, int maxInclusive)
-{
-    std::uniform_int_distribution<int> dist(minInclusive, maxInclusive);
-    return dist(RandomEngine());
-}
-
-float RandomFloat(float minInclusive, float maxInclusive)
-{
-    std::uniform_real_distribution<float> dist(minInclusive, maxInclusive);
-    return dist(RandomEngine());
-}
-} // namespace
 
 float RainTarget = 0;
 float RainCurrent = 0.f;
@@ -54,20 +33,20 @@ static  int RainPosition = 0;
 
 void CreateBonfire(vec3_t Position, vec3_t Angle)
 {
-    Position[0] += static_cast<float>(RandomInt(-8, 7));
-    Position[1] += static_cast<float>(RandomInt(-8, 7));
-    Position[2] += static_cast<float>(RandomInt(-8, 7));
+    Position[0] += static_cast<float>(Random::RangeInt(-8, 7));
+    Position[1] += static_cast<float>(Random::RangeInt(-8, 7));
+    Position[2] += static_cast<float>(Random::RangeInt(-8, 7));
     vec3_t Light;
     Vector(1.f, 1.f, 1.f, Light);
-    CreateParticle(BITMAP_FIRE, Position, Angle, Light, RandomInt(0, 3));
-    if (rand_fps_check(4))
+    CreateParticle(BITMAP_FIRE, Position, Angle, Light, Random::RangeInt(0, 3));
+    if (Random::FpsCheck(4))
     {
         CreateParticle(BITMAP_SPARK, Position, Angle, Light);
         vec3_t a;
-        Vector(-static_cast<float>(RandomInt(30, 89)), 0.f, RandomFloat(0.f, 360.f), a);
+        Vector(-static_cast<float>(Random::RangeInt(30, 89)), 0.f, Random::RangeFloat(0.f, 360.f), a);
         CreateJoint(BITMAP_JOINT_SPARK, Position, Position, a);
     }
-    const float Luminosity = static_cast<float>(RandomInt(6, 11)) * 0.1f;
+    const float Luminosity = static_cast<float>(Random::RangeInt(6, 11)) * 0.1f;
     Vector(Luminosity, Luminosity * 0.6f, Luminosity * 0.4f, Light);
     AddTerrainLight(Position[0], Position[1], Light, 4, PrimaryTerrainLight);
 }
@@ -82,24 +61,24 @@ void CreateFire(int Type, OBJECT* o, float x, float y, float z)
     Vector(x, y, z, p);
     VectorRotate(p, Matrix, Position);
     VectorAdd(Position, o->Position, Position);
-    Position[0] += static_cast<float>(RandomInt(-8, 7));
-    Position[1] += static_cast<float>(RandomInt(-8, 7));
-    Position[2] += static_cast<float>(RandomInt(-8, 7));
+    Position[0] += static_cast<float>(Random::RangeInt(-8, 7));
+    Position[1] += static_cast<float>(Random::RangeInt(-8, 7));
+    Position[2] += static_cast<float>(Random::RangeInt(-8, 7));
     switch (Type)
     {
     case 0:
-        Luminosity = static_cast<float>(RandomInt(6, 11)) * 0.1f;
+        Luminosity = static_cast<float>(Random::RangeInt(6, 11)) * 0.1f;
         Vector(Luminosity, Luminosity * 0.6f, Luminosity * 0.4f, Light);
-        if (rand_fps_check(2))
-            CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, RandomInt(0, 3));
+        if (Random::FpsCheck(2))
+            CreateParticle(BITMAP_FIRE, Position, o->Angle, Light, Random::RangeInt(0, 3));
         AddTerrainLight(Position[0], Position[1], Light, 4, PrimaryTerrainLight);
         break;
     case 1:
-        if (rand_fps_check(2))
+        if (Random::FpsCheck(2))
             CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light);
         break;
     case 2:
-        if (rand_fps_check(2))
+        if (Random::FpsCheck(2))
             CreateParticle(BITMAP_SMOKE, Position, o->Angle, o->Light, 2);
         break;
     }
@@ -147,9 +126,9 @@ bool CreateDevilSquareRain(PARTICLE* o, int Index)
     o->Type = BITMAP_RAIN;
     if (Index < 300)
     {
-        const float randomX = static_cast<float>(RandomInt(-800, 799));
-        const float randomY = static_cast<float>(RandomInt(-500, 899));
-        const float randomZ = static_cast<float>(RandomInt(300, 499));
+        const float randomX = static_cast<float>(Random::RangeInt(-800, 799));
+        const float randomY = static_cast<float>(Random::RangeInt(-500, 899));
+        const float randomZ = static_cast<float>(Random::RangeInt(300, 499));
         Vector(Hero->Object.Position[0] + randomX,
                Hero->Object.Position[1] + randomY,
                Hero->Object.Position[2] + randomZ,
@@ -157,26 +136,26 @@ bool CreateDevilSquareRain(PARTICLE* o, int Index)
     }
     else
     {
-        const float randomX = static_cast<float>(RandomInt(-800, 799));
-        const float randomY = static_cast<float>(RandomInt(1000, 1299)) - RainPosition;
-        const float randomZ = static_cast<float>(RandomInt(300, 499));
+        const float randomX = static_cast<float>(Random::RangeInt(-800, 799));
+        const float randomY = static_cast<float>(Random::RangeInt(1000, 1299)) - RainPosition;
+        const float randomZ = static_cast<float>(Random::RangeInt(300, 499));
         Vector(Hero->Object.Position[0] + randomX,
                Hero->Object.Position[1] + randomY,
                Hero->Object.Position[2] + randomZ,
                o->Position);
     }
 
-    if (rand_fps_check(2))
+    if (Random::FpsCheck(2))
     {
-        Vector(-static_cast<float>(RandomInt(20, 39)), 0.f, 0.f, o->Angle);
+        Vector(-static_cast<float>(Random::RangeInt(20, 39)), 0.f, 0.f, o->Angle);
     }
     else
     {
-        Vector(-static_cast<float>(RandomInt(30, 49) + RainAngle), 0.f, 0.f, o->Angle);
+        Vector(-static_cast<float>(Random::RangeInt(30, 49) + RainAngle), 0.f, 0.f, o->Angle);
     }
 
     vec3_t Velocity;
-    Vector(0.f, 0.f, -static_cast<float>((RandomInt(0, 39) + RainSpeed) * FPS_ANIMATION_FACTOR), Velocity);
+    Vector(0.f, 0.f, -static_cast<float>((Random::RangeInt(0, 39) + RainSpeed) * FPS_ANIMATION_FACTOR), Velocity);
     float Matrix[3][4];
     AngleMatrix(o->Angle, Matrix);
     VectorRotate(Velocity, Matrix, o->Velocity);
@@ -190,13 +169,13 @@ bool CreateChaosCastleRain(PARTICLE* o, int Index)
 
     o->Type = BITMAP_RAIN;
     o->TurningForce[0] = 1.f;
-    o->TurningForce[1] = 30.f + static_cast<float>(RandomInt(0, 9));
+    o->TurningForce[1] = 30.f + static_cast<float>(Random::RangeInt(0, 9));
 
     if (Index < 300)
     {
-        const float randomX = static_cast<float>(RandomInt(-800, 799));
-        const float randomY = static_cast<float>(RandomInt(-500, 899));
-        const float randomZ = static_cast<float>(RandomInt(300, 499));
+        const float randomX = static_cast<float>(Random::RangeInt(-800, 799));
+        const float randomY = static_cast<float>(Random::RangeInt(-500, 899));
+        const float randomZ = static_cast<float>(Random::RangeInt(300, 499));
         Vector(Hero->Object.Position[0] + randomX,
                Hero->Object.Position[1] + randomY,
                Hero->Object.Position[2] + randomZ,
@@ -204,24 +183,24 @@ bool CreateChaosCastleRain(PARTICLE* o, int Index)
     }
     else
     {
-        const float randomX = static_cast<float>(RandomInt(-800, 799));
-        const float randomY = static_cast<float>(RandomInt(1000, 1299)) - RainPosition;
-        const float randomZ = static_cast<float>(RandomInt(300, 499));
+        const float randomX = static_cast<float>(Random::RangeInt(-800, 799));
+        const float randomY = static_cast<float>(Random::RangeInt(1000, 1299)) - RainPosition;
+        const float randomZ = static_cast<float>(Random::RangeInt(300, 499));
         Vector(Hero->Object.Position[0] + randomX,
                Hero->Object.Position[1] + randomY,
                Hero->Object.Position[2] + randomZ,
                o->Position);
     }
-    if (rand_fps_check(2))
+    if (Random::FpsCheck(2))
     {
-        Vector(-static_cast<float>(RandomInt(20, 39)), 0.f, 0.f, o->Angle);
+        Vector(-static_cast<float>(Random::RangeInt(20, 39)), 0.f, 0.f, o->Angle);
     }
     else
     {
-        Vector(-static_cast<float>(RandomInt(30, 49) + RainAngle), 0.f, 0.f, o->Angle);
+        Vector(-static_cast<float>(Random::RangeInt(30, 49) + RainAngle), 0.f, 0.f, o->Angle);
     }
     vec3_t Velocity;
-    Vector(0.f, 0.f, -static_cast<float>((RandomInt(0, 39) + RainSpeed + 20) * FPS_ANIMATION_FACTOR), Velocity);
+    Vector(0.f, 0.f, -static_cast<float>((Random::RangeInt(0, 39) + RainSpeed + 20) * FPS_ANIMATION_FACTOR), Velocity);
     float Matrix[3][4];
     AngleMatrix(o->Angle, Matrix);
     VectorRotate(Velocity, Matrix, o->Velocity);
@@ -235,24 +214,24 @@ bool CreateLorenciaLeaf(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     vec3_t Position;
-    Vector(Hero->Object.Position[0] + static_cast<float>(RandomInt(-800, 799)),
-        Hero->Object.Position[1] + static_cast<float>(RandomInt(-500, 899)),
-        Hero->Object.Position[2] + static_cast<float>(RandomInt(50, 349)),
+    Vector(Hero->Object.Position[0] + static_cast<float>(Random::RangeInt(-800, 799)),
+        Hero->Object.Position[1] + static_cast<float>(Random::RangeInt(-500, 899)),
+        Hero->Object.Position[2] + static_cast<float>(Random::RangeInt(50, 349)),
         Position);
     VectorCopy(Position, o->Position);
     VectorCopy(Position, o->StartPosition);
-    o->Velocity[0] = -static_cast<float>(RandomInt(64, 127)) * 0.1f;
+    o->Velocity[0] = -static_cast<float>(Random::RangeInt(64, 127)) * 0.1f;
     if (Position[1] < CameraPosition[1] + 400.f)
     {
         o->Velocity[0] = -o->Velocity[0] + 3.2f;
     }
 
     o->Velocity[0] *= FPS_ANIMATION_FACTOR;
-    o->Velocity[1] = static_cast<float>(RandomInt(-16, 15)) * 0.1f * FPS_ANIMATION_FACTOR;
-    o->Velocity[2] = static_cast<float>(RandomInt(-16, 15)) * 0.1f * FPS_ANIMATION_FACTOR;
-    o->TurningForce[0] = static_cast<float>(RandomInt(-8, 7)) * 0.1f;
-    o->TurningForce[1] = static_cast<float>(RandomInt(-32, 31)) * 0.1f;
-    o->TurningForce[2] = static_cast<float>(RandomInt(-8, 7)) * 0.1f;
+    o->Velocity[1] = static_cast<float>(Random::RangeInt(-16, 15)) * 0.1f * FPS_ANIMATION_FACTOR;
+    o->Velocity[2] = static_cast<float>(Random::RangeInt(-16, 15)) * 0.1f * FPS_ANIMATION_FACTOR;
+    o->TurningForce[0] = static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f;
+    o->TurningForce[1] = static_cast<float>(Random::RangeInt(-32, 31)) * 0.1f;
+    o->TurningForce[2] = static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f;
 
     return true;
 }
@@ -271,13 +250,13 @@ bool CreateHeavenRain(PARTICLE* o, int index)
     {
         o->Type = BITMAP_RAIN;
         Vector(
-            Hero->Object.Position[0] + static_cast<float>(RandomInt(-800, 799)),
-            Hero->Object.Position[1] + static_cast<float>(RandomInt(-500, 899)),
-            Hero->Object.Position[2] + static_cast<float>(RandomInt(200, 399)),
+            Hero->Object.Position[0] + static_cast<float>(Random::RangeInt(-800, 799)),
+            Hero->Object.Position[1] + static_cast<float>(Random::RangeInt(-500, 899)),
+            Hero->Object.Position[2] + static_cast<float>(Random::RangeInt(200, 399)),
             o->Position);
         Vector(-30.f, 0.f, 0.f, o->Angle);
         vec3_t Velocity;
-        Vector(0.f, 0.f, -static_cast<float>(RandomInt(20, 43)), Velocity);
+        Vector(0.f, 0.f, -static_cast<float>(Random::RangeInt(20, 43)), Velocity);
         float Matrix[3][4];
         AngleMatrix(o->Angle, Matrix);
         VectorRotate(Velocity, Matrix, o->Velocity);
@@ -291,18 +270,18 @@ bool CreateDeviasSnow(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     o->Scale = 5.f;
-    if (rand_fps_check(10))
+    if (Random::FpsCheck(10))
     {
         o->Type = BITMAP_LEAF2;
         o->Scale = 10.f;
     }
-    Vector(Hero->Object.Position[0] + static_cast<float>(RandomInt(-800, 799)),
-        Hero->Object.Position[1] + static_cast<float>(RandomInt(-500, 899)),
-        Hero->Object.Position[2] + static_cast<float>(RandomInt(200, 399)),
+    Vector(Hero->Object.Position[0] + static_cast<float>(Random::RangeInt(-800, 799)),
+        Hero->Object.Position[1] + static_cast<float>(Random::RangeInt(-500, 899)),
+        Hero->Object.Position[2] + static_cast<float>(Random::RangeInt(200, 399)),
         o->Position);
     Vector(-30.f, 0.f, 0.f, o->Angle);
     vec3_t Velocity;
-    Vector(0.f, 0.f, -static_cast<float>(RandomInt(8, 23)), Velocity);
+    Vector(0.f, 0.f, -static_cast<float>(Random::RangeInt(8, 23)), Velocity);
     float Matrix[3][4];
     AngleMatrix(o->Angle, Matrix);
     VectorRotate(Velocity, Matrix, o->Velocity);
@@ -316,19 +295,19 @@ bool CreateAtlanseLeaf(PARTICLE* o)
 
     o->Type = BITMAP_LEAF1;
     vec3_t Position;
-    Vector(Hero->Object.Position[0] + static_cast<float>(RandomInt(-800, 799)),
-        Hero->Object.Position[1] + static_cast<float>(RandomInt(-500, 899)),
-        Hero->Object.Position[2] + static_cast<float>(RandomInt(50, 349)),
+    Vector(Hero->Object.Position[0] + static_cast<float>(Random::RangeInt(-800, 799)),
+        Hero->Object.Position[1] + static_cast<float>(Random::RangeInt(-500, 899)),
+        Hero->Object.Position[2] + static_cast<float>(Random::RangeInt(50, 349)),
         Position);
     VectorCopy(Position, o->Position);
     VectorCopy(Position, o->StartPosition);
-    o->Velocity[0] = -static_cast<float>(RandomInt(64, 127)) * 0.1f;
+    o->Velocity[0] = -static_cast<float>(Random::RangeInt(64, 127)) * 0.1f;
     if (Position[1] < CameraPosition[1] + 400.f) o->Velocity[0] = -o->Velocity[0] + 3.2f;
-    o->Velocity[1] = static_cast<float>(RandomInt(-16, 15)) * 0.1f;
-    o->Velocity[2] = static_cast<float>(RandomInt(-16, 15)) * 0.1f;
-    o->TurningForce[0] = static_cast<float>(RandomInt(-8, 7)) * 0.1f;
-    o->TurningForce[1] = static_cast<float>(RandomInt(-32, 31)) * 0.1f;
-    o->TurningForce[2] = static_cast<float>(RandomInt(-8, 7)) * 0.1f;
+    o->Velocity[1] = static_cast<float>(Random::RangeInt(-16, 15)) * 0.1f;
+    o->Velocity[2] = static_cast<float>(Random::RangeInt(-16, 15)) * 0.1f;
+    o->TurningForce[0] = static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f;
+    o->TurningForce[1] = static_cast<float>(Random::RangeInt(-32, 31)) * 0.1f;
+    o->TurningForce[2] = static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f;
 
     return true;
 }
@@ -349,7 +328,7 @@ bool MoveDevilSquareRain(PARTICLE* o)
     {
         o->Live = false;
         o->Position[2] = Height + 10.f;
-        if (rand_fps_check(4))
+        if (Random::FpsCheck(4))
             CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light);
         else
             CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light);
@@ -367,7 +346,7 @@ bool MoveChaosCastleRain(PARTICLE* o)
     {
         o->Live = false;
         o->Position[2] = Height + 10.f;
-        if (rand_fps_check(4))
+        if (Random::FpsCheck(4))
             CreateParticle(BITMAP_RAIN_CIRCLE, o->Position, o->Angle, o->Light);
         else
             CreateParticle(BITMAP_RAIN_CIRCLE + 1, o->Position, o->Angle, o->Light);
@@ -393,14 +372,14 @@ bool MoveHeavenRain(PARTICLE* o)
     }
     else
     {
-        o->Velocity[0] += static_cast<float>(RandomInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
-        o->Velocity[1] += static_cast<float>(RandomInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
-        o->Velocity[2] += static_cast<float>(RandomInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[0] += static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[1] += static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[2] += static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
         VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
 
-        o->TurningForce[0] += static_cast<float>(RandomInt(-4, 3)) * 0.02f * FPS_ANIMATION_FACTOR;
-        o->TurningForce[1] += static_cast<float>(RandomInt(-8, 7)) * 0.02f * FPS_ANIMATION_FACTOR;
-        o->TurningForce[2] += static_cast<float>(RandomInt(-4, 3)) * 0.02f * FPS_ANIMATION_FACTOR;
+        o->TurningForce[0] += static_cast<float>(Random::RangeInt(-4, 3)) * 0.02f * FPS_ANIMATION_FACTOR;
+        o->TurningForce[1] += static_cast<float>(Random::RangeInt(-8, 7)) * 0.02f * FPS_ANIMATION_FACTOR;
+        o->TurningForce[2] += static_cast<float>(Random::RangeInt(-4, 3)) * 0.02f * FPS_ANIMATION_FACTOR;
         VectorAdd(o->Angle, o->TurningForce, o->Angle);
 
         vec3_t Range;
@@ -426,9 +405,9 @@ void MoveEtcLeaf(PARTICLE* o)
     }
     else
     {
-        o->Velocity[0] += static_cast<float>(RandomInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
-        o->Velocity[1] += static_cast<float>(RandomInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
-        o->Velocity[2] += static_cast<float>(RandomInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[0] += static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[1] += static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
+        o->Velocity[2] += static_cast<float>(Random::RangeInt(-8, 7)) * 0.1f * FPS_ANIMATION_FACTOR;
         VectorAddScaled(o->Position, o->Velocity, o->Position, FPS_ANIMATION_FACTOR);
     }
 }

--- a/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
+++ b/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
@@ -14,25 +14,9 @@
 #include "DSPlaySound.h"
 #include "WSclient.h"
 #include "SkillManager.h"
+#include "Random.h"
 
 #include <cmath>
-#include <random>
-
-namespace
-{
-std::mt19937& RandomEngine()
-{
-    static std::mt19937 engine{std::random_device{}()};
-    return engine;
-}
-
-float RandomFloat(float minInclusive, float maxInclusive)
-{
-    static std::uniform_real_distribution<float> dist;
-    using Dist = std::uniform_real_distribution<float>;
-    return dist(RandomEngine(), Dist::param_type{minInclusive, maxInclusive});
-}
-} // namespace
 
 void RenderCircle(int Type, vec3_t ObjectPosition, float ScaleBottom, float ScaleTop, float Height, float Rotation, float LightTop, float TextureV)
 {
@@ -328,8 +312,8 @@ void CreateArrows(CHARACTER* c, OBJECT* o, OBJECT* to, WORD SkillIndex, WORD Ski
             vec3_t a;
             for (int i = 0; i < 15; ++i)
             {
-                Vector(RandomFloat(0.f, 360.f), 0.f, 0.f, a);
-                if (rand_fps_check(2))
+                Vector(Random::RangeFloat(0.f, 360.f), 0.f, 0.f, a);
+                if (Random::FpsCheck(2))
                 {
                     CreateJoint(BITMAP_JOINT_SPARK, Position, Position, a, 3);
                 }

--- a/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
+++ b/Source Main 5.2/source/ZzzEffectMagicSkill.cpp
@@ -313,7 +313,7 @@ void CreateArrows(CHARACTER* c, OBJECT* o, OBJECT* to, WORD SkillIndex, WORD Ski
             for (int i = 0; i < 15; ++i)
             {
                 Vector(Random::RangeFloat(0.f, 360.f), 0.f, 0.f, a);
-                if (Random::FpsCheck(2))
+                if (rand_fps_check(2))
                 {
                     CreateJoint(BITMAP_JOINT_SPARK, Position, Position, a, 3);
                 }

--- a/Source Main 5.2/source/ZzzEffectPointer.cpp
+++ b/Source Main 5.2/source/ZzzEffectPointer.cpp
@@ -13,23 +13,7 @@
 #include "ZzzEffect.h"
 #include "DSPlaySound.h"
 #include "WSclient.h"
-
-#include <random>
-
-namespace
-{
-std::mt19937& RandomEngine()
-{
-    static std::mt19937 engine{std::random_device{}()};
-    return engine;
-}
-
-int RandomInt(int minInclusive, int maxInclusive)
-{
-    std::uniform_int_distribution<int> dist(minInclusive, maxInclusive);
-    return dist(RandomEngine());
-}
-} // namespace
+#include "Random.h"
 
 PARTICLE  Pointers[MAX_POINTERS];
 
@@ -54,7 +38,7 @@ void CreatePointer(int Type, vec3_t Position, float Angle, vec3_t Light, float S
             case BITMAP_BLOOD:
             case BITMAP_BLOOD + 1:
             case BITMAP_FOOT:
-                o->LifeTime = 50 + RandomInt(0, 31);
+                o->LifeTime = 50 + Random::RangeInt(0, 31);
                 break;
             }
             return;


### PR DESCRIPTION
## Overview

The `Random` module provides thread-safe random number generation.

## Key Features

- **Thread-safe**: Uses `thread_local` storage for per-thread RNG state
- **High-quality**: Mersenne Twister (mt19937) with multi-source seeding
- **Modern C++17**: Pure standard library, no platform dependencies
- **Zero global state**: No mutexes, no shared state between threads

## API Reference

### Integer Random Numbers

```cpp
#include "Random.h"

// Get random integer in range [min, max] (both inclusive)
int value = Random::RangeInt(0, 100);        // 0 to 100
int dice = Random::RangeInt(1, 6);           // 1 to 6
int offset = Random::RangeInt(-50, 50);      // -50 to 50
```

### Floating Point Random Numbers

```cpp
// Get random float in range [min, max] (both inclusive)
float angle = Random::RangeFloat(0.0f, 360.0f);
float scale = Random::RangeFloat(0.8f, 1.2f);
float offset = Random::RangeFloat(-100.0f, 100.0f);

// Get random value in [0.0, 1.0]
float probability = Random::Unit();
double highPrecision = Random::UnitDouble();
```

### FPS-Aware Probability Checks

```cpp
// Check with FPS animation factor
extern double FPS_ANIMATION_FACTOR;

if (Random::FpsCheck(10, FPS_ANIMATION_FACTOR))
{
    // Happens ~10% of the time at reference FPS
    // Automatically adjusted for current FPS
}

// Simplified version (assumes factor = 1.0)
if (Random::FpsCheck(5))
{
    // Happens ~20% of the time
}
```

## Thread Safety

The module is fully thread-safe:

- Each thread gets its own independent `std::mt19937` engine
- No shared state between threads
- No mutexes or locks required
- Zero contention in multi-threaded scenarios

## Performance

- **Initialization**: One-time per thread (lazy initialization)
- **Generation**: Same performance as raw `std::mt19937`
- **Memory**: ~2.5KB per thread for MT19937 state
- **Overhead**: Negligible function call overhead (can be inlined)

## Design Rationale

### Why thread_local?

- **No locks**: Each thread has independent state
- **Cache-friendly**: No false sharing between threads
- **Lazy init**: Only initialized when first used per thread
- **Standard C++**: No platform-specific threading code

### Why Mersenne Twister?

- **High quality**: 2^19937-1 period, passes statistical tests
- **Fast**: Efficient on modern CPUs
- **Standard**: Part of C++11+ `<random>` library
- **Proven**: Industry standard for game development

### Why multiple random_device calls?

- **Better entropy**: Combines multiple hardware entropy sources
- **Seed diversity**: Reduces chance of identical seeds across threads
- **Robustness**: Works even if random_device has limited entropy

## Common Patterns

### Random Position Offset

```cpp
vec3_t offset;
offset[0] = static_cast<float>(Random::RangeInt(-50, 50));
offset[1] = static_cast<float>(Random::RangeInt(-50, 50));
offset[2] = static_cast<float>(Random::RangeInt(-50, 50));
VectorAdd(basePosition, offset, finalPosition);
```

### Random Angle

```cpp
vec3_t angle;
angle[0] = Random::RangeFloat(0.0f, 360.0f);
angle[1] = 0.0f;
angle[2] = Random::RangeFloat(0.0f, 360.0f);
```

### Probability-Based Spawning

```cpp
if (Random::FpsCheck(4, FPS_ANIMATION_FACTOR))
{
    CreateParticle(BITMAP_FIRE, position, angle, light);
}
```

### Random Selection

```cpp
int boneIndex = Random::RangeInt(0, 65);
int textureVariant = Random::RangeInt(0, 3);
```

## Notes

- All ranges are **inclusive** on both ends: `[min, max]`
- If `min >= max`, functions return `min` (safe fallback)
- FPS check clamps animation factor to `[0.0, 1.0]` automatically
- No need to call `srand()` or seed manually - handled automatically
