### PR TITLE
bug(exp_tracking): fix experience tracking, both in a bar and character screen

### DIFF
--- a/src/source/CharacterManager.cpp
+++ b/src/source/CharacterManager.cpp
@@ -33,6 +33,7 @@ namespace
     constexpr int kSpecialWingType = ITEM_WING + 135;
 
     constexpr int kDefaultClassTextIndex = 2305;
+    constexpr int kMasterExperienceUnlockLevel = 400;
 
     constexpr std::array<ClassTextEntry, 18> kClassTextEntries{{
         { CLASS_WIZARD, 20 },
@@ -222,6 +223,11 @@ bool CCharacterManager::IsThirdClass(const CLASS_TYPE byClass)
 bool CCharacterManager::IsMasterLevel(const CLASS_TYPE byClass)
 {
     return this->IsThirdClass(byClass);
+}
+
+bool CCharacterManager::IsMasterExperienceActive(const CLASS_TYPE byClass, const int level)
+{
+    return this->IsMasterLevel(byClass) && level >= kMasterExperienceUnlockLevel;
 }
 
 const wchar_t* CCharacterManager::GetCharacterClassText(const CLASS_TYPE byCharacterClass)

--- a/src/source/CharacterManager.h
+++ b/src/source/CharacterManager.h
@@ -9,6 +9,7 @@ public:
     bool IsSecondClass(const CLASS_TYPE byClass);
     bool IsThirdClass(const CLASS_TYPE byClass);
     bool IsMasterLevel(const CLASS_TYPE byClass);
+    bool IsMasterExperienceActive(const CLASS_TYPE byClass, const int level);
     CLASS_TYPE GetBaseClass(CLASS_TYPE iClass);
     const wchar_t* GetCharacterClassText(const CLASS_TYPE byClass);
     

--- a/src/source/NewUICharacterInfoWindow.cpp
+++ b/src/source/NewUICharacterInfoWindow.cpp
@@ -293,7 +293,7 @@ void SEASON3B::CNewUICharacterInfoWindow::RenderTableTexts()
     wchar_t strPoint[128];
 
     mu_swprintf(strLevel, GlobalText[200], CharacterAttribute->Level);
-    mu_swprintf(strExp, GlobalText[201], CharacterAttribute->Experience, CharacterAttribute->NextExperience);
+    mu_swprintf(strExp, GlobalText[1748], CharacterAttribute->Experience, CharacterAttribute->NextExperience);
 
     if (CharacterAttribute->Level > 9)
     {

--- a/src/source/NewUIMainFrameWindow.cpp
+++ b/src/source/NewUIMainFrameWindow.cpp
@@ -536,42 +536,42 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
     {
         x = 0; y = 470; width = 6; height = 4;
 
-        WORD wPriorLevel = wLevel - 1;
-        DWORD dwPriorExperience = 0;
+        __int64 iPriorLevel = wLevel - 1;
+        __int64 iPriorExperience = 0;
 
-        if (wPriorLevel > 0)
+        if (iPriorLevel > 0)
         {
-            dwPriorExperience = (9 + wPriorLevel) * wPriorLevel * wPriorLevel * 10;
+            iPriorExperience = (9 + iPriorLevel) * iPriorLevel * iPriorLevel * 10;
 
-            if (wPriorLevel > 255)
+            if (iPriorLevel > 255)
             {
-                int iLevelOverN = wPriorLevel - 255;
-                dwPriorExperience += (9 + iLevelOverN) * iLevelOverN * iLevelOverN * 1000;
+                const __int64 iLevelOverN = iPriorLevel - 255;
+                iPriorExperience += (9 + iLevelOverN) * iLevelOverN * iLevelOverN * 1000;
             }
         }
 
-        float fNeedExp = dwNexExperience - dwPriorExperience;
-        float fExp = dwExperience - dwPriorExperience;
+        double fNeedExp = (double)dwNexExperience - (double)iPriorExperience;
+        double fExp = (double)dwExperience - (double)iPriorExperience;
 
-        if (dwExperience < dwPriorExperience)
+        if (dwExperience < iPriorExperience)
         {
             fExp = 0.f;
         }
 
-        float fExpBarNum = 0.f;
+        double fExpBarNum = 0.f;
         if (fExp > 0.f && fNeedExp > 0)
         {
             fExpBarNum = (fExp / fNeedExp) * 10.f;
         }
 
-        float fProgress = fExpBarNum;
-        fProgress = fProgress - (int)fProgress;
+        double fProgress = fExpBarNum;
+        fProgress = fProgress - static_cast<long long>(fProgress);
 
         if (m_bExpEffect == true)
         {
-            float fPreProgress = 0.f;
-            fExp = m_dwPreExp - dwPriorExperience;
-            if (m_dwPreExp < dwPriorExperience)
+            double fPreProgress = 0.f;
+            fExp = (double)m_dwPreExp - (double)iPriorExperience;
+            if (m_dwPreExp < iPriorExperience)
             {
                 x = 2.f; y = 473.f; width = fProgress * 629.f; height = 4.f;
                 RenderBitmap(IMAGE_GAUGE_EXBAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
@@ -587,7 +587,7 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
                 {
                     fPreProgress = (fExp / fNeedExp) * 10.f;
                     iPreExpBarNum = (int)fPreProgress;
-                    fPreProgress = fPreProgress - (int)fPreProgress;
+                    fPreProgress = fPreProgress - static_cast<long long>(fPreProgress);
                 }
 
                 iExpBarNum = (int)fExpBarNum;
@@ -602,7 +602,7 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
                 }
                 else
                 {
-                    float fGapProgress = 0.f;
+                    double fGapProgress = 0.f;
                     fGapProgress = fProgress - fPreProgress;
                     x = 2.f; y = 473.f; width = fPreProgress * 629.f; height = 4.f;
                     RenderBitmap(IMAGE_GAUGE_EXBAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
@@ -2598,12 +2598,12 @@ void SEASON3B::CNewUIMainFrameWindow::SetGetExp_Wide(__int64 dwGetExp)
     }
 }
 
-void SEASON3B::CNewUIMainFrameWindow::SetPreExp(DWORD dwPreExp)
+void SEASON3B::CNewUIMainFrameWindow::SetPreExp(__int64 dwPreExp)
 {
     m_dwPreExp = dwPreExp;
 }
 
-void SEASON3B::CNewUIMainFrameWindow::SetGetExp(DWORD dwGetExp)
+void SEASON3B::CNewUIMainFrameWindow::SetGetExp(__int64 dwGetExp)
 {
     m_dwGetExp = dwGetExp;
 

--- a/src/source/NewUIMainFrameWindow.cpp
+++ b/src/source/NewUIMainFrameWindow.cpp
@@ -28,6 +28,17 @@
 #include "GameShop/InGameShopSystem.h"
 #endif //PBG_ADD_INGAMESHOP_UI_MAINFRAME
 
+namespace
+{
+    constexpr int MasterExperienceUnlockLevel = 400;
+
+    bool IsMasterExperienceActive()
+    {
+        return gCharacterManager.IsMasterLevel(CharacterAttribute->Class) == true
+            && CharacterAttribute->Level >= MasterExperienceUnlockLevel;
+    }
+}
+
 SEASON3B::CNewUIMainFrameWindow::CNewUIMainFrameWindow()
 {
     m_bExpEffect = false;
@@ -409,7 +420,7 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
     __int64 dwExperience;
     double x, y, width, height;
 
-    if (gCharacterManager.IsMasterLevel(CharacterAttribute->Class) == true)
+    if (IsMasterExperienceActive() == true)
     {
         wLevel = (__int64)Master_Level_Data.nMLevel;
         dwNexExperience = (__int64)Master_Level_Data.lNext_MasterLevel_Experince;
@@ -422,7 +433,7 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
         dwExperience = CharacterAttribute->Experience;
     }
 
-    if (gCharacterManager.IsMasterLevel(CharacterAttribute->Class) == true)
+    if (IsMasterExperienceActive() == true)
     {
         x = 0; y = 470; width = 6; height = 4;
 

--- a/src/source/NewUIMainFrameWindow.cpp
+++ b/src/source/NewUIMainFrameWindow.cpp
@@ -28,17 +28,6 @@
 #include "GameShop/InGameShopSystem.h"
 #endif //PBG_ADD_INGAMESHOP_UI_MAINFRAME
 
-namespace
-{
-    constexpr int MasterExperienceUnlockLevel = 400;
-
-    bool IsMasterExperienceActive()
-    {
-        return gCharacterManager.IsMasterLevel(CharacterAttribute->Class) == true
-            && CharacterAttribute->Level >= MasterExperienceUnlockLevel;
-    }
-}
-
 SEASON3B::CNewUIMainFrameWindow::CNewUIMainFrameWindow()
 {
     m_bExpEffect = false;
@@ -420,7 +409,7 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
     __int64 dwExperience;
     double x, y, width, height;
 
-    if (IsMasterExperienceActive() == true)
+    if (gCharacterManager.IsMasterExperienceActive(CharacterAttribute->Class, CharacterAttribute->Level) == true)
     {
         wLevel = (__int64)Master_Level_Data.nMLevel;
         dwNexExperience = (__int64)Master_Level_Data.lNext_MasterLevel_Experince;
@@ -433,7 +422,7 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
         dwExperience = CharacterAttribute->Experience;
     }
 
-    if (IsMasterExperienceActive() == true)
+    if (gCharacterManager.IsMasterExperienceActive(CharacterAttribute->Class, CharacterAttribute->Level) == true)
     {
         x = 0; y = 470; width = 6; height = 4;
 

--- a/src/source/NewUIMainFrameWindow.h
+++ b/src/source/NewUIMainFrameWindow.h
@@ -219,8 +219,8 @@ namespace SEASON3B
         void SetPreExp_Wide(__int64 dwPreExp);
         void SetGetExp_Wide(__int64 dwGetExp);
 
-        void SetPreExp(DWORD dwPreExp);
-        void SetGetExp(DWORD dwGetExp);
+        void SetPreExp(__int64 dwPreExp);
+        void SetGetExp(__int64 dwGetExp);
 
         // buttons
         void SetBtnState(int iBtnType, bool bStateDown);
@@ -259,8 +259,8 @@ namespace SEASON3B
         bool m_bExpEffect;
         DWORD m_dwExpEffectTime;
 
-        DWORD m_dwPreExp;
-        DWORD m_dwGetExp;
+        __int64 m_dwPreExp;
+        __int64 m_dwGetExp;
 
 #ifdef PBG_ADD_INGAMESHOP_UI_MAINFRAME
         CNewUIButton m_BtnCShop;

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -153,17 +153,6 @@ void AddDebugText(const unsigned char* Buffer, int Size)
 // Forward declaration
 static void HandleIncomingPacket(int32_t Handle, const BYTE* ReceiveBuffer, int32_t Size);
 
-namespace
-{
-    constexpr int MasterExperienceUnlockLevel = 400;
-
-    bool IsMasterExperienceActive()
-    {
-        return gCharacterManager.IsMasterLevel(CharacterAttribute->Class) == true
-            && CharacterAttribute->Level >= MasterExperienceUnlockLevel;
-    }
-}
-
 BOOL CreateSocket(const wchar_t* IpAddr, unsigned short Port)
 {
     BOOL bResult = TRUE;
@@ -943,7 +932,7 @@ void ReceiveRevival(const BYTE* ReceiveBuffer)
         return rawExperience;
     };
 
-    if (IsMasterExperienceActive() == true)
+    if (gCharacterManager.IsMasterExperienceActive(CharacterAttribute->Class, CharacterAttribute->Level) == true)
     {
         Master_Level_Data.lMasterLevel_Experince = static_cast<__int64>(selectRevivalExperience(
             rawRevivalExperience,
@@ -5349,7 +5338,7 @@ BOOL ReceiveDieExp(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     c->Dead = 1;
     c->Movement = false;
 
-    if (IsMasterExperienceActive() == true)
+    if (gCharacterManager.IsMasterExperienceActive(CharacterAttribute->Class, CharacterAttribute->Level) == true)
     {
         g_pMainFrame->SetPreExp_Wide(Master_Level_Data.lMasterLevel_Experince);
         g_pMainFrame->SetGetExp_Wide(Exp);
@@ -5365,7 +5354,7 @@ BOOL ReceiveDieExp(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     if (Exp > 0)
     {
         wchar_t Text[100];
-        if (IsMasterExperienceActive() == true)
+        if (gCharacterManager.IsMasterExperienceActive(CharacterAttribute->Class, CharacterAttribute->Level) == true)
         {
             mu_swprintf(Text, GlobalText[1750], Exp);
         }

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -153,6 +153,17 @@ void AddDebugText(const unsigned char* Buffer, int Size)
 // Forward declaration
 static void HandleIncomingPacket(int32_t Handle, const BYTE* ReceiveBuffer, int32_t Size);
 
+namespace
+{
+    constexpr int MasterExperienceUnlockLevel = 400;
+
+    bool IsMasterExperienceActive()
+    {
+        return gCharacterManager.IsMasterLevel(CharacterAttribute->Class) == true
+            && CharacterAttribute->Level >= MasterExperienceUnlockLevel;
+    }
+}
+
 BOOL CreateSocket(const wchar_t* IpAddr, unsigned short Port)
 {
     BOOL bResult = TRUE;
@@ -932,7 +943,7 @@ void ReceiveRevival(const BYTE* ReceiveBuffer)
         return rawExperience;
     };
 
-    if (gCharacterManager.IsMasterLevel(Hero->Class) == true)
+    if (IsMasterExperienceActive() == true)
     {
         Master_Level_Data.lMasterLevel_Experince = static_cast<__int64>(selectRevivalExperience(
             rawRevivalExperience,
@@ -5338,7 +5349,7 @@ BOOL ReceiveDieExp(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     c->Dead = 1;
     c->Movement = false;
 
-    if (gCharacterManager.IsMasterLevel(Hero->Class) == true)
+    if (IsMasterExperienceActive() == true)
     {
         g_pMainFrame->SetPreExp_Wide(Master_Level_Data.lMasterLevel_Experince);
         g_pMainFrame->SetGetExp_Wide(Exp);
@@ -5354,7 +5365,7 @@ BOOL ReceiveDieExp(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     if (Exp > 0)
     {
         wchar_t Text[100];
-        if (gCharacterManager.IsMasterLevel(Hero->Class) == true)
+        if (IsMasterExperienceActive() == true)
         {
             mu_swprintf(Text, GlobalText[1750], Exp);
         }

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -917,13 +917,34 @@ void ReceiveRevival(const BYTE* ReceiveBuffer)
     CharacterAttribute->Shield = Data->Shield;
     CharacterAttribute->SkillMana = Data->SkillMana;
 
+    const auto rawRevivalExperience = Data->CurrentExperience;
+    const auto swappedRevivalExperience = ntoh64(Data->CurrentExperience);
+    const auto selectRevivalExperience = [](uint64_t rawExperience, uint64_t swappedExperience, uint64_t nextExperience)
+    {
+        const bool isRawPlausible = rawExperience <= nextExperience;
+        const bool isSwappedPlausible = swappedExperience <= nextExperience;
+        if (isRawPlausible != isSwappedPlausible)
+        {
+            return isRawPlausible ? rawExperience : swappedExperience;
+        }
+
+        // Fallback to legacy interpretation when both variants are plausible or implausible.
+        return rawExperience;
+    };
+
     if (gCharacterManager.IsMasterLevel(Hero->Class) == true)
     {
-        Master_Level_Data.lMasterLevel_Experince = ntoh64(Data->CurrentExperience);
+        Master_Level_Data.lMasterLevel_Experince = static_cast<__int64>(selectRevivalExperience(
+            rawRevivalExperience,
+            swappedRevivalExperience,
+            static_cast<uint64_t>(Master_Level_Data.lNext_MasterLevel_Experince)));
     }
     else
     {
-        CharacterAttribute->Experience = ntoh64(Data->CurrentExperience);
+        CharacterAttribute->Experience = selectRevivalExperience(
+            rawRevivalExperience,
+            swappedRevivalExperience,
+            CharacterAttribute->NextExperience);
     }
 
     CharacterMachine->Gold = Data->Gold;

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -919,11 +919,11 @@ void ReceiveRevival(const BYTE* ReceiveBuffer)
 
     if (gCharacterManager.IsMasterLevel(Hero->Class) == true)
     {
-        Master_Level_Data.lMasterLevel_Experince = Data->CurrentExperience;
+        Master_Level_Data.lMasterLevel_Experince = ntoh64(Data->CurrentExperience);
     }
     else
     {
-        CharacterAttribute->Experience = Data->CurrentExperience;
+        CharacterAttribute->Experience = ntoh64(Data->CurrentExperience);
     }
 
     CharacterMachine->Gold = Data->Gold;
@@ -5325,7 +5325,7 @@ BOOL ReceiveDieExp(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     }
     else
     {
-        g_pMainFrame->SetPreExp(CharacterAttribute->Experience & 0xFFFFFFFF);
+        g_pMainFrame->SetPreExp(CharacterAttribute->Experience);
         g_pMainFrame->SetGetExp(Exp);
         CharacterAttribute->Experience += Exp;
     }
@@ -5413,7 +5413,7 @@ BOOL ReceiveDieExpLarge(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     }
     else
     {
-        g_pMainFrame->SetPreExp(CharacterAttribute->Experience & 0xFFFFFFFF);
+        g_pMainFrame->SetPreExp(CharacterAttribute->Experience);
         g_pMainFrame->SetGetExp(addedExperience);
         CharacterAttribute->Experience += addedExperience;
     }
@@ -7589,7 +7589,7 @@ void Receive_Master_LevelUp(const BYTE* ReceiveBuffer, int Size)
     //	Master_Level_Data.nTotalMPoint		= Data->nTotalMPoint;
     Master_Level_Data.nMaxPoint = Data->nMaxPoint;
 
-    if (Size >= sizeof(LPPMSG_MASTERLEVEL_UP_EXTENDED))
+    if (Size >= sizeof(PMSG_MASTERLEVEL_UP_EXTENDED))
     {
         auto ExtData = (LPPMSG_MASTERLEVEL_UP_EXTENDED)ReceiveBuffer;
         Master_Level_Data.wMaxLife = ExtData->wMaxLife;
@@ -7667,7 +7667,7 @@ void Receive_Master_Level_Exp(const BYTE* ReceiveBuffer, int Size)
     Master_Level_Data.lNext_MasterLevel_Experince |= Data->btMNextExp8;
     Master_Level_Data.nMLevelUpMPoint = Data->nMLPoint;
 
-    if (Size >= sizeof(LPPMSG_MASTERLEVEL_INFO_EXTENDED))
+    if (Size >= sizeof(PMSG_MASTERLEVEL_INFO_EXTENDED))
     {
         auto ExtData = (LPPMSG_MASTERLEVEL_INFO_EXTENDED)ReceiveBuffer;
         Master_Level_Data.wMaxLife = ExtData->wMaxLife;

--- a/src/source/ZzzInfomation.cpp
+++ b/src/source/ZzzInfomation.cpp
@@ -3404,13 +3404,15 @@ void CHARACTER_MACHINE::CalculateWalkSpeed()
 
 void CHARACTER_MACHINE::CalculateNextExperince()
 {
+    const uint64_t characterLevel = static_cast<uint64_t>(Character.Level);
+
     Character.Experience = Character.NextExperience;
-    Character.NextExperience = (9 + Character.Level) * (Character.Level) * (Character.Level) * 10;
+    Character.NextExperience = (9ull + characterLevel) * characterLevel * characterLevel * 10ull;
 
     if (Character.Level > 255)
     {
-        int LevelOver_N = Character.Level - 255;
-        Character.NextExperience += (9 + LevelOver_N) * LevelOver_N * LevelOver_N * 1000;
+        const uint64_t levelOverN = static_cast<uint64_t>(Character.Level - 255);
+        Character.NextExperience += (9ull + levelOverN) * levelOverN * levelOverN * 1000ull;
     }
 }
 


### PR DESCRIPTION
This PR fixes experience tracking. 

Fixes a bug when after some level experience starts showing as $current_experience/0 in Character screen. 
Also fixes a bug with the experience progress bar which sometimes stayed at 0 after leveling up.

The problem appeared during casts and reassignment between 32-bit and 64-bit int and floating types, this PR ensures that experience values do not overflow.

