### PR TITLE
Mu Helper: fix targeting monster behind a wall

### DIFF
--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -214,6 +214,16 @@ namespace MUHelper
         if ((iDistance <= m_iHuntingDistance)
             || (bIsAttacking && m_config.bLongRangeCounterAttack))
         {
+            // Reject targets that are not reachable (e.g. behind a wall).
+            // Use a temporary path so we don't clobber Hero->Path.
+            int iTargetX = (int)(pTarget->Object.Position[0] / TERRAIN_SCALE);
+            int iTargetY = (int)(pTarget->Object.Position[1] / TERRAIN_SCALE);
+            PATH_t tempPath;
+            if (!PathFinding2(Hero->PositionX, Hero->PositionY, iTargetX, iTargetY, &tempPath, m_iHuntingDistance))
+            {
+                return;
+            }
+
             _targetsLock.lock();
 
             m_setTargets.insert(iTargetId);
@@ -224,11 +234,12 @@ namespace MUHelper
             }
 
             _targetsLock.unlock();
-        }
 
-        if (m_config.bUseSelfDefense && IsMonster(pTarget))
-        {
-            m_iCurrentTarget = iTargetId;
+            // Only assign as self-defense target if reachability passed above.
+            if (m_config.bUseSelfDefense && IsMonster(pTarget))
+            {
+                m_iCurrentTarget = iTargetId;
+            }
         }
     }
 
@@ -897,11 +908,15 @@ namespace MUHelper
                     return 0;
                 }
 
-                bool bTargetNear = CheckTile(Hero, &Hero->Object, fSkillDistance);
-                bool bNoWall = CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY);
+                // Path exists but LOS is blocked.
+                if (!CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY))
+                {
+                    DeleteTarget(iTarget);
+                    return 0;
+                }
 
-                // Target is not near or the path is obstructed by a wall, move closer
-                if (!bTargetNear || !bNoWall)
+                // Target is not yet in range, move closer.
+                if (!CheckTile(Hero, &Hero->Object, fSkillDistance))
                 {
                     Hero->Path.Lock.lock();
 
@@ -986,10 +1001,15 @@ namespace MUHelper
             return 0;
         }
 
-        const bool bTargetNear = CheckTile(Hero, &Hero->Object, fRange);
-        const bool bNoWall = CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY);
+        // Path exists but LOS is blocked.
+        if (!CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY))
+        {
+            DeleteTarget(iTarget);
+            return 0;
+        }
 
-        if (!bTargetNear || !bNoWall)
+        // Target is not yet in range, move closer.
+        if (!CheckTile(Hero, &Hero->Object, fRange))
         {
             Hero->Path.Lock.lock();
             const int pathNum = std::min<int>(tempPath.PathNum, 2);

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -214,18 +214,6 @@ namespace MUHelper
         if ((iDistance <= m_iHuntingDistance)
             || (bIsAttacking && m_config.bLongRangeCounterAttack))
         {
-            // Reject targets that are not reachable (e.g. behind a wall).
-            int iTargetX = (int)(pTarget->Object.Position[0] / TERRAIN_SCALE);
-            int iTargetY = (int)(pTarget->Object.Position[1] / TERRAIN_SCALE);
-            if (!CheckWall(Hero->PositionX, Hero->PositionY, iTargetX, iTargetY))
-            {
-                PATH_t tempPath;
-                if (!PathFinding2(Hero->PositionX, Hero->PositionY, iTargetX, iTargetY, &tempPath, m_iHuntingDistance))
-                {
-                    return;
-                }
-            }
-
             _targetsLock.lock();
 
             m_setTargets.insert(iTargetId);
@@ -236,12 +224,11 @@ namespace MUHelper
             }
 
             _targetsLock.unlock();
+        }
 
-            // Only assign as self-defense target if reachability passed above.
-            if (m_config.bUseSelfDefense && IsMonster(pTarget))
-            {
-                m_iCurrentTarget = iTargetId;
-            }
+        if (m_config.bUseSelfDefense && IsMonster(pTarget))
+        {
+            m_iCurrentTarget = iTargetId;
         }
     }
 

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -215,13 +215,15 @@ namespace MUHelper
             || (bIsAttacking && m_config.bLongRangeCounterAttack))
         {
             // Reject targets that are not reachable (e.g. behind a wall).
-            // Use a temporary path so we don't clobber Hero->Path.
             int iTargetX = (int)(pTarget->Object.Position[0] / TERRAIN_SCALE);
             int iTargetY = (int)(pTarget->Object.Position[1] / TERRAIN_SCALE);
-            PATH_t tempPath;
-            if (!PathFinding2(Hero->PositionX, Hero->PositionY, iTargetX, iTargetY, &tempPath, m_iHuntingDistance))
+            if (!CheckWall(Hero->PositionX, Hero->PositionY, iTargetX, iTargetY))
             {
-                return;
+                PATH_t tempPath;
+                if (!PathFinding2(Hero->PositionX, Hero->PositionY, iTargetX, iTargetY, &tempPath, m_iHuntingDistance))
+                {
+                    return;
+                }
             }
 
             _targetsLock.lock();
@@ -908,15 +910,15 @@ namespace MUHelper
                     return 0;
                 }
 
-                // Path exists but LOS is blocked.
-                if (!CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY))
+                const bool bTargetNear = CheckTile(Hero, &Hero->Object, fSkillDistance);
+                if (bTargetNear && !CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY))
                 {
                     DeleteTarget(iTarget);
                     return 0;
                 }
 
                 // Target is not yet in range, move closer.
-                if (!CheckTile(Hero, &Hero->Object, fSkillDistance))
+                if (!bTargetNear)
                 {
                     Hero->Path.Lock.lock();
 
@@ -1001,15 +1003,15 @@ namespace MUHelper
             return 0;
         }
 
-        // Path exists but LOS is blocked.
-        if (!CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY))
+        const bool bTargetNear = CheckTile(Hero, &Hero->Object, fRange);
+        if (bTargetNear && !CheckWall(Hero->PositionX, Hero->PositionY, TargetX, TargetY))
         {
             DeleteTarget(iTarget);
             return 0;
         }
 
         // Target is not yet in range, move closer.
-        if (!CheckTile(Hero, &Hero->Object, fRange))
+        if (!bTargetNear)
         {
             Hero->Path.Lock.lock();
             const int pathNum = std::min<int>(tempPath.PathNum, 2);


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

The helper would lock onto monsters that were visible but unreachable (e.g. behind a wall), causing the player to walk into the wall indefinitely.

## Related issues

Closes #423

## Checklist

- [X] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [X] I have built the project locally (see [`docs/build-guide.md`](docs/build-guide.md)).
- [X] Changes are focused on one concern; the diff is as small as it reasonably can be.


https://github.com/user-attachments/assets/55e43499-7008-46f6-8eb3-b5237d6ae534

 