### PR TITLE
Fpscounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ What I have done so far:
       * Change FPS-Limit: `$fps <value>`
       * Enable V-Sync: `$vsync on`
       * Disable V-Sync: `$vsync off`
+      * Show simple FPS counter: `$fpscounter on` / `$fpscounter off`
+      * Show detailed performance overlay (FPS stats, percentiles, frame graph): `$details on` / `$details off`
   * 🔥 Optimized some OpenGL calls by using vertex arrays. This should result in
     a better frame rate when many players and objects are visible.
   * 🔥 Added inventory and vault extensions.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ What I have done so far:
     * The options menu includes a checkbox to reduce effects to achieve higher frame rates.
     * Chat commands:
       * Change FPS-Limit: `$fps <value>`
-      * Enable V-Sync: `$vsync on`
-      * Disable V-Sync: `$vsync off`
+      * V-Sync: `$vsync on` / `$vsync off`
       * Show simple FPS counter: `$fpscounter on` / `$fpscounter off`
       * Show detailed performance overlay (FPS stats, percentiles, frame graph): `$details on` / `$details off`
   * 🔥 Optimized some OpenGL calls by using vertex arrays. This should result in

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -92,6 +92,12 @@ static constexpr int MIN_FRAMES_FOR_STATS = 10;
 static constexpr float GRAPH_MAX_MS = 33.3f;        // graph Y-axis scale (30fps)
 static constexpr float THRESHOLD_60FPS_MS = 16.67f;  // 60 FPS threshold
 static constexpr float THRESHOLD_40FPS_MS = 25.0f;   // 40 FPS threshold
+static constexpr float DEBUG_TEXT_X = 10.0f;          // debug overlay X position
+static constexpr int DEBUG_TEXT_Y_START = 26;         // debug overlay Y start
+static constexpr int DEBUG_TEXT_LINE_HEIGHT = 10;     // line spacing
+static constexpr float DEBUG_GRAPH_WIDTH = 200.0f;    // frame graph width
+static constexpr float DEBUG_GRAPH_HEIGHT = 40.0f;    // frame graph height
+static constexpr float DEBUG_GRAPH_Y_OFFSET = 2.0f;   // gap between text and graph
 
 static float s_frameTimesMs[FRAME_HISTORY_SIZE] = {};
 static int s_frameIndex = 0;
@@ -486,24 +492,24 @@ static void RenderDebugInfo()
     g_pRenderText->SetBgColor(0, 0, 0, 100);
     g_pRenderText->SetTextColor(255, 255, 255, 200);
 
-    int y = 26;
+    int y = DEBUG_TEXT_Y_START;
     swprintf(szLine, L"FPS: %.1f  Avg: %.1f  Max: %.1f  Vsync: %d  CPU: %.1f%%",
         FPS_AVG, s_avgFps, s_highestFps, IsVSyncEnabled(), CPU_AVG);
-    g_pRenderText->RenderText(10, y, szLine); y += 10;
+    g_pRenderText->RenderText((int)DEBUG_TEXT_X, y, szLine); y += DEBUG_TEXT_LINE_HEIGHT;
 
     swprintf(szLine, L"1%% Low: %.1f  Slowest: %.1f  Frame: %.2fms",
         s_onePercentLow, s_slowestFrameFps,
         (s_avgFps > 0.0f) ? 1000.0f / s_avgFps : 0.0f);
-    g_pRenderText->RenderText(10, y, szLine); y += 10;
+    g_pRenderText->RenderText((int)DEBUG_TEXT_X, y, szLine); y += DEBUG_TEXT_LINE_HEIGHT;
 
     swprintf(szLine, L"MousePos: %d %d %d", MouseX, MouseY, MouseLButtonPush);
-    g_pRenderText->RenderText(10, y, szLine); y += 10;
+    g_pRenderText->RenderText((int)DEBUG_TEXT_X, y, szLine); y += DEBUG_TEXT_LINE_HEIGHT;
 
     swprintf(szLine, L"Camera3D: %.1f %.1f:%.1f:%.1f", CameraFOV, CameraAngle[0], CameraAngle[1], CameraAngle[2]);
-    g_pRenderText->RenderText(10, y, szLine); y += 10;
+    g_pRenderText->RenderText((int)DEBUG_TEXT_X, y, szLine); y += DEBUG_TEXT_LINE_HEIGHT;
 
     // Frame time graph below text
-    RenderFrameGraph(10.0f, (float)(y + 2), 200.0f, 40.0f);
+    RenderFrameGraph(DEBUG_TEXT_X, (float)y + DEBUG_GRAPH_Y_OFFSET, DEBUG_GRAPH_WIDTH, DEBUG_GRAPH_HEIGHT);
 
     g_pRenderText->SetFont(g_hFont);
     EndBitmap();
@@ -525,7 +531,7 @@ static void RenderFpsCounter()
     g_pRenderText->SetTextColor(255, 255, 255, 200);
 
     swprintf(szLine, L"FPS: %.1f", FPS_AVG);
-    g_pRenderText->RenderText(10, 26, szLine);
+    g_pRenderText->RenderText((int)DEBUG_TEXT_X, DEBUG_TEXT_Y_START, szLine);
 
     g_pRenderText->SetFont(g_hFont);
     EndBitmap();

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -440,6 +440,7 @@ static void RenderFrameGraph(float graphX, float graphY, float graphW, float gra
     float barW = gw / FRAME_HISTORY_SIZE;
     int oldest = (s_frameCount < FRAME_HISTORY_SIZE) ? 0 : s_frameIndex;
 
+    glBegin(GL_QUADS);
     for (int i = 0; i < s_frameCount; i++)
     {
         int idx = (oldest + i) % FRAME_HISTORY_SIZE;
@@ -456,13 +457,12 @@ static void RenderFrameGraph(float graphX, float graphY, float graphW, float gra
             glColor4f(0.9f, 0.2f, 0.2f, 0.8f);
 
         float bx = gx + i * barW;
-        glBegin(GL_QUADS);
         glVertex2f(bx, glBottom);
         glVertex2f(bx + barW, glBottom);
         glVertex2f(bx + barW, glBottom + barH);
         glVertex2f(bx, glBottom + barH);
-        glEnd();
     }
+    glEnd();
 
     glEnable(GL_TEXTURE_2D);
 }

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -85,6 +85,19 @@ static float s_onePercentLow = 0.0f;
 static float s_pointOnePercentLow = 0.0f;
 static double s_lastStatsUpdate = 0.0;
 
+void ResetFrameStats()
+{
+    memset(s_frameTimesMs, 0, sizeof(s_frameTimesMs));
+    s_frameIndex = 0;
+    s_frameCount = 0;
+    s_lastFrameTime = 0.0;
+    s_highestFps = 0.0;
+    s_avgFps = 0.0f;
+    s_onePercentLow = 0.0f;
+    s_pointOnePercentLow = 0.0f;
+    s_lastStatsUpdate = 0.0;
+}
+
 static void UpdateFrameStats()
 {
     double now = WorldTime;

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -58,6 +58,15 @@ extern bool Destroy;
 extern double WorldTime;
 extern float FPS_ANIMATION_FACTOR;
 
+static bool g_bShowDebugInfo =
+#ifdef _DEBUG
+    true;
+#else
+    false;
+#endif
+
+void SetShowDebugInfo(bool enabled) { g_bShowDebugInfo = enabled; }
+
 void SetTargetFps(double targetFps)
 {
     if (IsVSyncEnabled() && targetFps >= GetFPSLimit())
@@ -298,7 +307,9 @@ static bool RenderCurrentScene(HDC hDC)
  */
 static void RenderDebugInfo()
 {
-#if defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
+    if (!g_bShowDebugInfo)
+        return;
+
     BeginBitmap();
     wchar_t szDebugText[128];
     swprintf(szDebugText, L"FPS: %.1f Vsync: %d CPU: %.1f%%", FPS_AVG, IsVSyncEnabled(), CPU_AVG);
@@ -314,7 +325,6 @@ static void RenderDebugInfo()
     g_pRenderText->RenderText(10, 46, szCamera3D);
     g_pRenderText->SetFont(g_hFont);
     EndBitmap();
-#endif // defined(_DEBUG) || defined(LDS_FOR_DEVELOPMENT_TESTMODE) || defined(LDS_UNFIXED_FIXEDFRAME_FORDEBUG)
 }
 
 /**

--- a/src/source/Scenes/SceneManager.h
+++ b/src/source/Scenes/SceneManager.h
@@ -113,3 +113,8 @@ void MainScene(HDC hDC);
 // FPS management (legacy - use g_frameTiming instead)
 void SetTargetFps(double targetFps);
 double GetTargetFps();
+
+// Debug overlay controls
+void SetShowDebugInfo(bool enabled);
+void SetShowFpsCounter(bool enabled);
+void ResetFrameStats();

--- a/src/source/Utilities/Log/muConsoleDebug.cpp
+++ b/src/source/Utilities/Log/muConsoleDebug.cpp
@@ -85,49 +85,42 @@ bool CmuConsoleDebug::CheckCommand(const std::wstring& strCommand)
         SetShowFpsCounter(true);
         return true;
     }
-
-    if (strCommand.compare(L"$fpscounter off") == 0)
+    else if (strCommand.compare(L"$fpscounter off") == 0)
     {
         SetShowFpsCounter(false);
         return true;
     }
-
-    if (strCommand.compare(L"$details on") == 0)
+    else if (strCommand.compare(L"$details on") == 0)
     {
         SetShowDebugInfo(true);
         return true;
     }
-
-    if (strCommand.compare(L"$details off") == 0)
+    else if (strCommand.compare(L"$details off") == 0)
     {
         SetShowDebugInfo(false);
         return true;
     }
-
-    if (strCommand.compare(0, 4, L"$fps") == 0)
+    else if (strCommand.compare(0, 4, L"$fps") == 0)
     {
         auto fps_str = strCommand.substr(5);
         auto target_fps = std::stof(fps_str);
         SetTargetFps(target_fps);
         return true;
     }
-
-    if (strCommand.compare(L"$vsync on") == 0)
+    else if (strCommand.compare(L"$vsync on") == 0)
     {
         EnableVSync();
         SetTargetFps(-1); // unlimited
         ResetFrameStats();
         return true;
     }
-
-    if (strCommand.compare(L"$vsync off") == 0)
+    else if (strCommand.compare(L"$vsync off") == 0)
     {
         DisableVSync();
         ResetFrameStats();
         return true;
     }
-
-    if (strCommand.compare(0, 7, L"$winmsg") == 0)
+    else if (strCommand.compare(0, 7, L"$winmsg") == 0)
     {
         auto str_limit = strCommand.substr(8);
         auto message_limit = std::stof(str_limit);

--- a/src/source/Utilities/Log/muConsoleDebug.cpp
+++ b/src/source/Utilities/Log/muConsoleDebug.cpp
@@ -105,12 +105,16 @@ bool CmuConsoleDebug::CheckCommand(const std::wstring& strCommand)
     {
         EnableVSync();
         SetTargetFps(-1); // unlimited
+        extern void ResetFrameStats();
+        ResetFrameStats();
         return true;
     }
 
     if (strCommand.compare(L"$vsync off") == 0)
     {
         DisableVSync();
+        extern void ResetFrameStats();
+        ResetFrameStats();
         return true;
     }
 

--- a/src/source/Utilities/Log/muConsoleDebug.cpp
+++ b/src/source/Utilities/Log/muConsoleDebug.cpp
@@ -79,6 +79,20 @@ void CmuConsoleDebug::UpdateMainScene()
 
 bool CmuConsoleDebug::CheckCommand(const std::wstring& strCommand)
 {
+    if (strCommand.compare(L"$fpscounter on") == 0)
+    {
+        extern void SetShowDebugInfo(bool);
+        SetShowDebugInfo(true);
+        return true;
+    }
+
+    if (strCommand.compare(L"$fpscounter off") == 0)
+    {
+        extern void SetShowDebugInfo(bool);
+        SetShowDebugInfo(false);
+        return true;
+    }
+
     if (strCommand.compare(0, 4, L"$fps") == 0)
     {
         auto fps_str = strCommand.substr(5);

--- a/src/source/Utilities/Log/muConsoleDebug.cpp
+++ b/src/source/Utilities/Log/muConsoleDebug.cpp
@@ -15,6 +15,7 @@
 #include "GlobalBitmap.h"
 #include "ZzzTexture.h"
 #include "Scenes/SceneCore.h"
+#include "Scenes/SceneManager.h"
 
 #ifdef _EDITOR
 #include "../MuEditor/UI/Console/MuEditorConsoleUI.h"
@@ -81,14 +82,24 @@ bool CmuConsoleDebug::CheckCommand(const std::wstring& strCommand)
 {
     if (strCommand.compare(L"$fpscounter on") == 0)
     {
-        extern void SetShowDebugInfo(bool);
-        SetShowDebugInfo(true);
+        SetShowFpsCounter(true);
         return true;
     }
 
     if (strCommand.compare(L"$fpscounter off") == 0)
     {
-        extern void SetShowDebugInfo(bool);
+        SetShowFpsCounter(false);
+        return true;
+    }
+
+    if (strCommand.compare(L"$details on") == 0)
+    {
+        SetShowDebugInfo(true);
+        return true;
+    }
+
+    if (strCommand.compare(L"$details off") == 0)
+    {
         SetShowDebugInfo(false);
         return true;
     }
@@ -105,7 +116,6 @@ bool CmuConsoleDebug::CheckCommand(const std::wstring& strCommand)
     {
         EnableVSync();
         SetTargetFps(-1); // unlimited
-        extern void ResetFrameStats();
         ResetFrameStats();
         return true;
     }
@@ -113,7 +123,6 @@ bool CmuConsoleDebug::CheckCommand(const std::wstring& strCommand)
     if (strCommand.compare(L"$vsync off") == 0)
     {
         DisableVSync();
-        extern void ResetFrameStats();
         ResetFrameStats();
         return true;
     }


### PR DESCRIPTION
This pull request significantly enhances the in-game performance monitoring capabilities by introducing both a basic FPS counter and a comprehensive debug overlay. The detailed overlay provides crucial metrics like 1% low FPS and a visual frame time graph, offering a much deeper understanding of performance consistency beyond just average frame rates. These new tools are easily accessible and controllable via chat commands, enabling developers and users to quickly diagnose and analyze performance characteristics.

### Highlights

* **New Performance Overlays**: Introduced a simple FPS counter ('$fpscounter') and a detailed performance overlay ('$details') displaying average FPS, 1% low, slowest frame, and a visual frame time graph.
* **Detailed Frame Statistics**: Implemented a frame statistics tracker to record frame times, calculate average FPS, 1% low, and the slowest frame over a history of recent frames.
* **Visual Frame Time Graph**: Added a graphical representation of recent frame times, color-coded to indicate performance thresholds (e.g., 60 FPS, 40 FPS).
* **Console Command Integration**: New console commands ('$fpscounter on/off', '$details on/off') allow dynamic toggling of the performance overlays. 'ResetFrameStats()' is now called when VSync settings are changed.