### PR TITLE
feat(camera_zoom): basic camera zoom + config.ini

### DIFF
--- a/src/source/Camera/CameraUtility.cpp
+++ b/src/source/Camera/CameraUtility.cpp
@@ -18,6 +18,7 @@
 #include "../GMDoppelGanger2.h"
 #include "../w_MapHeaders.h"
 #include "../UIManager.h"
+#include "../NewUICommon.h"
 
 // External variable declarations (definitions remain in ZzzScene.cpp)
 extern short g_shCameraLevel;
@@ -26,6 +27,59 @@ extern float CameraDistanceTarget;
 extern float CameraDistance;
 extern float Camera3DFov;
 extern bool Camera3DRoll;
+
+namespace
+{
+    constexpr short MinUserCameraLevel = 0;
+    constexpr short MaxUserCameraLevel = 4;
+    short g_shUserCameraLevel = 0;
+}
+
+short GetUserCameraZoomLevel()
+{
+    return g_shUserCameraLevel;
+}
+
+void SetUserCameraZoomLevel(short level)
+{
+    if (level < MinUserCameraLevel)
+    {
+        level = MinUserCameraLevel;
+    }
+    else if (level > MaxUserCameraLevel)
+    {
+        level = MaxUserCameraLevel;
+    }
+
+    g_shUserCameraLevel = level;
+}
+
+/**
+ * @brief Handles user camera zoom hotkeys in main scene.
+ */
+static void UpdateUserZoomHotkeys()
+{
+    if (SceneFlag != MAIN_SCENE || CameraTopViewEnable)
+    {
+        return;
+    }
+
+    // Avoid stealing page navigation keys while UI text/input widgets are active.
+    if (g_pUIManager && g_pUIManager->IsInputEnable())
+    {
+        return;
+    }
+
+    if (SEASON3B::IsPress(VK_PRIOR)) // PageUp: zoom out
+    {
+        g_shUserCameraLevel = std::min<short>(g_shUserCameraLevel + 1, MaxUserCameraLevel);
+    }
+
+    if (SEASON3B::IsPress(VK_NEXT)) // PageDown: zoom in
+    {
+        g_shUserCameraLevel = std::max<short>(g_shUserCameraLevel - 1, MinUserCameraLevel);
+    }
+}
 
 /**
  * @brief Calculates camera view distance based on scene and world settings.
@@ -117,24 +171,16 @@ static void CalculateCameraPosition(vec3_t outCameraPosition)
     vec3_t Position, TransformPosition;
     float Matrix[3][4];
 
-    CameraViewFar = CalculateCameraViewFar(SceneFlag);
-
     Vector(0.f, -CameraDistance, 0.f, Position);
     AngleMatrix(CameraAngle, Matrix);
     VectorIRotate(Position, Matrix, TransformPosition);
 
-    if (SceneFlag == MAIN_SCENE)
+    if (SceneFlag == LOG_IN_SCENE || SceneFlag == CHARACTER_SCENE)
     {
-        g_pCatapultWindow->GetCameraPos(Position);
+        // Keep menu/character scenes at the classic fixed zoom to avoid broken framing.
+        g_shCameraLevel = 0;
     }
-    else if (CCameraMove::GetInstancePtr()->IsTourMode())
-    {
-        CCameraMove::GetInstancePtr()->UpdateTourWayPoint();
-        CCameraMove::GetInstancePtr()->GetCurrentCameraPos(Position);
-        CameraViewFar = 390.f * CCameraMove::GetInstancePtr()->GetCurrentCameraDistanceLevel();
-    }
-
-    if (g_Direction.IsDirection() && !g_Direction.m_bDownHero)
+    else if (g_Direction.IsDirection() && !g_Direction.m_bDownHero)
     {
         Hero->Object.Position[2] = 300.0f;
         g_shCameraLevel = g_Direction.GetCameraPosition(Position);
@@ -147,7 +193,23 @@ static void CalculateCameraPosition(vec3_t outCameraPosition)
     {
         g_shCameraLevel = 5;
     }
-    else g_shCameraLevel = 0;
+    else
+    {
+        g_shCameraLevel = g_shUserCameraLevel;
+    }
+
+    CameraViewFar = CalculateCameraViewFar(SceneFlag);
+
+    if (SceneFlag == MAIN_SCENE)
+    {
+        g_pCatapultWindow->GetCameraPos(Position);
+    }
+    else if (CCameraMove::GetInstancePtr()->IsTourMode())
+    {
+        CCameraMove::GetInstancePtr()->UpdateTourWayPoint();
+        CCameraMove::GetInstancePtr()->GetCurrentCameraPos(Position);
+        CameraViewFar = 390.f * CCameraMove::GetInstancePtr()->GetCurrentCameraDistanceLevel();
+    }
 
     if (CCameraMove::GetInstancePtr()->IsTourMode())
     {
@@ -376,6 +438,7 @@ bool MoveMainCamera()
     bool bLockCamera = false;
 
     SetCameraFOV();
+    UpdateUserZoomHotkeys();
 
 #ifdef ENABLE_EDIT2
     HandleEditorMode();

--- a/src/source/Camera/CameraUtility.h
+++ b/src/source/Camera/CameraUtility.h
@@ -31,3 +31,7 @@ extern CameraState g_CameraState;
 // Main camera controller
 // Returns true if camera is locked
 bool MoveMainCamera();
+
+// User-configurable gameplay zoom level (0..4)
+short GetUserCameraZoomLevel();
+void SetUserCameraZoomLevel(short level);

--- a/src/source/GameConfig/GameConfig.cpp
+++ b/src/source/GameConfig/GameConfig.cpp
@@ -42,6 +42,7 @@ void GameConfig::Load()
     m_windowMode   = ReadBool(CfgSectionWindow, CfgKeyWindowed, CfgDefaultWindowed);
 
     m_colorDepth = ReadInt(CfgSectionGraphics, CfgKeyColorDepth, CfgDefaultColorDepth);
+    SetCameraZoomLevel(ReadInt(CfgSectionGraphics, CfgKeyCameraZoomLevel, CfgDefaultCameraZoomLevel));
 
     m_soundEnabled = ReadBool(CfgSectionAudio, CfgKeySoundEnabled, CfgDefaultSoundEnabled);
     m_musicEnabled = ReadBool(CfgSectionAudio, CfgKeyMusicEnabled, CfgDefaultMusicEnabled);
@@ -69,6 +70,7 @@ void GameConfig::Save()
 
     WriteInt(CfgSectionGraphics, CfgKeyColorDepth, m_colorDepth);
     WriteInt(CfgSectionGraphics, CfgKeyRenderTextType, m_renderTextType);
+    WriteInt(CfgSectionGraphics, CfgKeyCameraZoomLevel, m_cameraZoomLevel);
 
     WriteBool(CfgSectionAudio, CfgKeySoundEnabled, m_soundEnabled);
     WriteBool(CfgSectionAudio, CfgKeyMusicEnabled, m_musicEnabled);
@@ -97,6 +99,20 @@ void GameConfig::SetWindowMode(bool windowed)
 void GameConfig::SetColorDepth(int depth)
 {
     m_colorDepth = depth;
+}
+
+void GameConfig::SetCameraZoomLevel(int level)
+{
+    if (level < 0)
+    {
+        level = 0;
+    }
+    else if (level > 4)
+    {
+        level = 4;
+    }
+
+    m_cameraZoomLevel = level;
 }
 
 void GameConfig::SetSoundEnabled(bool enabled)

--- a/src/source/GameConfig/GameConfig.h
+++ b/src/source/GameConfig/GameConfig.h
@@ -23,7 +23,9 @@ public:
 
     // Graphics
     int GetColorDepth() const { return m_colorDepth; }
+    int GetCameraZoomLevel() const { return m_cameraZoomLevel; }
     void SetColorDepth(int depth);
+    void SetCameraZoomLevel(int level);
 
     // Audio
     bool GetSoundEnabled() const { return m_soundEnabled; }
@@ -77,6 +79,7 @@ private:
     bool m_windowMode;
 
     int m_colorDepth;
+    int m_cameraZoomLevel;
 
     bool m_soundEnabled;
     bool m_musicEnabled;

--- a/src/source/GameConfig/GameConfigConstants.h
+++ b/src/source/GameConfig/GameConfigConstants.h
@@ -19,6 +19,7 @@ namespace CfgKeys
     // Graphics
     inline constexpr wchar_t CfgKeyColorDepth[]     = L"ColorDepth";
     inline constexpr wchar_t CfgKeyRenderTextType[] = L"RenderTextType";
+    inline constexpr wchar_t CfgKeyCameraZoomLevel[] = L"CameraZoomLevel";
 
     // Audio
     inline constexpr wchar_t CfgKeySoundEnabled[] = L"SoundEnabled";
@@ -43,6 +44,7 @@ namespace CfgDefaults
     inline constexpr bool CfgDefaultWindowed     = true;
 
     inline constexpr int  CfgDefaultColorDepth = 0;
+    inline constexpr int  CfgDefaultCameraZoomLevel = 0;
 
     inline constexpr bool CfgDefaultSoundEnabled = true;
     inline constexpr bool CfgDefaultMusicEnabled = false;

--- a/src/source/Winmain.cpp
+++ b/src/source/Winmain.cpp
@@ -14,6 +14,7 @@
 #include "ZzzTexture.h"
 #include "ZzzOpenData.h"
 #include "Scenes/SceneCore.h"
+#include "Camera/CameraUtility.h"
 #include "ZzzBMD.h"
 #include "ZzzInfomation.h"
 #include "ZzzObject.h"
@@ -366,6 +367,7 @@ void DestroyWindow()
 {
     // Save game configuration to config.ini
     GameConfig::GetInstance().SetVolumeLevel(g_pOption->GetVolumeLevel());
+    GameConfig::GetInstance().SetCameraZoomLevel(GetUserCameraZoomLevel());
     GameConfig::GetInstance().Save();
 
 #ifdef _EDITOR
@@ -1022,6 +1024,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLin
     // Apply graphics settings from INI
     m_nColorDepth = GameConfig::GetInstance().GetColorDepth();
     g_iRenderTextType = GameConfig::GetInstance().GetRenderTextType();
+    SetUserCameraZoomLevel(static_cast<short>(GameConfig::GetInstance().GetCameraZoomLevel()));
 
     // Apply login settings from INI
     m_RememberMe = GameConfig::GetInstance().GetRememberMe() ? 1 : 0;


### PR DESCRIPTION
Camera zoom in MuMain feels much closer than zoom in original 1.04d client. 
I was hoping there is some way to zoom out, but couldn't find anything and made PgUp and PgDown keys to change Camera Zoom slightly. The Zoom level is also persisted into config.ini for memoization.

I played with it for a day and I like the ability to zoom a lot.

Obviously it is quite experimental, it might have bugs, I didn't test it in all areas, but did test in most.
Otherwise, I think it could be a really nice addition to this awesome client.