### PR TITLE
Fix: triple-shot and PrintPKLog

### DIFF
--- a/src/source/Engine/Object/ZzzCharacter.cpp
+++ b/src/source/Engine/Object/ZzzCharacter.cpp
@@ -4855,6 +4855,7 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
             case AT_SKILL_TRIPLE_SHOT_STR:
             case AT_SKILL_TRIPLE_SHOT_MASTERY:
                 CreateArrows(c, o, NULL, FindHotKey((c->Skill)), 1);
+                break;
             case AT_SKILL_PENETRATION:
             case AT_SKILL_PENETRATION_STR:
                 CreateArrows(c, o, NULL, FindHotKey((c->Skill)), 0, (c->Skill));

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -4885,7 +4885,7 @@ void AttackElf(CHARACTER* c, int Skill, float Distance)
         ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
+        g_MovementSkill.m_iTarget = SelectedCharacter;
     }
     if (!CheckTile(c, o, Distance))
     {
@@ -6262,7 +6262,7 @@ void AttackWizard(CHARACTER* c, int Skill, float Distance)
 
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
+        g_MovementSkill.m_iTarget = SelectedCharacter;
 
         switch (Skill)
         {
@@ -7135,10 +7135,6 @@ int ExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance)
                 }
                 if (ClassIndex == CLASS_ELF)
                 {
-                    ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
-                    g_MovementSkill.m_bMagic = TRUE;
-                    g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-                    g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
                     if (SkillElf(c, &CharacterMachine->Equipment[i]))
                     {
                         return (int) ExecuteSkillComplete(c);

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -195,7 +195,7 @@ void PrintPKLog(CHARACTER* pCha)
 
     if (pCha)
     {
-        if (pCha->PK >= PVP_MURDERER2 && pCha->Object.Type == KIND_PLAYER)
+        if (pCha->PK >= PVP_MURDERER2 && pCha->Object.Kind == KIND_PLAYER)
         {
             g_ErrorReport.Write(L"!!!!!!!!!!!!!!!!! PK !!!!!!!!!!!!!!!\n");
             g_ErrorReport.WriteCurrentTime();
@@ -1870,7 +1870,7 @@ int	getTargetCharacterKey(CHARACTER* c, int selected)
         }
     }
 
-    if ((sc->PK >= PVP_MURDERER2 && sc->Object.Type == KIND_PLAYER) || (HIBYTE(GetAsyncKeyState(VK_CONTROL)) == 128 && sc != Hero))
+    if ((sc->PK >= PVP_MURDERER2 && sc->Object.Kind == KIND_PLAYER) || (HIBYTE(GetAsyncKeyState(VK_CONTROL)) == 128 && sc != Hero))
     {
         return sc->Key;
     }
@@ -4885,7 +4885,14 @@ void AttackElf(CHARACTER* c, int Skill, float Distance)
         ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        g_MovementSkill.m_iTarget = SelectedCharacter;
+        if (CheckAttack())
+        {
+            g_MovementSkill.m_iTarget = SelectedCharacter;
+        }
+        else
+        {
+            g_MovementSkill.m_iTarget = -1;
+        }
     }
     if (!CheckTile(c, o, Distance))
     {
@@ -6262,7 +6269,14 @@ void AttackWizard(CHARACTER* c, int Skill, float Distance)
 
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        g_MovementSkill.m_iTarget = SelectedCharacter;
+        if (CheckAttack())
+        {
+            g_MovementSkill.m_iTarget = SelectedCharacter;
+        }
+        else
+        {
+            g_MovementSkill.m_iTarget = -1;
+        }
 
         switch (Skill)
         {
@@ -7135,6 +7149,16 @@ int ExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance)
                 }
                 if (ClassIndex == CLASS_ELF)
                 {
+                    g_MovementSkill.m_bMagic = TRUE;
+                    g_MovementSkill.m_iSkill = Hero->CurrentSkill;
+                    if (CheckAttack())
+                    {
+                        g_MovementSkill.m_iTarget = SelectedCharacter;
+                    }
+                    else
+                    {
+                        g_MovementSkill.m_iTarget = -1;
+                    }
                     if (SkillElf(c, &CharacterMachine->Equipment[i]))
                     {
                         return (int) ExecuteSkillComplete(c);

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -4885,14 +4885,7 @@ void AttackElf(CHARACTER* c, int Skill, float Distance)
         ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        if (CheckAttack())
-        {
-            g_MovementSkill.m_iTarget = SelectedCharacter;
-        }
-        else
-        {
-            g_MovementSkill.m_iTarget = -1;
-        }
+        g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
     }
     if (!CheckTile(c, o, Distance))
     {
@@ -6269,14 +6262,7 @@ void AttackWizard(CHARACTER* c, int Skill, float Distance)
 
         g_MovementSkill.m_bMagic = TRUE;
         g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-        if (CheckAttack())
-        {
-            g_MovementSkill.m_iTarget = SelectedCharacter;
-        }
-        else
-        {
-            g_MovementSkill.m_iTarget = -1;
-        }
+        g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
 
         switch (Skill)
         {
@@ -7149,16 +7135,10 @@ int ExecuteSkill(CHARACTER* c, ActionSkillType Skill, float Distance)
                 }
                 if (ClassIndex == CLASS_ELF)
                 {
+                    ZeroMemory(&g_MovementSkill, sizeof(g_MovementSkill));
                     g_MovementSkill.m_bMagic = TRUE;
                     g_MovementSkill.m_iSkill = Hero->CurrentSkill;
-                    if (CheckAttack())
-                    {
-                        g_MovementSkill.m_iTarget = SelectedCharacter;
-                    }
-                    else
-                    {
-                        g_MovementSkill.m_iTarget = -1;
-                    }
+                    g_MovementSkill.m_iTarget = CheckAttack() ? SelectedCharacter : -1;
                     if (SkillElf(c, &CharacterMachine->Equipment[i]))
                     {
                         return (int) ExecuteSkillComplete(c);


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->
Credit to: https://github.com/andrescolombo/MuMain

## Summary

- ZzzCharacter.cpp: Add missing break in Triple Shot switch case to prevent fall-through to Penetration handler
- ZzzInterface.cpp: Fix Object.Type → Object.Kind in PrintPKLog() and getTargetCharacterKey() to correctly identify player type

## Checklist

- [x] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [x] I have built the project locally (see [`docs/build-guide.md`](docs/build-guide.md)).
- [x] Changes are focused on one concern; the diff is as small as it reasonably can be.
