### PR TITLE
Fix quest dialog: accept, progress display, and cancel

### DIFF
--- a/src/source/GameLogic/Quests/QuestMng.cpp
+++ b/src/source/GameLogic/Quests/QuestMng.cpp
@@ -279,7 +279,16 @@ void CQuestMng::SetCurQuestProgress(DWORD dwQuestIndex)
         return;
     }
 
-    if (0 == m_mapQuestProgress[dwQuestIndex].m_byUIType)
+    QuestProgressMap::const_iterator iter = m_mapQuestProgress.find(dwQuestIndex);
+    if (iter == m_mapQuestProgress.end())
+    {
+        wchar_t szMessage[128];
+        ::mu_swprintf(szMessage, L"Quest progress entry missing for index 0x%08X\r\n", dwQuestIndex);
+        g_ErrorReport.Write(szMessage);
+        return;
+    }
+
+    if (0 == iter->second.m_byUIType)
     {
         g_pQuestProgress->SetContents(dwQuestIndex);
         if (!g_pNewUISystem->IsVisible(SEASON3B::INTERFACE_QUEST_PROGRESS))
@@ -819,8 +828,8 @@ void CQuestMng::SendQuestIndexByEtcSelection()
         return;
 
     auto iter = m_listQuestIndexByEtc.begin();
-    const auto questNumber = static_cast<uint16_t>((*iter & 0xFF00) >> 16);
-    const auto questGroup = static_cast<uint16_t>(*iter & 0xFF);
+    const auto questNumber = static_cast<uint16_t>(LOWORD(*iter));
+    const auto questGroup = static_cast<uint16_t>(HIWORD(*iter));
     SocketClient->ToGameServer()->SendQuestSelectRequest(questNumber, questGroup, 0);
 }
 

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -10203,9 +10203,11 @@ void ReceiveQuestByNPCEPList(const BYTE* ReceiveBuffer)
 
 void ReceiveQuestQSSelSentence(const BYTE* ReceiveBuffer)
 {
-    auto pData = (LPPMSG_NPC_QUESTEXP_INFO)ReceiveBuffer;
+    auto pData = (LPPMSG_QUEST_STEP_INFO)ReceiveBuffer;
+    const DWORD dwQuestIndex
+        = (static_cast<DWORD>(pData->m_wQuestGroup) << 16) | pData->m_wQuestStepNumber;
 
-    g_QuestMng.SetCurQuestProgress(pData->m_dwQuestIndex);
+    g_QuestMng.SetCurQuestProgress(dwQuestIndex);
 }
 
 void ReceiveQuestQSRequestReward(const BYTE* ReceiveBuffer)
@@ -10270,6 +10272,7 @@ void ReceiveProgressQuestRequestReward(const BYTE* ReceiveBuffer)
 {
     auto pData = (LPPMSG_NPC_QUESTEXP_INFO)ReceiveBuffer;
     g_QuestMng.SetQuestRequestReward(ReceiveBuffer);
+    g_QuestMng.SetEPRequestRewardState(pData->m_dwQuestIndex, true);
     g_pMyQuestInfoWindow->SetSelQuestRequestReward();
 }
 
@@ -13711,8 +13714,20 @@ static void ProcessPacket(const BYTE* ReceiveBuffer, int32_t Size)
         break;
     case 0xF6:
     {
-        auto Data = (LPPHEADER_DEFAULT_SUBCODE)ReceiveBuffer;
-        switch (Data->SubCode)
+        BYTE bySubcode;
+
+        if (bIsC1C3)
+        {
+            auto Data = (LPPHEADER_DEFAULT_SUBCODE)ReceiveBuffer;
+            bySubcode = Data->SubCode;
+        }
+        else
+        {
+            auto Data = (LPPHEADER_DEFAULT_SUBCODE_WORD)ReceiveBuffer;
+            bySubcode = Data->SubCode;
+        }
+
+        switch (bySubcode)
         {
 #ifdef ASG_ADD_TIME_LIMIT_QUEST
         case 0x00:

--- a/src/source/Network/Server/WSclient.h
+++ b/src/source/Network/Server/WSclient.h
@@ -1306,6 +1306,21 @@ typedef struct
     DWORD			m_dwQuestIndex;
 } PMSG_NPC_QUESTEXP_INFO, * LPPMSG_NPC_QUESTEXP_INFO;
 
+// GC[0xF6][0x0B] QuestStepInfo. C1 packet, 11 bytes. The server sends it
+// when the player selects a quest in the quest list (carrying StartingNumber),
+// when a quest has been started (carrying Number), or after the player refused
+// to start (carrying RefuseNumber). The client uses the (Group, StepNumber)
+// pair to look up the local quest progress entry.
+#pragma pack(push, 1)
+typedef struct
+{
+    PBMSG_HEADER	Header;
+    BYTE			SubCode;
+    WORD			m_wQuestStepNumber;
+    WORD			m_wQuestGroup;
+} PMSG_QUEST_STEP_INFO, * LPPMSG_QUEST_STEP_INFO;
+#pragma pack(pop)
+
 
 enum QUEST_REQUEST_TYPE : BYTE
 {

--- a/src/source/UI/Legacy/UIControls.cpp
+++ b/src/source/UI/Legacy/UIControls.cpp
@@ -5846,8 +5846,8 @@ BOOL CUICurQuestListBox::DoLineMouseAction(int iLineNumber)
             g_pMyQuestInfoWindow->QuestGiveUpBtnEnable(true);
             g_pMyQuestInfoWindow->SetSelQuestSummary();
 
-            const auto questNumber = static_cast<uint16_t>((m_TextListIter->m_dwIndex & 0xFF00) >> 16);
-            const auto questGroup = static_cast<uint16_t>(m_TextListIter->m_dwIndex & 0xFF);
+            const auto questNumber = static_cast<uint16_t>(LOWORD(m_TextListIter->m_dwIndex));
+            const auto questGroup = static_cast<uint16_t>(HIWORD(m_TextListIter->m_dwIndex));
             SocketClient->ToGameServer()->SendQuestStateRequest(questNumber, questGroup);
         }
     }

--- a/src/source/UI/NewUI/Dialogs/NewUICommonMessageBox.cpp
+++ b/src/source/UI/NewUI/Dialogs/NewUICommonMessageBox.cpp
@@ -2488,8 +2488,9 @@ bool SEASON3B::CQuestGiveUpMsgBoxLayout::SetLayout()
 
 CALLBACK_RESULT SEASON3B::CQuestGiveUpMsgBoxLayout::OkBtnDown(class CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam)
 {
-    const auto questNumber = static_cast<uint16_t>((g_pMyQuestInfoWindow->GetSelQuestIndex() & 0xFF00) >> 16);
-    const auto questGroup = static_cast<uint16_t>(g_pMyQuestInfoWindow->GetSelQuestIndex() & 0xFF);
+    const DWORD dwSelectedQuest = g_pMyQuestInfoWindow->GetSelQuestIndex();
+    const auto questNumber = static_cast<uint16_t>(LOWORD(dwSelectedQuest));
+    const auto questGroup = static_cast<uint16_t>(HIWORD(dwSelectedQuest));
     SocketClient->ToGameServer()->SendQuestCancelRequest(questNumber, questGroup);
 
     PlayBuffer(SOUND_CLICK01);

--- a/src/source/UI/NewUI/NPCs/NewUINPCDialogue.cpp
+++ b/src/source/UI/NewUI/NPCs/NewUINPCDialogue.cpp
@@ -558,8 +558,9 @@ void CNewUINPCDialogue::ProcessSelTextResult()
         }
         else
         {
-            auto questNumber = (uint16_t)((m_adwQuestIndex[m_nSelSelText - 1] & 0xFF00) >> 16);
-            auto questGroup = (uint16_t)(m_adwQuestIndex[m_nSelSelText - 1] & 0xFF);
+            const DWORD dwSelectedQuest = m_adwQuestIndex[m_nSelSelText - 1];
+            const auto questNumber = static_cast<uint16_t>(LOWORD(dwSelectedQuest));
+            const auto questGroup = static_cast<uint16_t>(HIWORD(dwSelectedQuest));
             SocketClient->ToGameServer()->SendQuestSelectRequest(questNumber, questGroup, (BYTE)m_nSelSelText);
         }
     }

--- a/src/source/UI/NewUI/Quests/NewUIQuestProgress.cpp
+++ b/src/source/UI/NewUI/Quests/NewUIQuestProgress.cpp
@@ -142,8 +142,8 @@ bool CNewUIQuestProgress::ProcessBtns()
     {
         if (m_btnComplete.UpdateMouseEvent())
         {
-            const auto questNumber = static_cast<uint16_t>((m_dwCurQuestIndex & 0xFF00) >> 16);
-            const auto questGroup = static_cast<uint16_t>(m_dwCurQuestIndex & 0xFF);
+            const auto questNumber = static_cast<uint16_t>(LOWORD(m_dwCurQuestIndex));
+            const auto questGroup = static_cast<uint16_t>(HIWORD(m_dwCurQuestIndex));
             SocketClient->ToGameServer()->SendQuestCompletionRequest(questNumber, questGroup);
             PlayBuffer(SOUND_CLICK01);
             m_bCanClick = false;
@@ -177,8 +177,8 @@ bool CNewUIQuestProgress::UpdateSelTextMouseEvent()
             m_nSelAnswer = static_cast<QuestProceedAction>(i + 1);
             if (SEASON3B::IsRelease(VK_LBUTTON))
             {
-                const auto questNumber = static_cast<uint16_t>((m_dwCurQuestIndex & 0xFF00) >> 16);
-                const auto questGroup = static_cast<uint16_t>(m_dwCurQuestIndex & 0xFF);
+                const auto questNumber = static_cast<uint16_t>(LOWORD(m_dwCurQuestIndex));
+                const auto questGroup = static_cast<uint16_t>(HIWORD(m_dwCurQuestIndex));
                 SocketClient->ToGameServer()->SendQuestProceedRequest(questNumber, questGroup, m_nSelAnswer);
                 PlayBuffer(SOUND_CLICK01);
                 m_bCanClick = false;

--- a/src/source/UI/NewUI/Quests/NewUIQuestProgressByEtc.cpp
+++ b/src/source/UI/NewUI/Quests/NewUIQuestProgressByEtc.cpp
@@ -147,8 +147,8 @@ bool CNewUIQuestProgressByEtc::ProcessBtns()
     {
         if (m_btnComplete.UpdateMouseEvent())
         {
-            const auto questNumber = static_cast<uint16_t>((m_dwCurQuestIndex & 0xFF00) >> 16);
-            const auto questGroup = static_cast<uint16_t>(m_dwCurQuestIndex & 0xFF);
+            const auto questNumber = static_cast<uint16_t>(LOWORD(m_dwCurQuestIndex));
+            const auto questGroup = static_cast<uint16_t>(HIWORD(m_dwCurQuestIndex));
             SocketClient->ToGameServer()->SendQuestCompletionRequest(questNumber, questGroup);
             PlayBuffer(SOUND_CLICK01);
             m_bCanClick = false;
@@ -182,8 +182,8 @@ bool CNewUIQuestProgressByEtc::UpdateSelTextMouseEvent()
 
             if (SEASON3B::IsRelease(VK_LBUTTON))
             {
-                const auto questNumber = static_cast<uint16_t>((m_dwCurQuestIndex & 0xFF00) >> 16);
-                const auto questGroup = static_cast<uint16_t>(m_dwCurQuestIndex & 0xFF);
+                const auto questNumber = static_cast<uint16_t>(LOWORD(m_dwCurQuestIndex));
+                const auto questGroup = static_cast<uint16_t>(HIWORD(m_dwCurQuestIndex));
                 SocketClient->ToGameServer()->SendQuestProceedRequest(questNumber, questGroup, m_nSelAnswer);
                 PlayBuffer(SOUND_CLICK01);
                 m_bCanClick = false;


### PR DESCRIPTION
Make the Season 6 NPC quest flow work end to end against OpenMU:

- Handle C2-header packets in the 0xF6 quest dispatcher. The extended quest progress (0x0C) and quest state (0x1B) packets use a C2 header, so the subcode sits one byte later; the dispatcher only handled C1, so those handlers never ran. Select the subcode offset by header type, matching the existing 0xF8 dispatcher.
- Read the QuestStepInfo (0x0B) packet with its real C1 layout and rebuild the quest index from (group, step number).
- Replace the broken (x & 0xFF00) >> 16 quest-index extraction, which is always zero, with LOWORD/HIWORD in every quest send path: select, accept, refuse, completion, cancel, and quest state request.
- Set the request/reward state flag when the hero quest window receives quest state (0x1B), so requirements and rewards render there as well.
- Guard the quest progress lookup against a missing map entry.

Also requires changes on Server side here the PR https://github.com/MUnique/OpenMU/pull/789

Closes #414
Closes #418
