### PR TITLE
feat(inventory): various RMB improvements around stash and inventory extensions

### DIFF
--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -1047,8 +1047,12 @@ namespace MUHelper
             }
             else
             {
-                SocketClient->ToGameServer()->SendPickupItemRequest(m_iCurrentItem);
-                DeleteItem(m_iCurrentItem);
+                if (SendGetItem == -1)
+                {
+                    SendGetItem = m_iCurrentItem;
+                    SocketClient->ToGameServer()->SendPickupItemRequest(m_iCurrentItem);
+                    DeleteItem(m_iCurrentItem);
+                }
             }
         }
 

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -1047,12 +1047,8 @@ namespace MUHelper
             }
             else
             {
-                if (SendGetItem == -1)
-                {
-                    SendGetItem = m_iCurrentItem;
-                    SocketClient->ToGameServer()->SendPickupItemRequest(m_iCurrentItem);
-                    DeleteItem(m_iCurrentItem);
-                }
+                SocketClient->ToGameServer()->SendPickupItemRequest(m_iCurrentItem);
+                DeleteItem(m_iCurrentItem);
             }
         }
 

--- a/src/source/NewUICommonMessageBox.cpp
+++ b/src/source/NewUICommonMessageBox.cpp
@@ -2544,7 +2544,7 @@ CALLBACK_RESULT SEASON3B::CHighValueItemCheckMsgBoxLayout::OkBtnDown(class CNewU
         }
     }
 
-    if (iSourceIndex != -1)
+    if (iSourceIndex >= MAX_EQUIPMENT_INDEX && iSourceIndex < MAX_MY_INVENTORY_EX_INDEX)
     {
         SocketClient->ToGameServer()->SendSellItemToNpcRequest(iSourceIndex);
         g_pNPCShop->SetSellingItem(true);

--- a/src/source/NewUIInventoryExtension.cpp
+++ b/src/source/NewUIInventoryExtension.cpp
@@ -136,16 +136,12 @@ bool CNewUIInventoryExtension::InventoryProcess()
         return false;
     }
 
-    int targetExtensionIndex = 0;
-    CNewUIInventoryCtrl* target = nullptr;
     for (auto* extension : m_extensions)
     {
         if (extension->CheckPtInRect(MouseX, MouseY))
         {
             return g_pMyInventory->HandleInventoryActions(extension);
         }
-
-        targetExtensionIndex++;
     }
 
     return false;
@@ -330,6 +326,29 @@ void CNewUIInventoryExtension::DeleteAllItems() const
             extension->RemoveAllItems();
         }
     }
+}
+
+int CNewUIInventoryExtension::FindEmptySlot(int cx, int cy, const CNewUIInventoryCtrl* excluded) const
+{
+    if (CharacterAttribute == nullptr)
+    {
+        return -1;
+    }
+
+    for (int i = 0; i < CharacterAttribute->InventoryExtensions; ++i)
+    {
+        auto* extension = m_extensions[i];
+        if (extension && extension != excluded)
+        {
+            const int emptySlot = extension->FindEmptySlot(cx, cy);
+            if (emptySlot != -1)
+            {
+                return emptySlot;
+            }
+        }
+    }
+
+    return -1;
 }
 
 CNewUIInventoryCtrl* CNewUIInventoryExtension::GetOwnerOf(const CNewUIPickedItem* pPickedItem) const

--- a/src/source/NewUIInventoryExtension.h
+++ b/src/source/NewUIInventoryExtension.h
@@ -59,6 +59,7 @@ namespace SEASON3B
         bool InsertItem(int iIndex, std::span<const BYTE> pbyItemPacket) const;
         void DeleteItem(int iIndex) const;
         void DeleteAllItems() const;
+        int FindEmptySlot(int cx, int cy, const CNewUIInventoryCtrl* excluded = nullptr) const;
         CNewUIInventoryCtrl* GetOwnerOf(const CNewUIPickedItem* pPickedItem) const;
     private:
         void Init();

--- a/src/source/NewUIMyInventory.cpp
+++ b/src/source/NewUIMyInventory.cpp
@@ -513,7 +513,8 @@ bool CNewUIMyInventory::UpdateMouseEvent()
             const int iSourceIndex = pPickedItem->GetSourceLinealPos();
             const int tx = (int)(CollisionPosition[0] / TERRAIN_SCALE);
             const int ty = (int)(CollisionPosition[1] / TERRAIN_SCALE);
-            if (pPickedItem->GetOwnerInventory() == m_pNewInventoryCtrl)
+            if (pPickedItem->GetOwnerInventory() == m_pNewInventoryCtrl
+                || g_pMyInventoryExt->GetOwnerOf(pPickedItem) != nullptr)
             {
                 if (Hero->Dead == 0)
                 {
@@ -878,6 +879,11 @@ int CNewUIMyInventory::FindEmptySlot(IN int cx, IN int cy) const
 
 int CNewUIMyInventory::FindEmptySlot(ITEM* pItem) const
 {
+    if (pItem == nullptr)
+    {
+        return -1;
+    }
+
     const ITEM_ATTRIBUTE* pItemAttr = &ItemAttribute[pItem->Type];
     if (m_pNewInventoryCtrl)
     {
@@ -885,6 +891,33 @@ int CNewUIMyInventory::FindEmptySlot(ITEM* pItem) const
     }
 
     return -1;
+}
+
+int CNewUIMyInventory::FindEmptySlotIncludingExtensions(IN int cx, IN int cy) const
+{
+    const int baseInventorySlot = FindEmptySlot(cx, cy);
+    if (baseInventorySlot != -1)
+    {
+        return baseInventorySlot;
+    }
+
+    if (g_pMyInventoryExt != nullptr)
+    {
+        return g_pMyInventoryExt->FindEmptySlot(cx, cy);
+    }
+
+    return -1;
+}
+
+int CNewUIMyInventory::FindEmptySlotIncludingExtensions(ITEM* pItem) const
+{
+    if (pItem == nullptr)
+    {
+        return -1;
+    }
+
+    const ITEM_ATTRIBUTE* pItemAttr = &ItemAttribute[pItem->Type];
+    return FindEmptySlotIncludingExtensions(pItemAttr->Width, pItemAttr->Height);
 }
 
 void CNewUIMyInventory::UI2DEffectCallback(LPVOID pClass, DWORD dwParamA, DWORD dwParamB)
@@ -2033,6 +2066,72 @@ bool CNewUIMyInventory::TryConsumeItem(CNewUIInventoryCtrl* targetControl, ITEM*
     return false;
 }
 
+bool CNewUIMyInventory::TryTransferBetweenInventorySections(CNewUIInventoryCtrl* sourceControl)
+{
+    if (sourceControl == nullptr || g_pMyInventoryExt == nullptr)
+    {
+        return false;
+    }
+
+    ITEM* pItem = sourceControl->FindItemAtPt(MouseX, MouseY);
+    if (pItem == nullptr)
+    {
+        return false;
+    }
+
+    const int sourceIndex = sourceControl->GetIndexByItem(pItem);
+    if (sourceIndex < 0)
+    {
+        return false;
+    }
+
+    const ITEM_ATTRIBUTE* itemAttribute = &ItemAttribute[pItem->Type];
+    int destinationIndex = -1;
+
+    if (sourceControl == g_pMyInventory->GetInventoryCtrl())
+    {
+        destinationIndex = g_pMyInventoryExt->FindEmptySlot(itemAttribute->Width, itemAttribute->Height);
+    }
+    else
+    {
+        destinationIndex = g_pMyInventory->FindEmptySlot(itemAttribute->Width, itemAttribute->Height);
+        if (destinationIndex == -1)
+        {
+            destinationIndex = g_pMyInventoryExt->FindEmptySlot(itemAttribute->Width, itemAttribute->Height, sourceControl);
+        }
+    }
+
+    if (destinationIndex == -1 || destinationIndex == sourceIndex)
+    {
+        return true;
+    }
+
+    if (!CNewUIInventoryCtrl::CreatePickedItem(sourceControl, pItem))
+    {
+        return false;
+    }
+
+    sourceControl->RemoveItem(pItem);
+
+    CNewUIPickedItem* pickedItem = CNewUIInventoryCtrl::GetPickedItem();
+    if (pickedItem == nullptr || pickedItem->GetItem() == nullptr)
+    {
+        CNewUIInventoryCtrl::BackupPickedItem();
+        return false;
+    }
+
+    pickedItem->HidePickedItem();
+
+    if (!SendRequestEquipmentItem(STORAGE_TYPE::INVENTORY, sourceIndex,
+        pickedItem->GetItem(), STORAGE_TYPE::INVENTORY, destinationIndex))
+    {
+        CNewUIInventoryCtrl::BackupPickedItem();
+        return false;
+    }
+
+    return true;
+}
+
 // TODO: This whole logic (and possibly others) should be moved into a 'controller' class or similar.
 bool CNewUIMyInventory::HandleInventoryActions(CNewUIInventoryCtrl* targetControl)
 {
@@ -2094,7 +2193,17 @@ bool CNewUIMyInventory::HandleInventoryActions(CNewUIInventoryCtrl* targetContro
 
         if (g_pNewUISystem->IsVisible(INTERFACE_STORAGE))
         {
-            return g_pStorageInventory->ProcessMyInvenItemAutoMove();
+            if (g_pStorageInventory->ProcessMyInvenItemAutoMove(targetControl))
+            {
+                return true;
+            }
+
+            if (g_pNewUISystem->IsVisible(INTERFACE_STORAGE_EXT))
+            {
+                return g_pStorageInventoryExt->ProcessMyInvenItemAutoMove(targetControl);
+            }
+
+            return false;
         }
 
         // Right-click to sell items at NPC shop
@@ -2161,6 +2270,13 @@ bool CNewUIMyInventory::HandleInventoryActions(CNewUIInventoryCtrl* targetContro
             // Hide the picked item so it's not visually displayed while selling
             pPickedItem->HidePickedItem();
 
+            const int sourceIndex = pPickedItem->GetSourceLinealPos();
+            if (sourceIndex < MAX_EQUIPMENT_INDEX || sourceIndex >= MAX_MY_INVENTORY_EX_INDEX)
+            {
+                CNewUIInventoryCtrl::BackupPickedItem();
+                return false;
+            }
+
             if (IsHighValueItem(pItem))
             {
                 // Show confirmation dialog for expensive items
@@ -2169,7 +2285,7 @@ bool CNewUIMyInventory::HandleInventoryActions(CNewUIInventoryCtrl* targetContro
             }
 
             // For regular items, send sell request immediately
-            SocketClient->ToGameServer()->SendSellItemToNpcRequest(iIndex);
+            SocketClient->ToGameServer()->SendSellItemToNpcRequest(sourceIndex);
             g_pNPCShop->SetSellingItem(true);
             return true;
         }
@@ -2182,6 +2298,11 @@ bool CNewUIMyInventory::HandleInventoryActions(CNewUIInventoryCtrl* targetContro
             && !g_pNewUISystem->IsVisible(SEASON3B::INTERFACE_LUCKYITEMWND)
             && !g_pNewUISystem->IsVisible(INTERFACE_MIXINVENTORY))
         {
+            if (g_pNewUISystem->IsVisible(INTERFACE_INVENTORY_EXT))
+            {
+                return TryTransferBetweenInventorySections(targetControl);
+            }
+
             ITEM* pItem = targetControl->FindItemAtPt(MouseX, MouseY);
             if (!pItem)
             {

--- a/src/source/NewUIMyInventory.cpp
+++ b/src/source/NewUIMyInventory.cpp
@@ -2095,10 +2095,6 @@ bool CNewUIMyInventory::TryTransferBetweenInventorySections(CNewUIInventoryCtrl*
     else
     {
         destinationIndex = g_pMyInventory->FindEmptySlot(itemAttribute->Width, itemAttribute->Height);
-        if (destinationIndex == -1)
-        {
-            destinationIndex = g_pMyInventoryExt->FindEmptySlot(itemAttribute->Width, itemAttribute->Height, sourceControl);
-        }
     }
 
     if (destinationIndex == -1 || destinationIndex == sourceIndex)

--- a/src/source/NewUIMyInventory.h
+++ b/src/source/NewUIMyInventory.h
@@ -142,6 +142,8 @@ namespace SEASON3B
         int FindItemReverseIndex(short sType, int iLevel = -1) const;
         int FindEmptySlot(IN int cx, IN int cy) const;
         int FindEmptySlot(ITEM* pItem) const;
+        int FindEmptySlotIncludingExtensions(IN int cx, IN int cy) const;
+        int FindEmptySlotIncludingExtensions(ITEM* pItem) const;
         bool IsItem(short int siType, bool bcheckPick = false) const;
         int	GetNumItemByKey(DWORD dwItemKey) const;
         int GetNumItemByType(short sItemType) const;
@@ -195,6 +197,7 @@ namespace SEASON3B
         static bool TryStackItems(CNewUIInventoryCtrl* targetControl, ITEM* pPickItem, int iSourceIndex,
             int iTargetIndex);
         static bool TryConsumeItem(CNewUIInventoryCtrl* targetControl, ITEM* pItem, const int iIndex);
+        static bool TryTransferBetweenInventorySections(CNewUIInventoryCtrl* sourceControl);
 
         bool InventoryProcess() const;
         bool BtnProcess();

--- a/src/source/NewUINPCShop.cpp
+++ b/src/source/NewUINPCShop.cpp
@@ -360,11 +360,13 @@ bool SEASON3B::CNewUINPCShop::InventoryProcess()
 
         if (pPickedItem->GetSourceStorageType() == STORAGE_TYPE::INVENTORY)
         {
-            int iSourceIndex = pPickedItem->GetSourceLinealPos();
-            SocketClient->ToGameServer()->SendSellItemToNpcRequest(iSourceIndex);
-            g_pNPCShop->SetSellingItem(true);
-
-            return true;
+            const int iSourceIndex = pPickedItem->GetSourceLinealPos();
+            if (iSourceIndex >= MAX_EQUIPMENT_INDEX && iSourceIndex < MAX_MY_INVENTORY_EX_INDEX)
+            {
+                SocketClient->ToGameServer()->SendSellItemToNpcRequest(iSourceIndex);
+                g_pNPCShop->SetSellingItem(true);
+                return true;
+            }
         }
     }
 

--- a/src/source/NewUIStorageInventory.cpp
+++ b/src/source/NewUIStorageInventory.cpp
@@ -24,6 +24,7 @@ CNewUIStorageInventory::CNewUIStorageInventory()
     m_pNewUIMng = nullptr;
     m_pNewInventoryCtrl = nullptr;
     m_Pos.x = m_Pos.y = 0;
+    m_nBackupSourceInvenIndex = -1;
 }
 
 CNewUIStorageInventory::~CNewUIStorageInventory()
@@ -376,7 +377,7 @@ void CNewUIStorageInventory::ProcessStorageItemAutoMove()
     ITEM* pItemObj = m_pNewInventoryCtrl->FindItemAtPt(MouseX, MouseY);
     if (pItemObj)
     {
-        int nDstIndex = g_pMyInventory->FindEmptySlot(pItemObj);
+        int nDstIndex = g_pMyInventory->FindEmptySlotIncludingExtensions(pItemObj);
         if (-1 != nDstIndex)
         {
             SetItemAutoMove(true);
@@ -391,7 +392,7 @@ void CNewUIStorageInventory::ProcessStorageItemAutoMove()
     }
 }
 
-bool CNewUIStorageInventory::ProcessMyInvenItemAutoMove()
+bool CNewUIStorageInventory::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl)
 {
     if (g_pPickedItem && g_pPickedItem->GetItem())
     {
@@ -403,8 +404,17 @@ bool CNewUIStorageInventory::ProcessMyInvenItemAutoMove()
         return false;
     }
 
-    const auto pMyInvenCtrl = g_pMyInventory->GetInventoryCtrl();
-    if (const auto pItemObj = pMyInvenCtrl->FindItemAtPt(MouseX, MouseY))
+    if (sourceCtrl == nullptr)
+    {
+        sourceCtrl = g_pMyInventory->GetInventoryCtrl();
+    }
+
+    if (sourceCtrl == nullptr)
+    {
+        return false;
+    }
+
+    if (const auto pItemObj = sourceCtrl->FindItemAtPt(MouseX, MouseY))
     {
         if (pItemObj->Type == ITEM_WIZARDS_RING)
             return false;
@@ -412,9 +422,13 @@ bool CNewUIStorageInventory::ProcessMyInvenItemAutoMove()
         const int emptySlotIndex = FindEmptySlot(pItemObj);
         if (-1 != emptySlotIndex)
         {
-            SetItemAutoMove(true);
+            const int nSrcIndex = sourceCtrl->GetIndexByItem(pItemObj);
+            if (nSrcIndex < 0)
+            {
+                return false;
+            }
 
-            const int nSrcIndex = pMyInvenCtrl->GetIndexByItem(pItemObj);
+            SetItemAutoMove(true, nSrcIndex);
             SendRequestItemToStorage(pItemObj, nSrcIndex, emptySlotIndex);
             PlayBuffer(SOUND_GET_ITEM01);
             return true;
@@ -508,7 +522,7 @@ bool CNewUIStorageInventory::ProcessBtns()
     return false;
 }
 
-void CNewUIStorageInventory::SetItemAutoMove(bool bItemAutoMove)
+void CNewUIStorageInventory::SetItemAutoMove(bool bItemAutoMove, int nSourceInvenIndex)
 {
     m_bItemAutoMove = bItemAutoMove;
 
@@ -516,9 +530,13 @@ void CNewUIStorageInventory::SetItemAutoMove(bool bItemAutoMove)
     {
         m_nBackupMouseX = MouseX;
         m_nBackupMouseY = MouseY;
+        m_nBackupSourceInvenIndex = nSourceInvenIndex;
     }
     else
+    {
         m_nBackupMouseX = m_nBackupMouseY = 0;
+        m_nBackupSourceInvenIndex = -1;
+    }
 }
 
 void CNewUIStorageInventory::InitBackupItemInfo()
@@ -526,6 +544,7 @@ void CNewUIStorageInventory::InitBackupItemInfo()
     m_bTakeZen = false;
     m_nBackupTakeZen = 0;
     m_nBackupInvenIndex = -1;
+    m_nBackupSourceInvenIndex = -1;
 }
 
 void CNewUIStorageInventory::SetBackupTakeZen(int nZen)
@@ -630,9 +649,20 @@ void CNewUIStorageInventory::ProcessToReceiveStorageItems(int nIndex, std::span<
     {
         if (IsItemAutoMove())
         {
-            CNewUIInventoryCtrl* pMyInvenCtrl = g_pMyInventory->GetInventoryCtrl();
-            ITEM* pItemObj = pMyInvenCtrl->FindItemAtPt(m_nBackupMouseX, m_nBackupMouseY);
-            g_pMyInventory->GetInventoryCtrl()->RemoveItem(pItemObj);
+            if (m_nBackupSourceInvenIndex >= MAX_EQUIPMENT_INDEX && m_nBackupSourceInvenIndex < MAX_MY_INVENTORY_INDEX)
+            {
+                g_pMyInventory->DeleteItem(m_nBackupSourceInvenIndex);
+            }
+            else if (m_nBackupSourceInvenIndex >= MAX_MY_INVENTORY_INDEX && m_nBackupSourceInvenIndex < MAX_MY_INVENTORY_EX_INDEX)
+            {
+                g_pMyInventoryExt->DeleteItem(m_nBackupSourceInvenIndex);
+            }
+            else
+            {
+                CNewUIInventoryCtrl* pMyInvenCtrl = g_pMyInventory->GetInventoryCtrl();
+                ITEM* pItemObj = pMyInvenCtrl->FindItemAtPt(m_nBackupMouseX, m_nBackupMouseY);
+                g_pMyInventory->GetInventoryCtrl()->RemoveItem(pItemObj);
+            }
 
             SetItemAutoMove(false);
         }

--- a/src/source/NewUIStorageInventory.h
+++ b/src/source/NewUIStorageInventory.h
@@ -63,6 +63,7 @@ namespace SEASON3B
         bool					m_bTakeZen;
         int						m_nBackupTakeZen;
         int						m_nBackupInvenIndex;
+        int						m_nBackupSourceInvenIndex;
 
     public:
         CNewUIStorageInventory();
@@ -92,7 +93,7 @@ namespace SEASON3B
 
         void SetBackupTakeZen(int nZen);
 
-        bool ProcessMyInvenItemAutoMove();
+        bool ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl = nullptr);
 
         void SendRequestItemToMyInven(ITEM* pItemObj, int nStorageIndex, int nInvenIndex);
 
@@ -103,7 +104,7 @@ namespace SEASON3B
 
         int GetPointedItemIndex();
 
-        void SetItemAutoMove(bool bItemAutoMove);
+        void SetItemAutoMove(bool bItemAutoMove, int nSourceInvenIndex = -1);
         void SendRequestItemToStorage(ITEM* pItemObj, int nInvenIndex, int nStorageIndex);
     private:
         void LoadImages();

--- a/src/source/NewUIStorageInventoryExt.cpp
+++ b/src/source/NewUIStorageInventoryExt.cpp
@@ -21,6 +21,7 @@ CNewUIStorageInventoryExt::CNewUIStorageInventoryExt()
     m_pNewUIMng = nullptr;
     m_pNewInventoryCtrl = nullptr;
     m_Pos.x = m_Pos.y = 0;
+    m_nBackupSourceInvenIndex = -1;
 }
 
 CNewUIStorageInventoryExt::~CNewUIStorageInventoryExt()
@@ -285,7 +286,7 @@ void CNewUIStorageInventoryExt::ProcessStorageItemAutoMove()
 
     if (const auto pItemObj = m_pNewInventoryCtrl->FindItemAtPt(MouseX, MouseY))
     {
-        const int nDstIndex = g_pMyInventory->FindEmptySlot(pItemObj);
+        const int nDstIndex = g_pMyInventory->FindEmptySlotIncludingExtensions(pItemObj);
         if (-1 != nDstIndex)
         {
             SetItemAutoMove(true);
@@ -296,6 +297,52 @@ void CNewUIStorageInventoryExt::ProcessStorageItemAutoMove()
             PlayBuffer(SOUND_GET_ITEM01);
         }
     }
+}
+
+bool CNewUIStorageInventoryExt::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl)
+{
+    if (g_pPickedItem && g_pPickedItem->GetItem())
+    {
+        return false;
+    }
+
+    if (IsItemAutoMove())
+    {
+        return false;
+    }
+
+    if (sourceCtrl == nullptr)
+    {
+        sourceCtrl = g_pMyInventory->GetInventoryCtrl();
+    }
+
+    if (sourceCtrl == nullptr)
+    {
+        return false;
+    }
+
+    if (const auto pItemObj = sourceCtrl->FindItemAtPt(MouseX, MouseY))
+    {
+        if (pItemObj->Type == ITEM_WIZARDS_RING)
+            return false;
+
+        const int emptySlotIndex = FindEmptySlot(pItemObj);
+        if (emptySlotIndex != -1)
+        {
+            const int nSrcIndex = sourceCtrl->GetIndexByItem(pItemObj);
+            if (nSrcIndex < 0)
+            {
+                return false;
+            }
+
+            SetItemAutoMove(true, nSrcIndex);
+            g_pStorageInventory->SendRequestItemToStorage(pItemObj, nSrcIndex, emptySlotIndex);
+            PlayBuffer(SOUND_GET_ITEM01);
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool CNewUIStorageInventoryExt::ProcessBtns() const
@@ -309,7 +356,7 @@ bool CNewUIStorageInventoryExt::ProcessBtns() const
     return false;
 }
 
-void CNewUIStorageInventoryExt::SetItemAutoMove(bool bItemAutoMove)
+void CNewUIStorageInventoryExt::SetItemAutoMove(bool bItemAutoMove, int nSourceInvenIndex)
 {
     m_bItemAutoMove = bItemAutoMove;
 
@@ -317,10 +364,12 @@ void CNewUIStorageInventoryExt::SetItemAutoMove(bool bItemAutoMove)
     {
         m_nBackupMouseX = MouseX;
         m_nBackupMouseY = MouseY;
+        m_nBackupSourceInvenIndex = nSourceInvenIndex;
     }
     else
     {
         m_nBackupMouseX = m_nBackupMouseY = 0;
+        m_nBackupSourceInvenIndex = -1;
     }
 }
 
@@ -343,9 +392,20 @@ void CNewUIStorageInventoryExt::ProcessToReceiveStorageItems(int nIndex, std::sp
 
     if (IsItemAutoMove())
     {
-        CNewUIInventoryCtrl* pMyInvenCtrl = g_pMyInventory->GetInventoryCtrl();
-        ITEM* pItemObj = pMyInvenCtrl->FindItemAtPt(m_nBackupMouseX, m_nBackupMouseY);
-        g_pMyInventory->GetInventoryCtrl()->RemoveItem(pItemObj);
+        if (m_nBackupSourceInvenIndex >= MAX_EQUIPMENT_INDEX && m_nBackupSourceInvenIndex < MAX_MY_INVENTORY_INDEX)
+        {
+            g_pMyInventory->DeleteItem(m_nBackupSourceInvenIndex);
+        }
+        else if (m_nBackupSourceInvenIndex >= MAX_MY_INVENTORY_INDEX && m_nBackupSourceInvenIndex < MAX_MY_INVENTORY_EX_INDEX)
+        {
+            g_pMyInventoryExt->DeleteItem(m_nBackupSourceInvenIndex);
+        }
+        else
+        {
+            CNewUIInventoryCtrl* pMyInvenCtrl = g_pMyInventory->GetInventoryCtrl();
+            ITEM* pItemObj = pMyInvenCtrl->FindItemAtPt(m_nBackupMouseX, m_nBackupMouseY);
+            g_pMyInventory->GetInventoryCtrl()->RemoveItem(pItemObj);
+        }
 
         SetItemAutoMove(false);
     }

--- a/src/source/NewUIStorageInventoryExt.h
+++ b/src/source/NewUIStorageInventoryExt.h
@@ -37,6 +37,7 @@ namespace SEASON3B
         bool					m_bItemAutoMove;
         int						m_nBackupMouseX;
         int						m_nBackupMouseY;
+        int						m_nBackupSourceInvenIndex;
 
     public:
         CNewUIStorageInventoryExt();
@@ -59,6 +60,7 @@ namespace SEASON3B
         bool ProcessClosing() const;
         bool InsertItem(int iIndex, std::span<const BYTE> pbyItemPacket) const;
         int FindEmptySlot(const ITEM* pItemObj) const;
+        bool ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl = nullptr);
 
         bool IsItemAutoMove() const { return m_bItemAutoMove; }
 
@@ -68,7 +70,7 @@ namespace SEASON3B
 
         int GetPointedItemIndex() const;
 
-        void SetItemAutoMove(bool bItemAutoMove);
+        void SetItemAutoMove(bool bItemAutoMove, int nSourceInvenIndex = -1);
 
     private:
         void LoadImages() const;

--- a/src/source/NewUISystem.cpp
+++ b/src/source/NewUISystem.cpp
@@ -769,6 +769,7 @@ void CNewUISystem::Show(DWORD dwKey)
         HideAllGroupA();
         g_pNPCShop->OpenningProcess();
         m_pNewUIMng->ShowInterface(INTERFACE_INVENTORY);
+        g_pNPCShop->SetPos(640 - 190 * 2, 0);
         g_pMainFrame->SetBtnState(MAINFRAME_BTN_MYINVEN, true);
     }
     else if (dwKey == INTERFACE_STORAGE)
@@ -1168,7 +1169,7 @@ void CNewUISystem::Hide(DWORD dwKey)
 
         if (IsVisible(INTERFACE_INVENTORY_EXT))
         {
-            m_pNewUIMng->ShowInterface(INTERFACE_INVENTORY_EXT, false);
+            Hide(INTERFACE_INVENTORY_EXT);
         }
 
         if (IsVisible(INTERFACE_MIXINVENTORY))
@@ -1244,6 +1245,10 @@ void CNewUISystem::Hide(DWORD dwKey)
     }
     else if (dwKey == INTERFACE_NPCSHOP)
     {
+        if (IsVisible(INTERFACE_INVENTORY_EXT))
+        {
+            Hide(INTERFACE_INVENTORY_EXT);
+        }
         g_pNPCShop->ClosingProcess();
         g_pMainFrame->SetBtnState(MAINFRAME_BTN_MYINVEN, false);
         m_pNewUIMng->ShowInterface(INTERFACE_INVENTORY, false);
@@ -1268,7 +1273,10 @@ void CNewUISystem::Hide(DWORD dwKey)
         if (!g_pStorageInventory->ProcessClosing())
             return;
         g_pMainFrame->SetBtnState(MAINFRAME_BTN_MYINVEN, false);
-        m_pNewUIMng->ShowInterface(INTERFACE_INVENTORY_EXT, false);
+        if (IsVisible(INTERFACE_INVENTORY_EXT))
+        {
+            Hide(INTERFACE_INVENTORY_EXT);
+        }
         m_pNewUIMng->ShowInterface(INTERFACE_INVENTORY, false);
         Show(INTERFACE_HERO_POSITION_INFO);
     }
@@ -1324,6 +1332,10 @@ void CNewUISystem::Hide(DWORD dwKey)
     }
     else if (dwKey == INTERFACE_TRADE)
     {
+        if (IsVisible(INTERFACE_INVENTORY_EXT))
+        {
+            Hide(INTERFACE_INVENTORY_EXT);
+        }
         g_pTrade->ProcessClosing();
         g_pMainFrame->SetBtnState(MAINFRAME_BTN_MYINVEN, false);
         m_pNewUIMng->ShowInterface(INTERFACE_INVENTORY, false);

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -5733,9 +5733,6 @@ void ReceiveGetItem(std::span<const BYTE> ReceiveBuffer)
             else
                 PlayBuffer(SOUND_GET_ITEM01, &Hero->Object);
         }
-#ifdef FOR_WORK
-        Items[ItemKey].Object.Live = false;
-#endif
     }
     SendGetItem = -1;
 

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -1224,7 +1224,7 @@ void ReceiveDeleteInventory(const BYTE* ReceiveBuffer)
         {
             g_pMyInventory->DeleteItem(itemindex);
         }
-        else if (itemindex > MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
+        else if (itemindex >= MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
         {
             g_pMyInventoryExt->DeleteItem(itemindex);
         }
@@ -5707,7 +5707,7 @@ void ReceiveGetItem(std::span<const BYTE> ReceiveBuffer)
                         pickedItem = g_pMyInventory->FindItem(itemIndex);
                     }
                 }
-                else if (itemIndex >= MAX_MY_INVENTORY_INDEX && Data2->Result < MAX_MY_INVENTORY_EX_INDEX)
+                else if (itemIndex >= MAX_MY_INVENTORY_INDEX && itemIndex < MAX_MY_INVENTORY_EX_INDEX)
                 {
                     if (g_pMyInventoryExt->InsertItem(itemIndex, itemData))
                     {
@@ -5920,7 +5920,7 @@ void ReceiveModifyItemExtended(std::span<const BYTE> ReceiveBuffer)
     {
         g_pMyInventory->InsertItem(itemindex, itemData);
     }
-    else if (itemindex > MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
+    else if (itemindex >= MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
     {
         g_pMyInventoryExt->InsertItem(itemindex, itemData);
     }
@@ -6396,6 +6396,8 @@ void ReceiveSell(const BYTE* ReceiveBuffer)
     {
         SEASON3B::CNewUIInventoryCtrl::BackupPickedItem();
     }
+
+    g_pNPCShop->SetSellingItem(false);
 }
 
 void ReceiveRepair(const BYTE* ReceiveBuffer)
@@ -8929,7 +8931,7 @@ void ReceivePurchaseItem(std::span<const BYTE> ReceiveBuffer)
         {
             g_pMyInventory->InsertItem(itemindex, itemData);
         }
-        else if (itemindex > MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
+        else if (itemindex >= MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
         {
             g_pMyInventoryExt->InsertItem(itemindex, itemData);
         }

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -5733,6 +5733,9 @@ void ReceiveGetItem(std::span<const BYTE> ReceiveBuffer)
             else
                 PlayBuffer(SOUND_GET_ITEM01, &Hero->Object);
         }
+#ifdef FOR_WORK
+        Items[ItemKey].Object.Live = false;
+#endif
     }
     SendGetItem = -1;
 

--- a/src/source/ZzzInterface.cpp
+++ b/src/source/ZzzInterface.cpp
@@ -3556,7 +3556,7 @@ void Action(CHARACTER* c, OBJECT* o, bool Now)
             SendGetItem = ItemKey;
             SocketClient->ToGameServer()->SendPickupItemRequest(ItemKey);
         }
-        else if (g_pMyInventory->FindEmptySlot(&Items[ItemKey].Item) == -1)
+        else if (g_pMyInventory->FindEmptySlotIncludingExtensions(&Items[ItemKey].Item) == -1)
         {
             wchar_t Text[256];
             mu_swprintf(Text, GlobalText[375]);


### PR DESCRIPTION
RMB = right mouse button

PR contains several improvements around vault & inventory extensions, I tried to make it work the same way it works in original 1.04d client.

- allows to drop items directly from inventory extensions
- allows to sell items to vendors directly from inventory extensions
- allows to use RMB to move items from inventory extension to main inventory
- allows to use RMB to move items from main inventory to extension
- allows to loot into inventory extension (previous behavior: items looted into extension only possible with MuHelper, otherwise "Inventory is full messages is displayed and item disappeared", item shows on the ground after re-login if item is still there).

I have tested this extensively in my fork of MuMain, it works great, I didn't see any bugs, but I am not a C++ expert.
These are the immediate pains that I felt after moving from 1.04d onto MuMain (which I love so much now, thanks for it <3).

❤️ 