### PR TITLE
fix(exp): experience bar overflows

### DIFF
--- a/src/source/NewUIMainFrameWindow.cpp
+++ b/src/source/NewUIMainFrameWindow.cpp
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include <algorithm>
 
 #include "NewUIMainFrameWindow.h"	// self
 #include "NewUIOptionWindow.h"
@@ -408,6 +409,21 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
     __int64 dwNexExperience;
     __int64 dwExperience;
     double x, y, width, height;
+    const auto buildExpSegment = [](const double ratio, int& digit, double& fraction)
+    {
+        const double clampedRatio = std::clamp(ratio, 0.0, 1.0);
+        if (clampedRatio >= 1.0)
+        {
+            digit = 9;
+            fraction = 1.0;
+            return;
+        }
+
+        const double scaled = clampedRatio * 10.0;
+        digit = std::clamp(static_cast<int>(scaled), 0, 9);
+        fraction = scaled - static_cast<double>(static_cast<long long>(scaled));
+        fraction = std::clamp(fraction, 0.0, 1.0);
+    };
 
     if (gCharacterManager.IsMasterExperienceActive(CharacterAttribute->Class, CharacterAttribute->Level) == true)
     {
@@ -450,27 +466,24 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
                 );
         iBaseExperience = (iData_Master - (__int64)3892250000) / (__int64)2;	// B
 
-        double fNeedExp = (double)dwNexExperience - (double)iBaseExperience;
-        double fExp = (double)dwExperience - (double)iBaseExperience;
-
-        if (dwExperience < iBaseExperience)
+        const __int64 lowerBound = iBaseExperience;
+        __int64 upperBound = dwNexExperience;
+        if (upperBound < lowerBound)
         {
-            fExp = 0.f;
+            upperBound = lowerBound;
         }
 
-        double fExpBarNum = 0.f;
-        if (fExp > 0.f && fNeedExp > 0)
-        {
-            fExpBarNum = ((double)fExp / (double)fNeedExp) * (double)10.f;
-        }
-
-        double fProgress = fExpBarNum - static_cast<long long>(fExpBarNum);
+        const double fNeedExp = static_cast<double>(upperBound - lowerBound);
+        const double fClampedExp = std::clamp(static_cast<double>(dwExperience), static_cast<double>(lowerBound), static_cast<double>(upperBound));
+        const double fRatio = (fNeedExp > 0.0) ? std::clamp((fClampedExp - static_cast<double>(lowerBound)) / fNeedExp, 0.0, 1.0) : 0.0;
+        int iExp = 0;
+        double fProgress = 0.0;
+        buildExpSegment(fRatio, iExp, fProgress);
 
         if (m_bExpEffect == true)
         {
             double fPreProgress = 0.f;
-            double fPreExp = (double)m_loPreExp - (double)iBaseExperience;
-            if (m_loPreExp < iBaseExperience)
+            if (m_loPreExp < lowerBound)
             {
                 x = 2.f; y = 473.f; width = fProgress * 629.f; height = 4.f;
                 RenderBitmap(IMAGE_MASTER_GAUGE_BAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
@@ -481,16 +494,14 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
             else
             {
                 int iPreExpBarNum = 0;
-                int iExpBarNum = 0;
-                if (fPreExp > 0.f && fNeedExp > 0.f)
+                if (fNeedExp > 0.f)
                 {
-                    fPreProgress = ((double)fPreExp / (double)fNeedExp) * (double)10.f;
-                    iPreExpBarNum = (int)fPreProgress;
-                    fPreProgress = static_cast<double>(fPreProgress) - static_cast<long long>(fPreProgress);
+                    const double fPreClampedExp = std::clamp(static_cast<double>(m_loPreExp), static_cast<double>(lowerBound), static_cast<double>(upperBound));
+                    const double fPreRatio = std::clamp((fPreClampedExp - static_cast<double>(lowerBound)) / fNeedExp, 0.0, 1.0);
+                    buildExpSegment(fPreRatio, iPreExpBarNum, fPreProgress);
                 }
-                iExpBarNum = (int)fExpBarNum;
 
-                if (iExpBarNum > iPreExpBarNum)
+                if (iExp > iPreExpBarNum)
                 {
                     x = 2.f; y = 473.f; width = fProgress * 629.f; height = 4.f;
                     RenderBitmap(IMAGE_MASTER_GAUGE_BAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
@@ -500,8 +511,8 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
                 }
                 else
                 {
-                    double fGapProgress = 0.f;
-                    fGapProgress = (double)fProgress - (double)fPreProgress;
+                    double fGapProgress = fProgress - fPreProgress;
+                    fGapProgress = std::clamp(fGapProgress, 0.0, 1.0);
                     x = 2.f; y = 473.f; width = (double)fPreProgress * (double)629.f; height = 4.f;
                     RenderBitmap(IMAGE_MASTER_GAUGE_BAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
 
@@ -519,7 +530,6 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
             RenderBitmap(IMAGE_MASTER_GAUGE_BAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
         }
 
-        int iExp = (int)fExpBarNum;
         x = 635.f; y = 469.f;
         SEASON3B::RenderNumber(x, y, iExp);
 
@@ -550,28 +560,24 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
             }
         }
 
-        double fNeedExp = (double)dwNexExperience - (double)iPriorExperience;
-        double fExp = (double)dwExperience - (double)iPriorExperience;
-
-        if (dwExperience < iPriorExperience)
+        const __int64 lowerBound = iPriorExperience;
+        __int64 upperBound = dwNexExperience;
+        if (upperBound < lowerBound)
         {
-            fExp = 0.f;
+            upperBound = lowerBound;
         }
 
-        double fExpBarNum = 0.f;
-        if (fExp > 0.f && fNeedExp > 0)
-        {
-            fExpBarNum = (fExp / fNeedExp) * 10.f;
-        }
-
-        double fProgress = fExpBarNum;
-        fProgress = fProgress - static_cast<long long>(fProgress);
+        const double fNeedExp = static_cast<double>(upperBound - lowerBound);
+        const double fClampedExp = std::clamp(static_cast<double>(dwExperience), static_cast<double>(lowerBound), static_cast<double>(upperBound));
+        const double fRatio = (fNeedExp > 0.0) ? std::clamp((fClampedExp - static_cast<double>(lowerBound)) / fNeedExp, 0.0, 1.0) : 0.0;
+        int iExp = 0;
+        double fProgress = 0.0;
+        buildExpSegment(fRatio, iExp, fProgress);
 
         if (m_bExpEffect == true)
         {
             double fPreProgress = 0.f;
-            fExp = (double)m_dwPreExp - (double)iPriorExperience;
-            if (m_dwPreExp < iPriorExperience)
+            if (m_dwPreExp < lowerBound)
             {
                 x = 2.f; y = 473.f; width = fProgress * 629.f; height = 4.f;
                 RenderBitmap(IMAGE_GAUGE_EXBAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
@@ -582,17 +588,14 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
             else
             {
                 int iPreExpBarNum = 0;
-                int iExpBarNum = 0;
-                if (fExp > 0.f && fNeedExp > 0.f)
+                if (fNeedExp > 0.f)
                 {
-                    fPreProgress = (fExp / fNeedExp) * 10.f;
-                    iPreExpBarNum = (int)fPreProgress;
-                    fPreProgress = fPreProgress - static_cast<long long>(fPreProgress);
+                    const double fPreClampedExp = std::clamp(static_cast<double>(m_dwPreExp), static_cast<double>(lowerBound), static_cast<double>(upperBound));
+                    const double fPreRatio = std::clamp((fPreClampedExp - static_cast<double>(lowerBound)) / fNeedExp, 0.0, 1.0);
+                    buildExpSegment(fPreRatio, iPreExpBarNum, fPreProgress);
                 }
 
-                iExpBarNum = (int)fExpBarNum;
-
-                if (iExpBarNum > iPreExpBarNum)
+                if (iExp > iPreExpBarNum)
                 {
                     x = 2.f; y = 473.f; width = fProgress * 629.f; height = 4.f;
                     RenderBitmap(IMAGE_GAUGE_EXBAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
@@ -602,8 +605,8 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
                 }
                 else
                 {
-                    double fGapProgress = 0.f;
-                    fGapProgress = fProgress - fPreProgress;
+                    double fGapProgress = fProgress - fPreProgress;
+                    fGapProgress = std::clamp(fGapProgress, 0.0, 1.0);
                     x = 2.f; y = 473.f; width = fPreProgress * 629.f; height = 4.f;
                     RenderBitmap(IMAGE_GAUGE_EXBAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
                     x += width; width = fGapProgress * 629.f;
@@ -620,7 +623,6 @@ void SEASON3B::CNewUIMainFrameWindow::RenderExperience()
             RenderBitmap(IMAGE_GAUGE_EXBAR, x, y, width, height, 0.f, 0.f, 6.f / 8.f, 4.f / 4.f);
         }
 
-        int iExp = (int)fExpBarNum;
         x = 635.f; y = 469.f;
         SEASON3B::RenderNumber(x, y, iExp);
 

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -66,7 +66,7 @@
 #include "FatigueTimeSystem.h"
 #endif //PBG_ADD_SECRETBUFF
 #include <codecvt>
-#include <climits>
+#include <limits>
 
 #include "ServerListManager.h"
 #include "MonkSystem.h"
@@ -155,6 +155,9 @@ void AddDebugText(const unsigned char* Buffer, int Size)
 // Forward declaration
 static void HandleIncomingPacket(int32_t Handle, const BYTE* ReceiveBuffer, int32_t Size);
 
+static constexpr int64_t kInt64Max = std::numeric_limits<int64_t>::max();
+static constexpr int64_t kInt64Min = std::numeric_limits<int64_t>::min();
+
 static uint64_t GetNormalLowerBound(const WORD level)
 {
     if (level <= 1)
@@ -178,23 +181,23 @@ static int64_t GetMasterLowerBound(const short masterLevel)
 {
     const auto saturatingAdd = [](const int64_t left, const int64_t right)
     {
-        if (right > 0 && left > LLONG_MAX - right)
+        if (right > 0 && left > kInt64Max - right)
         {
-            return LLONG_MAX;
+            return kInt64Max;
         }
 
-        if (right < 0 && left < LLONG_MIN - right)
+        if (right < 0 && left < kInt64Min - right)
         {
-            return LLONG_MIN;
+            return kInt64Min;
         }
 
         return left + right;
     };
     const auto saturatingSub = [&](const int64_t left, const int64_t right)
     {
-        if (right == LLONG_MIN)
+        if (right == kInt64Min)
         {
-            return static_cast<int64_t>(LLONG_MAX);
+            return kInt64Max;
         }
 
         return saturatingAdd(left, -right);
@@ -206,49 +209,31 @@ static int64_t GetMasterLowerBound(const short masterLevel)
             return static_cast<int64_t>(0);
         }
 
-        if (left == -1 && right == LLONG_MIN)
+        const auto magnitude = [](const int64_t value)
         {
-            return LLONG_MAX;
-        }
+            if (value >= 0)
+            {
+                return static_cast<uint64_t>(value);
+            }
 
-        if (right == -1 && left == LLONG_MIN)
-        {
-            return LLONG_MAX;
-        }
+            if (value == kInt64Min)
+            {
+                return uint64_t{1} << 63;
+            }
 
-        if (left > 0)
+            return static_cast<uint64_t>(-value);
+        };
+
+        const bool isNegativeResult = (left < 0) != (right < 0);
+        const uint64_t resultLimit = isNegativeResult
+            ? (uint64_t{1} << 63)
+            : static_cast<uint64_t>(kInt64Max);
+        const uint64_t leftMagnitude = magnitude(left);
+        const uint64_t rightMagnitude = magnitude(right);
+
+        if (leftMagnitude > resultLimit / rightMagnitude)
         {
-            if (right > 0)
-            {
-                if (left > LLONG_MAX / right)
-                {
-                    return LLONG_MAX;
-                }
-            }
-            else
-            {
-                if (right < LLONG_MIN / left)
-                {
-                    return LLONG_MIN;
-                }
-            }
-        }
-        else
-        {
-            if (right > 0)
-            {
-                if (left < LLONG_MIN / right)
-                {
-                    return LLONG_MIN;
-                }
-            }
-            else
-            {
-                if (left < LLONG_MAX / right)
-                {
-                    return LLONG_MAX;
-                }
-            }
+            return isNegativeResult ? kInt64Min : kInt64Max;
         }
 
         return left * right;
@@ -257,12 +242,12 @@ static int64_t GetMasterLowerBound(const short masterLevel)
     {
         if (denominator == 0)
         {
-            return numerator >= 0 ? LLONG_MAX : LLONG_MIN;
+            return numerator >= 0 ? kInt64Max : kInt64Min;
         }
 
-        if (numerator == LLONG_MIN && denominator == -1)
+        if (numerator == kInt64Min && denominator == -1)
         {
-            return LLONG_MAX;
+            return kInt64Max;
         }
 
         return numerator / denominator;
@@ -1131,8 +1116,8 @@ void ReceiveRevival(const BYTE* ReceiveBuffer)
         const auto rawRevivalExperience = Data->CurrentExperience;
         const auto swappedRevivalExperience = ntoh64(Data->CurrentExperience);
 
-        const bool rawConvertible = rawRevivalExperience <= static_cast<uint64_t>(LLONG_MAX);
-        const bool swappedConvertible = swappedRevivalExperience <= static_cast<uint64_t>(LLONG_MAX);
+        const bool rawConvertible = rawRevivalExperience <= static_cast<uint64_t>(kInt64Max);
+        const bool swappedConvertible = swappedRevivalExperience <= static_cast<uint64_t>(kInt64Max);
         const auto rawCandidate = rawConvertible ? static_cast<int64_t>(rawRevivalExperience) : currentExperience;
         const auto swappedCandidate = swappedConvertible ? static_cast<int64_t>(swappedRevivalExperience) : currentExperience;
 

--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -66,6 +66,7 @@
 #include "FatigueTimeSystem.h"
 #endif //PBG_ADD_SECRETBUFF
 #include <codecvt>
+#include <climits>
 
 #include "ServerListManager.h"
 #include "MonkSystem.h"
@@ -153,6 +154,210 @@ void AddDebugText(const unsigned char* Buffer, int Size)
 
 // Forward declaration
 static void HandleIncomingPacket(int32_t Handle, const BYTE* ReceiveBuffer, int32_t Size);
+
+static uint64_t GetNormalLowerBound(const WORD level)
+{
+    if (level <= 1)
+    {
+        return 0;
+    }
+
+    const uint64_t priorLevel = static_cast<uint64_t>(level - 1);
+    uint64_t priorExperience = (9ull + priorLevel) * priorLevel * priorLevel * 10ull;
+
+    if (priorLevel > 255ull)
+    {
+        const uint64_t levelOverN = priorLevel - 255ull;
+        priorExperience += (9ull + levelOverN) * levelOverN * levelOverN * 1000ull;
+    }
+
+    return priorExperience;
+}
+
+static int64_t GetMasterLowerBound(const short masterLevel)
+{
+    const auto saturatingAdd = [](const int64_t left, const int64_t right)
+    {
+        if (right > 0 && left > LLONG_MAX - right)
+        {
+            return LLONG_MAX;
+        }
+
+        if (right < 0 && left < LLONG_MIN - right)
+        {
+            return LLONG_MIN;
+        }
+
+        return left + right;
+    };
+    const auto saturatingSub = [&](const int64_t left, const int64_t right)
+    {
+        if (right == LLONG_MIN)
+        {
+            return static_cast<int64_t>(LLONG_MAX);
+        }
+
+        return saturatingAdd(left, -right);
+    };
+    const auto saturatingMul = [](const int64_t left, const int64_t right)
+    {
+        if (left == 0 || right == 0)
+        {
+            return static_cast<int64_t>(0);
+        }
+
+        if (left == -1 && right == LLONG_MIN)
+        {
+            return LLONG_MAX;
+        }
+
+        if (right == -1 && left == LLONG_MIN)
+        {
+            return LLONG_MAX;
+        }
+
+        if (left > 0)
+        {
+            if (right > 0)
+            {
+                if (left > LLONG_MAX / right)
+                {
+                    return LLONG_MAX;
+                }
+            }
+            else
+            {
+                if (right < LLONG_MIN / left)
+                {
+                    return LLONG_MIN;
+                }
+            }
+        }
+        else
+        {
+            if (right > 0)
+            {
+                if (left < LLONG_MIN / right)
+                {
+                    return LLONG_MIN;
+                }
+            }
+            else
+            {
+                if (left < LLONG_MAX / right)
+                {
+                    return LLONG_MAX;
+                }
+            }
+        }
+
+        return left * right;
+    };
+    const auto saturatingDiv = [](const int64_t numerator, const int64_t denominator)
+    {
+        if (denominator == 0)
+        {
+            return numerator >= 0 ? LLONG_MAX : LLONG_MIN;
+        }
+
+        if (numerator == LLONG_MIN && denominator == -1)
+        {
+            return LLONG_MAX;
+        }
+
+        return numerator / denominator;
+    };
+
+    const int64_t totalLevel = saturatingAdd(static_cast<int64_t>(masterLevel), static_cast<int64_t>(400));
+    const int64_t overLevel = saturatingSub(totalLevel, static_cast<int64_t>(255));
+
+    const int64_t leftTerm = saturatingMul(
+        saturatingMul(
+            saturatingMul(saturatingAdd(static_cast<int64_t>(9), totalLevel), totalLevel),
+            totalLevel),
+        static_cast<int64_t>(10));
+    const int64_t rightTerm = saturatingMul(
+        saturatingMul(
+            saturatingMul(saturatingAdd(static_cast<int64_t>(9), overLevel), overLevel),
+            overLevel),
+        static_cast<int64_t>(1000));
+    const int64_t dataMaster = saturatingAdd(leftTerm, rightTerm);
+    const int64_t numerator = saturatingSub(dataMaster, static_cast<int64_t>(3892250000ll));
+
+    return saturatingDiv(numerator, static_cast<int64_t>(2));
+}
+
+static uint64_t ClampToInterval(const uint64_t value, const uint64_t lower, uint64_t upper)
+{
+    if (upper < lower)
+    {
+        upper = lower;
+    }
+
+    if (value < lower)
+    {
+        return lower;
+    }
+
+    if (value > upper)
+    {
+        return upper;
+    }
+
+    return value;
+}
+
+static int64_t ClampToInterval(const int64_t value, const int64_t lower, int64_t upper)
+{
+    if (upper < lower)
+    {
+        upper = lower;
+    }
+
+    if (value < lower)
+    {
+        return lower;
+    }
+
+    if (value > upper)
+    {
+        return upper;
+    }
+
+    return value;
+}
+
+static uint64_t SaturatingAddToUpper(const uint64_t current, const uint64_t add, uint64_t upper)
+{
+    if (upper < current)
+    {
+        upper = current;
+    }
+
+    const uint64_t remaining = upper - current;
+    if (add >= remaining)
+    {
+        return upper;
+    }
+
+    return current + add;
+}
+
+static int64_t SaturatingAddToUpper(const int64_t current, const int64_t add, int64_t upper)
+{
+    if (upper < current)
+    {
+        upper = current;
+    }
+
+    const int64_t remaining = upper - current;
+    if (add >= remaining)
+    {
+        return upper;
+    }
+
+    return current + add;
+}
 
 BOOL CreateSocket(const wchar_t* IpAddr, unsigned short Port)
 {
@@ -918,34 +1123,56 @@ void ReceiveRevival(const BYTE* ReceiveBuffer)
     CharacterAttribute->Shield = Data->Shield;
     CharacterAttribute->SkillMana = Data->SkillMana;
 
-    const auto rawRevivalExperience = Data->CurrentExperience;
-    const auto swappedRevivalExperience = ntoh64(Data->CurrentExperience);
-    const auto selectRevivalExperience = [](uint64_t rawExperience, uint64_t swappedExperience, uint64_t nextExperience)
-    {
-        const bool isRawPlausible = rawExperience <= nextExperience;
-        const bool isSwappedPlausible = swappedExperience <= nextExperience;
-        if (isRawPlausible != isSwappedPlausible)
-        {
-            return isRawPlausible ? rawExperience : swappedExperience;
-        }
-
-        // Fallback to legacy interpretation when both variants are plausible or implausible.
-        return rawExperience;
-    };
-
     if (gCharacterManager.IsMasterExperienceActive(CharacterAttribute->Class, CharacterAttribute->Level) == true)
     {
-        Master_Level_Data.lMasterLevel_Experince = static_cast<__int64>(selectRevivalExperience(
-            rawRevivalExperience,
-            swappedRevivalExperience,
-            static_cast<uint64_t>(Master_Level_Data.lNext_MasterLevel_Experince)));
+        const auto lowerBound = GetMasterLowerBound(Master_Level_Data.nMLevel);
+        const auto upperBound = Master_Level_Data.lNext_MasterLevel_Experince;
+        const auto currentExperience = Master_Level_Data.lMasterLevel_Experince;
+        const auto rawRevivalExperience = Data->CurrentExperience;
+        const auto swappedRevivalExperience = ntoh64(Data->CurrentExperience);
+
+        const bool rawConvertible = rawRevivalExperience <= static_cast<uint64_t>(LLONG_MAX);
+        const bool swappedConvertible = swappedRevivalExperience <= static_cast<uint64_t>(LLONG_MAX);
+        const auto rawCandidate = rawConvertible ? static_cast<int64_t>(rawRevivalExperience) : currentExperience;
+        const auto swappedCandidate = swappedConvertible ? static_cast<int64_t>(swappedRevivalExperience) : currentExperience;
+
+        const bool isRawPlausible = rawConvertible && (rawCandidate >= lowerBound && rawCandidate <= upperBound);
+        const bool isSwappedPlausible = swappedConvertible && (swappedCandidate >= lowerBound && swappedCandidate <= upperBound);
+
+        int64_t selectedExperience = currentExperience;
+        if (isRawPlausible != isSwappedPlausible)
+        {
+            selectedExperience = isRawPlausible ? rawCandidate : swappedCandidate;
+        }
+        else if (isRawPlausible && isSwappedPlausible)
+        {
+            selectedExperience = rawCandidate;
+        }
+
+        Master_Level_Data.lMasterLevel_Experince = ClampToInterval(selectedExperience, lowerBound, upperBound);
     }
     else
     {
-        CharacterAttribute->Experience = selectRevivalExperience(
-            rawRevivalExperience,
-            swappedRevivalExperience,
-            CharacterAttribute->NextExperience);
+        const auto lowerBound = GetNormalLowerBound(CharacterAttribute->Level);
+        const auto upperBound = CharacterAttribute->NextExperience;
+        const auto currentExperience = CharacterAttribute->Experience;
+        const auto rawRevivalExperience = Data->CurrentExperience;
+        const auto swappedRevivalExperience = ntoh64(Data->CurrentExperience);
+
+        const bool isRawPlausible = rawRevivalExperience >= lowerBound && rawRevivalExperience <= upperBound;
+        const bool isSwappedPlausible = swappedRevivalExperience >= lowerBound && swappedRevivalExperience <= upperBound;
+
+        uint64_t selectedExperience = currentExperience;
+        if (isRawPlausible != isSwappedPlausible)
+        {
+            selectedExperience = isRawPlausible ? rawRevivalExperience : swappedRevivalExperience;
+        }
+        else if (isRawPlausible && isSwappedPlausible)
+        {
+            selectedExperience = rawRevivalExperience;
+        }
+
+        CharacterAttribute->Experience = ClampToInterval(selectedExperience, lowerBound, upperBound);
     }
 
     CharacterMachine->Gold = Data->Gold;
@@ -5343,13 +5570,29 @@ BOOL ReceiveDieExp(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     {
         g_pMainFrame->SetPreExp_Wide(Master_Level_Data.lMasterLevel_Experince);
         g_pMainFrame->SetGetExp_Wide(Exp);
-        Master_Level_Data.lMasterLevel_Experince += Exp;
+
+        const auto lowerBound = GetMasterLowerBound(Master_Level_Data.nMLevel);
+        const auto upperBound = Master_Level_Data.lNext_MasterLevel_Experince;
+        const auto currentExperience = ClampToInterval(Master_Level_Data.lMasterLevel_Experince, lowerBound, upperBound);
+        const auto addedExperience = static_cast<int64_t>(Exp);
+        Master_Level_Data.lMasterLevel_Experince = ClampToInterval(
+            SaturatingAddToUpper(currentExperience, addedExperience, upperBound),
+            lowerBound,
+            upperBound);
     }
     else
     {
         g_pMainFrame->SetPreExp(CharacterAttribute->Experience);
         g_pMainFrame->SetGetExp(Exp);
-        CharacterAttribute->Experience += Exp;
+
+        const auto lowerBound = GetNormalLowerBound(CharacterAttribute->Level);
+        const auto upperBound = CharacterAttribute->NextExperience;
+        const auto currentExperience = ClampToInterval(CharacterAttribute->Experience, lowerBound, upperBound);
+        const auto addedExperience = static_cast<uint64_t>(Exp);
+        CharacterAttribute->Experience = ClampToInterval(
+            SaturatingAddToUpper(currentExperience, addedExperience, upperBound),
+            lowerBound,
+            upperBound);
     }
 
     if (Exp > 0)
@@ -5431,13 +5674,27 @@ BOOL ReceiveDieExpLarge(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     {
         g_pMainFrame->SetPreExp_Wide(Master_Level_Data.lMasterLevel_Experince);
         g_pMainFrame->SetGetExp_Wide(addedExperience);
-        Master_Level_Data.lMasterLevel_Experince += addedExperience;
+
+        const auto lowerBound = GetMasterLowerBound(Master_Level_Data.nMLevel);
+        const auto upperBound = Master_Level_Data.lNext_MasterLevel_Experince;
+        const auto currentExperience = ClampToInterval(Master_Level_Data.lMasterLevel_Experince, lowerBound, upperBound);
+        Master_Level_Data.lMasterLevel_Experince = ClampToInterval(
+            SaturatingAddToUpper(currentExperience, static_cast<int64_t>(addedExperience), upperBound),
+            lowerBound,
+            upperBound);
     }
     else
     {
         g_pMainFrame->SetPreExp(CharacterAttribute->Experience);
         g_pMainFrame->SetGetExp(addedExperience);
-        CharacterAttribute->Experience += addedExperience;
+
+        const auto lowerBound = GetNormalLowerBound(CharacterAttribute->Level);
+        const auto upperBound = CharacterAttribute->NextExperience;
+        const auto currentExperience = ClampToInterval(CharacterAttribute->Experience, lowerBound, upperBound);
+        CharacterAttribute->Experience = ClampToInterval(
+            SaturatingAddToUpper(currentExperience, static_cast<uint64_t>(addedExperience), upperBound),
+            lowerBound,
+            upperBound);
     }
 
     if (addedExperience > 0)


### PR DESCRIPTION
Fixes bar overflows when sometimes it shows numbers > 9, both for master and normal experience progression.
This PR is manually tested by myself, works pretty well so far.