### PR TITLE
Improve performance skill req check caching

### DIFF
--- a/src/source/SkillManager.cpp
+++ b/src/source/SkillManager.cpp
@@ -238,6 +238,16 @@ void CSkillManager::RebuildSkillRequirementsCache()
         return;
     }
 
+    const bool isGuardian = gMapManager.IsEmpireGuardian();
+
+    DemendConditionInfo heroCharacterInfo;
+    heroCharacterInfo.SkillLevel = CharacterMachine->Character.Level;
+    heroCharacterInfo.SkillStrength = CharacterMachine->Character.Strength + CharacterMachine->Character.AddStrength;
+    heroCharacterInfo.SkillDexterity = CharacterMachine->Character.Dexterity + CharacterMachine->Character.AddDexterity;
+    heroCharacterInfo.SkillVitality = CharacterMachine->Character.Vitality + CharacterMachine->Character.AddVitality;
+    heroCharacterInfo.SkillEnergy = CharacterMachine->Character.Energy + CharacterMachine->Character.AddEnergy;
+    heroCharacterInfo.SkillCharisma = CharacterMachine->Character.Charisma + CharacterMachine->Character.AddCharisma;
+
     for (int skillType = 0; skillType < MAX_SKILLS; ++skillType)
     {
         if (SkillAttribute[skillType].Energy == 0)
@@ -246,13 +256,13 @@ void CSkillManager::RebuildSkillRequirementsCache()
             continue;
         }
 
-        if ((true == gMapManager.IsEmpireGuardian()) && (skillType == AT_SKILL_TELEPORT_ALLY || skillType == AT_SKILL_TELEPORT))
+        if (isGuardian && (skillType == AT_SKILL_TELEPORT_ALLY || skillType == AT_SKILL_TELEPORT))
         {
             m_aSkillRequirementsFulfilled[skillType] = false;
             continue;
         }
 
-        ActionSkillType baseSkill = MasterSkillToBaseSkillIndex((ActionSkillType)skillType);
+        ActionSkillType baseSkill = MasterSkillToBaseSkillIndex(static_cast<ActionSkillType>(skillType));
 
         DemendConditionInfo skillRequirements;
         skillRequirements.SkillLevel = SkillAttribute[baseSkill].Level;
@@ -261,14 +271,6 @@ void CSkillManager::RebuildSkillRequirementsCache()
         skillRequirements.SkillVitality = 0;
         skillRequirements.SkillEnergy = (20 + (SkillAttribute[baseSkill].Energy * SkillAttribute[baseSkill].Level) * 0.04);
         skillRequirements.SkillCharisma = SkillAttribute[baseSkill].Charisma;
-
-        DemendConditionInfo heroCharacterInfo;
-        heroCharacterInfo.SkillLevel = CharacterMachine->Character.Level;
-        heroCharacterInfo.SkillStrength = CharacterMachine->Character.Strength + CharacterMachine->Character.AddStrength;
-        heroCharacterInfo.SkillDexterity = CharacterMachine->Character.Dexterity + CharacterMachine->Character.AddDexterity;
-        heroCharacterInfo.SkillVitality = CharacterMachine->Character.Vitality + CharacterMachine->Character.AddVitality;
-        heroCharacterInfo.SkillEnergy = CharacterMachine->Character.Energy + CharacterMachine->Character.AddEnergy;
-        heroCharacterInfo.SkillCharisma = CharacterMachine->Character.Charisma + CharacterMachine->Character.AddCharisma;
 
         m_aSkillRequirementsFulfilled[skillType] = (skillRequirements <= heroCharacterInfo);
     }

--- a/src/source/SkillManager.cpp
+++ b/src/source/SkillManager.cpp
@@ -12,6 +12,8 @@ extern bool CheckAttack();
 
 CSkillManager::CSkillManager() // OK
 {
+    m_bSkillRequirementsCacheDirty = true;
+    memset(m_aSkillRequirementsFulfilled, 0, sizeof(m_aSkillRequirementsFulfilled));
 }
 
 CSkillManager::~CSkillManager() // OK
@@ -209,37 +211,67 @@ bool CSkillManager::AreSkillRequirementsFulfilled(ActionSkillType skillType)
         return false;
     }
 
-    if ((true == gMapManager.IsEmpireGuardian()) && (skillType == AT_SKILL_TELEPORT_ALLY || skillType == AT_SKILL_TELEPORT))
+    // Rebuild cache if dirty (on first call after stat/skill changes)
+    if (m_bSkillRequirementsCacheDirty)
     {
-        return false;
+        RebuildSkillRequirementsCache();
     }
 
-    //if (SkillAttribute[SkillType].Energy == 0)
-    //{
-    //    return true;
-    //}
+    return m_aSkillRequirementsFulfilled[skillType];
+}
 
-    skillType = MasterSkillToBaseSkillIndex(skillType);
+void CSkillManager::InvalidateSkillRequirementsCache()
+{
+    m_bSkillRequirementsCacheDirty = true;
+}
 
-    DemendConditionInfo skillRequirements;
+void CSkillManager::InitializeSkillRequirementsCache()
+{
+    m_bSkillRequirementsCacheDirty = true;
+    RebuildSkillRequirementsCache();
+}
 
-    skillRequirements.SkillLevel = SkillAttribute[skillType].Level;
-    skillRequirements.SkillStrength = SkillAttribute[skillType].Strength;
-    skillRequirements.SkillDexterity = SkillAttribute[skillType].Dexterity;
-    skillRequirements.SkillVitality = 0;
-    skillRequirements.SkillEnergy = (20 + (SkillAttribute[skillType].Energy * SkillAttribute[skillType].Level) * 0.04);
-    skillRequirements.SkillCharisma = SkillAttribute[skillType].Charisma;
+void CSkillManager::RebuildSkillRequirementsCache()
+{
+    if (!m_bSkillRequirementsCacheDirty)
+    {
+        return;
+    }
 
-    DemendConditionInfo heroCharacterInfo;
+    for (int skillType = 0; skillType < MAX_SKILLS; ++skillType)
+    {
+        if (SkillAttribute[skillType].Energy == 0)
+        {
+            m_aSkillRequirementsFulfilled[skillType] = true;
+            continue;
+        }
 
-    heroCharacterInfo.SkillLevel = CharacterMachine->Character.Level;
-    heroCharacterInfo.SkillStrength = CharacterMachine->Character.Strength + CharacterMachine->Character.AddStrength;
-    heroCharacterInfo.SkillDexterity = CharacterMachine->Character.Dexterity + CharacterMachine->Character.AddDexterity;
-    heroCharacterInfo.SkillVitality = CharacterMachine->Character.Vitality + CharacterMachine->Character.AddVitality;
-    heroCharacterInfo.SkillEnergy = CharacterMachine->Character.Energy + CharacterMachine->Character.AddEnergy;
-    heroCharacterInfo.SkillCharisma = CharacterMachine->Character.Charisma + CharacterMachine->Character.AddCharisma;
+        if ((true == gMapManager.IsEmpireGuardian()) && (skillType == AT_SKILL_TELEPORT_ALLY || skillType == AT_SKILL_TELEPORT))
+        {
+            m_aSkillRequirementsFulfilled[skillType] = false;
+            continue;
+        }
 
-    auto result = skillRequirements <= heroCharacterInfo;
+        ActionSkillType baseSkill = MasterSkillToBaseSkillIndex((ActionSkillType)skillType);
 
-    return result;
+        DemendConditionInfo skillRequirements;
+        skillRequirements.SkillLevel = SkillAttribute[baseSkill].Level;
+        skillRequirements.SkillStrength = SkillAttribute[baseSkill].Strength;
+        skillRequirements.SkillDexterity = SkillAttribute[baseSkill].Dexterity;
+        skillRequirements.SkillVitality = 0;
+        skillRequirements.SkillEnergy = (20 + (SkillAttribute[baseSkill].Energy * SkillAttribute[baseSkill].Level) * 0.04);
+        skillRequirements.SkillCharisma = SkillAttribute[baseSkill].Charisma;
+
+        DemendConditionInfo heroCharacterInfo;
+        heroCharacterInfo.SkillLevel = CharacterMachine->Character.Level;
+        heroCharacterInfo.SkillStrength = CharacterMachine->Character.Strength + CharacterMachine->Character.AddStrength;
+        heroCharacterInfo.SkillDexterity = CharacterMachine->Character.Dexterity + CharacterMachine->Character.AddDexterity;
+        heroCharacterInfo.SkillVitality = CharacterMachine->Character.Vitality + CharacterMachine->Character.AddVitality;
+        heroCharacterInfo.SkillEnergy = CharacterMachine->Character.Energy + CharacterMachine->Character.AddEnergy;
+        heroCharacterInfo.SkillCharisma = CharacterMachine->Character.Charisma + CharacterMachine->Character.AddCharisma;
+
+        m_aSkillRequirementsFulfilled[skillType] = (skillRequirements <= heroCharacterInfo);
+    }
+
+    m_bSkillRequirementsCacheDirty = false;
 }

--- a/src/source/SkillManager.cpp
+++ b/src/source/SkillManager.cpp
@@ -256,13 +256,12 @@ void CSkillManager::RebuildSkillRequirementsCache()
             continue;
         }
 
-        if (isGuardian && (skillType == AT_SKILL_TELEPORT_ALLY || skillType == AT_SKILL_TELEPORT))
+        ActionSkillType baseSkill = MasterSkillToBaseSkillIndex(static_cast<ActionSkillType>(skillType));
+        if (isGuardian && (baseSkill == AT_SKILL_TELEPORT_ALLY || baseSkill == AT_SKILL_TELEPORT))
         {
             m_aSkillRequirementsFulfilled[skillType] = false;
             continue;
         }
-
-        ActionSkillType baseSkill = MasterSkillToBaseSkillIndex(static_cast<ActionSkillType>(skillType));
 
         DemendConditionInfo skillRequirements;
         skillRequirements.SkillLevel = SkillAttribute[baseSkill].Level;

--- a/src/source/SkillManager.cpp
+++ b/src/source/SkillManager.cpp
@@ -250,12 +250,6 @@ void CSkillManager::RebuildSkillRequirementsCache()
 
     for (int skillType = 0; skillType < MAX_SKILLS; ++skillType)
     {
-        if (SkillAttribute[skillType].Energy == 0)
-        {
-            m_aSkillRequirementsFulfilled[skillType] = true;
-            continue;
-        }
-
         ActionSkillType baseSkill = MasterSkillToBaseSkillIndex(static_cast<ActionSkillType>(skillType));
         if (isGuardian && (baseSkill == AT_SKILL_TELEPORT_ALLY || baseSkill == AT_SKILL_TELEPORT))
         {

--- a/src/source/SkillManager.h
+++ b/src/source/SkillManager.h
@@ -49,7 +49,16 @@ public:
     ActionSkillType MasterSkillToBaseSkillIndex(ActionSkillType masterSkill);
     bool skillVScharactorCheck(const DemendConditionInfo& basicInfo, const DemendConditionInfo& heroInfo);
     bool AreSkillRequirementsFulfilled(ActionSkillType skilltype);
-public:
+
+    // Cache management
+    void InvalidateSkillRequirementsCache();
+    void InitializeSkillRequirementsCache();
+
+private:
+    void RebuildSkillRequirementsCache();
+
+    bool m_bSkillRequirementsCacheDirty;
+    bool m_aSkillRequirementsFulfilled[MAX_SKILLS];
 };
 
 extern CSkillManager gSkillManager;

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -897,6 +897,9 @@ BOOL ReceiveJoinMapServer(std::span<const BYTE> ReceiveBuffer)
         g_pNewUISystem->Hide(SEASON3B::INTERFACE_EMPIREGUARDIAN_TIMER);
     }
 
+    // Initialize skill requirements cache on character login
+    gSkillManager.InitializeSkillRequirementsCache();
+
     g_ConsoleDebug->Write(MCD_RECEIVE, L"0x03 [ReceiveJoinMapServer]");
 
     return (TRUE);
@@ -1136,6 +1139,9 @@ void ReceiveMagicList(const BYTE* ReceiveBuffer)
 
     if (Master_Skill_Bool > -1 && Skill_Bool > -1)
         CharacterAttribute->Skill[Skill_Bool] = AT_SKILL_UNDEFINED;
+
+    // Skills have changed, invalidate skill requirements cache
+    gSkillManager.InvalidateSkillRequirementsCache();
 
     g_ConsoleDebug->Write(MCD_RECEIVE, L"0x11 [ReceiveMagicList]");
 }
@@ -6417,6 +6423,9 @@ void ReceiveLevelUp(const BYTE* ReceiveBuffer, int Size)
         CharacterAttribute->ManaMax = Data->MaxMana;
         CharacterAttribute->Life = Data->MaxLife;
         CharacterAttribute->Mana = Data->MaxMana;
+
+        // Character level changed, invalidate skill requirements cache
+        gSkillManager.InvalidateSkillRequirementsCache();
         CharacterAttribute->ShieldMax = Data->MaxShield;
         CharacterAttribute->SkillManaMax = Data->SkillManaMax;
         CharacterAttribute->AddPoint = Data->AddPoint;
@@ -6433,6 +6442,9 @@ void ReceiveLevelUp(const BYTE* ReceiveBuffer, int Size)
         CharacterAttribute->ManaMax = Data->MaxMana;
         CharacterAttribute->Life = Data->MaxLife;
         CharacterAttribute->Mana = Data->MaxMana;
+
+        // Character level changed, invalidate skill requirements cache
+        gSkillManager.InvalidateSkillRequirementsCache();
         CharacterAttribute->ShieldMax = Data->MaxShield;
         CharacterAttribute->SkillManaMax = Data->SkillManaMax;
         CharacterAttribute->AddPoint = Data->AddPoint;
@@ -6544,6 +6556,9 @@ void ReceiveSetPointsExtended(const BYTE* ReceiveBuffer)
     CharacterAttribute->Charisma = Data->Charisma;
 
     CharacterMachine->CalculateAll();
+
+    // Character stats changed, invalidate skill requirements cache
+    gSkillManager.InvalidateSkillRequirementsCache();
 }
 
 void ReceiveStatsExtended(const BYTE* ReceiveBuffer)

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -6558,6 +6558,7 @@ void ReceiveSetPointsExtended(const BYTE* ReceiveBuffer)
     CharacterMachine->CalculateAll();
 
     // Character stats changed, invalidate skill requirements cache
+    // it is called in `CalculatedAll` already, but for future changes and understandability also kept here because it does not have a huge impact.
     gSkillManager.InvalidateSkillRequirementsCache();
 }
 

--- a/src/source/ZzzInfomation.cpp
+++ b/src/source/ZzzInfomation.cpp
@@ -3618,4 +3618,7 @@ void CHARACTER_MACHINE::CalculateAll()
         FinalSuccessDefense = true;
     else
         FinalSuccessDefense = false;
+
+    // Stats recalculated (equipment/items changed), invalidate skill requirements cache
+    gSkillManager.InvalidateSkillRequirementsCache();
 }


### PR DESCRIPTION
## Tested in Devias 3 i had about 8+% fps increase.
### There is definitely other checks that could get a similar update later

This pull request significantly enhances performance by implementing a caching layer for skill requirement checks. Instead of recalculating skill prerequisites every time, the system now stores these results and intelligently invalidates the cache only when underlying character attributes, skills, or equipment change. This approach minimizes computational overhead, leading to a smoother and more responsive user experience, especially in scenarios where skill checks are frequent.

### Highlights

* **Skill Requirements Caching**: Introduced a caching system for `AreSkillRequirementsFulfilled` to optimize performance by avoiding redundant calculations of skill requirements.
* **Cache Invalidation**: Implemented mechanisms to invalidate the skill requirements cache when relevant character data changes, including character level-ups, stat point allocations, skill changes (learning/unlearning), and equipment changes that recalculate stats.
* **Cache Initialization**: Ensured the skill requirements cache is initialized and rebuilt upon character login (joining a map server) to provide accurate data from the start of a session.
* **Refactored Skill Check Logic**: The detailed logic for checking individual skill requirements has been moved into a new private `RebuildSkillRequirementsCache` method, which populates the cache for all skills.