### PR TITLE
Add docs/CODING_RULES.md and unified AI/contributor entry point

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- Thanks for contributing! Please fill in the sections below. -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] I have read and followed [`docs/CODING_RULES.md`](../docs/CODING_RULES.md).
+- [ ] I have built the project locally (see [`docs/build-guide.md`](../docs/build-guide.md)).
+- [ ] Changes are focused on one concern; the diff is as small as it reasonably can be.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@
 
 ## Checklist
 
-- [ ] I have read and followed [`docs/CODING_RULES.md`](../docs/CODING_RULES.md).
-- [ ] I have built the project locally (see [`docs/build-guide.md`](../docs/build-guide.md)).
+- [ ] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
+- [ ] I have built the project locally (see [`docs/build-guide.md`](docs/build-guide.md)).
 - [ ] Changes are focused on one concern; the diff is as small as it reasonably can be.

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,4 @@ build-mingw/
 
 **/*.log
 # Local-only files
-docs/CODING_RULES.md
 docs/reviews/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Agent Instructions
+
+This file is the entry point for AI coding assistants (Claude Code, Cursor, Codex,
+etc.) working in this repository. It also applies to human contributors.
+
+## Coding rules — read first
+
+**The coding rules in [`docs/CODING_RULES.md`](docs/CODING_RULES.md) apply to all
+code changes in this repository, by humans and by AI agents alike.**
+
+Before writing or modifying code:
+
+1. Read [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
+2. Apply the rules to any new or changed code.
+3. When reviewing a change (including via `/review` or `/ultrareview`), treat
+   `docs/CODING_RULES.md` as the authoritative style and quality baseline.
+
+The rules are not exhaustive — they capture the conventions that matter most for
+this codebase. Follow the style of surrounding code where the rules don't speak.
+
+## Build setup
+
+The project uses CMake. Supported build environments and setup steps are
+documented in [`docs/build-guide.md`](docs/build-guide.md).
+
+Quick references:
+
+- Requirements and IDE-specific instructions: [`README.md`](README.md).
+- Cross-platform / WSL build details: [`docs/build-guide.md`](docs/build-guide.md).
+
+## Branch and PR conventions
+
+- Target branch for PRs is `main`.
+- Keep changes focused — one concern per commit (see rule 10 in the coding
+  rules). Smaller diffs review faster.
+- Match the style of existing commit messages in `git log`.
+- Reference the related issue in the PR description when applicable.
+
+## Out of scope for AI changes
+
+Don't perform large retroactive cleanups of existing code to fit the rules unless
+the user explicitly asks for it. Apply the rules going forward; pre-existing
+code can be refactored opportunistically when you're already touching it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+See [`AGENTS.md`](AGENTS.md) — the canonical entry point for AI assistants and
+contributors. It points at [`docs/CODING_RULES.md`](docs/CODING_RULES.md), which
+applies to all code changes.

--- a/README.md
+++ b/README.md
@@ -259,6 +259,16 @@ The [OpenMU launcher](https://github.com/MUnique/OpenMU/releases/download/v0.8.1
 will work as well. By default, it connects to localhost and port `44406`.
 The client identifies itself with Version `2.04d` and serial `k1Pk2jcET48mxL3b`.
 
+## Contributing
+
+### Coding rules
+
+All code changes — by humans and AI assistants — should follow
+[`docs/CODING_RULES.md`](docs/CODING_RULES.md). Read it before opening a PR.
+
+AI coding assistants (Claude Code, Cursor, Codex, etc.) should also read
+[`AGENTS.md`](AGENTS.md), which points at the same rules and at the build guide.
+
 ## Credits
 
   * Webzen

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -2,6 +2,10 @@
 
 These rules apply to all code changes in this project. Read before you commit.
 
+The rules are language-agnostic in spirit. Where a rule cites C++ specifics
+(e.g. `.h`/`.cpp` separation, RAII, smart pointers), the equivalent idiom
+applies to the C# tree (e.g. one type per file, `IDisposable` + `using`).
+
 ---
 
 ## 1. Keep Functions Short and Focused — Break Apart Monoliths

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -2,9 +2,9 @@
 
 These rules apply to all code changes in this project. Read before you commit.
 
-The rules are language-agnostic in spirit. Where a rule cites C++ specifics
-(e.g. `.h`/`.cpp` separation, RAII, smart pointers), the equivalent idiom
-applies to the C# tree (e.g. one type per file, `IDisposable` + `using`).
+The rules apply to both the C++ client and the C# `ClientLibrary`. Where the
+right idiom differs between the two languages, the rule below calls out each
+language explicitly.
 
 ---
 
@@ -44,9 +44,9 @@ applies to the C# tree (e.g. one type per file, `IDisposable` + `using`).
 
 ## 6. One Class Per File
 
-- Each new class or significant struct gets its **own file**, named after the class.
-- Header and implementation separated (`.h` / `.cpp`).
-- Small helper structs tightly coupled to a single class may stay in that class's header.
+- Each new class or significant struct/type gets its **own file**, named after the class.
+- **C++:** header and implementation separated (`.h` / `.cpp`). Small helper structs tightly coupled to a single class may stay in that class's header.
+- **C#:** one public type per `.cs` file. Small helper types (private nested types, tightly coupled `record`s/`enum`s) may stay in the owning class's file.
 
 ## 7. Consistent Style
 
@@ -56,9 +56,10 @@ applies to the C# tree (e.g. one type per file, `IDisposable` + `using`).
 
 ## 8. Guard Against Leaks and Dangling State
 
-- Every allocation has a clear owner and a clear cleanup path.
-- Prefer RAII and smart pointers over manual memory management when possible.
-- Don't leave resources (handles, connections, textures) open on early-exit paths.
+- Every allocation/resource has a clear owner and a clear cleanup path.
+- **C++:** prefer RAII and smart pointers (`std::unique_ptr`, `std::shared_ptr`) over manual `new` / `delete`.
+- **C#:** implement `IDisposable` for types that own unmanaged resources, and consume them with `using` statements/blocks.
+- Don't leave resources (handles, connections, textures, streams) open on early-exit paths.
 
 ## 9. Readable Over Clever
 

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -1,0 +1,69 @@
+# Coding Rules
+
+These rules apply to all code changes in this project. Read before you commit.
+
+---
+
+## 1. Keep Functions Short and Focused — Break Apart Monoliths
+
+- A function does **one thing**. If you can describe it with "and", split it.
+- When touching a large function, **extract at least one** logical block into its own function before you're done. You don't have to refactor everything — just leave it better than you found it.
+- If the extracted code doesn't belong in the current file, **move it to a new file** in an appropriate folder. Over time this breaks apart monolithic files naturally.
+- Aim for functions that fit on one screen (~40 lines). Logic-heavy functions get shorter limits.
+
+## 2. Exit Early
+
+- Handle error cases and edge conditions **at the top** of a function.
+- Avoid deep nesting. Prefer `if (bad) return;` over wrapping the entire body in `if (good) { ... }`.
+- Each early exit should have a clear reason — don't silently swallow errors.
+
+## 3. No Hard-Coded Values
+
+- Numbers, strings, paths, sizes, timers, colors — if it's not self-evident, **give it a name**.
+- Use constants, enums, or config values. A magic number buried in logic is a bug waiting to happen.
+- `0` and `1` in boolean/trivial contexts are fine. `3.14f`, `1000`, `0xFF00FF` are not.
+
+## 4. Write Reusable Code
+
+- Before writing new logic, check if something similar already exists. Don't duplicate.
+- Extract shared logic into utility functions or helpers when two or more callers need it.
+- Design parameters to be general where it costs nothing, but don't over-abstract for hypothetical future use.
+
+## 5. Separate Concerns by Layer
+
+- **Rendering**, **game logic**, **UI**, **data**, **networking**, and **input** are distinct layers. Don't cross these boundaries.
+- UI must not contain game logic. Rendering must not parse network packets. Keep each layer self-contained.
+- When touching existing code that mixes concerns, extract toward the correct layer.
+- New systems should be composable, self-contained components with clear ownership hierarchies.
+- Group related data and behavior together. Don't scatter related logic across unrelated files.
+- Name things precisely — if a name needs a comment to explain it, pick a better name.
+
+## 6. One Class Per File
+
+- Each new class or significant struct gets its **own file**, named after the class.
+- Header and implementation separated (`.h` / `.cpp`).
+- Small helper structs tightly coupled to a single class may stay in that class's header.
+
+## 7. Consistent Style
+
+- Follow the style of the surrounding code. Don't introduce a new convention in one file.
+- Use the existing naming conventions for the module you're working in.
+- Keep includes minimal — only what the file actually uses.
+
+## 8. Guard Against Leaks and Dangling State
+
+- Every allocation has a clear owner and a clear cleanup path.
+- Prefer RAII and smart pointers over manual memory management when possible.
+- Don't leave resources (handles, connections, textures) open on early-exit paths.
+
+## 9. Readable Over Clever
+
+- Write code that is obvious to read, even if a "clever" version is shorter.
+- Complex expressions get broken into named intermediate variables.
+- If a block of code needs a comment to explain *what* it does, refactor it so it doesn't.
+
+## 10. Think Before You Add
+
+- Every new dependency, abstraction, or pattern has a maintenance cost. Justify it.
+- Smaller diffs are easier to review. Keep changes focused on one concern per commit.
+- If you're unsure about a structural decision, ask before building on top of it.


### PR DESCRIPTION
## Summary
- Moves `CODING_RULES.md` into `docs/` (was kept locally and excluded via `.gitignore`).
- Adds `AGENTS.md` as a single canonical entry point for AI assistants (Claude Code, Cursor, Codex, etc.) and human contributors. `CLAUDE.md` is a one-line pointer to it.
- Links the coding rules from `README.md` (new "Contributing" section) and adds a short `.github/pull_request_template.md` with a checklist that references the rules.

## Acceptance criteria (from #341)
- [x] `docs/CODING_RULES.md` exists in the repo.
- [x] `README.md` links to it.
- [x] An `AGENTS.md` and `CLAUDE.md` exist at the repo root and point agents at `docs/CODING_RULES.md` (and `docs/build-guide.md`). `AGENTS.md` is the canonical file; `CLAUDE.md` is a pointer to avoid two copies.
- [x] PR template references the coding rules.

## Out of scope
No retroactive cleanup of existing code the rules apply going forward, as called out in the issue.

Closes #341