### PR TITLE
Docs submodule init

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ The project uses three git submodules under `src/ThirdParty/`:
 
 - `SDL` - windowing, input and audio backend (required for all builds)
 - `SDL_mixer` - audio mixer (required for all builds)
-- `imgui` - in-game editor UI (Debug builds only)
+- `imgui` - in-game editor UI (Debug builds with `-DENABLE_EDITOR=ON`)
 
-CMake initializes these automatically on first configure. If that fails (e.g. `git` is not on `PATH`), run from the repository root:
+CMake initializes these automatically on first configure. If that fails for any reason, run from the repository root:
 
 ```bash
 git submodule update --init

--- a/README.md
+++ b/README.md
@@ -64,17 +64,17 @@ What needs to be done for Season 6:
 
 ### First Time Setup - Initialize Submodules
 
-The project uses ImGui as a git submodule for the in-game editor (debug builds only). After cloning the repository, you must initialize the submodules
-if CMake did not do this automatically which it should
+The project uses three git submodules under `src/ThirdParty/`:
+
+- `SDL` - windowing, input and audio backend (required for all builds)
+- `SDL_mixer` - audio mixer (required for all builds)
+- `imgui` - in-game editor UI (Debug builds only)
+
+CMake initializes these automatically on first configure. If that fails (e.g. `git` is not on `PATH`), run from the repository root:
 
 ```bash
-# From the repository root
 git submodule update --init
 ```
-
-This will download the ImGui library into `src/ThirdParty/imgui`.
-
-**Note:** This is only required for **Debug builds** (`Global Debug` configuration). Release builds do not require ImGui.
 
 ### Build Configurations
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The project uses three git submodules under `src/ThirdParty/`:
 
 - `SDL` - windowing, input and audio backend (required for all builds)
 - `SDL_mixer` - audio mixer (required for all builds)
-- `imgui` - in-game editor UI (Debug builds with `-DENABLE_EDITOR=ON`)
+- `imgui` - in-game editor UI (only needed when built with `-DENABLE_EDITOR=ON`, independent of Debug/Release)
 
 CMake initializes these automatically on first configure. If that fails for any reason, run from the repository root:
 
@@ -78,18 +78,20 @@ git submodule update --init
 
 ### Build Configurations
 
-#### Debug Builds (`Global Debug`)
-- Includes the in-game MU Editor (ImGui-based)
-- Requires ImGui submodule to be initialized (see above)
+There are two orthogonal choices: **editor on/off** (configure-time, picked via preset) and **Debug/Release** (build-time).
+
+#### Editor builds (`windows-x86-mueditor` / `windows-x64-mueditor`)
+- Configure preset sets `ENABLE_EDITOR=ON`
+- Includes the in-game MU Editor (ImGui-based); the `imgui` submodule must be initialized
 - Press **F12** in-game to toggle the editor
 - Start with `--editor` flag to launch with editor enabled
 - Preprocessor define: `_EDITOR`
 
-#### Release Builds (`Global Release`)
-- No editor code included
-- ImGui submodule not required
-- Optimized for production use
+#### Standard builds (`windows-x86` / `windows-x64`)
+- Configure preset sets `ENABLE_EDITOR=OFF`; no editor code is compiled in and the `imgui` submodule is unused
 - Zero editor overhead
+
+Either configuration can be built as Debug or Release via the corresponding build preset (`*-debug` or `*-release`).
 
 ### Building with CMake and MinGW-w64 (Linux)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ There are two orthogonal choices: **editor on/off** (configure-time, picked via 
 - Preprocessor define: `_EDITOR`
 
 #### Standard builds (`windows-x86` / `windows-x64`)
-- Configure preset sets `ENABLE_EDITOR=OFF`; no editor code is compiled in and the `imgui` submodule is unused
+- Configure preset sets `ENABLE_EDITOR=OFF`; no editor code is compiled in and the `imgui` submodule is not initialized
 - Zero editor overhead
 
 Either configuration can be built as Debug or Release via the corresponding build preset (`*-debug` or `*-release`).

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -72,3 +72,14 @@ language explicitly.
 - Every new dependency, abstraction, or pattern has a maintenance cost. Justify it.
 - Smaller diffs are easier to review. Keep changes focused on one concern per commit.
 - If you're unsure about a structural decision, ask before building on top of it.
+
+## 11. Document Usage, Not Internals
+
+- New, changed, or removed systems get a docs update, but only at the **usage** level: what the feature does and how players or admins use it.
+  - In scope: gameplay features, admin/editor workflows (e.g. editor usage), UI behaviour, configuration the user touches.
+  - Out of scope: function signatures, class diagrams, internal data flow. The code is the source of truth for those.
+- The one exception is **game/business logic and non-obvious calculations** - the rules a system enforces (drop rates, EXP curves, combat resolution, trade flow) and the math behind them (damage formulas, collision math). Document the rules and the *why* of any formula, so a reader understands the behaviour without having to read the code.
+  - When you change a rule or formula like this (not just edit nearby code), add the docs if they're missing or update them if behaviour shifts. Most of this is currently undocumented, so treat first contact as the chance to capture it.
+  - Where it helps, note how the original S6 client handled it vs. how we do it now - the contrast is often the most useful part for a future reader.
+- Extend an existing file in `docs/` rather than starting a new one. Don't fragment.
+- If it doesn't help a player, an admin, or someone reaching for a formula, don't write it.

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -81,5 +81,5 @@ language explicitly.
 - The one exception is **game/business logic and non-obvious calculations** - the rules a system enforces (drop rates, EXP curves, combat resolution, trade flow) and the math behind them (damage formulas, collision math). Document the rules and the *why* of any formula, so a reader understands the behaviour without having to read the code.
   - When you change a rule or formula like this (not just edit nearby code), add the docs if they're missing or update them if behaviour shifts. Most of this is currently undocumented, so treat first contact as the chance to capture it.
   - Where it helps, note how the original S6 client handled it vs. how we do it now - the contrast is often the most useful part for a future reader.
-- Extend an existing file in `docs/` rather than starting a new one. Don't fragment.
+- Extend an existing file in `docs/` for related content rather than starting a new one. A distinct, self-contained system (e.g. `camera-system.md`, `options-window.md`) can have its own file.
 - If it doesn't help a player, an admin, or someone reaching for a formula, don't write it.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,10 +9,6 @@ cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH REPO_ROOT)
 
 include("${REPO_ROOT}/cmake/EnsureSubmodule.cmake")
 
-mu_ensure_submodule("ThirdParty/imgui"
-  INDICATOR "imgui.cpp"
-  URL "https://github.com/ocornut/imgui.git")
-
 mu_ensure_submodule("ThirdParty/SDL"
   INDICATOR "CMakeLists.txt"
   URL "https://github.com/libsdl-org/SDL.git")
@@ -99,6 +95,10 @@ endif()
 
 # ImGui static library (required when editor is enabled)
 if(ENABLE_EDITOR)
+  mu_ensure_submodule("ThirdParty/imgui"
+    INDICATOR "imgui.cpp"
+    URL "https://github.com/ocornut/imgui.git")
+
   add_library(imgui STATIC
     "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/imgui.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/imgui_draw.cpp"


### PR DESCRIPTION
  Documentation cleanup in two areas:

  **README**
  - Submodule init section now lists all three submodules (`SDL`, `SDL_mixer`, `imgui`) and notes that CMake
   auto-inits them.
  - `imgui` is gated by `-DENABLE_EDITOR=ON`, not by Debug/Release.
  - Build Configurations section restructured: editor on/off (configure-time) and Debug/Release (build-time)
   are orthogonal. Stale `Global Debug` / `Global Release` labels dropped in favour of the actual preset
  names.

  **Coding Rules**
  - New rule 11 "Document Usage, Not Internals": usage-level docs for new/changed systems, with an exception
   for game/business logic and non-obvious calculations (drop rates, EXP curves, damage formulas).
  Encourages capturing rules on first contact since most are currently undocumented.