### PR TITLE
Fix devil's beam effect

### DIFF
--- a/src/source/ZzzEffectJoint.cpp
+++ b/src/source/ZzzEffectJoint.cpp
@@ -1021,10 +1021,9 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 break;
             case BITMAP_JOINT_LASER + 1:
                 o->bTileMapping = true;
-                break;
             case BITMAP_BLUR + 1:
                 o->Scale = 60.f;
-                o->Velocity = 40.f;
+                o->Velocity = 40.f / FPS_ANIMATION_FACTOR;
                 o->MaxTails = 50;
                 o->LifeTime = 2;
                 if (o->SubType == 0)


### PR DESCRIPTION
Devil's beam effect was not drawn because
of a redundant break on joint laser case.

Also, velocity should be normalized for base
FPS- this might be needed across all velocity
values in this file, but it needs further testing.