### PR TITLE
Fix displaying of system messages by default

### DIFF
--- a/src/source/NewUIChatLogWindow.cpp
+++ b/src/source/NewUIChatLogWindow.cpp
@@ -1089,6 +1089,7 @@ void SEASON3B::CNewUISystemLogWindow::Init()
     m_nShowingLines = 6;
     m_iCurrentRenderEndLine = -1;
     m_fBackAlpha = 0.6f;
+    m_bShowMessages = true;
 }
 
 


### PR DESCRIPTION
System messages (experience, picked up items) are enabled by default after logging in, but no messages are shown.
This PR fixes the issue.