### PR TITLE
Fix devil's beam effect

### DIFF
--- a/src/source/ZzzEffectJoint.cpp
+++ b/src/source/ZzzEffectJoint.cpp
@@ -1021,7 +1021,6 @@ void CreateJoint(int Type, vec3_t Position, vec3_t TargetPosition, vec3_t Angle,
                 break;
             case BITMAP_JOINT_LASER + 1:
                 o->bTileMapping = true;
-                break;
             case BITMAP_BLUR + 1:
                 o->Scale = 60.f;
                 o->Velocity = 40.f;
@@ -4678,9 +4677,8 @@ void MoveJoint(JOINT* o, int iIndex)
                 Vector(Luminosity * 0.f, Luminosity * 0.1f, Luminosity * 0.2f, Light);
             }
             AddTerrainLight(o->Position[0], o->Position[1], Light, 2, PrimaryTerrainLight);
-            Vector(0.f, -o->Velocity * FPS_ANIMATION_FACTOR, 0.f, Position);
+            Vector(0.f, -o->Velocity, 0.f, Position);
             VectorRotate(Position, Matrix, p);
-            VectorScale(p, FPS_ANIMATION_FACTOR, p)
             VectorAddScaled(o->Position, p, o->Position, FPS_ANIMATION_FACTOR);
         }
         break;


### PR DESCRIPTION
Devil's beam uses the joint laser effect,
but the joint laser case stopped before the
shared beam setup ran. Removing the break
lets the effect receive the scale, speed,
lifetime, and tail settings that the shared
beam update code expects.

Additionally, remove one extra movement
slowdown from the shared beam path. The effect
already adjusts for higher FPS by increasing
tail count and scaling movement, so the extra
slowdown made the 60 FPS version advance too
little per frame and look blurrier than at
30 FPS. Removing it makes the 60 FPS beam look
identical to 30 FPS.