### PR TITLE
Use client-side pathfinding for observers

### DIFF
--- a/src/source/WSclient.cpp
+++ b/src/source/WSclient.cpp
@@ -1914,13 +1914,11 @@ void ReceiveMoveCharacter(std::span<const BYTE> ReceiveBuffer)
         MUHelper::g_MuHelper.AddTarget(Key, false);
     }
 
-    c->PositionX = Data->SourceX;
-    c->PositionY = Data->SourceY;
     c->TargetX = Data->TargetX;
     c->TargetY = Data->TargetY;
     c->TargetAngle = Data->PathMetadata >> 4;
 
-    g_ConsoleDebug->Write(MCD_RECEIVE, L"ID : %ls | sX : %d | sY : %d | tX : %d | tY : %d", c->ID, c->PositionX, c->PositionY, c->TargetX, c->TargetY);
+    g_ConsoleDebug->Write(MCD_RECEIVE, L"ID : %ls | sX : %d | sY : %d | tX : %d | tY : %d", c->ID, Data->SourceX, Data->SourceY, c->TargetX, c->TargetY);
 
     if (Key == HeroKey)
     {
@@ -1943,18 +1941,6 @@ void ReceiveMoveCharacter(std::span<const BYTE> ReceiveBuffer)
         return;
     }
 
-    // If already walking and receiving another walk command, don't interrupt with SetPlayerStop
-    if (c->Movement && pathNum == 0)
-    {
-        c->Movement = false;
-        SetPlayerStop(c);
-    }
-
-    auto pathData = const_cast<BYTE*>(ReceiveBuffer.subspan(fixedSize).data());
-
-    PATH_t* pCharPath = &c->Path;
-    pCharPath->Lock.lock();
-
     if (c->Appear == 0)
     {
         int iDefaultWall = TW_CHARACTER;
@@ -1965,31 +1951,16 @@ void ReceiveMoveCharacter(std::span<const BYTE> ReceiveBuffer)
             iDefaultWall = TW_NOMOVE;
         }
 
-        BYTE direction = c->TargetAngle;
-        POINT nextPos = MovePoint(static_cast<EPathDirection>(direction), { Data->SourceX, Data->SourceY });
-
-        pCharPath->PathX[0] = nextPos.x;
-        pCharPath->PathY[0] = nextPos.y;
-
-        for (int i = 0; i < pathNum; ++i)
+        if (PathFinding2(c->PositionX, c->PositionY, c->TargetX, c->TargetY, &c->Path, 0.0f, iDefaultWall))
         {
-            int byteIndex = i / 2;
-
-            direction = (i % 2 == 0) ? (pathData[byteIndex] >> 4) & 0x0F : (pathData[byteIndex] & 0x0F);
-
-            nextPos = MovePoint(static_cast<EPathDirection>(direction), nextPos);
-
-            pCharPath->PathX[i + 1] = nextPos.x;
-            pCharPath->PathY[i + 1] = nextPos.y;
+            c->Movement = true;
         }
-
-        pCharPath->PathNum = pathNum + 1;
-        pCharPath->Direction = direction;
-        pCharPath->CurrentPath = 0;
-        pCharPath->CurrentPathFloat = 0;
+        else
+        {
+            c->Movement = false;
+            SetPlayerStop(c);
+        }
     }
-
-    pCharPath->Lock.unlock();
 }
 
 void ReceiveMovePosition(const BYTE* ReceiveBuffer)


### PR DESCRIPTION
Server-side observer path replay is extremely flaky and delayed in practice, while client-side pathfinding is much smoother and more responsive, as shown in the videos below:

Server-side observer pathfinding: https://youtu.be/zo7H19BjdQ0
Client-side observer pathfinding: https://youtu.be/fSTDhl-TtaI

This only changes observer-side visualization. The server remains fully position-authoritative and still validates the active client, so this does not weaken security or makes it any easier to cheat.