### PR TITLE
Fix JumpTime push movement 

### DIFF
--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include <memory>
 #include "UIManager.h"
 #include "Guild/GuildCache.h"
@@ -1800,6 +1800,11 @@ void ReceiveMovePosition(const BYTE* ReceiveBuffer)
     c->TargetX = Data->PositionX;
     c->TargetY = Data->PositionY;
     c->JumpTime = 1;
+    c->Movement = false;
+    c->Path.PathNum = 0;
+    c->Path.CurrentPath = 0;
+    c->Path.CurrentPathFloat = 0;
+    SetPlayerStop(c);
 }
 
 extern int EnableEvent;

--- a/src/source/ZzzCharacter.cpp
+++ b/src/source/ZzzCharacter.cpp
@@ -3065,8 +3065,8 @@ void  PushingCharacter(CHARACTER* c, OBJECT* o)
         }
         else
         {
-            o->Position[0] += (((float)c->TargetX + 0.5f) * TERRAIN_SCALE - o->Position[0]) * Speed + FPS_ANIMATION_FACTOR;
-            o->Position[1] += (((float)c->TargetY + 0.5f) * TERRAIN_SCALE - o->Position[1]) * Speed + FPS_ANIMATION_FACTOR;
+            o->Position[0] += (((float)c->TargetX + 0.5f) * TERRAIN_SCALE - o->Position[0]) * Speed * FPS_ANIMATION_FACTOR;
+            o->Position[1] += (((float)c->TargetY + 0.5f) * TERRAIN_SCALE - o->Position[1]) * Speed * FPS_ANIMATION_FACTOR;
             if (o->Type != MODEL_BALL)
                 o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
             c->JumpTime += FPS_ANIMATION_FACTOR;

--- a/src/source/ZzzCharacter.cpp
+++ b/src/source/ZzzCharacter.cpp
@@ -3072,6 +3072,13 @@ void  PushingCharacter(CHARACTER* c, OBJECT* o)
             c->JumpTime += FPS_ANIMATION_FACTOR;
             if (c->JumpTime > 15)
             {
+                c->PositionX = c->TargetX;
+                c->PositionY = c->TargetY;
+                o->Position[0] = ((float)c->TargetX + 0.5f) * TERRAIN_SCALE;
+                o->Position[1] = ((float)c->TargetY + 0.5f) * TERRAIN_SCALE;
+                if (o->Type != MODEL_BALL)
+                    o->Position[2] = RequestTerrainHeight(o->Position[0], o->Position[1]);
+
                 if (o->Type == MODEL_CRUST)
                     SetPlayerStop(c);
 

--- a/src/source/ZzzInterface.cpp
+++ b/src/source/ZzzInterface.cpp
@@ -7357,6 +7357,11 @@ void MoveHero()
     if (c->Object.Live == 0)
         return;
 
+    if (c->JumpTime > 0)
+    {
+        return;
+    }
+
     if (LoadingWorld > 0)
     {
         LoadingWorld--;


### PR DESCRIPTION
This PR fixes JumpTime push issues on the client:

- Stop normal hero movement processing while JumpTime is active so regular movement does not overlap with push interpolation.
- Fix PushingCharacter position update to scale by FPS_ANIMATION_FACTOR instead of adding it.
- Finalize the pushed character state cleanly at the end of the JumpTime interpolation
- OpenMU [stops async walker](https://github.com/MUnique/OpenMU/blob/22747db8d7d863b30d165774edcd62003d0ed679/src/GameLogic/Player.cs#L1334) when sending a force move to client, but client does not stop walking, which causes mismatches between server/client player positions after a force move, therefore stop walking on client side as well

This fixes #303 alongside many movement quirks I encountered in-game