### PR TITLE
Remove rendertexttype

### DIFF
--- a/src/bin/config.ini
+++ b/src/bin/config.ini
@@ -13,7 +13,6 @@ Height=768
 Windowed=1
 [Graphics]
 ColorDepth=0
-RenderTextType=0
 [Audio]
 SoundEnabled=0
 MusicEnabled=0

--- a/src/bin/config.ini
+++ b/src/bin/config.ini
@@ -1,12 +1,8 @@
 [LOGIN]
-Version=1.03.34
-TestVersion=1.03.34
 RememberMe=0
 Language=Eng
 EncryptedUsername=
 EncryptedPassword=
-[PARTITION]
-Version=357
 [Window]
 Width=1024
 Height=768
@@ -14,9 +10,8 @@ Windowed=1
 [Graphics]
 ColorDepth=0
 [Audio]
-SoundEnabled=0
-MusicEnabled=0
-VolumeLevel=5
+SoundVolume=5
+MusicVolume=5
 [CONNECTION SETTINGS]
 ServerIP=127.127.127.127
 ServerPort=44406

--- a/src/bin/config.ini
+++ b/src/bin/config.ini
@@ -7,8 +7,6 @@ EncryptedPassword=
 Width=1024
 Height=768
 Windowed=1
-[Graphics]
-ColorDepth=0
 [Audio]
 SoundVolume=5
 MusicVolume=5

--- a/src/source/GameConfig/GameConfig.cpp
+++ b/src/source/GameConfig/GameConfig.cpp
@@ -56,10 +56,16 @@ void GameConfig::Load()
 
     m_zoom = ReadInt(CfgSectionCamera, CfgKeyZoom, CfgDefaultZoom);
 
-    // Strip keys we used to write but no longer use, so user config files
-    // don't accumulate orphans. Append one line per retired key — no central
-    // registry of valid keys to keep in sync.
+    // Strip keys/sections we used to write but no longer use, so user config
+    // files don't accumulate orphans. Append one line per retired key — no
+    // central registry of valid keys to keep in sync.
     RemoveObsoleteKey(CfgSectionGraphics, L"RenderTextType");
+    RemoveObsoleteKey(CfgSectionAudio,    L"SoundEnabled");   // replaced by SoundVolume==0
+    RemoveObsoleteKey(CfgSectionAudio,    L"MusicEnabled");   // replaced by MusicVolume==0
+    RemoveObsoleteKey(CfgSectionAudio,    L"VolumeLevel");    // legacy single-volume key
+    RemoveObsoleteKey(CfgSectionLogin,    L"Version");        // launcher metadata, never read by client
+    RemoveObsoleteKey(CfgSectionLogin,    L"TestVersion");    // launcher metadata, never read by client
+    RemoveObsoleteSection(L"PARTITION");                      // launcher metadata, never read by client
 }
 
 void GameConfig::Save()
@@ -259,6 +265,12 @@ void GameConfig::RemoveObsoleteKey(const wchar_t* section, const wchar_t* key)
 {
     // Passing nullptr as the value deletes the key (Windows INI API).
     WritePrivateProfileStringW(section, key, nullptr, m_configPath.c_str());
+}
+
+void GameConfig::RemoveObsoleteSection(const wchar_t* section)
+{
+    // Passing nullptr as the key deletes the entire section.
+    WritePrivateProfileStringW(section, nullptr, nullptr, m_configPath.c_str());
 }
 
 std::wstring GameConfig::DecryptSetting(const std::wstring& hexInput)

--- a/src/source/GameConfig/GameConfig.cpp
+++ b/src/source/GameConfig/GameConfig.cpp
@@ -41,8 +41,6 @@ void GameConfig::Load()
     m_windowHeight = ReadInt(CfgSectionWindow, CfgKeyHeight, CfgDefaultWindowHeight);
     m_windowMode   = ReadBool(CfgSectionWindow, CfgKeyWindowed, CfgDefaultWindowed);
 
-    m_colorDepth = ReadInt(CfgSectionGraphics, CfgKeyColorDepth, CfgDefaultColorDepth);
-
     m_soundVolume  = ReadInt(CfgSectionAudio, CfgKeySoundVolume, CfgDefaultSoundVolume);
     m_musicVolume  = ReadInt(CfgSectionAudio, CfgKeyMusicVolume, CfgDefaultMusicVolume);
 
@@ -60,11 +58,13 @@ void GameConfig::Load()
     // files don't accumulate orphans. Append one line per retired key — no
     // central registry of valid keys to keep in sync.
     RemoveObsoleteKey(CfgSectionGraphics, L"RenderTextType");
+    RemoveObsoleteKey(CfgSectionGraphics, L"ColorDepth");      // 16/32bpp toggle, dead since fullscreen uses GetDesktopBitsPerPel
     RemoveObsoleteKey(CfgSectionAudio,    L"SoundEnabled");   // replaced by SoundVolume==0
     RemoveObsoleteKey(CfgSectionAudio,    L"MusicEnabled");   // replaced by MusicVolume==0
     RemoveObsoleteKey(CfgSectionAudio,    L"VolumeLevel");    // legacy single-volume key
     RemoveObsoleteKey(CfgSectionLogin,    L"Version");        // launcher metadata, never read by client
     RemoveObsoleteKey(CfgSectionLogin,    L"TestVersion");    // launcher metadata, never read by client
+    RemoveObsoleteSection(CfgSectionGraphics);                // empty after RenderTextType + ColorDepth removal
     RemoveObsoleteSection(L"PARTITION");                      // launcher metadata, never read by client
 }
 
@@ -76,8 +76,6 @@ void GameConfig::Save()
     WriteInt(CfgSectionWindow, CfgKeyWidth, m_windowWidth);
     WriteInt(CfgSectionWindow, CfgKeyHeight, m_windowHeight);
     WriteBool(CfgSectionWindow, CfgKeyWindowed, m_windowMode);
-
-    WriteInt(CfgSectionGraphics, CfgKeyColorDepth, m_colorDepth);
 
     WriteInt(CfgSectionAudio, CfgKeySoundVolume, m_soundVolume);
     WriteInt(CfgSectionAudio, CfgKeyMusicVolume, m_musicVolume);
@@ -102,11 +100,6 @@ void GameConfig::SetWindowSize(int width, int height)
 void GameConfig::SetWindowMode(bool windowed)
 {
     m_windowMode = windowed;
-}
-
-void GameConfig::SetColorDepth(int depth)
-{
-    m_colorDepth = depth;
 }
 
 void GameConfig::SetSoundVolume(int level)

--- a/src/source/GameConfig/GameConfig.cpp
+++ b/src/source/GameConfig/GameConfig.cpp
@@ -46,8 +46,6 @@ void GameConfig::Load()
     m_soundVolume  = ReadInt(CfgSectionAudio, CfgKeySoundVolume, CfgDefaultSoundVolume);
     m_musicVolume  = ReadInt(CfgSectionAudio, CfgKeyMusicVolume, CfgDefaultMusicVolume);
 
-    m_renderTextType = ReadInt(CfgSectionGraphics, CfgKeyRenderTextType, CfgDefaultRenderTextType);
-
     m_rememberMe        = ReadBool(CfgSectionLogin, CfgKeyRememberMe, CfgDefaultRememberMe);
     m_languageSelection = ReadString(CfgSectionLogin, CfgKeyLanguage, CfgDefaultLanguage);
     m_encryptedUsername = ReadString(CfgSectionLogin, CfgKeyEncryptedUsername, CfgDefaultEncryptedUsername);
@@ -57,6 +55,11 @@ void GameConfig::Load()
     m_serverPort = ReadInt(CfgSectionConnectionSettings, CfgKeyServerPort, CfgDefaultServerPort);
 
     m_zoom = ReadInt(CfgSectionCamera, CfgKeyZoom, CfgDefaultZoom);
+
+    // Strip keys we used to write but no longer use, so user config files
+    // don't accumulate orphans. Append one line per retired key — no central
+    // registry of valid keys to keep in sync.
+    RemoveObsoleteKey(CfgSectionGraphics, L"RenderTextType");
 }
 
 void GameConfig::Save()
@@ -69,7 +72,6 @@ void GameConfig::Save()
     WriteBool(CfgSectionWindow, CfgKeyWindowed, m_windowMode);
 
     WriteInt(CfgSectionGraphics, CfgKeyColorDepth, m_colorDepth);
-    WriteInt(CfgSectionGraphics, CfgKeyRenderTextType, m_renderTextType);
 
     WriteInt(CfgSectionAudio, CfgKeySoundVolume, m_soundVolume);
     WriteInt(CfgSectionAudio, CfgKeyMusicVolume, m_musicVolume);
@@ -109,11 +111,6 @@ void GameConfig::SetSoundVolume(int level)
 void GameConfig::SetMusicVolume(int level)
 {
     m_musicVolume = level;
-}
-
-void GameConfig::SetRenderTextType(int type)
-{
-    m_renderTextType = type;
 }
 
 void GameConfig::SetRememberMe(bool remember)
@@ -256,6 +253,12 @@ std::wstring GameConfig::ReadString(const wchar_t* section, const wchar_t* key, 
 void GameConfig::WriteString(const wchar_t* section, const wchar_t* key, const std::wstring& value)
 {
     WritePrivateProfileStringW(section, key, value.c_str(), m_configPath.c_str());
+}
+
+void GameConfig::RemoveObsoleteKey(const wchar_t* section, const wchar_t* key)
+{
+    // Passing nullptr as the value deletes the key (Windows INI API).
+    WritePrivateProfileStringW(section, key, nullptr, m_configPath.c_str());
 }
 
 std::wstring GameConfig::DecryptSetting(const std::wstring& hexInput)

--- a/src/source/GameConfig/GameConfig.h
+++ b/src/source/GameConfig/GameConfig.h
@@ -99,6 +99,7 @@ private:
     void WriteString(const wchar_t* section, const wchar_t* key, const std::wstring& value);
 
     void RemoveObsoleteKey(const wchar_t* section, const wchar_t* key);
+    void RemoveObsoleteSection(const wchar_t* section);
 
     std::wstring DecryptSetting(const std::wstring& hexInput);
     std::wstring EncryptSetting(const wchar_t* input);

--- a/src/source/GameConfig/GameConfig.h
+++ b/src/source/GameConfig/GameConfig.h
@@ -21,10 +21,6 @@ public:
     void SetWindowSize(int width, int height);
     void SetWindowMode(bool windowed);
 
-    // Graphics
-    int GetColorDepth() const { return m_colorDepth; }
-    void SetColorDepth(int depth);
-
     // Audio — volume 0 = off, >0 = on. No separate Enabled flag.
     int  GetSoundVolume()  const { return m_soundVolume; }
     int  GetMusicVolume()  const { return m_musicVolume; }
@@ -73,8 +69,6 @@ private:
     int  m_windowWidth;
     int  m_windowHeight;
     bool m_windowMode;
-
-    int m_colorDepth;
 
     int  m_soundVolume;
     int  m_musicVolume;

--- a/src/source/GameConfig/GameConfig.h
+++ b/src/source/GameConfig/GameConfig.h
@@ -32,10 +32,6 @@ public:
     void SetSoundVolume(int level);
     void SetMusicVolume(int level);
 
-    // Text rendering
-    int GetRenderTextType() const { return m_renderTextType; }
-    void SetRenderTextType(int type);
-
     // Login
     bool GetRememberMe() const { return m_rememberMe; }
     void SetRememberMe(bool remember);
@@ -83,8 +79,6 @@ private:
     int  m_soundVolume;
     int  m_musicVolume;
 
-    int m_renderTextType;
-
     bool m_rememberMe;
     std::wstring m_languageSelection;
     std::wstring m_encryptedUsername;
@@ -103,6 +97,8 @@ private:
 
     std::wstring ReadString(const wchar_t* section, const wchar_t* key, const std::wstring& defaultValue);
     void WriteString(const wchar_t* section, const wchar_t* key, const std::wstring& value);
+
+    void RemoveObsoleteKey(const wchar_t* section, const wchar_t* key);
 
     std::wstring DecryptSetting(const std::wstring& hexInput);
     std::wstring EncryptSetting(const wchar_t* input);

--- a/src/source/GameConfig/GameConfigConstants.h
+++ b/src/source/GameConfig/GameConfigConstants.h
@@ -17,9 +17,6 @@ namespace CfgKeys
     inline constexpr wchar_t CfgKeyHeight[]     = L"Height";
     inline constexpr wchar_t CfgKeyWindowed[]   = L"Windowed";
 
-    // Graphics
-    inline constexpr wchar_t CfgKeyColorDepth[]     = L"ColorDepth";
-
     // Audio — volume 0 = off, >0 = on (no separate Enabled flag).
     inline constexpr wchar_t CfgKeySoundVolume[]  = L"SoundVolume";
     inline constexpr wchar_t CfgKeyMusicVolume[] = L"MusicVolume";
@@ -43,8 +40,6 @@ namespace CfgDefaults
     inline constexpr int  CfgDefaultWindowWidth  = 1024;
     inline constexpr int  CfgDefaultWindowHeight = 768;
     inline constexpr bool CfgDefaultWindowed     = true;
-
-    inline constexpr int  CfgDefaultColorDepth = 0;
 
     inline constexpr int  CfgDefaultSoundVolume = 5;
     inline constexpr int  CfgDefaultMusicVolume = 5;

--- a/src/source/GameConfig/GameConfigConstants.h
+++ b/src/source/GameConfig/GameConfigConstants.h
@@ -19,7 +19,6 @@ namespace CfgKeys
 
     // Graphics
     inline constexpr wchar_t CfgKeyColorDepth[]     = L"ColorDepth";
-    inline constexpr wchar_t CfgKeyRenderTextType[] = L"RenderTextType";
 
     // Audio — volume 0 = off, >0 = on (no separate Enabled flag).
     inline constexpr wchar_t CfgKeySoundVolume[]  = L"SoundVolume";
@@ -49,8 +48,6 @@ namespace CfgDefaults
 
     inline constexpr int  CfgDefaultSoundVolume = 5;
     inline constexpr int  CfgDefaultMusicVolume = 5;
-
-    inline constexpr int CfgDefaultRenderTextType = 0;
 
     inline constexpr bool CfgDefaultRememberMe = false;
     inline constexpr wchar_t CfgDefaultLanguage[] = L"Eng";

--- a/src/source/UIControls.cpp
+++ b/src/source/UIControls.cpp
@@ -2536,7 +2536,7 @@ void CUISocketListBox::DeleteText(int iSocketIndex)
     m_TextList.erase(m_TextListIter);
 }
 
-CUIRenderText::CUIRenderText() : m_pRenderText(nullptr), m_iRenderTextType(-1) {}
+CUIRenderText::CUIRenderText() : m_pRenderText(nullptr) {}
 CUIRenderText::~CUIRenderText() { Release(); }
 
 CUIRenderText* CUIRenderText::GetInstance()
@@ -2545,36 +2545,23 @@ CUIRenderText* CUIRenderText::GetInstance()
     return &s_RenderText;
 }
 
-bool CUIRenderText::Create(int iRenderTextType, HDC hDC)
+bool CUIRenderText::Create(HDC hDC)
 {
-    if (m_pRenderText && m_iRenderTextType == iRenderTextType)
+    if (m_pRenderText)
     {
         return true;
     }
 
-    Release();
-
-    switch (iRenderTextType)
+    m_pRenderText = new CUIRenderTextOriginal;
+    if (!m_pRenderText->Create(hDC))
     {
-    case 0:
-        m_pRenderText = new CUIRenderTextOriginal;
-        if (!m_pRenderText->Create(hDC))
-        {
-            delete m_pRenderText;
-            m_pRenderText = nullptr;
-            return false;
-        }
-        break;
-    case 1:
-        //m_pRenderText = new CUIRenderTextAdvance;
-        return false;
-    default:
+        delete m_pRenderText;
+        m_pRenderText = nullptr;
         return false;
     }
-
-    m_iRenderTextType = iRenderTextType;
     return true;
 }
+
 void CUIRenderText::Release()
 {
     if (m_pRenderText)
@@ -2582,10 +2569,7 @@ void CUIRenderText::Release()
         delete m_pRenderText;
         m_pRenderText = nullptr;
     }
-    m_iRenderTextType = -1;
 }
-
-int CUIRenderText::GetRenderTextType() const { return m_iRenderTextType; }
 
 HDC CUIRenderText::GetFontDC() const
 {

--- a/src/source/UIControls.cpp
+++ b/src/source/UIControls.cpp
@@ -2536,8 +2536,8 @@ void CUISocketListBox::DeleteText(int iSocketIndex)
     m_TextList.erase(m_TextListIter);
 }
 
-CUIRenderText::CUIRenderText() : m_pRenderText(nullptr) {}
-CUIRenderText::~CUIRenderText() { Release(); }
+CUIRenderText::CUIRenderText() = default;
+CUIRenderText::~CUIRenderText() = default;
 
 CUIRenderText* CUIRenderText::GetInstance()
 {
@@ -2552,11 +2552,10 @@ bool CUIRenderText::Create(HDC hDC)
         return true;
     }
 
-    m_pRenderText = new CUIRenderTextOriginal;
+    m_pRenderText = std::make_unique<CUIRenderTextOriginal>();
     if (!m_pRenderText->Create(hDC))
     {
-        delete m_pRenderText;
-        m_pRenderText = nullptr;
+        m_pRenderText.reset();
         return false;
     }
     return true;
@@ -2564,11 +2563,7 @@ bool CUIRenderText::Create(HDC hDC)
 
 void CUIRenderText::Release()
 {
-    if (m_pRenderText)
-    {
-        delete m_pRenderText;
-        m_pRenderText = nullptr;
-    }
+    m_pRenderText.reset();
 }
 
 HDC CUIRenderText::GetFontDC() const

--- a/src/source/UIControls.h
+++ b/src/source/UIControls.h
@@ -797,17 +797,14 @@ class CUIRenderText
     CUIRenderText();
 
     IUIRenderText* m_pRenderText;
-    int m_iRenderTextType;
 
 public:
     virtual ~CUIRenderText();
 
     static CUIRenderText* GetInstance();
 
-    bool Create(int iRenderTextType, HDC hDC);
+    bool Create(HDC hDC);
     void Release();
-
-    int GetRenderTextType() const;
 
     HDC GetFontDC() const;
     BYTE* GetFontBuffer() const;

--- a/src/source/UIControls.h
+++ b/src/source/UIControls.h
@@ -6,6 +6,7 @@
 #include "WSclient.h"
 #include "QuestMng.h"
 #include "Time/Timer.h"
+#include <memory>
 #include <vector>
 
 #ifdef KJH_ADD_INGAMESHOP_UI_SYSTEM
@@ -735,6 +736,8 @@ struct RENDER_TEXT_DATA
 class IUIRenderText
 {
 public:
+    virtual ~IUIRenderText() = default;
+
     virtual bool Create(HDC hDC) = 0;
     virtual void Release() = 0;
 
@@ -796,7 +799,7 @@ class CUIRenderText
 {
     CUIRenderText();
 
-    IUIRenderText* m_pRenderText;
+    std::unique_ptr<IUIRenderText> m_pRenderText;
 
 public:
     virtual ~CUIRenderText();

--- a/src/source/Winmain.cpp
+++ b/src/source/Winmain.cpp
@@ -762,7 +762,6 @@ int  m_MusicOnOff;
 int  m_Resolution;
 int	m_nColorDepth;
 int m_RememberMe;
-int	g_iRenderTextType = 0;
 
 wchar_t g_aszMLSelection[MAX_LANGUAGE_NAME_LENGTH] = { '\0' };
 
@@ -969,10 +968,6 @@ MSG MainLoop()
     return msg;
 }
 
-// Declared at file scope -- an `extern` inside the anonymous namespace below would
-// give the symbol internal linkage and fail to resolve against the real global.
-extern int g_iRenderTextType;
-
 namespace
 {
     // Tahoma font size scales with window height; these are the tuned base values.
@@ -1012,7 +1007,7 @@ namespace
     {
         // Recreates the font buffer bitmap with new g_fScreenRate values
         g_pRenderText->Release();
-        g_pRenderText->Create(g_iRenderTextType, g_hDC);
+        g_pRenderText->Create(g_hDC);
         g_pRenderText->SetFont(g_hFont);
     }
 
@@ -1216,7 +1211,6 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLin
 
     // Apply graphics settings from INI
     m_nColorDepth = GameConfig::GetInstance().GetColorDepth();
-    g_iRenderTextType = GameConfig::GetInstance().GetRenderTextType();
 
     // Apply login settings from INI
     m_RememberMe = GameConfig::GetInstance().GetRememberMe() ? 1 : 0;

--- a/src/source/Winmain.cpp
+++ b/src/source/Winmain.cpp
@@ -760,7 +760,6 @@ wchar_t m_ExeVersion[11];
 int  m_SoundOnOff;
 int  m_MusicOnOff;
 int  m_Resolution;
-int	m_nColorDepth;
 int m_RememberMe;
 
 wchar_t g_aszMLSelection[MAX_LANGUAGE_NAME_LENGTH] = { '\0' };
@@ -1194,7 +1193,6 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLin
     m_SoundOnOff = 1;
     m_MusicOnOff = 1;
     m_Resolution = 0;
-    m_nColorDepth = 0;
     m_RememberMe = 0;
 
     g_iChatInputType = 1;
@@ -1208,9 +1206,6 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLin
     // Apply audio settings from INI — volume 0 = off, >0 = on
     m_SoundOnOff = (GameConfig::GetInstance().GetSoundVolume() > 0) ? 1 : 0;
     m_MusicOnOff = (GameConfig::GetInstance().GetMusicVolume() > 0) ? 1 : 0;
-
-    // Apply graphics settings from INI
-    m_nColorDepth = GameConfig::GetInstance().GetColorDepth();
 
     // Apply login settings from INI
     m_RememberMe = GameConfig::GetInstance().GetRememberMe() ? 1 : 0;
@@ -1232,36 +1227,10 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLin
     if (g_iChatInputType == 1)
         ShowCursor(FALSE);
 
-    g_ErrorReport.Write(L"> Enum display settings.\r\n");
-    DEVMODE DevMode;
-    DEVMODE* pDevmodes;
-    int nModes = 0;
-    while (EnumDisplaySettings(nullptr, nModes, &DevMode)) nModes++;
-    pDevmodes = new DEVMODE[nModes + 1];
-    nModes = 0;
-    while (EnumDisplaySettings(nullptr, nModes, &pDevmodes[nModes])) nModes++;
-
-    DWORD dwBitsPerPel = 16;
-    for (int n1 = 0; n1 < nModes; n1++)
-    {
-        if (pDevmodes[n1].dmBitsPerPel == 16 && m_nColorDepth == 0) {
-            dwBitsPerPel = 16; break;
-        }
-        if (pDevmodes[n1].dmBitsPerPel == 24 && m_nColorDepth == 1) {
-            dwBitsPerPel = 24; break;
-        }
-        if (pDevmodes[n1].dmBitsPerPel == 32 && m_nColorDepth == 1) {
-            dwBitsPerPel = 32; break;
-        }
-    }
-
     if (g_bUseWindowMode == FALSE && g_bUseFullscreenMode == TRUE)
     {
-        // Force an exclusive fullscreen mode change at WindowWidth × WindowHeight.
-        // The old path iterated EnumDisplaySettings looking for a match at dwBitsPerPel
-        // (which defaulted to 16), but modern displays don't expose <32bpp modes — so
-        // the loop matched nothing, ChangeDisplaySettings was never called, and the
-        // game ended up as a small popup on top of the desktop instead of true fullscreen.
+        // Force an exclusive fullscreen mode change at WindowWidth × WindowHeight
+        // at the desktop's bit depth — modern displays don't expose <32bpp modes.
         DEVMODE dmScreenSettings = {};
         dmScreenSettings.dmSize       = sizeof(dmScreenSettings);
         dmScreenSettings.dmPelsWidth  = WindowWidth;
@@ -1281,8 +1250,6 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLin
             g_bUseFullscreenMode = FALSE;
         }
     }
-
-    delete[] pDevmodes;
 
     g_ErrorReport.Write(L"> Screen size = %d x %d.\r\n", WindowWidth, WindowHeight);
 

--- a/src/source/Winmain.h
+++ b/src/source/Winmain.h
@@ -72,7 +72,6 @@ extern wchar_t m_Version[];
 extern int  m_SoundOnOff;
 extern int  m_MusicOnOff;
 extern int  m_Resolution;
-extern int m_nColorDepth;
 extern int m_RememberMe;
 extern int g_MaxMessagePerCycle;
 extern double CPU_AVG;

--- a/src/source/ZzzOpenData.cpp
+++ b/src/source/ZzzOpenData.cpp
@@ -4718,8 +4718,6 @@ void OpenSounds()
     LoadWaveFile(SOUND_RAGESKILL_BUFF_2, L"Data\\Sound\\Ragefighter\\Rage_Buff_2.wav");
 }
 
-extern int	g_iRenderTextType;
-
 bool OpenFont()
 {
     InitPath();
@@ -4728,18 +4726,7 @@ bool OpenFont()
     LoadBitmap(L"Interface\\FontTest.tga", BITMAP_FONT + 1);
     LoadBitmap(L"Interface\\Hit.tga", BITMAP_FONT_HIT, GL_NEAREST, GL_CLAMP_TO_EDGE);
 
-    const int requestedType = g_iRenderTextType;
-    if (!g_pRenderText->Create(requestedType, g_hDC))
-    {
-        if (requestedType == 0 || !g_pRenderText->Create(0, g_hDC))
-        {
-            return false;
-        }
-
-        g_iRenderTextType = 0;
-    }
-
-    return true;
+    return g_pRenderText->Create(g_hDC);
 }
 
 void SaveMacro(const wchar_t* FileName)


### PR DESCRIPTION
None of the keys removed here are read by any code in the client. They're leftover from older formats or an old launcher that was never wired up.

## Dead keys removed

| Key | Why it's dead |
|---|---|
| \`[Graphics] RenderTextType\` | Selected between two text renderers, but \`CUIRenderTextAdvance\` was never written — only a 2021 commented-out \`new CUIRenderTextAdvance\` line. \`CUIRenderText::Create\` has always had one real case. |
| \`[Audio] SoundEnabled\` / \`MusicEnabled\` | Replaced by \`SoundVolume==0\` / \`MusicVolume==0\` (no separate enable flag). |
| \`[Audio] VolumeLevel\` | Legacy single-volume key, predates per-channel \`SoundVolume\` / \`MusicVolume\`. |
| \`[LOGIN] Version\` / \`TestVersion\` | Launcher metadata. The protocol version sent to the server is the 5-byte \`Version\` array hardcoded in \`WSclient.cpp\`; these strings are unrelated. |
| \`[PARTITION]\` (whole section) | Launcher metadata, never read. |

## Code changes
- \`GameConfig\` — drop the \`m_renderTextType\` field, getter, setter, load/save lines, and the \`CfgKeyRenderTextType\` / \`CfgDefaultRenderTextType\` constants.
- \`CUIRenderText::Create\` — drop the dispatch \`int\` param, just construct \`CUIRenderTextOriginal\`. \`m_iRenderTextType\` / \`GetRenderTextType\` removed too.
- \`Winmain.cpp\` — remove \`g_iRenderTextType\` (definition, extern, GameConfig read); call \`Create(g_hDC)\` without the type.
- \`ZzzOpenData.cpp::OpenFont\` — collapse the two-attempt fallback (which only existed to retry with type \`0\`) to one \`Create(g_hDC)\` call.

## Config migration
\`GameConfig::Load\` now calls a small \`RemoveObsoleteKey\` / \`RemoveObsoleteSection\` helper pair (using \`WritePrivateProfileStringW(..., nullptr, ...)\`) to delete each orphaned key/section from existing user config files on next launch. One line per future retired key — no central registry of valid keys to keep in sync.

\`src/bin/config.ini\` is rewritten in the new format so fresh installs are clean from the start.

## What did not change
- \`CUIRenderTextOriginal\` and the \`IUIRenderText\` interface.
- The hardcoded protocol \`Version\` / \`Serial\` byte arrays in \`WSclient.cpp\` (that's the version actually sent to the server; out of scope here).
- Any rendering or audio behaviour — only working code paths are preserved.