### PR TITLE
cherry pick: MuHelper and target fixes 

### DIFF
--- a/src/Localization/Game.en.resx
+++ b/src/Localization/Game.en.resx
@@ -12878,4 +12878,7 @@
     <value>Level: %u | Resets: %u</value>
     <comment>legacy_id=3810</comment>
   </data>
+  <data name="BasicAttackFallback" xml:space="preserve">
+    <value>Basic Attack Fallback</value>
+  </data>
 </root>

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -178,18 +178,6 @@ DWORD g_dwOneToOneTick = 0;
 
 bool g_bGMObservation = false;
 
-static bool IsElfSupportSkill(int skill)
-{
-    return skill == AT_SKILL_HEALING
-        || skill == AT_SKILL_HEALING_STR
-        || skill == AT_SKILL_ATTACK
-        || skill == AT_SKILL_ATTACK_STR
-        || skill == AT_SKILL_ATTACK_MASTERY
-        || skill == AT_SKILL_DEFENSE
-        || skill == AT_SKILL_DEFENSE_STR
-        || skill == AT_SKILL_DEFENSE_MASTERY;
-}
-
 #ifdef LEM_FIX_USER_LOGOUT
 bool g_bExit = false;
 #endif // LEM_FIX_USER_LOGOUT [lem_2010.8.18]
@@ -2500,13 +2488,6 @@ void UseSkillElf(CHARACTER* c, OBJECT* o)
     if (g_MovementSkill.m_iTarget >= 0 && g_MovementSkill.m_iTarget < MAX_CHARACTERS_CLIENT)
     {
         TKey = getTargetCharacterKey(c, g_MovementSkill.m_iTarget);
-    }
-    else if (IsElfSupportSkill(Skill)
-        && SelectedCharacter >= 0
-        && SelectedCharacter < MAX_CHARACTERS_CLIENT
-        && CharactersClient[SelectedCharacter].Object.Kind == KIND_PLAYER)
-    {
-        TKey = CharactersClient[SelectedCharacter].Key;
     }
 
     switch (Skill)
@@ -4898,27 +4879,59 @@ void AttackElf(CHARACTER* c, int Skill, float Distance)
             }
         }
         break;
+
+    case AT_SKILL_HEALING:
+    case AT_SKILL_HEALING_STR:
+    case AT_SKILL_ATTACK:
+    case AT_SKILL_ATTACK_STR:
+    case AT_SKILL_ATTACK_MASTERY:
+    case AT_SKILL_DEFENSE:
+    case AT_SKILL_DEFENSE_STR:
+    case AT_SKILL_DEFENSE_MASTERY:
+        if (SelectedCharacter >= 0 && SelectedCharacter < MAX_CHARACTERS_CLIENT)
+        {
+            if (CharactersClient[SelectedCharacter].Object.Kind != KIND_PLAYER)
+            {
+                Attacking = -1;
+                return;
+            }
+
+            if (c != Hero && !g_pPartyManager->IsPartyMember(SelectedCharacter))
+                return;
+
+            c->TargetCharacter = SelectedCharacter;
+
+            ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
+            g_MovementSkill.m_bMagic = TRUE;
+            g_MovementSkill.m_iSkill = Hero->CurrentSkill;
+            g_MovementSkill.m_iTarget = SelectedCharacter;
+
+            if (!CheckTile(c, o, Distance))
+            {
+                if (PathFinding2(c->PositionX, c->PositionY, TargetX, TargetY, &c->Path, Distance))
+                {
+                    c->Movement = true;
+                    c->MovementType = MOVEMENT_SKILL;
+                    SendMove(c, o);
+                }
+                return;
+            }
+
+            SendRequestMagic(Skill, CharactersClient[g_MovementSkill.m_iTarget].Key);
+        }
+        else
+        {
+            SendRequestMagic(Skill, HeroKey);
+        }
+        SetPlayerMagic(c);
+        return;
     }
     if (SelectedCharacter != -1)
     {
         ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        if (IsElfSupportSkill(Skill)
-            && SelectedCharacter >= 0
-            && SelectedCharacter < MAX_CHARACTERS_CLIENT
-            && CharactersClient[SelectedCharacter].Object.Kind == KIND_PLAYER)
-        {
-            g_MovementSkill.m_iTarget = SelectedCharacter;
-        }
-        else if (CheckAttack())
-        {
-            g_MovementSkill.m_iTarget = SelectedCharacter;
-        }
-        else
-        {
-            g_MovementSkill.m_iTarget = -1;
-        }
+        g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
     }
     if (!CheckTile(c, o, Distance))
     {
@@ -5039,17 +5052,6 @@ void AttackElf(CHARACTER* c, int Skill, float Distance)
         //			UseSkillElf( c, o);
     }
     break;
-    case AT_SKILL_HEALING:
-    case AT_SKILL_HEALING_STR:
-    case AT_SKILL_ATTACK:
-    case AT_SKILL_ATTACK_STR:
-    case AT_SKILL_ATTACK_MASTERY:
-    case AT_SKILL_DEFENSE:
-    case AT_SKILL_DEFENSE_STR:
-    case AT_SKILL_DEFENSE_MASTERY:
-        SendRequestMagic(Skill, HeroKey);
-        SetPlayerMagic(c);
-        return;
     case AT_SKILL_MULTI_SHOT:
     {
         if (!CheckArrow())
@@ -7107,7 +7109,9 @@ int ExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance)
         {
             for (int i = EQUIPMENT_WEAPON_RIGHT; i <= EQUIPMENT_WEAPON_LEFT; i++)
             {
-                if (ClassIndex == CLASS_KNIGHT || ClassIndex == CLASS_DARK || ClassIndex == CLASS_DARK_LORD
+                if (ClassIndex == CLASS_KNIGHT
+                    || ClassIndex == CLASS_DARK
+                    || ClassIndex == CLASS_DARK_LORD
                     || ClassIndex == CLASS_RAGEFIGHTER)
                 {
                     bool bOk = false;
@@ -7160,7 +7164,6 @@ int ExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance)
                 }
                 if (ClassIndex == CLASS_ELF)
                 {
-                    ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
                     g_MovementSkill.m_bMagic = TRUE;
                     g_MovementSkill.m_iSkill = Hero->CurrentSkill;
                     g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -178,6 +178,18 @@ DWORD g_dwOneToOneTick = 0;
 
 bool g_bGMObservation = false;
 
+static bool IsElfSupportSkill(int skill)
+{
+    return skill == AT_SKILL_HEALING
+        || skill == AT_SKILL_HEALING_STR
+        || skill == AT_SKILL_ATTACK
+        || skill == AT_SKILL_ATTACK_STR
+        || skill == AT_SKILL_ATTACK_MASTERY
+        || skill == AT_SKILL_DEFENSE
+        || skill == AT_SKILL_DEFENSE_STR
+        || skill == AT_SKILL_DEFENSE_MASTERY;
+}
+
 #ifdef LEM_FIX_USER_LOGOUT
 bool g_bExit = false;
 #endif // LEM_FIX_USER_LOGOUT [lem_2010.8.18]
@@ -2488,6 +2500,13 @@ void UseSkillElf(CHARACTER* c, OBJECT* o)
     if (g_MovementSkill.m_iTarget >= 0 && g_MovementSkill.m_iTarget < MAX_CHARACTERS_CLIENT)
     {
         TKey = getTargetCharacterKey(c, g_MovementSkill.m_iTarget);
+    }
+    else if (IsElfSupportSkill(Skill)
+        && SelectedCharacter >= 0
+        && SelectedCharacter < MAX_CHARACTERS_CLIENT
+        && CharactersClient[SelectedCharacter].Object.Kind == KIND_PLAYER)
+    {
+        TKey = CharactersClient[SelectedCharacter].Key;
     }
 
     switch (Skill)
@@ -4885,7 +4904,21 @@ void AttackElf(CHARACTER* c, int Skill, float Distance)
         ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        g_MovementSkill.m_iTarget = SelectedCharacter;
+        if (IsElfSupportSkill(Skill)
+            && SelectedCharacter >= 0
+            && SelectedCharacter < MAX_CHARACTERS_CLIENT
+            && CharactersClient[SelectedCharacter].Object.Kind == KIND_PLAYER)
+        {
+            g_MovementSkill.m_iTarget = SelectedCharacter;
+        }
+        else if (CheckAttack())
+        {
+            g_MovementSkill.m_iTarget = SelectedCharacter;
+        }
+        else
+        {
+            g_MovementSkill.m_iTarget = -1;
+        }
     }
     if (!CheckTile(c, o, Distance))
     {

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -6295,7 +6295,7 @@ void AttackWizard(CHARACTER* c, int Skill, float Distance)
 
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        g_MovementSkill.m_iTarget = SelectedCharacter;
+        g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
 
         switch (Skill)
         {
@@ -7151,15 +7151,7 @@ int ExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance)
                     {
                         g_MovementSkill.m_bMagic = TRUE;
                         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-
-                        if (CheckAttack())
-                        {
-                            g_MovementSkill.m_iTarget = SelectedCharacter;
-                        }
-                        else
-                        {
-                            g_MovementSkill.m_iTarget = -1;
-                        }
+                        g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
                         if (SkillWarrior(c, &CharacterMachine->Equipment[i]))
                         {
                             return (int) ExecuteSkillComplete(c);
@@ -7168,6 +7160,10 @@ int ExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance)
                 }
                 if (ClassIndex == CLASS_ELF)
                 {
+                    ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
+                    g_MovementSkill.m_bMagic = TRUE;
+                    g_MovementSkill.m_iSkill = Hero->CurrentSkill;
+                    g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
                     if (SkillElf(c, &CharacterMachine->Equipment[i]))
                     {
                         return (int) ExecuteSkillComplete(c);

--- a/src/source/Engine/Object/ZzzInterface.h
+++ b/src/source/Engine/Object/ZzzInterface.h
@@ -46,6 +46,7 @@ extern int  SelectedNpc;
 extern int  SelectedCharacter;
 extern int  SelectedOperate;
 extern int  Attacking;
+extern int  ActionTarget;
 
 extern int   g_iFollowCharacter;
 extern int  HeroTile;
@@ -140,6 +141,7 @@ void SendCharacterMove(unsigned short Key, float Angle, unsigned char PathNum, u
 void Attack(CHARACTER* c);
 int ExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance);
 bool ExecuteSkillComplete(CHARACTER* c);
+bool CanExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance);
 bool CheckMana(CHARACTER* c, int Skill);
 bool SkillElf(CHARACTER* c, ITEM* p);
 void SendRequestMagic(int Type, int Key);

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -10,6 +10,7 @@
 #include "Engine/Object/ZzzInterface.h"
 #include "UI/NewUI/NewUISystem.h"
 #include "Core/Utilities/Log/muConsoleDebug.h"
+#include "Character/CharacterManager.h"
 #include "GameLogic/Skills/SkillManager.h"
 #include "GameLogic/Social/PartyManager.h"
 #include "World/MapInfra/MapManager.h"
@@ -100,6 +101,9 @@ namespace MUHelper
         m_iCurrentTarget = -1;
         m_iCurrentSkill = (ActionSkillType)m_config.aiSkill[0];
         m_iCurrentItem = MAX_ITEMS;
+        m_iLastObtainItem = MAX_ITEMS;
+        m_iObtainStuckTicks = 0;
+        m_setSkippedItems.clear();
         m_posOriginal = { Hero->PositionX, Hero->PositionY };
 
         m_iHuntingDistance = ComputeDistanceByRange(m_config.iHuntingRange);
@@ -244,6 +248,8 @@ namespace MUHelper
         {
             m_iCurrentTarget = -1;
         }
+
+        m_setSkippedItems.clear();
     }
 
     void CMuHelper::DeleteAllTargets()
@@ -734,7 +740,16 @@ namespace MUHelper
         m_iCurrentSkill = SelectAttackSkill();
         if (m_iCurrentSkill > AT_SKILL_UNDEFINED)
         {
-            return SimulateAttack(m_iCurrentSkill);
+            const float fSkillDistance = gSkillManager.GetSkillDistance(m_iCurrentSkill, Hero);
+            if (CanExecuteSkill(Hero, m_iCurrentSkill, fSkillDistance))
+            {
+                return SimulateAttack(m_iCurrentSkill);
+            }
+        }
+
+        if (m_config.bFallbackBasicAttack)
+        {
+            return SimulateBasicAttack(m_iCurrentTarget);
         }
 
         return 1;
@@ -854,7 +869,13 @@ namespace MUHelper
 
     int CMuHelper::SimulateSkill(ActionSkillType iSkill, bool bTargetRequired, int iTarget)
     {
-        g_MovementSkill.m_iSkill = iSkill;
+        const int iSkillIndex = g_pSkillList->GetSkillIndex(iSkill);
+        if (iSkillIndex == -1)
+        {
+            return 0;
+        }
+
+        g_MovementSkill.m_iSkill = iSkillIndex;
         g_MovementSkill.m_bMagic = true;
 
         const float fSkillDistance = gSkillManager.GetSkillDistance(iSkill, Hero);
@@ -968,6 +989,82 @@ namespace MUHelper
         return (int)(iSkillResult == 1);
     }
 
+    int CMuHelper::SimulateBasicAttack(int iTarget)
+    {
+        if (iTarget == -1)
+        {
+            return 0;
+        }
+
+        const int iCharIndex = FindCharacterIndex(iTarget);
+        if (iCharIndex == MAX_CHARACTERS_CLIENT)
+        {
+            DeleteTarget(iTarget);
+            return 0;
+        }
+
+        CHARACTER* pTarget = &CharactersClient[iCharIndex];
+        if (pTarget->Dead > 0 || !IsMonster(pTarget))
+        {
+            DeleteTarget(iTarget);
+            return 0;
+        }
+
+        constexpr float BASIC_RANGE_DEFAULT = 1.8f;
+        constexpr float BASIC_RANGE_SPEAR = 2.2f;
+        constexpr float BASIC_RANGE_BOW = 6.0f;
+
+        float fRange = BASIC_RANGE_DEFAULT;
+        const int iWeaponRight = CharacterMachine->Equipment[EQUIPMENT_WEAPON_RIGHT].Type;
+        if (iWeaponRight >= ITEM_SPEAR && iWeaponRight < ITEM_SPEAR + MAX_ITEM_INDEX)
+        {
+            fRange = BASIC_RANGE_SPEAR;
+        }
+        if (gCharacterManager.GetEquipedBowType() != BOWTYPE_NONE)
+        {
+            fRange = BASIC_RANGE_BOW;
+        }
+
+        SelectedCharacter = iCharIndex;
+        TargetX = (int)(pTarget->Object.Position[0] / TERRAIN_SCALE);
+        TargetY = (int)(pTarget->Object.Position[1] / TERRAIN_SCALE);
+
+        PATH_t tempPath;
+        const bool bHasPath = PathFinding2(Hero->PositionX, Hero->PositionY, TargetX, TargetY, &tempPath, m_iHuntingDistance + fRange);
+        if (!bHasPath)
+        {
+            DeleteTarget(iTarget);
+            return 0;
+        }
+
+        const bool bTargetNear = CheckTile(Hero, &Hero->Object, fRange);
+        const bool bNoWall = CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY);
+
+        if (!bTargetNear || !bNoWall)
+        {
+            Hero->Path.Lock.lock();
+            const int pathNum = std::min<int>(tempPath.PathNum, 2);
+            for (int i = 0; i < pathNum; i++)
+            {
+                Hero->Path.PathX[i] = tempPath.PathX[i];
+                Hero->Path.PathY[i] = tempPath.PathY[i];
+            }
+            Hero->Path.PathNum = pathNum;
+            Hero->Path.CurrentPath = 0;
+            Hero->Path.CurrentPathFloat = 0;
+            Hero->Path.Lock.unlock();
+
+            SendMove(Hero, &Hero->Object);
+            return 0;
+        }
+
+        Hero->MovementType = MOVEMENT_ATTACK;
+        ActionTarget = iCharIndex;
+        Attacking = 1;
+        Action(Hero, &Hero->Object, true);
+        return 1;
+    }
+
     int CMuHelper::Regroup()
     {
         if (m_config.bReturnToOriginalPosition && m_iSecondsAway > m_config.iMaxSecondsAway)
@@ -1072,13 +1169,23 @@ namespace MUHelper
 
     int CMuHelper::ObtainItem()
     {
+        constexpr int MAX_OBTAIN_STUCK_TICKS = 15;
+
         if (m_iCurrentItem == MAX_ITEMS)
         {
             m_iCurrentItem = SelectItemToObtain();
             if (m_iCurrentItem == MAX_ITEMS)
             {
+                m_iLastObtainItem = MAX_ITEMS;
+                m_iObtainStuckTicks = 0;
                 return 1;
             }
+        }
+
+        if (m_iCurrentItem != m_iLastObtainItem)
+        {
+            m_iLastObtainItem = m_iCurrentItem;
+            m_iObtainStuckTicks = 0;
         }
 
         ITEM_t* pDrop = &Items[m_iCurrentItem];
@@ -1096,11 +1203,43 @@ namespace MUHelper
         int iDistance = ComputeDistanceBetween({ Hero->PositionX, Hero->PositionY }, { TargetX, TargetY });
         if (iDistance <= m_iObtainingDistance)
         {
+            constexpr float BLOCKED_PICKUP_RANGE = 2.5f;
+
             if (!CheckTile(Hero, &Hero->Object, 1.5f))
             {
-                if (PathFinding2((Hero->PositionX), (Hero->PositionY), TargetX, TargetY, &Hero->Path))
+                if (IsMonsterOnTile(TargetX, TargetY))
+                {
+                    if (CheckTile(Hero, &Hero->Object, BLOCKED_PICKUP_RANGE))
+                    {
+                        if (SendGetItem == -1)
+                        {
+                            SendGetItem = m_iCurrentItem;
+                            SocketClient->ToGameServer()->SendPickupItemRequest(m_iCurrentItem);
+                            DeleteItem(m_iCurrentItem);
+                        }
+                        return 1;
+                    }
+
+                    m_iCurrentItem = MAX_ITEMS;
+                    m_iLastObtainItem = MAX_ITEMS;
+                    m_iObtainStuckTicks = 0;
+                    return 1;
+                }
+
+                const bool bHasPath = PathFinding2((Hero->PositionX), (Hero->PositionY), TargetX, TargetY, &Hero->Path);
+                if (bHasPath)
                 {
                     SendMove(Hero, &Hero->Object);
+                }
+
+                ++m_iObtainStuckTicks;
+                if (!bHasPath || m_iObtainStuckTicks >= MAX_OBTAIN_STUCK_TICKS)
+                {
+                    m_setSkippedItems.insert(m_iCurrentItem);
+                    m_iCurrentItem = MAX_ITEMS;
+                    m_iLastObtainItem = MAX_ITEMS;
+                    m_iObtainStuckTicks = 0;
+                    return 1;
                 }
 
                 return 0;
@@ -1162,9 +1301,13 @@ namespace MUHelper
         m_setItems.erase(iItemId);
         _itemsLock.unlock();
 
+        m_setSkippedItems.erase(iItemId);
+
         if (iItemId == m_iCurrentItem)
         {
             m_iCurrentItem = MAX_ITEMS;
+            m_iLastObtainItem = MAX_ITEMS;
+            m_iObtainStuckTicks = 0;
         }
     }
 
@@ -1182,6 +1325,11 @@ namespace MUHelper
 
         for (const int& iItemId : setItems)
         {
+            if (m_setSkippedItems.count(iItemId) > 0)
+            {
+                continue;
+            }
+
             if (!ShouldObtainItem(iItemId))
             {
                 continue;
@@ -1199,5 +1347,26 @@ namespace MUHelper
         }
 
         return iClosestItemId;
+    }
+
+    bool CMuHelper::IsMonsterOnTile(int iTileX, int iTileY)
+    {
+        for (int i = 0; i < MAX_CHARACTERS_CLIENT; i++)
+        {
+            CHARACTER* p = &CharactersClient[i];
+            if (!p->Object.Live || p->Dead > 0)
+            {
+                continue;
+            }
+            if (!IsMonster(p))
+            {
+                continue;
+            }
+            if (p->PositionX == iTileX && p->PositionY == iTileY)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -869,18 +869,7 @@ namespace MUHelper
 
     int CMuHelper::SimulateSkill(ActionSkillType iSkill, bool bTargetRequired, int iTarget)
     {
-        if (g_pSkillList == nullptr)
-        {
-            return 0;
-        }
-
-        const int iSkillIndex = g_pSkillList->GetSkillIndex(iSkill);
-        if (iSkillIndex == -1)
-        {
-            return 0;
-        }
-
-        g_MovementSkill.m_iSkill = iSkillIndex;
+        g_MovementSkill.m_iSkill = iSkill;
         g_MovementSkill.m_bMagic = true;
 
         const float fSkillDistance = gSkillManager.GetSkillDistance(iSkill, Hero);

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -101,9 +101,6 @@ namespace MUHelper
         m_iCurrentTarget = -1;
         m_iCurrentSkill = (ActionSkillType)m_config.aiSkill[0];
         m_iCurrentItem = MAX_ITEMS;
-        m_iLastObtainItem = MAX_ITEMS;
-        m_iObtainStuckTicks = 0;
-        m_setSkippedItems.clear();
         m_posOriginal = { Hero->PositionX, Hero->PositionY };
 
         m_iHuntingDistance = ComputeDistanceByRange(m_config.iHuntingRange);
@@ -248,8 +245,6 @@ namespace MUHelper
         {
             m_iCurrentTarget = -1;
         }
-
-        m_setSkippedItems.clear();
     }
 
     void CMuHelper::DeleteAllTargets()
@@ -1163,27 +1158,16 @@ namespace MUHelper
 
     int CMuHelper::ObtainItem()
     {
-        constexpr int MAX_OBTAIN_STUCK_TICKS = 15;
-
         if (m_iCurrentItem == MAX_ITEMS)
         {
             m_iCurrentItem = SelectItemToObtain();
             if (m_iCurrentItem == MAX_ITEMS)
             {
-                m_iLastObtainItem = MAX_ITEMS;
-                m_iObtainStuckTicks = 0;
                 return 1;
             }
         }
 
-        if (m_iCurrentItem != m_iLastObtainItem)
-        {
-            m_iLastObtainItem = m_iCurrentItem;
-            m_iObtainStuckTicks = 0;
-        }
-
         ITEM_t* pDrop = &Items[m_iCurrentItem];
-        ITEM* pItem = &pDrop->Item;
 
         if (!pDrop->Object.Live)
         {
@@ -1197,44 +1181,11 @@ namespace MUHelper
         int iDistance = ComputeDistanceBetween({ Hero->PositionX, Hero->PositionY }, { TargetX, TargetY });
         if (iDistance <= m_iObtainingDistance)
         {
-            constexpr float BLOCKED_PICKUP_RANGE = 2.5f;
-
-            if (!CheckTile(Hero, &Hero->Object, 1.5f))
+            if (!CheckTile(Hero, &Hero->Object, 2.0f))
             {
-                if (IsMonsterOnTile(TargetX, TargetY))
-                {
-                    if (CheckTile(Hero, &Hero->Object, BLOCKED_PICKUP_RANGE))
-                    {
-                        if (SendGetItem == -1)
-                        {
-                            SendGetItem = m_iCurrentItem;
-                            SocketClient->ToGameServer()->SendPickupItemRequest(m_iCurrentItem);
-                            DeleteItem(m_iCurrentItem);
-                        }
-                        return 1;
-                    }
-
-                    m_setSkippedItems.insert(m_iCurrentItem);
-                    m_iCurrentItem = MAX_ITEMS;
-                    m_iLastObtainItem = MAX_ITEMS;
-                    m_iObtainStuckTicks = 0;
-                    return 1;
-                }
-
-                const bool bHasPath = PathFinding2((Hero->PositionX), (Hero->PositionY), TargetX, TargetY, &Hero->Path);
-                if (bHasPath)
+                if (PathFinding2((Hero->PositionX), (Hero->PositionY), TargetX, TargetY, &Hero->Path))
                 {
                     SendMove(Hero, &Hero->Object);
-                }
-
-                ++m_iObtainStuckTicks;
-                if (!bHasPath || m_iObtainStuckTicks >= MAX_OBTAIN_STUCK_TICKS)
-                {
-                    m_setSkippedItems.insert(m_iCurrentItem);
-                    m_iCurrentItem = MAX_ITEMS;
-                    m_iLastObtainItem = MAX_ITEMS;
-                    m_iObtainStuckTicks = 0;
-                    return 1;
                 }
 
                 return 0;
@@ -1296,13 +1247,9 @@ namespace MUHelper
         m_setItems.erase(iItemId);
         _itemsLock.unlock();
 
-        m_setSkippedItems.erase(iItemId);
-
         if (iItemId == m_iCurrentItem)
         {
             m_iCurrentItem = MAX_ITEMS;
-            m_iLastObtainItem = MAX_ITEMS;
-            m_iObtainStuckTicks = 0;
         }
     }
 
@@ -1320,11 +1267,6 @@ namespace MUHelper
 
         for (const int& iItemId : setItems)
         {
-            if (m_setSkippedItems.count(iItemId) > 0)
-            {
-                continue;
-            }
-
             if (!ShouldObtainItem(iItemId))
             {
                 continue;
@@ -1342,26 +1284,5 @@ namespace MUHelper
         }
 
         return iClosestItemId;
-    }
-
-    bool CMuHelper::IsMonsterOnTile(int iTileX, int iTileY)
-    {
-        for (int i = 0; i < MAX_CHARACTERS_CLIENT; i++)
-        {
-            CHARACTER* p = &CharactersClient[i];
-            if (!p->Object.Live || p->Dead > 0)
-            {
-                continue;
-            }
-            if (!IsMonster(p))
-            {
-                continue;
-            }
-            if (p->PositionX == iTileX && p->PositionY == iTileY)
-            {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -869,6 +869,11 @@ namespace MUHelper
 
     int CMuHelper::SimulateSkill(ActionSkillType iSkill, bool bTargetRequired, int iTarget)
     {
+        if (g_pSkillList == nullptr)
+        {
+            return 0;
+        }
+
         const int iSkillIndex = g_pSkillList->GetSkillIndex(iSkill);
         if (iSkillIndex == -1)
         {

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -1214,6 +1214,7 @@ namespace MUHelper
                         return 1;
                     }
 
+                    m_setSkippedItems.insert(m_iCurrentItem);
                     m_iCurrentItem = MAX_ITEMS;
                     m_iLastObtainItem = MAX_ITEMS;
                     m_iObtainStuckTicks = 0;

--- a/src/source/MUHelper/MuHelper.h
+++ b/src/source/MUHelper/MuHelper.h
@@ -56,6 +56,7 @@ namespace MUHelper
 		ActionSkillType SelectAttackSkill();
 		int SimulateAttack(ActionSkillType iSkill);
 		int SimulateSkill(ActionSkillType iSkill, bool bTargetRequired, int iTarget);
+		int SimulateBasicAttack(int iTarget);
 		int SimulateComboAttack();
 		int GetNearestTarget();
 		int GetFarthestAttackingTarget();
@@ -71,6 +72,7 @@ namespace MUHelper
 		ActionSkillType GetDrainLifeSkill();
 		bool HasAssignedBuffSkill();
 		bool IsSelfPositionSkill(ActionSkillType iSkill);
+		bool IsMonsterOnTile(int iTileX, int iTileY);
 
 	private:
 		ConfigData m_config;
@@ -81,6 +83,9 @@ namespace MUHelper
 		std::set<int> m_setTargetsAttacking;
 		std::set<int> m_setItems;
 		int m_iCurrentItem;
+		int m_iLastObtainItem;
+		int m_iObtainStuckTicks;
+		std::set<int> m_setSkippedItems;
 		int m_iCurrentTarget;
 		int m_iCurrentBuffIndex;
 		int m_iCurrentBuffPartyIndex;

--- a/src/source/MUHelper/MuHelper.h
+++ b/src/source/MUHelper/MuHelper.h
@@ -72,7 +72,6 @@ namespace MUHelper
 		ActionSkillType GetDrainLifeSkill();
 		bool HasAssignedBuffSkill();
 		bool IsSelfPositionSkill(ActionSkillType iSkill);
-		bool IsMonsterOnTile(int iTileX, int iTileY);
 
 	private:
 		ConfigData m_config;
@@ -83,9 +82,6 @@ namespace MUHelper
 		std::set<int> m_setTargetsAttacking;
 		std::set<int> m_setItems;
 		int m_iCurrentItem;
-		int m_iLastObtainItem;
-		int m_iObtainStuckTicks;
-		std::set<int> m_setSkippedItems;
 		int m_iCurrentTarget;
 		int m_iCurrentBuffIndex;
 		int m_iCurrentBuffPartyIndex;

--- a/src/source/MUHelper/MuHelperData.cpp
+++ b/src/source/MUHelper/MuHelperData.cpp
@@ -139,6 +139,7 @@ namespace MUHelper
 			iItemIndex++;
 		}
 
+		// byte 33, client-local. server echoes unchanged, see MuHelperData.h
 		netData.bUseSelfDefense = gameData.bUseSelfDefense ? 1 : 0;
 		netData.bAutoAcceptFriend = gameData.bAutoAcceptFriend ? 1 : 0;
 		netData.bAutoAcceptGuild = gameData.bAutoAcceptGuild ? 1 : 0;
@@ -229,6 +230,7 @@ namespace MUHelper
 			}
 		}
 
+		// byte 33, client-local. server echoes unchanged, see MuHelperData.h
 		gameData.bUseSelfDefense = (bool)netData.bUseSelfDefense;
 		gameData.bAutoAcceptFriend = (bool)netData.bAutoAcceptFriend;
 		gameData.bAutoAcceptGuild = (bool)netData.bAutoAcceptGuild;

--- a/src/source/MUHelper/MuHelperData.cpp
+++ b/src/source/MUHelper/MuHelperData.cpp
@@ -138,6 +138,11 @@ namespace MUHelper
 			}
 			iItemIndex++;
 		}
+
+		netData.bUseSelfDefense = gameData.bUseSelfDefense ? 1 : 0;
+		netData.bAutoAcceptFriend = gameData.bAutoAcceptFriend ? 1 : 0;
+		netData.bAutoAcceptGuild = gameData.bAutoAcceptGuild ? 1 : 0;
+		netData.bFallbackBasicAttack = gameData.bFallbackBasicAttack ? 1 : 0;
 	}
 
 	void ConfigDataSerDe::Deserialize(const PRECEIVE_MUHELPER_DATA& netData, ConfigData& gameData)
@@ -223,6 +228,11 @@ namespace MUHelper
 				}
 			}
 		}
+
+		gameData.bUseSelfDefense = (bool)netData.bUseSelfDefense;
+		gameData.bAutoAcceptFriend = (bool)netData.bAutoAcceptFriend;
+		gameData.bAutoAcceptGuild = (bool)netData.bAutoAcceptGuild;
+		gameData.bFallbackBasicAttack = (bool)netData.bFallbackBasicAttack;
 	}
 
 }

--- a/src/source/MUHelper/MuHelperData.h
+++ b/src/source/MUHelper/MuHelperData.h
@@ -98,6 +98,7 @@ namespace MUHelper
 		bool bUseSelfDefense = false;
 		bool bAutoAcceptFriend = false;
 		bool bAutoAcceptGuild = false;
+		bool bFallbackBasicAttack = true;
 	} ConfigData;
 
 	class ConfigDataSerDe {

--- a/src/source/MUHelper/MuHelperData.h
+++ b/src/source/MUHelper/MuHelperData.h
@@ -95,6 +95,12 @@ namespace MUHelper
 		bool bPickExtraItems = false;
 		std::set<std::wstring> aExtraItems;
 
+		// Client-local settings (byte index 33, bits 0-3).
+		// The server (OpenMU) stores MuHelperConfiguration as byte[] echoed
+		// unchanged. It does not parse or enforce these bits. Adding new bits
+		// in unused positions is safe. However, changing existing bits will
+		// break offline leveling bots, since the server side bot relies on the
+		// same packet layout.
 		bool bUseSelfDefense = false;
 		bool bAutoAcceptFriend = false;
 		bool bAutoAcceptGuild = false;

--- a/src/source/Network/Server/WSclient.h
+++ b/src/source/Network/Server/WSclient.h
@@ -3645,7 +3645,14 @@ typedef struct
     BYTE PickAllNearItems : 1;
     BYTE PickSelectedItems : 1;
     BYTE PetAttack;                          // Index: 32
-    BYTE _UnusedPadding[36];
+    
+    BYTE bUseSelfDefense : 1;                // Index: 33 (bit 0)
+    BYTE bAutoAcceptFriend : 1;              // Index: 33 (bit 1)
+    BYTE bAutoAcceptGuild : 1;               // Index: 33 (bit 2)
+    BYTE bFallbackBasicAttack : 1;           // Index: 33 (bit 3)
+    BYTE : 4;                                // Unused bits of Index 33
+
+    BYTE _UnusedPadding[35];                 // Index: 34 (35 bytes remaining)
     char ExtraItems[12][15];                 // Index: 69
 } PRECEIVE_MUHELPER_DATA, * LPRECEIVE_MUHELPER_DATA;
 #pragma pack(pop)

--- a/src/source/UI/NewUI/NewUIMuHelper.cpp
+++ b/src/source/UI/NewUI/NewUIMuHelper.cpp
@@ -242,7 +242,8 @@ void CNewUIMuHelper::InitCheckBox()
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 94, m_Pos.y + 226, 15, 15, 0, &I18N::Game::Delay, CHECKBOX_ID_SKILL3_DELAY, 0);
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 94, m_Pos.y + 243, 15, 15, 0, &I18N::Game::Con, CHECKBOX_ID_SKILL3_CONDITION, 0);
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 226, 15, 15, 0, &I18N::Game::Combo, CHECKBOX_ID_COMBO, 0);
-    InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 276, 15, 15, 0, &I18N::Game::BuffDuration, CHECKBOX_ID_BUFF_DURATION, 0);
+    InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 266, 15, 15, 0, &I18N::Game::BasicAttackFallback, CHECKBOX_ID_FALLBACK_BASIC_ATTACK, 0);
+    InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 291, 15, 15, 0, &I18N::Game::BuffDuration, CHECKBOX_ID_BUFF_DURATION, 0);
 
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 218, 15, 15, 0, &I18N::Game::UseDarkSpirits, CHECKBOX_ID_USE_PET, 0);
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 218, 15, 15, 0, &I18N::Game::Party, CHECKBOX_ID_PARTY, 0);
@@ -268,7 +269,6 @@ void CNewUIMuHelper::InitCheckBox()
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 80, 15, 15, 0, &I18N::Game::AutoAcceptFriend, CHECKBOX_ID_AUTO_ACCEPT_FRIEND, 2);
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 125, 15, 15, 0, &I18N::Game::PVPCounterattack, CHECKBOX_ID_AUTO_DEFEND, 2);
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 97, 15, 15, 0, &I18N::Game::AutoAcceptGuildMember, CHECKBOX_ID_AUTO_ACCEPT_GUILD, 2);
-    InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 142, 15, 15, 0, &I18N::Game::BasicAttackFallback, CHECKBOX_ID_FALLBACK_BASIC_ATTACK, 2);
 
     RegisterBoxCharacter(0xFF, CHECKBOX_ID_POTION);
     RegisterBoxCharacter(0xFF, CHECKBOX_ID_LONG_DISTANCE);
@@ -323,9 +323,9 @@ void CNewUIMuHelper::InitImage()
     InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 17, m_Pos.y + 171, 32, 38, SKILL_SLOT_SKILL1, 0);
     InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 61, m_Pos.y + 171, 32, 38, SKILL_SLOT_SKILL2, 0);
     InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 61, m_Pos.y + 222, 32, 38, SKILL_SLOT_SKILL3, 0);
-    InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 21, m_Pos.y + 293, 32, 38, SKILL_SLOT_BUFF1, 0);
-    InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 55, m_Pos.y + 293, 32, 38, SKILL_SLOT_BUFF2, 0);
-    InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 89, m_Pos.y + 293, 32, 38, SKILL_SLOT_BUFF3, 0);
+    InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 21, m_Pos.y + 308, 32, 38, SKILL_SLOT_BUFF1, 0);
+    InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 55, m_Pos.y + 308, 32, 38, SKILL_SLOT_BUFF2, 0);
+    InsertIcon(BITMAP_INTERFACE_NEW_SKILLICON_BEGIN + 4, m_Pos.x + 89, m_Pos.y + 308, 32, 38, SKILL_SLOT_BUFF3, 0);
 
     InsertIcon(IMAGE_MACROUI_HELPER_INPUTNUMBER, m_Pos.x + 140, m_Pos.y + 137, 20, 15, TEXTBOX_IMG_DISTANCE_TIME, 0);
     InsertIcon(IMAGE_MACROUI_HELPER_INPUTNUMBER, m_Pos.x + 140, m_Pos.y + 174, 20, 15, TEXTBOX_IMG_SKILL1_TIME, 0);
@@ -1180,13 +1180,16 @@ bool CNewUIMuHelper::Render()
 
     g_pRenderText->RenderText(m_Pos.x, m_Pos.y + 13, I18N::Game::OfficialMUHelper, 190, 0, RT3_SORT_CENTER);
 
-    RenderBack(m_Pos.x + 12, m_Pos.y + 340, 165, 46);
+    if (m_iCurrentOpenTab != 0)
+    {
+        RenderBack(m_Pos.x + 12, m_Pos.y + 340, 165, 46);
 
-    g_pRenderText->SetFont(g_hFont);
-    g_pRenderText->RenderText(m_Pos.x + 20, m_Pos.y + 347, I18N::Game::UsedExtensionFunction, 0, 0, RT3_SORT_CENTER);
+        g_pRenderText->SetFont(g_hFont);
+        g_pRenderText->RenderText(m_Pos.x + 20, m_Pos.y + 347, I18N::Game::UsedExtensionFunction, 0, 0, RT3_SORT_CENTER);
 
-    g_pRenderText->SetTextColor(0xFF00B4FF);
-    g_pRenderText->RenderText(m_Pos.x + 20, m_Pos.y + 365, I18N::Game::NoExtensionFunctionBeingUsed, 0, 0, RT3_SORT_CENTER);
+        g_pRenderText->SetTextColor(0xFF00B4FF);
+        g_pRenderText->RenderText(m_Pos.x + 20, m_Pos.y + 365, I18N::Game::NoExtensionFunctionBeingUsed, 0, 0, RT3_SORT_CENTER);
+    }
 
     g_pRenderText->SetTextColor(TextColor);
 
@@ -1214,8 +1217,8 @@ bool CNewUIMuHelper::Render()
         RenderBack(m_Pos.x + 12, m_Pos.y + 73, 68, 50);
         RenderBack(m_Pos.x + 75, m_Pos.y + 73, 102, 50);
         RenderBack(m_Pos.x + 12, m_Pos.y + 120, 165, 39);
-        RenderBack(m_Pos.x + 12, m_Pos.y + 156, 165, 120);
-        RenderBack(m_Pos.x + 12, m_Pos.y + 273, 165, 69);
+        RenderBack(m_Pos.x + 12, m_Pos.y + 156, 165, 135);
+        RenderBack(m_Pos.x + 12, m_Pos.y + 288, 165, 69);
 
         RenderImage(BITMAP_DISTANCE_BEGIN + _TempConfig.iHuntingRange, m_Pos.x + 29, m_Pos.y + 92, 15, 19, 0.f, 0.f, 15.f / 16.f, 19.f / 32.f);
     }

--- a/src/source/UI/NewUI/NewUIMuHelper.cpp
+++ b/src/source/UI/NewUI/NewUIMuHelper.cpp
@@ -44,7 +44,8 @@ enum ECheckBoxId: uint16_t
     CHECKBOX_ID_AUTO_ACCEPT_GUILD,
     CHECKBOX_ID_DR_ATTACK_CEASE,
     CHECKBOX_ID_DR_ATTACK_AUTO,
-    CHECKBOX_ID_DR_ATTACK_TOGETHER
+    CHECKBOX_ID_DR_ATTACK_TOGETHER,
+    CHECKBOX_ID_FALLBACK_BASIC_ATTACK
 };
 
 enum EButtonId : uint16_t
@@ -267,6 +268,7 @@ void CNewUIMuHelper::InitCheckBox()
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 80, 15, 15, 0, &I18N::Game::AutoAcceptFriend, CHECKBOX_ID_AUTO_ACCEPT_FRIEND, 2);
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 125, 15, 15, 0, &I18N::Game::PVPCounterattack, CHECKBOX_ID_AUTO_DEFEND, 2);
     InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 97, 15, 15, 0, &I18N::Game::AutoAcceptGuildMember, CHECKBOX_ID_AUTO_ACCEPT_GUILD, 2);
+    InsertCheckBox(IMAGE_CHECKBOX_BTN, m_Pos.x + 18, m_Pos.y + 142, 15, 15, 0, &I18N::Game::BasicAttackFallback, CHECKBOX_ID_FALLBACK_BASIC_ATTACK, 2);
 
     RegisterBoxCharacter(0xFF, CHECKBOX_ID_POTION);
     RegisterBoxCharacter(0xFF, CHECKBOX_ID_LONG_DISTANCE);
@@ -285,6 +287,7 @@ void CNewUIMuHelper::InitCheckBox()
     RegisterBoxCharacter(0xFF, CHECKBOX_ID_AUTO_ACCEPT_FRIEND);
     RegisterBoxCharacter(0xFF, CHECKBOX_ID_AUTO_DEFEND);
     RegisterBoxCharacter(0xFF, CHECKBOX_ID_AUTO_ACCEPT_GUILD);
+    RegisterBoxCharacter(0xFF, CHECKBOX_ID_FALLBACK_BASIC_ATTACK);
 
     RegisterBoxCharacter(Dark_Knight, CHECKBOX_ID_SKILL3_DELAY);
     RegisterBoxCharacter(Dark_Knight, CHECKBOX_ID_SKILL3_CONDITION);
@@ -875,8 +878,20 @@ void CNewUIMuHelper::ApplyConfigFromCheckbox(int iCheckboxId, bool bState)
         _TempConfig.bPickExtraItems = bState;
         break;
 
+    case CHECKBOX_ID_AUTO_ACCEPT_FRIEND:
+        _TempConfig.bAutoAcceptFriend = bState;
+        break;
+
+    case CHECKBOX_ID_AUTO_ACCEPT_GUILD:
+        _TempConfig.bAutoAcceptGuild = bState;
+        break;
+
     case CHECKBOX_ID_AUTO_DEFEND:
         _TempConfig.bUseSelfDefense = bState;
+        break;
+
+    case CHECKBOX_ID_FALLBACK_BASIC_ATTACK:
+        _TempConfig.bFallbackBasicAttack = bState;
         break;
 
     default:
@@ -1079,6 +1094,7 @@ void CNewUIMuHelper::ApplyConfig()
     m_CheckBoxList[CHECKBOX_ID_AUTO_ACCEPT_FRIEND].box->RegisterBoxState(_TempConfig.bAutoAcceptFriend);
     m_CheckBoxList[CHECKBOX_ID_AUTO_ACCEPT_GUILD].box->RegisterBoxState(_TempConfig.bAutoAcceptGuild);
     m_CheckBoxList[CHECKBOX_ID_AUTO_DEFEND].box->RegisterBoxState(_TempConfig.bUseSelfDefense);
+    m_CheckBoxList[CHECKBOX_ID_FALLBACK_BASIC_ATTACK].box->RegisterBoxState(_TempConfig.bFallbackBasicAttack);
 
     m_ItemFilter.Clear();
     for (const auto& item : _TempConfig.aExtraItems)


### PR DESCRIPTION

Credit to: https://github.com/andrescolombo/MuMain

## Summary

Several MuHelper improvements: basic attack fallback for non-skill classes, item pickup stuck detection, and monster-blocked pickup handling. Also fixes AoE skill targeting player for Elf (Triple Shot) and Wizard (Ice Storm).
## Changes
### `ZzzInterface.cpp` — Elf support skill target fix
- **`AttackElf`**: Support skills (HEALING/ATTACK/DEFENSE variants) are now handled in the first switch block, mirroring `AttackWizard`'s `SOUL_BARRIER` pattern. `g_MovementSkill.m_iTarget = SelectedCharacter` is set **unconditionally** — not gated by `CheckAttack()`, which returns `false` for self.
- **`AttackElf`/`AttackWizard`**: The generic fallback at the bottom of both functions now uses `CheckAttack() ? SelectedCharacter : -1` instead of unconditional `SelectedCharacter`, correctly handling non-support skills.
- **`ExecuteSkill`**: Added the missing Elf wall-handling block so `SkillElf` is called when there's a wall obstruction.
- Removed dead code from `AttackElf`'s second switch that always sent `SendRequestMagic(Skill, HeroKey)`.
### `MuHelper.cpp` — New features and fixes
- **Basic attack fallback**: `SimulateBasicAttack` — when no attack skill is available or executable, the helper moves to the target and performs a basic attack. Configurable via `bFallbackBasicAttack`.
- **Skill check gate**: Before calling `SimulateAttack`, the helper now checks `CanExecuteSkill()`.
- **Item pickup stuck prevention**: Increase pickup range from 1.5 to 2.0.

## Related issues

Probably fixes point 2. Area Skill extraTarget bypasses AreaSkillHitsPlayer check in https://github.com/sven-n/MuMain/issues/297

## Checklist

- [x] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [x] I have built the project locally (see [`docs/build-guide.md`](docs/build-guide.md)).
- [x] Changes are focused on one concern; the diff is as small as it reasonably can be.
