### PR TITLE
Fix walk jitter

### DIFF
--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -1731,7 +1731,8 @@ void ReceiveMoveCharacter(std::span<const BYTE> ReceiveBuffer)
         return;
     }
 
-    if (c->Movement)
+    // If already walking and receiving another walk command, don't interrupt with SetPlayerStop
+    if (c->Movement && pathNum == 0)
     {
         c->Movement = false;
         SetPlayerStop(c);

--- a/src/source/ZzzCharacter.cpp
+++ b/src/source/ZzzCharacter.cpp
@@ -6326,7 +6326,6 @@ void MoveMonsterClient(CHARACTER* c, OBJECT* o)
             {
                 c->Movement = false;
                 SetPlayerStop(c);
-                c->Object.Angle[2] = ((float)(c->TargetAngle) - 1.f) * 45.f;
             }
 
             MoveCharacterPosition(c);


### PR DESCRIPTION
This PR fixes some issues in MuMain that cause walk jitter:

1. When another player sends consecutive walk packets (i.e., sends a 2nd walk request while the first one did not yet finish), receivers called SetPlayerStop() immediately followed by SetPlayerWalk which caused jitter in walking animation. Instead, just keep walking
2. When a player finishes walking, the client would force him immediately to some angle which is most of the time different from the direction he was walking to, which is quite ugly and unnatural. Instead, keep the last step direction