### PR TITLE
Fix alt+right-click crash from ODR-violating SelectedCharacter extern

### DIFF
--- a/src/source/NewUIHotKey.cpp
+++ b/src/source/NewUIHotKey.cpp
@@ -51,8 +51,6 @@ void SEASON3B::CNewUIHotKey::Release()
 
 bool SEASON3B::CNewUIHotKey::UpdateMouseEvent()
 {
-    extern int SelectedCharacter;
-
     if (g_isCharacterBuff((&Hero->Object), eBuff_DuelWatch))
     {
         return true;


### PR DESCRIPTION
CNewUIHotKey::UpdateMouseEvent is in namespace SEASON3B, so the local 'extern int SelectedCharacter;' declares SEASON3B::Selected- Character. UIManager.cpp:43 already defines that name as 'int& SelectedCharacter = ::SelectedCharacter;' a reference, stored under the hood as a pointer to the real ::SelectedCharacter.

Same mangled name, different types: ODR violation, silently linked. The function read the pointer's bits (~10M, a positive number that passes the >= 0 check) instead of the int's value, then computed &CharactersClient[~10M] -> wild pointer -> AV on any alt+right-click anywhere in the world.

Drop the bogus extern. The file-scope 'using namespace SEASON3B;' already brings the correctly-typed reference into scope, and reading it produces the dereferenced int as expected.