### PR TITLE
Add ENABLE_EDITOR matrix to MinGW CI workflows

### DIFF
--- a/.github/workflows/mingw-build-dev.yml
+++ b/.github/workflows/mingw-build-dev.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   build-mingw:
+    name: build-mingw (editor-${{ matrix.editor }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        editor: [OFF, ON]
 
     steps:
       - name: Checkout repository
@@ -54,6 +59,7 @@ jobs:
             -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}/cmake/toolchains/mingw-w64-i686.cmake" \
             -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_EDITOR=${{ matrix.editor }} \
             -DMU_TURBOJPEG_STATIC_LIB="${GITHUB_WORKSPACE}/_deps/mingw-i686/lib/libturbojpeg.a"
 
       - name: Build
@@ -63,6 +69,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: main-exe-mingw
+          name: main-exe-mingw-editor-${{ matrix.editor }}
           path: build-mingw/src/Main.exe
           if-no-files-found: error

--- a/.github/workflows/mingw-build-pr.yml
+++ b/.github/workflows/mingw-build-pr.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   build-mingw:
+    name: build-mingw (editor-${{ matrix.editor }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        editor: [OFF, ON]
     env:
       WINEDEBUG: -all
       WINEPREFIX: ${{ github.workspace }}/.wineprefix
@@ -63,6 +68,7 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}/cmake/toolchains/mingw-w64-i686.cmake" \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
+            -DENABLE_EDITOR=${{ matrix.editor }} \
             -DMU_TURBOJPEG_STATIC_LIB="${GITHUB_WORKSPACE}/_deps/mingw-i686/lib/libturbojpeg.a"
 
       - name: Build

--- a/.github/workflows/mingw-build.yml
+++ b/.github/workflows/mingw-build.yml
@@ -7,8 +7,14 @@ on:
 
 jobs:
   build-mingw:
+    name: build-mingw (editor-${{ matrix.editor }})
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        editor: [OFF, ON]
+
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -54,6 +60,7 @@ jobs:
             -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}/cmake/toolchains/mingw-w64-i686.cmake" \
             -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_EDITOR=${{ matrix.editor }} \
             -DMU_TURBOJPEG_STATIC_LIB="${GITHUB_WORKSPACE}/_deps/mingw-i686/lib/libturbojpeg.a"
       
       - name: Build
@@ -63,6 +70,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: main-exe-mingw
+          name: main-exe-mingw-editor-${{ matrix.editor }}
           path: build-mingw/src/Main.exe
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- Toggling `ENABLE_EDITOR` changes a large amount of compiled code (MuEditor sources, ImGui static lib, link order) but CI only covered the OFF case.
- Add a `editor: [OFF, ON]` matrix to all three MinGW workflows (`mingw-build.yml`, `mingw-build-dev.yml`, `mingw-build-pr.yml`) so both variants build in parallel on every push/PR.
- Rename uploaded artifacts in the dev and main workflows with an `-editor-OFF` / `-editor-ON` suffix to keep them distinct.

## Test plan
- [x] First push to this branch runs both `build-mingw (editor-OFF)` and `build-mingw (editor-ON)` jobs concurrently
- [x] Both jobs share the libjpeg-turbo cache entry (cache key is unchanged)
- [x] `editor-ON` job initializes the ImGui submodule during configure via `mu_ensure_submodule`
- [x] PR run executes `ctest` for both matrix variants