### PR TITLE
Translate camera and MU Helper help-screen hotkeys

### DIFF
--- a/src/Localization/Game.de.resx
+++ b/src/Localization/Game.de.resx
@@ -496,6 +496,18 @@
     <value>F4 : Größe des Chatfensters anpassen</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - 3D-Kamera umschalten</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - Kamera-Zoom sperren / entsperren</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - Kameraansicht zurücksetzen</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - MU Helper umschalten</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Geben Sie ein: Chat-Modus</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.en.resx
+++ b/src/Localization/Game.en.resx
@@ -496,6 +496,18 @@
     <value>F4 : Adjust Chat Window size</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - Toggle 3D Camera</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - Lock / Unlock Camera Zoom</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - Reset Camera View</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - Toggle MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Enter: Chatting Mode</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.es.resx
+++ b/src/Localization/Game.es.resx
@@ -496,6 +496,18 @@
     <value>F4: Ajustar el tamaño de la ventana de chat</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - Alternar cámara 3D</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - Bloquear / Desbloquear zoom de cámara</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - Restablecer vista de cámara</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - Alternar MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Ingrese: Modo de chat</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.id.resx
+++ b/src/Localization/Game.id.resx
@@ -496,6 +496,18 @@
     <value>F4 : Sesuaikan ukuran Jendela Obrolan</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - Alihkan Kamera 3D</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - Kunci / Buka Kunci Zoom Kamera</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - Atur Ulang Tampilan Kamera</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - Alihkan MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Masuk: Mode Obrolan</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.pl.resx
+++ b/src/Localization/Game.pl.resx
@@ -496,6 +496,18 @@
     <value>F4: Dostosuj rozmiar okna czatu</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - Przełącz kamerę 3D</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - Zablokuj / Odblokuj przybliżenie kamery</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - Zresetuj widok kamery</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - Przełącz MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Wejdź: Tryb czatu</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.pt.resx
+++ b/src/Localization/Game.pt.resx
@@ -496,6 +496,18 @@
     <value>F4: Ajustar o tamanho da janela de bate-papo</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - Alternar câmera 3D</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - Bloquear / Desbloquear zoom da câmera</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - Redefinir visão da câmera</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - Alternar MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Entre: modo de bate-papo</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.ru.resx
+++ b/src/Localization/Game.ru.resx
@@ -496,6 +496,18 @@
     <value>F4: настроить размер окна чата.</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - Переключить 3D-камеру</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - Заблокировать / Разблокировать масштаб камеры</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - Сбросить вид камеры</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - Переключить MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Войдите: режим чата</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.tl.resx
+++ b/src/Localization/Game.tl.resx
@@ -496,6 +496,18 @@
     <value>F4 : Ayusin ang laki ng Chat Window</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - I-toggle ang 3D Camera</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - I-lock / I-unlock ang Camera Zoom</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - I-reset ang Camera View</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - I-toggle ang MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Pumasok: Chatting Mode</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.uk.resx
+++ b/src/Localization/Game.uk.resx
@@ -496,6 +496,18 @@
     <value>F4 : Налаштувати розмір вікна чату</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - Перемкнути 3D-камеру</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - Заблокувати / Розблокувати масштаб камери</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - Скинути вигляд камери</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - Перемкнути MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>Вхід: Режим чату</value>
     <comment>legacy_id=125</comment>

--- a/src/Localization/Game.zh-TW.resx
+++ b/src/Localization/Game.zh-TW.resx
@@ -496,6 +496,18 @@
     <value>F4 : 調整聊天視窗大小</value>
     <comment>legacy_id=124</comment>
   </data>
+  <data name="F9 - Toggle 3D Camera" xml:space="preserve">
+    <value>F9 - 切換 3D 攝影機</value>
+  </data>
+  <data name="F10 - Lock / Unlock Camera Zoom" xml:space="preserve">
+    <value>F10 - 鎖定 / 解鎖攝影機縮放</value>
+  </data>
+  <data name="F11 - Reset Camera View" xml:space="preserve">
+    <value>F11 - 重置攝影機視角</value>
+  </data>
+  <data name="Home - Toggle MU Helper" xml:space="preserve">
+    <value>Home - 切換 MU Helper</value>
+  </data>
   <data name="Enter: Chatting Mode" xml:space="preserve">
     <value>進入：聊天模式</value>
     <comment>legacy_id=125</comment>

--- a/src/source/UI/NewUI/Dialogs/NewUIHelpWindow.cpp
+++ b/src/source/UI/NewUI/Dialogs/NewUIHelpWindow.cpp
@@ -10,19 +10,6 @@
 
 using namespace SEASON3B;
 
-namespace
-{
-    // Engine-only help-text entries. These three lines describe debug camera
-    // hotkeys that the original game didn't ship with, so they live outside
-    // the resx-driven translation pipeline; they're rendered as-is in the
-    // F1 help panel.
-    constexpr const wchar_t* kCustomHelpLines[] = {
-        L"F9 - Toggle 3D Camera",
-        L"F10 - Lock / Unlock Camera Zoom",
-        L"F11 - Reset Camera View",
-    };
-}
-
 SEASON3B::CNewUIHelpWindow::CNewUIHelpWindow()
 {
     m_pNewUIMng = NULL;
@@ -142,8 +129,15 @@ bool SEASON3B::CNewUIHelpWindow::Render()
             iTextNum++;
         }
 
-        // Insert engine-added F9 / F10 / F11 entries between F4 and the rest.
-        for (const wchar_t* line : kCustomHelpLines)
+        // Insert engine-added camera and MU Helper hotkey entries between F4
+        // and the rest of the shipped entries.
+        const wchar_t* const extraHelpLines[] = {
+            I18N::Game::F9Toggle3DCamera,
+            I18N::Game::F10LockUnlockCameraZoom,
+            I18N::Game::F11ResetCameraView,
+            I18N::Game::HomeToggleMUHelper,
+        };
+        for (const wchar_t* line : extraHelpLines)
         {
             wcsncpy_s(TextList[iTextNum], line, 99);
             TextListColor[iTextNum] = TEXT_COLOR_WHITE;


### PR DESCRIPTION
The F1 help screen had three engine-injected camera hotkey lines (F9 / F10 / F11) hardcoded in English in NewUIHelpWindow.cpp, plus no entry at all for the Home key MU Helper toggle. Move all four lines into Game.*.resx so they participate in the resx translation pipeline, and render them via the generated I18N::Game accessors.
