### PR TITLE
Fix login scene cleanup ordering

### DIFF
--- a/src/source/Scenes/LoginScene.cpp
+++ b/src/source/Scenes/LoginScene.cpp
@@ -345,13 +345,13 @@ void NewMoveLogInScene()
 
         CCameraMove::GetInstancePtr()->SetTourMode(FALSE);
 
+        // Tear down the login scene data before asking the server for the
+        // account characters, otherwise a fast reply can be cleared again.
+        ReleaseLogoSceneData();
+
         SceneFlag = CHARACTER_SCENE;
         CurrentProtocolState = REQUEST_CHARACTERS_LIST;
         SocketClient->ToGameServer()->SendRequestCharacterList(g_pMultiLanguage->GetLanguage());
-
-        ReleaseLogoSceneData();
-
-        ClearCharacters();
     }
 
     g_ConsoleDebug->UpdateMainScene();


### PR DESCRIPTION
Previously, the client requested the new account's character list first and then cleaned up the old login scene. If the server responded quickly, the new characters could be created and then immediately cleared by the late cleanup, leaving the character selection screen empty.

Reproduce against a local OpenMU server: log into one account, return to server selection, then log into a different account and the character selection screen appears empty.