### PR TITLE
Fix F1 help-window crash and add GlobalText fallbacks

### DIFF
--- a/src/source/GlobalText.h
+++ b/src/source/GlobalText.h
@@ -74,11 +74,15 @@ namespace detail
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <map>
 #include <string>
 #include <type_traits>
 #include <vector>
+
+void LogMissingGlobalText(int key);
 
 template <class T>
 class TGlobalText
@@ -129,6 +133,9 @@ class TGlobalText
     };
 
     leaf::TStringSet<T>		m_StringSet;
+    std::map<int, std::basic_string<T>>	m_MissingTextCache;
+
+    static constexpr std::size_t MISSING_TEXT_BUFFER_SIZE = 64;
 
 public:
 
@@ -250,9 +257,18 @@ public:
 
     bool Add(int key, const T* szString) { return m_StringSet.Add(key, szString); }
     bool Remove(int key) { return m_StringSet.Remove(key); }
-    void RemoveAll() { m_StringSet.RemoveAll(); }
+    void RemoveAll()
+    {
+        m_StringSet.RemoveAll();
+        m_MissingTextCache.clear();
+    }
 
-    const T* Get(int key) { return m_StringSet[key]; }
+    const T* Get(int key)
+    {
+        if (const T* found = m_StringSet.Find(key))
+            return found;
+        return GetMissingFallback(key);
+    }
     size_t GetStringSize(int key) { return m_StringSet.FindObj(key).size(); }
 
     std::uint16_t GetNumCountryCode(const std::wstring& strAlpha3Code)
@@ -277,6 +293,31 @@ public:
     }
 
 protected:
+    const T* GetMissingFallback(int key)
+    {
+        auto it = m_MissingTextCache.find(key);
+        if (it != m_MissingTextCache.end())
+            return it->second.c_str();
+
+        LogMissingGlobalText(key);
+
+        std::basic_string<T> fallback;
+        if constexpr (std::is_same_v<T, wchar_t>)
+        {
+            wchar_t buf[MISSING_TEXT_BUFFER_SIZE];
+            std::swprintf(buf, MISSING_TEXT_BUFFER_SIZE, L"No Translation for %d", key);
+            fallback.assign(buf);
+        }
+        else
+        {
+            char buf[MISSING_TEXT_BUFFER_SIZE];
+            std::snprintf(buf, MISSING_TEXT_BUFFER_SIZE, "No Translation for %d", key);
+            fallback.assign(buf);
+        }
+        auto inserted = m_MissingTextCache.emplace(key, std::move(fallback));
+        return inserted.first->second.c_str();
+    }
+
     static void BuxConvert(std::uint8_t* data, std::size_t length)
     {
         static constexpr std::array<std::uint8_t, 3> byBuxCode{ 0xfc,0xcf,0xab };

--- a/src/source/NewUIHelpWindow.cpp
+++ b/src/source/NewUIHelpWindow.cpp
@@ -9,6 +9,19 @@
 
 using namespace SEASON3B;
 
+namespace
+{
+    // Engine-only help-text entries registered programmatically via
+    // SEASON3B::RegisterCustomHelpText(). Keys are above MAX_NUMBER_OF_TEXTS
+    // (9999) so they can't collide with shipped GlobalText.bmd entries.
+    constexpr int HELP_KEY_F9_TOGGLE_CAMERA = 10000;
+}
+
+void SEASON3B::RegisterCustomHelpText()
+{
+    GlobalText.Add(HELP_KEY_F9_TOGGLE_CAMERA, L"F9 - Toggle 3D Camera");
+}
+
 SEASON3B::CNewUIHelpWindow::CNewUIHelpWindow()
 {
     m_pNewUIMng = NULL;
@@ -119,7 +132,27 @@ bool SEASON3B::CNewUIHelpWindow::Render()
         mu_swprintf(TextList[iTextNum], L"\n");
         iTextNum++;
 
-        for (int i = 0; i < 19; ++i)
+        // Render F1-F4 entries (GlobalText[121..124]) first.
+        for (int i = 0; i < 4; ++i)
+        {
+            wcscpy(TextList[iTextNum], GlobalText[121 + i]);
+            TextListColor[iTextNum] = TEXT_COLOR_WHITE;
+            TextBold[iTextNum] = false;
+            iTextNum++;
+        }
+
+        // Insert engine-added F9 entry between F4 and the rest.
+        // wcsncpy + explicit terminator: HELP_KEY_F9_TOGGLE_CAMERA can be
+        // overridden by .bmd translations of arbitrary length, so guard
+        // the 100-wchar TextList row against overflow.
+        wcsncpy(TextList[iTextNum], GlobalText[HELP_KEY_F9_TOGGLE_CAMERA], 99);
+        TextList[iTextNum][99] = L'\0';
+        TextListColor[iTextNum] = TEXT_COLOR_WHITE;
+        TextBold[iTextNum] = false;
+        iTextNum++;
+
+        // Render the remaining shipped entries (GlobalText[125..139]).
+        for (int i = 4; i < 19; ++i)
         {
             wcscpy(TextList[iTextNum], GlobalText[121 + i]);
             TextListColor[iTextNum] = TEXT_COLOR_WHITE;

--- a/src/source/NewUIHelpWindow.cpp
+++ b/src/source/NewUIHelpWindow.cpp
@@ -95,9 +95,14 @@ bool SEASON3B::CNewUIHelpWindow::Render()
     EnableAlphaTest();
     glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
-    extern wchar_t TextList[50][100];
-    extern int TextListColor[50];
-    extern int TextBold[50];
+    // Reference-bind to the global arrays in ZzzInventory.cpp. A naive
+    // `extern wchar_t TextList[50][100];` here would resolve to
+    // SEASON3B::TextList (the reference defined in UIManager.cpp) because
+    // this function is in the SEASON3B namespace -- and the linker stores
+    // that reference as a 4-byte read-only pointer, so writing to it crashes.
+    wchar_t (&TextList)[50][100] = ::TextList;
+    int (&TextListColor)[50] = ::TextListColor;
+    int (&TextBold)[50] = ::TextBold;
 
     if (m_iIndex == 0)
     {

--- a/src/source/NewUIHelpWindow.h
+++ b/src/source/NewUIHelpWindow.h
@@ -11,6 +11,10 @@
 
 namespace SEASON3B
 {
+    // Adds engine-only help-text entries to GlobalText that aren't shipped in
+    // the localized .bmd files. Call once after GlobalText.Load().
+    void RegisterCustomHelpText();
+
     class CNewUIHelpWindow : public CNewUIObj
     {
     public:

--- a/src/source/ZzzInfomation.cpp
+++ b/src/source/ZzzInfomation.cpp
@@ -41,6 +41,11 @@ static  DWORD   g_dwWorldStateBack = 0;
 
 CGlobalTextW GlobalText;
 
+void LogMissingGlobalText(int key)
+{
+    g_ErrorReport.Write(L"GlobalText: missing key %d\r\n", key);
+}
+
 void SaveTextFile(wchar_t* FileName)
 {
     FILE* fp = _wfopen(FileName, L"wb");

--- a/src/source/ZzzOpenData.cpp
+++ b/src/source/ZzzOpenData.cpp
@@ -24,6 +24,7 @@
 #include "Event.h"
 #include "ChangeRingManager.h"
 #include "NewUISystem.h"
+#include "NewUIHelpWindow.h"
 #include "CameraMove.h"
 #include "QuestMng.h"
 #include "ServerListManager.h"
@@ -5421,6 +5422,7 @@ void OpenTextData()
 
     mu_swprintf(Text, L"Data\\Local\\%ls\\Text_%ls.bmd", g_strSelectedML.c_str(), g_strSelectedML.c_str());
     GlobalText.Load(Text, CGlobalText::LD_USA_CANADA_TEXTS | CGlobalText::LD_FOREIGN_TEXTS);
+    SEASON3B::RegisterCustomHelpText();
     OpenMacro(L"Data\\Macro.txt");
 }
 


### PR DESCRIPTION
## Summary
Three related changes to the help-window / localization path, motivated by investigating issue #351.

### 1. Show fallback text and log warnings for missing GlobalText keys (`9e3b3420`)
`GlobalText[key]` previously returned an empty string when the key wasn't loaded from the shipped `Text_*.bmd` file — silently dropping the entry on non-localized clients. `Get()` now returns a cached `"No Translation for N"` placeholder instead, making missing keys visible in the UI, and writes a one-line warning to the error report log so they can be tracked down.

### 2. Fix F1 help-window crash from extern shadowing global TextList (`eb3af561`) — closes #351
The `extern wchar_t TextList[50][100];` declaration inside `SEASON3B::CNewUIHelpWindow::Render()` resolved to `SEASON3B::TextList` (a reference defined in `UIManager.cpp`) instead of the global `::TextList` defined in `ZzzInventory.cpp`. The linker stored the reference as a 4-byte read-only pointer, so the first write inside `Render()` (e.g. `mu_swprintf(TextList[0], L"\n")`) crashed the client whenever F1 was pressed.

The fix binds local references to the global arrays explicitly:

```cpp
wchar_t (&TextList)[50][100] = ::TextList;
int (&TextListColor)[50] = ::TextListColor;
int (&TextBold)[50] = ::TextBold;
```

so reads and writes go through the real arrays.

### 3. Add F9 toggle-camera entry to F1 help (`d7062d64`)
Injects `"F9 - Toggle 3D Camera"` into the GlobalText map at startup under key `10000` (above `MAX_NUMBER_OF_TEXTS` so it never collides with shipped `.bmd` entries) and renders it on page 0 of the F1 help between the F4 line and the rest. Translation tracking: #353.

## Test plan
- [x] Build on MinGW-w64 i686 — link clean, no new warnings related to these changes
- [x] Press F1 in-game — help window opens, shows pages 0/1, including the new "F9 - Toggle 3D Camera" line in position 5
- [x] Press F1 again to cycle to page 1, third press hides
- [x] No regression: F2/F3/F4 etc. continue to work