### PR TITLE
Keep NPC dialogue open when clicking an adjacent NPC

### DIFF
--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -7364,6 +7364,12 @@ void MoveHero()
     CHARACTER* c = Hero;
     OBJECT* o = &c->Object;
 
+    // Re-arm world clicks once the button is released; the latch only suppresses the held click.
+    // Kept above the early returns below (stun/sleep/dead/loading) so a release during any of
+    // those states still clears the latch and the next click is honoured.
+    if (!MouseLButton)
+        s_bIgnoreHeldClickAfterNpcTalk = false;
+
     if (o->CurrentAction == PLAYER_CHANGE_UP)
     {
         return;
@@ -7548,10 +7554,6 @@ void MoveHero()
     }
 
     CheckGate();
-
-    // Re-arm world clicks once the button is released; the latch only suppresses the held click.
-    if (!MouseLButton)
-        s_bIgnoreHeldClickAfterNpcTalk = false;
 
     if (!MouseOnWindow && false == g_pNewUISystem->CheckMouseUse())
     {

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -92,6 +92,11 @@ int   LoadingWorld = 0;
 int   ItemHelp = 0;
 int   MouseUpdateTime = 0;
 int   MouseUpdateTimeMax = 6;
+// Latched when a click opens an NPC conversation while the button is still held.
+// The world click handler ignores the held button until it is physically released, so the
+// same click can't fall through to ground movement and instantly close the NPC window.
+// A fresh press (e.g. deliberately clicking the ground to walk away) still works normally.
+static bool s_bIgnoreHeldClickAfterNpcTalk = false;
 bool  WhisperEnable = true;
 bool  ChatWindowEnable = true;
 int   InputFrame = 0;
@@ -7544,10 +7549,14 @@ void MoveHero()
 
     CheckGate();
 
+    // Re-arm world clicks once the button is released; the latch only suppresses the held click.
+    if (!MouseLButton)
+        s_bIgnoreHeldClickAfterNpcTalk = false;
+
     if (!MouseOnWindow && false == g_pNewUISystem->CheckMouseUse())
     {
         bool Success = false;
-        if (MouseUpdateTime >= MouseUpdateTimeMax)
+        if (MouseUpdateTime >= MouseUpdateTimeMax && !s_bIgnoreHeldClickAfterNpcTalk)
         {
             if (!EnableFastInput)
             {
@@ -7723,6 +7732,18 @@ void MoveHero()
                 && !g_pNewUISystem->IsVisible(SEASON3B::INTERFACE_STORAGE)
                 )
             {
+                // Talking to an NPC opens a window (dialogue/quest/shop). The physical button is
+                // usually still held at this point, and the held button keeps re-entering this
+                // handler every frame. The moment the cursor isn't on the NPC's pick-box it would
+                // fall through to the ground-move branch below and walk the hero away, instantly
+                // closing the window the same click just opened. Most visible on adjacent NPCs such
+                // as the Elf Soldier, whose narrow dialogue doesn't cover the cursor the way a wide
+                // shop window does. Latch the held click so it's ignored until released; a fresh
+                // press still moves the hero normally. Also restart the debounce like the sibling
+                // branches (attack/ground-move) do.
+                s_bIgnoreHeldClickAfterNpcTalk = true;
+                MouseUpdateTime = 0;
+
                 if (g_isCharacterBuff(o, eBuff_CrywolfNPCHide) == false)
                     c->MovementType = MOVEMENT_TALK;
 


### PR DESCRIPTION
A held left-click that opened an NPC conversation kept re-entering the world click handler every frame. The moment the cursor left the NPC's pick-box the click fell through to the ground-move branch and walked the hero away, which instantly closed the window the same click had just opened. This was most visible on adjacent NPCs such as the Elf Soldier, whose narrow dialogue does not cover the cursor the way a wide shop window does.

Latch the held button when a talk opens an NPC window so it is ignored until physically released; a fresh press still moves the hero normally. Also restart the click debounce in the talk branch like the attack and ground-move branches.