### PR TITLE
Right click sell

### DIFF
--- a/Source Main 5.2/source/NewUICommonMessageBox.cpp
+++ b/Source Main 5.2/source/NewUICommonMessageBox.cpp
@@ -2548,6 +2548,12 @@ CALLBACK_RESULT SEASON3B::CHighValueItemCheckMsgBoxLayout::OkBtnDown(class CNewU
     {
         SocketClient->ToGameServer()->SendSellItemToNpcRequest(iSourceIndex);
         g_pNPCShop->SetSellingItem(true);
+        // Note: picked item will be cleaned up by ReceiveSell when server responds
+    }
+    else
+    {
+        // If no valid item, restore it
+        CNewUIInventoryCtrl::BackupPickedItem();
     }
 
     PlayBuffer(SOUND_CLICK01);

--- a/Source Main 5.2/source/NewUIMyInventory.cpp
+++ b/Source Main 5.2/source/NewUIMyInventory.cpp
@@ -2142,20 +2142,21 @@ bool CNewUIMyInventory::HandleInventoryActions(CNewUIInventoryCtrl* targetContro
                 return false;
             }
 
-            // Create a picked item and remove from inventory (same as drag-and-drop)
+            // Create a picked item (same as drag-and-drop)
             if (!CNewUIInventoryCtrl::CreatePickedItem(targetControl, pItem))
             {
                 return false;
             }
 
-            // Remove item from inventory display (will be restored if sell fails)
-            targetControl->RemoveItem(pItem);
-
+            // Verify the picked item was created successfully before removing from inventory
             CNewUIPickedItem* pPickedItem = CNewUIInventoryCtrl::GetPickedItem();
             if (!pPickedItem)
             {
                 return false;
             }
+
+            // Now it's safe to remove item from inventory display (will be restored if sell fails)
+            targetControl->RemoveItem(pItem);
 
             // Hide the picked item so it's not visually displayed while selling
             pPickedItem->HidePickedItem();

--- a/Source Main 5.2/source/NewUIMyInventory.cpp
+++ b/Source Main 5.2/source/NewUIMyInventory.cpp
@@ -1484,7 +1484,8 @@ bool CNewUIMyInventory::EquipmentWindowProcess()
         const int iSourceIndex = m_iPointedSlot;
         if (GetRepairMode() != REPAIR_MODE_ON && EquipmentItem == false
             && pPickedItem == nullptr
-            && iSourceIndex != -1)
+            && iSourceIndex != -1
+            && !g_pNewUISystem->IsVisible(INTERFACE_NPCSHOP))  // Don't unequip when NPC shop is open
         {
             ResetMouseRButton();
 

--- a/Source Main 5.2/source/NewUINPCShop.cpp
+++ b/Source Main 5.2/source/NewUINPCShop.cpp
@@ -150,14 +150,6 @@ bool SEASON3B::CNewUINPCShop::UpdateMouseEvent()
 
     if (CheckMouseIn(m_Pos.x, m_Pos.y, NPCSHOP_WIDTH, NPCSHOP_HEIGHT))
     {
-        if (SEASON3B::IsPress(VK_RBUTTON))
-        {
-            MouseRButton = false;
-            MouseRButtonPop = false;
-            MouseRButtonPush = false;
-            return false;
-        }
-
         if (SEASON3B::IsNone(VK_LBUTTON) == false)
         {
             return false;


### PR DESCRIPTION
Adds feature to right click sell items in shops.

Open Question should it even be possible to unequip items in shop? possible accidential sell of non valuable items. we could add an additional check if you realy want to sell the item if it was equiped previously and still allow to unequip items on right click when shop is visible. Note this might be a bit more tricky

closes #252 