### PR TITLE
Fix legacy quest state storage to preserve all four quests in the byte

### DIFF
--- a/src/source/CSQuest.cpp
+++ b/src/source/CSQuest.cpp
@@ -314,8 +314,13 @@ void CSQuest::setQuestList(int index, int result)
     m_byCurrQuestIndex = static_cast<std::uint8_t>(index);
     m_byCurrQuestIndexWnd = std::max<std::uint8_t>(static_cast<std::uint8_t>(index), m_byCurrQuestIndexWnd);
 
-    const auto questState = static_cast<std::uint8_t>(result & QUEST_STATE_MASK);
-    StoreQuestState(m_byQuestList.data(), m_byQuestList.size(), index, questState);
+    // Server protocol 0xA1/0xA2: 'result' is the complete byte holding the packed states
+    // of all four quests in the same group as 'index'. Store it as-is.
+    const auto byteIndex = static_cast<std::size_t>(index) / QUEST_STATES_PER_ENTRY;
+    if (byteIndex < m_byQuestList.size())
+    {
+        m_byQuestList[byteIndex] = static_cast<std::uint8_t>(result);
+    }
 
     Hero->byExtensionSkill = 0;
     if (getQuestState(QUEST_COMBO) == QUEST_END)


### PR DESCRIPTION
Server packet 0xA1 (LegacyQuestStateDialog) and 0xA2 (LegacySetQuestStateResponse) send the State/NewState field as the complete byte holding the packed states of all four quests in the same group, not a single quest state.

The previous refactor masked the value to two bits and only updated the target quest's slot, which dropped the other three quests' states for that group and also wrote the wrong bits into the target slot. After clearing 3rd-class chain quest part 1, the server-sent packed byte 0x0E for quest 5 (END for quest 4 + QUEST_NO for quest 5) was being decoded as QUEST_END for quest 5  so the NPC showed nothing to give for the follow-up quest.

Restore the original behavior of writing the full packed byte into the group slot. Fixes the chain-quest follow-up regression reported in issue #336.