### PR TITLE
feat(lahap): make lahap treat inventory and extension as one

### DIFF
--- a/src/source/CComGem.cpp
+++ b/src/source/CComGem.cpp
@@ -27,6 +27,21 @@ namespace COMGEM
         {
             return (g_pMyInventory != nullptr) ? g_pMyInventory->GetInventoryCtrl() : nullptr;
         }
+
+        const ITEM* FindInventoryItemBySlot(const int slot)
+        {
+            if (slot < MAX_EQUIPMENT_INDEX || slot >= MAX_MY_INVENTORY_EX_INDEX)
+            {
+                return nullptr;
+            }
+
+            if (slot < MAX_MY_INVENTORY_INDEX)
+            {
+                return (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(slot) : nullptr;
+            }
+
+            return (g_pMyInventoryExt != nullptr) ? g_pMyInventoryExt->FindItem(slot) : nullptr;
+        }
     }
 
     //Locals
@@ -77,25 +92,27 @@ void COMGEM::ResetWantedList()
 
 bool COMGEM::FindWantedList()
 {
-    SEASON3B::CNewUIInventoryCtrl* pNewInventoryCtrl = GetInventoryCtrl();
-    if (pNewInventoryCtrl == nullptr)
+    if (GetInventoryCtrl() == nullptr)
     {
         ResetWantedList();
         return false;
     }
 
     bool foundAny = false;
-    const int nInvenMaxIndex = MAX_MY_INVENTORY_INDEX;
     ResetWantedList();
 
-    for (int i = 0; i < nInvenMaxIndex; ++i)
+    for (int slot = MAX_EQUIPMENT_INDEX; slot < MAX_MY_INVENTORY_EX_INDEX; ++slot)
     {
-        const ITEM* pItem = pNewInventoryCtrl->GetItem(i);
-        if (!pItem) continue;
+        const ITEM* pItem = FindInventoryItemBySlot(slot);
+        if (!pItem)
+        {
+            continue;
+        }
+
         if (isCompiledGem(pItem))
         {
             INTBYTEPAIR p;
-            p.first = pItem->y * pNewInventoryCtrl->GetNumberOfColumn() + pItem->x + MAX_EQUIPMENT_INDEX;
+            p.first = slot;
             p.second = pItem->Level;
             m_UnmixTarList.AddText(p.first, p.second);
             foundAny = true;
@@ -161,22 +178,23 @@ bool COMGEM::CheckMyInvValid()
     m_cPercent = 0;
     m_cCount = 0;
 
-    const int nInvenMaxIndex = MAX_MY_INVENTORY_INDEX;
-
     if (m_bType == ATTACH)
     {
-        SEASON3B::CNewUIInventoryCtrl* pNewInventoryCtrl = GetInventoryCtrl();
-        if (pNewInventoryCtrl == nullptr)
+        if (GetInventoryCtrl() == nullptr)
         {
             m_cErr = COMERROR_NOTALLOWED;
             m_cPercent = 0;
             return false;
         }
 
-        for (int i = 0; i < nInvenMaxIndex; ++i)
+        for (int slot = MAX_EQUIPMENT_INDEX; slot < MAX_MY_INVENTORY_EX_INDEX; ++slot)
         {
-            const ITEM* pItem = pNewInventoryCtrl->GetItem(i);
-            if (!pItem) continue;
+            const ITEM* pItem = FindInventoryItemBySlot(slot);
+            if (!pItem)
+            {
+                continue;
+            }
+
             if (m_cGemType == Check_Jewel_Unit(pItem->Type))	++m_cCount;
 
             if (m_cCount == m_cComType)
@@ -195,16 +213,14 @@ bool COMGEM::CheckMyInvValid()
     }
     else if (m_bType == DETACH)
     {
-        if (iUnMixIndex == -1 || iUnMixIndex >= MAX_MY_INVENTORY_EX_INDEX)
+        if (iUnMixIndex < MAX_EQUIPMENT_INDEX || iUnMixIndex >= MAX_MY_INVENTORY_EX_INDEX)
         {
             m_cErr = DEERROR_NOTALLOWED;
             m_cPercent = 0;
             return false;
         }
 
-        //SEASON3B::CNewUIInventoryCtrl * pNewInventoryCtrl = g_pMyInventory->GetInventoryCtrl();
-        //ITEM * pItem = pNewInventoryCtrl->GetItem(iUnMixIndex);
-        const ITEM* pItem = (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(iUnMixIndex) : nullptr;
+        const ITEM* pItem = FindInventoryItemBySlot(iUnMixIndex);
         if (pItem != nullptr && isCompiledGem(pItem))
         {
             ++m_cCount;

--- a/src/source/CComGem.cpp
+++ b/src/source/CComGem.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdint>
 
+#include "InventoryUtils.h"
 #include "ZzzInventory.h"
 #include "NewUIInventoryCtrl.h"
 #include "NewUISystem.h"
@@ -26,21 +27,6 @@ namespace COMGEM
         SEASON3B::CNewUIInventoryCtrl* GetInventoryCtrl()
         {
             return (g_pMyInventory != nullptr) ? g_pMyInventory->GetInventoryCtrl() : nullptr;
-        }
-
-        const ITEM* FindInventoryItemBySlot(const int slot)
-        {
-            if (slot < MAX_EQUIPMENT_INDEX || slot >= MAX_MY_INVENTORY_EX_INDEX)
-            {
-                return nullptr;
-            }
-
-            if (slot < MAX_MY_INVENTORY_INDEX)
-            {
-                return (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(slot) : nullptr;
-            }
-
-            return (g_pMyInventoryExt != nullptr) ? g_pMyInventoryExt->FindItem(slot) : nullptr;
         }
     }
 

--- a/src/source/InventoryUtils.h
+++ b/src/source/InventoryUtils.h
@@ -5,14 +5,34 @@
 
 #include "NewUISystem.h"
 
+inline bool IsMainInventorySlot(const int slot)
+{
+    return slot >= MAX_EQUIPMENT_INDEX && slot < MAX_MY_INVENTORY_INDEX;
+}
+
+inline bool IsInventoryExtensionSlot(const int slot)
+{
+    return slot >= MAX_MY_INVENTORY_INDEX && slot < MAX_MY_INVENTORY_EX_INDEX;
+}
+
+inline bool IsMyShopSlot(const int slot)
+{
+    return slot >= MAX_MY_INVENTORY_EX_INDEX && slot < MAX_MY_SHOP_INVENTORY_INDEX;
+}
+
+inline bool IsPlayerInventorySlot(const int slot)
+{
+    return IsMainInventorySlot(slot) || IsInventoryExtensionSlot(slot);
+}
+
 inline const ITEM* FindInventoryItemBySlot(const int slot)
 {
-    if (slot < MAX_EQUIPMENT_INDEX || slot >= MAX_MY_INVENTORY_EX_INDEX)
+    if (!IsPlayerInventorySlot(slot))
     {
         return nullptr;
     }
 
-    if (slot < MAX_MY_INVENTORY_INDEX)
+    if (IsMainInventorySlot(slot))
     {
         return (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(slot) : nullptr;
     }

--- a/src/source/InventoryUtils.h
+++ b/src/source/InventoryUtils.h
@@ -1,0 +1,23 @@
+#ifndef _INVENTORYUTILS_H_
+#define _INVENTORYUTILS_H_
+
+#pragma once
+
+#include "NewUISystem.h"
+
+inline const ITEM* FindInventoryItemBySlot(const int slot)
+{
+    if (slot < MAX_EQUIPMENT_INDEX || slot >= MAX_MY_INVENTORY_EX_INDEX)
+    {
+        return nullptr;
+    }
+
+    if (slot < MAX_MY_INVENTORY_INDEX)
+    {
+        return (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(slot) : nullptr;
+    }
+
+    return (g_pMyInventoryExt != nullptr) ? g_pMyInventoryExt->FindItem(slot) : nullptr;
+}
+
+#endif // _INVENTORYUTILS_H_

--- a/src/source/NewUICustomMessageBox.cpp
+++ b/src/source/NewUICustomMessageBox.cpp
@@ -27,6 +27,24 @@ char AppointType;
 
 using namespace SEASON3B;
 
+namespace
+{
+    ITEM* FindInventoryItemBySlot(const int slot)
+    {
+        if (slot < MAX_EQUIPMENT_INDEX || slot >= MAX_MY_INVENTORY_EX_INDEX)
+        {
+            return nullptr;
+        }
+
+        if (slot < MAX_MY_INVENTORY_INDEX)
+        {
+            return (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(slot) : nullptr;
+        }
+
+        return (g_pMyInventoryExt != nullptr) ? g_pMyInventoryExt->FindItem(slot) : nullptr;
+    }
+}
+
 SEASON3B::CNewUITextInputMsgBox::CNewUITextInputMsgBox()
 {
     m_pInputBox = NULL;
@@ -2068,6 +2086,12 @@ CALLBACK_RESULT SEASON3B::CGemIntegrationDisjointMsgBox::DisjointBtnDown(class C
     UNMIX_TEXT* pUT = COMGEM::m_UnmixTarList.GetSelectedText();
     if (pUT)
     {
+        ITEM* pItem = FindInventoryItemBySlot(pUT->m_iInvenIdx);
+        if (pItem == nullptr)
+        {
+            return CALLBACK_BREAK;
+        }
+
         COMGEM::SelectFromList(pUT->m_iInvenIdx, pUT->m_cLevel);
 
         SEASON3B::CNewUICommonMessageBox* pMsgBox = NULL;
@@ -2077,7 +2101,6 @@ CALLBACK_RESULT SEASON3B::CGemIntegrationDisjointMsgBox::DisjointBtnDown(class C
         {
             wchar_t strText[256] = { 0, };
             int	iGemLevel = COMGEM::GetUnMixGemLevel() + 1;
-            ITEM* pItem = g_pMyInventory->GetInventoryCtrl()->FindItem(pUT->m_iInvenIdx);
             int	  nIdx = COMGEM::Check_Jewel(pItem->Type);
             COMGEM::SetGem(nIdx);
             mu_swprintf(strText, GlobalText[1813], GlobalText[COMGEM::GetJewelIndex(nIdx, COMGEM::eGEM_NAME)], iGemLevel);

--- a/src/source/NewUICustomMessageBox.cpp
+++ b/src/source/NewUICustomMessageBox.cpp
@@ -13,6 +13,7 @@
 #include "npcBreeder.h"
 #include "ZzzOpenData.h"
 #include "DuelMgr.h"
+#include "InventoryUtils.h"
 #include "NewUISystem.h"
 #include "w_CursedTemple.h"
 
@@ -26,24 +27,6 @@ char AppointType;
 #define BATTLEMASTER	32
 
 using namespace SEASON3B;
-
-namespace
-{
-    ITEM* FindInventoryItemBySlot(const int slot)
-    {
-        if (slot < MAX_EQUIPMENT_INDEX || slot >= MAX_MY_INVENTORY_EX_INDEX)
-        {
-            return nullptr;
-        }
-
-        if (slot < MAX_MY_INVENTORY_INDEX)
-        {
-            return (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(slot) : nullptr;
-        }
-
-        return (g_pMyInventoryExt != nullptr) ? g_pMyInventoryExt->FindItem(slot) : nullptr;
-    }
-}
 
 SEASON3B::CNewUITextInputMsgBox::CNewUITextInputMsgBox()
 {
@@ -2086,7 +2069,7 @@ CALLBACK_RESULT SEASON3B::CGemIntegrationDisjointMsgBox::DisjointBtnDown(class C
     UNMIX_TEXT* pUT = COMGEM::m_UnmixTarList.GetSelectedText();
     if (pUT)
     {
-        ITEM* pItem = FindInventoryItemBySlot(pUT->m_iInvenIdx);
+        const ITEM* pItem = FindInventoryItemBySlot(pUT->m_iInvenIdx);
         if (pItem == nullptr)
         {
             return CALLBACK_BREAK;

--- a/src/source/UIControls.cpp
+++ b/src/source/UIControls.cpp
@@ -18,6 +18,7 @@
 #include "ReadScript.h"
 #include "CMVP1stDirection.h"
 #include "UIManager.h"
+#include "InventoryUtils.h"
 #include "NewUISystem.h"
 
 extern BYTE m_CrywolfState;
@@ -5102,21 +5103,6 @@ bool lessfunc(const UNMIX_TEXT& lhs, const UNMIX_TEXT& rhs)
     return (lhs.m_iInvenIdx > rhs.m_iInvenIdx);
 }
 
-static ITEM* FindInventoryItemBySlot(const int slot)
-{
-    if (slot < MAX_EQUIPMENT_INDEX || slot >= MAX_MY_INVENTORY_EX_INDEX)
-    {
-        return nullptr;
-    }
-
-    if (slot < MAX_MY_INVENTORY_INDEX)
-    {
-        return (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(slot) : nullptr;
-    }
-
-    return (g_pMyInventoryExt != nullptr) ? g_pMyInventoryExt->FindItem(slot) : nullptr;
-}
-
 void CUIUnmixgemList::Sort()
 {
     sort(m_TextList.begin(), m_TextList.end(), lessfunc);
@@ -5215,7 +5201,7 @@ BOOL CUIUnmixgemList::RenderDataLine(int iLineNumber)
 
     wchar_t oText[MAX_GLOBAL_TEXT_STRING] = { 0, };
 
-    ITEM* pItem = FindInventoryItemBySlot(m_TextListIter->m_iInvenIdx);
+    const ITEM* pItem = FindInventoryItemBySlot(m_TextListIter->m_iInvenIdx);
     if (pItem)
     {
         int	  nIdx = COMGEM::Check_Jewel(pItem->Type);

--- a/src/source/UIControls.cpp
+++ b/src/source/UIControls.cpp
@@ -5102,6 +5102,21 @@ bool lessfunc(const UNMIX_TEXT& lhs, const UNMIX_TEXT& rhs)
     return (lhs.m_iInvenIdx > rhs.m_iInvenIdx);
 }
 
+static ITEM* FindInventoryItemBySlot(const int slot)
+{
+    if (slot < MAX_EQUIPMENT_INDEX || slot >= MAX_MY_INVENTORY_EX_INDEX)
+    {
+        return nullptr;
+    }
+
+    if (slot < MAX_MY_INVENTORY_INDEX)
+    {
+        return (g_pMyInventory != nullptr) ? g_pMyInventory->FindItem(slot) : nullptr;
+    }
+
+    return (g_pMyInventoryExt != nullptr) ? g_pMyInventoryExt->FindItem(slot) : nullptr;
+}
+
 void CUIUnmixgemList::Sort()
 {
     sort(m_TextList.begin(), m_TextList.end(), lessfunc);
@@ -5109,7 +5124,7 @@ void CUIUnmixgemList::Sort()
 
 void CUIUnmixgemList::AddText(int iIndex, BYTE cComType)
 {
-    if (iIndex < 0 || iIndex > MAX_INVENTORY || cComType == COMGEM::NOCOM) return;
+    if (iIndex < MAX_EQUIPMENT_INDEX || iIndex >= MAX_MY_INVENTORY_EX_INDEX || cComType == COMGEM::NOCOM) return;
 
     for (unsigned int i = 0; i < m_TextList.size(); ++i)
     {
@@ -5200,7 +5215,7 @@ BOOL CUIUnmixgemList::RenderDataLine(int iLineNumber)
 
     wchar_t oText[MAX_GLOBAL_TEXT_STRING] = { 0, };
 
-    ITEM* pItem = g_pMyInventory->GetInventoryCtrl()->FindItem(m_TextListIter->m_iInvenIdx);
+    ITEM* pItem = FindInventoryItemBySlot(m_TextListIter->m_iInvenIdx);
     if (pItem)
     {
         int	  nIdx = COMGEM::Check_Jewel(pItem->Type);
@@ -5229,7 +5244,9 @@ BOOL CUIUnmixgemList::DoLineMouseAction(int iLineNumber)
             SLSetSelectLine(m_iCurrentRenderEndLine + iLineNumber + 1);
             UNMIX_TEXT* pt = GetSelectedText();
 
-            if (pt->m_cLevel != COMGEM::NOCOM && pt->m_iInvenIdx > 0 && pt->m_iInvenIdx < MAX_INVENTORY)
+            if (pt->m_cLevel != COMGEM::NOCOM
+                && pt->m_iInvenIdx >= MAX_EQUIPMENT_INDEX
+                && pt->m_iInvenIdx < MAX_MY_INVENTORY_EX_INDEX)
                 COMGEM::SelectFromList(pt->m_iInvenIdx, pt->m_cLevel);
 
             MouseLButtonDBClick = false;

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -28,6 +28,7 @@
 #include "CSMapServer.h"
 #include "npcGateSwitch.h"
 #include "CComGem.h"
+#include "InventoryUtils.h"
 #include "UIMapName.h" // rozy
 #include "UIMng.h"
 #include "CDirection.h"
@@ -1220,15 +1221,15 @@ void ReceiveDeleteInventory(const BYTE* ReceiveBuffer)
         {
             g_pMyInventory->UnequipItem(itemindex);
         }
-        else if (itemindex >= MAX_EQUIPMENT_INDEX && itemindex < MAX_MY_INVENTORY_INDEX)
+        else if (IsMainInventorySlot(itemindex))
         {
             g_pMyInventory->DeleteItem(itemindex);
         }
-        else if (itemindex > MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
+        else if (IsInventoryExtensionSlot(itemindex))
         {
             g_pMyInventoryExt->DeleteItem(itemindex);
         }
-        else if (itemindex >= MAX_MY_INVENTORY_EX_INDEX && itemindex < MAX_MY_SHOP_INVENTORY_INDEX)
+        else if (IsMyShopSlot(itemindex))
         {
             g_pMyShopInventory->DeleteItem(itemindex);
         }
@@ -1324,15 +1325,15 @@ BOOL ReceiveInventoryExtended(std::span<const BYTE> ReceiveBuffer)
         {
             g_pMyInventory->EquipItem(itemindex, itemData);
         }
-        else if (itemindex >= MAX_EQUIPMENT_INDEX && itemindex < MAX_MY_INVENTORY_INDEX)
+        else if (IsMainInventorySlot(itemindex))
         {
             g_pMyInventory->InsertItem(itemindex, itemData);
         }
-        else if (itemindex >= MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
+        else if (IsInventoryExtensionSlot(itemindex))
         {
             g_pMyInventoryExt->InsertItem(itemindex, itemData);
         }
-        else if (itemindex >= MAX_MY_INVENTORY_EX_INDEX && itemindex < MAX_MY_SHOP_INVENTORY_INDEX)
+        else if (IsMyShopSlot(itemindex))
         {
             g_pMyShopInventory->InsertItem(itemindex, itemData);
         }
@@ -5688,8 +5689,7 @@ void ReceiveGetItem(std::span<const BYTE> ReceiveBuffer)
             auto itemIndex = Data->Value;
             if (itemIndex != GET_ITEM_MULTI)
             {
-                auto Data2 = safe_cast<PRECEIVE_GET_ITEM_EXTENDED>(ReceiveBuffer);
-                if (Data2 == nullptr)
+                if (safe_cast<PRECEIVE_GET_ITEM_EXTENDED>(ReceiveBuffer) == nullptr)
                 {
                     assert(false);
                     return;
@@ -5700,14 +5700,14 @@ void ReceiveGetItem(std::span<const BYTE> ReceiveBuffer)
                 int length = CalcItemLength(itemData);
                 itemData = itemData.subspan(0, length);
 
-                if (itemIndex >= MAX_EQUIPMENT_INDEX && itemIndex < MAX_MY_INVENTORY_INDEX)
+                if (IsMainInventorySlot(itemIndex))
                 {
                     if (g_pMyInventory->InsertItem(itemIndex, itemData))
                     {
                         pickedItem = g_pMyInventory->FindItem(itemIndex);
                     }
                 }
-                else if (itemIndex >= MAX_MY_INVENTORY_INDEX && Data2->Result < MAX_MY_INVENTORY_EX_INDEX)
+                else if (IsInventoryExtensionSlot(itemIndex))
                 {
                     if (g_pMyInventoryExt->InsertItem(itemIndex, itemData))
                     {
@@ -5819,19 +5819,19 @@ BOOL ReceiveEquipmentItemExtended(std::span<const BYTE> ReceiveBuffer)
             {
                 g_pMyInventory->EquipItem(itemindex, itemData);
             }
-            else if (itemindex >= MAX_EQUIPMENT_INDEX && itemindex < MAX_MY_INVENTORY_INDEX)
+            else if (IsMainInventorySlot(itemindex))
             {
                 g_pStorageInventory->ProcessStorageItemAutoMoveSuccess();
                 g_pStorageInventoryExt->ProcessStorageItemAutoMoveSuccess();
                 g_pMyInventory->InsertItem(itemindex, itemData);
             }
-            else if (itemindex >= MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
+            else if (IsInventoryExtensionSlot(itemindex))
             {
                 g_pStorageInventory->ProcessStorageItemAutoMoveSuccess();
                 g_pStorageInventoryExt->ProcessStorageItemAutoMoveSuccess();
                 g_pMyInventoryExt->InsertItem(itemindex, itemData);
             }
-            else if (itemindex >= MAX_MY_INVENTORY_EX_INDEX && itemindex < MAX_MY_SHOP_INVENTORY_INDEX)
+            else if (IsMyShopSlot(itemindex))
             {
                 g_pMyShopInventory->InsertItem(itemindex, itemData);
             }
@@ -5916,11 +5916,11 @@ void ReceiveModifyItemExtended(std::span<const BYTE> ReceiveBuffer)
         g_pMyInventory->DeleteItem(itemindex);
     }
 
-    if (itemindex >= MAX_EQUIPMENT_INDEX && itemindex < MAX_MY_INVENTORY_INDEX)
+    if (IsMainInventorySlot(itemindex))
     {
         g_pMyInventory->InsertItem(itemindex, itemData);
     }
-    else if (itemindex > MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
+    else if (IsInventoryExtensionSlot(itemindex))
     {
         g_pMyInventoryExt->InsertItem(itemindex, itemData);
     }
@@ -6174,11 +6174,11 @@ void ReceiveBuyExtended(const std::span<const BYTE> ReceiveBuffer)
     }
     else
     {
-        if (Data->Index >= MAX_EQUIPMENT_INDEX && Data->Index < MAX_MY_INVENTORY_INDEX)
+        if (IsMainInventorySlot(Data->Index))
         {
             g_pMyInventory->InsertItem(Data->Index, itemData);
         }
-        else if (Data->Index >= MAX_MY_INVENTORY_INDEX && Data->Index < MAX_MY_INVENTORY_EX_INDEX)
+        else if (IsInventoryExtensionSlot(Data->Index))
         {
             g_pMyInventoryExt->InsertItem(Data->Index, itemData);
         }
@@ -8925,11 +8925,11 @@ void ReceivePurchaseItem(std::span<const BYTE> ReceiveBuffer)
         auto offset = sizeof(PURCHASEITEM_RESULTINFO);
         auto itemData = ReceiveBuffer.subspan(offset);
 
-        if (itemindex >= MAX_EQUIPMENT_INDEX && itemindex < MAX_MY_INVENTORY_INDEX)
+        if (IsMainInventorySlot(itemindex))
         {
             g_pMyInventory->InsertItem(itemindex, itemData);
         }
-        else if (itemindex > MAX_MY_INVENTORY_INDEX && itemindex < MAX_MY_INVENTORY_EX_INDEX)
+        else if (IsInventoryExtensionSlot(itemindex))
         {
             g_pMyInventoryExt->InsertItem(itemindex, itemData);
         }


### PR DESCRIPTION
This change makes Lahap to:

- consider jewels in inventory extension as well, instead of moving jewels around before talking to Lahap, player can have them spread across main and extension slots and they would get noticed by Lahap and combined.
- see and dismantle jewels from extension inventory slots

needs thorough testing, I have been testing this myself and didn't see any bugs so far.