### PR TITLE
Add $fpscounter chat command to toggle debug info overlay

### DIFF
--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -58,6 +58,15 @@ extern bool Destroy;
 extern double WorldTime;
 extern float FPS_ANIMATION_FACTOR;
 
+static bool g_bShowDebugInfo =
+#ifdef _DEBUG
+    true;
+#else
+    false;
+#endif
+
+void SetShowDebugInfo(bool enabled) { g_bShowDebugInfo = enabled; }
+
 void SetTargetFps(double targetFps)
 {
     if (IsVSyncEnabled() && targetFps >= GetFPSLimit())
@@ -298,7 +307,9 @@ static bool RenderCurrentScene(HDC hDC)
  */
 static void RenderDebugInfo()
 {
-#if defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
+    if (!g_bShowDebugInfo)
+        return;
+
     BeginBitmap();
     wchar_t szDebugText[128];
     swprintf(szDebugText, L"FPS: %.1f Vsync: %d CPU: %.1f%%", FPS_AVG, IsVSyncEnabled(), CPU_AVG);
@@ -314,7 +325,6 @@ static void RenderDebugInfo()
     g_pRenderText->RenderText(10, 46, szCamera3D);
     g_pRenderText->SetFont(g_hFont);
     EndBitmap();
-#endif // defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
 }
 
 /**

--- a/src/source/Utilities/Log/muConsoleDebug.cpp
+++ b/src/source/Utilities/Log/muConsoleDebug.cpp
@@ -79,6 +79,20 @@ void CmuConsoleDebug::UpdateMainScene()
 
 bool CmuConsoleDebug::CheckCommand(const std::wstring& strCommand)
 {
+    if (strCommand.compare(L"$fpscounter on") == 0)
+    {
+        extern void SetShowDebugInfo(bool);
+        SetShowDebugInfo(true);
+        return true;
+    }
+
+    if (strCommand.compare(L"$fpscounter off") == 0)
+    {
+        extern void SetShowDebugInfo(bool);
+        SetShowDebugInfo(false);
+        return true;
+    }
+
     if (strCommand.compare(0, 4, L"$fps") == 0)
     {
         auto fps_str = strCommand.substr(5);


### PR DESCRIPTION
RenderDebugInfo (FPS, mouse position, camera angles) is now:
- Always on in Debug builds
- Off by default in Release builds, toggle with $fpscounter on/off

The $fpscounter command is checked before the $fps prefix to avoid a crash from trying to parse "ounter on" as a float.