### PR TITLE
Add auto-reconnect on in-game connection loss

### DIFF
--- a/ClientLibrary/ConnectionManager.cs
+++ b/ClientLibrary/ConnectionManager.cs
@@ -84,7 +84,11 @@ public unsafe partial class ConnectionManager
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Error sending {0} bytes with handle {1}: {2}", count, handle, ex);
+                // A send failure means the connection is broken. Tear it down so
+                // the Disconnected event fires and the client can auto-reconnect,
+                // instead of silently swallowing the error and looking online.
+                Debug.WriteLine($"Error sending {count} bytes with handle {handle}: {ex}");
+                connection.DisconnectAndDispose();
             }
         }
         else
@@ -123,6 +127,8 @@ public unsafe partial class ConnectionManager
     {
         var tcpClient = new TcpClient(host, port);
 
+        ConfigureKeepAlive(tcpClient.Client);
+
         var socketConnection = SocketConnection.Create(tcpClient.Client);
 
         var encryptor = isEncrypted ? new PipelinedXor32Encryptor(new PipelinedSimpleModulusEncryptor(socketConnection.Output, PipelinedSimpleModulusEncryptor.DefaultClientKey).Writer) : null;
@@ -140,5 +146,80 @@ public unsafe partial class ConnectionManager
         };
 
         return handle;
+    }
+
+    /// <summary>
+    /// Idle time, in seconds, before the OS starts sending TCP keep-alive probes.
+    /// </summary>
+    private const int KeepAliveIdleSeconds = 4;
+
+    /// <summary>
+    /// Interval, in seconds, between TCP keep-alive probes.
+    /// </summary>
+    private const int KeepAliveIntervalSeconds = 2;
+
+    /// <summary>
+    /// Number of unanswered keep-alive probes before the connection is dropped.
+    /// </summary>
+    private const int KeepAliveRetryCount = 3;
+
+    /// <summary>
+    /// Enables aggressive TCP keep-alive so the OS detects dead or half-open
+    /// connections (server crash, network drop) within ~10 seconds and tears the
+    /// socket down. That makes the receive loop fault and raise
+    /// <see cref="Connection.Disconnected"/>, which the game client polls to
+    /// trigger auto-reconnect. Without this, a peer that vanishes without sending
+    /// FIN/RST keeps the connection alive for minutes. Probes are answered by the
+    /// healthy peer's OS automatically, so this never drops a live connection.
+    /// </summary>
+    /// <param name="socket">The connected socket to configure.</param>
+    private static void ConfigureKeepAlive(Socket socket)
+    {
+        try
+        {
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to enable SO_KEEPALIVE: {ex}");
+        }
+
+        // Modern cross-platform options (.NET 5+). Set each independently so an
+        // unsupported one doesn't skip the others (notably the retry count, which
+        // older Windows ignores).
+        TrySetSocketOption(socket, SocketOptionName.TcpKeepAliveTime, KeepAliveIdleSeconds);
+        TrySetSocketOption(socket, SocketOptionName.TcpKeepAliveInterval, KeepAliveIntervalSeconds);
+        TrySetSocketOption(socket, SocketOptionName.TcpKeepAliveRetryCount, KeepAliveRetryCount);
+
+        // Windows fallback/override: SIO_KEEPALIVE_VALS reliably sets the idle
+        // time and probe interval (in milliseconds) where the socket options
+        // above are sometimes ignored.
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                var values = new byte[12];
+                BitConverter.GetBytes(1u).CopyTo(values, 0);                                        // on
+                BitConverter.GetBytes((uint)(KeepAliveIdleSeconds * 1000)).CopyTo(values, 4);       // idle (ms)
+                BitConverter.GetBytes((uint)(KeepAliveIntervalSeconds * 1000)).CopyTo(values, 8);   // interval (ms)
+                socket.IOControl(IOControlCode.KeepAliveValues, values, null);
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to configure keep-alive via IOControl: {ex}");
+        }
+    }
+
+    private static void TrySetSocketOption(Socket socket, SocketOptionName option, int value)
+    {
+        try
+        {
+            socket.SetSocketOption(SocketOptionLevel.Tcp, option, value);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to set socket option {option}: {ex}");
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ What I have done so far:
     * Glow for red, blue and black fenrir
     * Additional screen resolutions
   * 🔥 Incorporated MU Helper UI and logic - there's some work to do but core functionality is usable
+  * 🔥 Auto-reconnect system
   * Removed if-defs for Rage Fighter class as we are targeting Season 6, so Rage
     Fighter should always be included.
   * Some minor bug fixes, e.g.:

--- a/src/Localization/Game.en.resx
+++ b/src/Localization/Game.en.resx
@@ -12881,4 +12881,25 @@
   <data name="BasicAttackFallback" xml:space="preserve">
     <value>Basic Attack Fallback</value>
   </data>
+  <data name="Connection lost" xml:space="preserve">
+    <value>Connection lost</value>
+  </data>
+  <data name="Checking server availability" xml:space="preserve">
+    <value>Checking server availability</value>
+  </data>
+  <data name="Connecting to the server" xml:space="preserve">
+    <value>Connecting to the server</value>
+  </data>
+  <data name="Logging in" xml:space="preserve">
+    <value>Logging in</value>
+  </data>
+  <data name="Loading character list" xml:space="preserve">
+    <value>Loading character list</value>
+  </data>
+  <data name="Entering the game" xml:space="preserve">
+    <value>Entering the game</value>
+  </data>
+  <data name="Retrying in seconds" xml:space="preserve">
+    <value>Retrying in %d seconds...</value>
+  </data>
 </root>

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -68,6 +68,12 @@ namespace MUHelper
         if (m_bActive)
         {
             TriggerStop();
+
+            // Stop the client-driven bot immediately instead of waiting for the
+            // server's status reply. After an auto-reconnect the server's new
+            // session doesn't have the helper marked active, so it never replies
+            // and the bot would otherwise keep running with no way to stop it.
+            Stop();
         }
         else
         {

--- a/src/source/Network/Reconnect/ReconnectManager.cpp
+++ b/src/source/Network/Reconnect/ReconnectManager.cpp
@@ -1,0 +1,552 @@
+#include "stdafx.h"
+#include "ReconnectManager.h"
+
+#include <ws2tcpip.h>  // GetAddrInfoW for the reachability probe (IPs + hostnames)
+
+#include <cmath>
+#include <cwchar>
+
+#include "Network/Server/WSclient.h"   // SocketClient, CreateSocket, DeleteSocket,
+                                       // ResetClientToLoginScene, protocol states
+#include "Scenes/SceneCore.h"          // SceneFlag, szServerIpAddress, g_ServerPort
+#include "Scenes/SceneCommon.h"        // SelectedHero, MAX_CHARACTERS_PER_ACCOUNT
+#include "Scenes/CharacterScene.h"     // StartGame
+#include "Engine/Object/ZzzCharacter.h"// CharactersClient
+#include "UI/Legacy/UIMng.h"           // CUIMng, m_LoginWin
+#include "Platform/Windows/Winmain.h"  // WM_START_RECONNECT
+#include "MUHelper/MuHelper.h"         // MUHelper::g_MuHelper
+
+// Timing (milliseconds). WorldTime is the wall-clock ms timer the rest of the
+// client uses for timeouts (see ZzzAI.cpp).
+namespace
+{
+    constexpr double PROBE_INTERVAL_MS = 5000.0;    // gap between reachability probes
+    constexpr double PROBE_TIMEOUT_MS = 2000.0;     // allow a probe this long to connect
+    constexpr double CONNECT_TIMEOUT_MS = 10000.0;  // wait for the server hello
+    constexpr double LOGIN_TIMEOUT_MS = 10000.0;    // login -> character list
+    constexpr double RETRY_INTERVAL_MS = 5000.0;    // gap between re-login retries
+    constexpr int STEP_COUNT = 4;                   // progress-bar steps
+
+    const uintptr_t NO_PROBE = static_cast<uintptr_t>(~0ull);  // == INVALID_SOCKET
+}
+
+extern double WorldTime;
+extern int LogIn;
+extern wchar_t LogInID[MAX_USERNAME_SIZE + 1];
+extern BYTE Version[SIZE_PROTOCOLVERSION];
+extern BYTE Serial[SIZE_PROTOCOLSERIAL + 1];
+extern BOOL g_bGameServerConnected;
+extern HWND g_hWnd;
+
+ReconnectManager& ReconnectManager::Instance()
+{
+    static ReconnectManager instance;
+    return instance;
+}
+
+void ReconnectManager::CacheServer(const wchar_t* ip, unsigned short port)
+{
+    if (ip == nullptr)
+    {
+        return;
+    }
+
+    wcscpy_s(m_serverIp, _countof(m_serverIp), ip);
+    m_serverPort = port;
+}
+
+void ReconnectManager::CacheCredentials(const wchar_t* username, const wchar_t* password)
+{
+    if (username == nullptr || password == nullptr)
+    {
+        return;
+    }
+
+    wcscpy_s(m_username, _countof(m_username), username);
+    wcscpy_s(m_password, _countof(m_password), password);
+}
+
+void ReconnectManager::CacheCharacter(const wchar_t* characterName)
+{
+    if (characterName == nullptr)
+    {
+        return;
+    }
+
+    wcscpy_s(m_characterName, _countof(m_characterName), characterName);
+
+    // A full session is only usable once we know the server, the account, and
+    // the character to resume.
+    m_hasSession = m_serverIp[0] != L'\0' && m_username[0] != L'\0' && m_characterName[0] != L'\0';
+}
+
+void ReconnectManager::ClearSession()
+{
+    m_hasSession = false;
+    m_serverIp[0] = L'\0';
+    m_username[0] = L'\0';
+    m_password[0] = L'\0';
+    m_characterName[0] = L'\0';
+}
+
+void ReconnectManager::RequestBegin()
+{
+    if (m_active || m_beginPending || !m_hasSession)
+    {
+        return;
+    }
+
+    // Capture the MU Helper state now (at the moment of disconnect), before
+    // anything in the reconnect can touch it, so it can be restored afterwards.
+    m_muHelperWasActive = MUHelper::g_MuHelper.IsActive();
+
+    // Don't tear the game down yet: keep the main scene rendering (frozen, since
+    // no server data arrives) and probe the server in the background. Only once
+    // it answers do we tear down and re-login. This just sets state, so it's safe
+    // to call from the render path.
+    m_active = true;
+    EnterPhase(Phase::Probing);
+    // Probe straight away instead of waiting out the first interval, so a brief
+    // blip recovers quickly.
+    m_phaseStartTime = WorldTime - PROBE_INTERVAL_MS;
+}
+
+void ReconnectManager::Begin()
+{
+    // Runs in the window-proc context once a probe found the server alive. The
+    // teardown (ReleaseMainData etc.) must run here, not mid-render.
+    if (!m_beginPending)
+    {
+        return;
+    }
+
+    m_beginPending = false;
+
+    if (!m_active)
+    {
+        return;
+    }
+
+    // Tear the live session down to a clean login state.
+    ResetClientToLoginScene();
+
+    // Cancel pressed while probing: stop here at the login screen.
+    if (m_abortAfterTeardown)
+    {
+        m_abortAfterTeardown = false;
+        Abort();
+        return;
+    }
+
+    // Connect (the probe already confirmed the server is up).
+    DeleteSocket();
+    CreateSocket(m_serverIp, m_serverPort);
+
+    if (IsSocketAlive())
+    {
+        g_bGameServerConnected = TRUE;
+        EnterPhase(Phase::Connecting);
+        return;
+    }
+
+    // Rare: the server went down again between the probe and the connect. Retry
+    // (we've already torn down, so this just re-opens the socket).
+    EnterPhase(Phase::Retrying);
+}
+
+void ReconnectManager::RequestCancel()
+{
+    if (!m_active)
+    {
+        return;
+    }
+
+    // Processed by Update() (scene-update phase) so the teardown never runs from
+    // the dialog's render call.
+    m_cancelRequested = true;
+}
+
+void ReconnectManager::Update()
+{
+    if (m_cancelRequested)
+    {
+        m_cancelRequested = false;
+        if (m_active)
+        {
+            if (m_phase == Phase::Probing && SceneFlag == MAIN_SCENE)
+            {
+                // The game world is still loaded; its teardown must run in the
+                // window proc, after which we land on the login screen.
+                m_abortAfterTeardown = true;
+                m_beginPending = true;
+                PostMessage(g_hWnd, WM_START_RECONNECT, 0, 0);
+            }
+            else
+            {
+                Abort();
+            }
+        }
+        return;
+    }
+
+    if (!m_active)
+    {
+        return;
+    }
+
+    switch (m_phase)
+    {
+    case Phase::Probing:        UpdateProbing();       break;
+    case Phase::Connecting:     UpdateConnecting();    break;
+    case Phase::LoggingIn:      UpdateLoggingIn();     break;
+    case Phase::SelectingChar:  UpdateSelectingChar(); break;
+    case Phase::Joining:        UpdateJoining();       break;
+    case Phase::Retrying:       UpdateRetrying();      break;
+    default:                                           break;
+    }
+}
+
+void ReconnectManager::UpdateProbing()
+{
+    // A probe found the server; waiting for Begin() to run in the window proc.
+    if (m_beginPending)
+    {
+        return;
+    }
+
+    if (m_probeSocket == NO_PROBE)
+    {
+        if (ElapsedMs() >= PROBE_INTERVAL_MS)
+        {
+            StartProbe();
+        }
+        return;
+    }
+
+    PollProbe();
+}
+
+void ReconnectManager::StartProbe()
+{
+    static bool s_wsaInitialised = false;
+    if (!s_wsaInitialised)
+    {
+        WSADATA wsaData;
+        WSAStartup(MAKEWORD(2, 2), &wsaData);
+        s_wsaInitialised = true;
+    }
+
+    const SOCKET probe = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (probe == INVALID_SOCKET)
+    {
+        EnterPhase(Phase::Probing);  // reset the interval timer and retry later
+        return;
+    }
+
+    // Resolve the cached address - works for both an IPv4 literal and a hostname.
+    addrinfoW hints = {};
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    addrinfoW* resolved = nullptr;
+    if (GetAddrInfoW(m_serverIp, nullptr, &hints, &resolved) != 0 || resolved == nullptr)
+    {
+        closesocket(probe);
+        EnterPhase(Phase::Probing);  // unresolvable right now; try again later
+        return;
+    }
+
+    sockaddr_in addr = *reinterpret_cast<sockaddr_in*>(resolved->ai_addr);
+    addr.sin_port = htons(m_serverPort);
+    FreeAddrInfoW(resolved);
+
+    u_long nonBlocking = 1;
+    ioctlsocket(probe, FIONBIO, &nonBlocking);
+
+    connect(probe, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));  // WSAEWOULDBLOCK expected
+
+    m_probeSocket = static_cast<uintptr_t>(probe);
+    m_probeStartTime = WorldTime;
+}
+
+void ReconnectManager::PollProbe()
+{
+    const SOCKET probe = static_cast<SOCKET>(m_probeSocket);
+
+    fd_set writeSet;
+    fd_set errorSet;
+    FD_ZERO(&writeSet);
+    FD_ZERO(&errorSet);
+    FD_SET(probe, &writeSet);
+    FD_SET(probe, &errorSet);
+
+    timeval immediate = {};
+    select(0, nullptr, &writeSet, &errorSet, &immediate);
+
+    if (FD_ISSET(probe, &writeSet))
+    {
+        int soError = 0;
+        int len = sizeof(soError);
+        getsockopt(probe, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&soError), &len);
+        CloseProbe();
+
+        if (soError == 0)
+        {
+            // Server is up - hand off to Begin() in the window proc to tear down
+            // and re-login.
+            m_beginPending = true;
+            PostMessage(g_hWnd, WM_START_RECONNECT, 0, 0);
+        }
+        else
+        {
+            EnterPhase(Phase::Probing);
+        }
+        return;
+    }
+
+    if (FD_ISSET(probe, &errorSet) || (WorldTime - m_probeStartTime) > PROBE_TIMEOUT_MS)
+    {
+        CloseProbe();
+        EnterPhase(Phase::Probing);
+    }
+}
+
+void ReconnectManager::CloseProbe()
+{
+    if (m_probeSocket != NO_PROBE)
+    {
+        closesocket(static_cast<SOCKET>(m_probeSocket));
+        m_probeSocket = NO_PROBE;
+    }
+}
+
+void ReconnectManager::UpdateConnecting()
+{
+    if (!IsSocketAlive())
+    {
+        EnterPhase(Phase::Retrying);
+        return;
+    }
+
+    // The game server answers a fresh connection with its hello packet, which
+    // ReceiveJoinServer turns into RECEIVE_JOIN_SERVER_SUCCESS (LogIn was reset
+    // to 0 by the teardown, so it takes the login branch).
+    if (CurrentProtocolState == RECEIVE_JOIN_SERVER_SUCCESS)
+    {
+        CUIMng& uiMng = CUIMng::Instance();
+        uiMng.HideWin(&uiMng.m_LoginWin);
+
+        LogIn = 1;
+        wcscpy_s(LogInID, _countof(LogInID), m_username);
+        CurrentProtocolState = REQUEST_LOG_IN;
+        SocketClient->ToGameServer()->SendLogin(m_username, m_password, Version, Serial);
+
+        EnterPhase(Phase::LoggingIn);
+        return;
+    }
+
+    if (ElapsedMs() > CONNECT_TIMEOUT_MS)
+    {
+        EnterPhase(Phase::Retrying);
+    }
+}
+
+void ReconnectManager::UpdateLoggingIn()
+{
+    if (!IsSocketAlive())
+    {
+        EnterPhase(Phase::Retrying);
+        return;
+    }
+
+    // On login success the login-scene loop (NewMoveLogInScene) requests the
+    // character list and switches to the character scene on its own. Wait for
+    // the list to arrive.
+    if (SceneFlag == CHARACTER_SCENE && CurrentProtocolState == RECEIVE_CHARACTERS_LIST)
+    {
+        EnterPhase(Phase::SelectingChar);
+        return;
+    }
+
+    // No progress: most often the server still has the old session marked
+    // "logged in" right after the crash and rejects the re-login. Retry - it
+    // clears within a few seconds. (The player can Cancel if credentials are
+    // genuinely wrong.)
+    if (ElapsedMs() > LOGIN_TIMEOUT_MS)
+    {
+        EnterPhase(Phase::Retrying);
+    }
+}
+
+void ReconnectManager::UpdateSelectingChar()
+{
+    if (!IsSocketAlive())
+    {
+        EnterPhase(Phase::Retrying);
+        return;
+    }
+
+    if (TrySelectCachedCharacter())
+    {
+        EnterPhase(Phase::Joining);
+        return;
+    }
+
+    // The character is gone (deleted on another client?) - fall back to manual
+    // selection rather than looping forever.
+    Abort();
+}
+
+void ReconnectManager::UpdateJoining()
+{
+    if (SceneFlag == MAIN_SCENE)
+    {
+        // Back in the world exactly where we left off.
+        if (m_muHelperWasActive)
+        {
+            // Resume the client-side MU Helper so its state matches what the
+            // player left running (and so the stop toggle works again).
+            MUHelper::g_MuHelper.Start();
+            m_muHelperWasActive = false;
+        }
+
+        m_active = false;
+        m_phase = Phase::Idle;
+        return;
+    }
+
+    // Loading can be slow, so only retry if the socket actually died.
+    if (!IsSocketAlive())
+    {
+        EnterPhase(Phase::Retrying);
+    }
+}
+
+void ReconnectManager::UpdateRetrying()
+{
+    if (ElapsedMs() < RETRY_INTERVAL_MS)
+    {
+        return;
+    }
+
+    // Already torn down (Begin ran once); just re-open the socket and let the
+    // Connecting phase re-drive the login. Reset the protocol state so the
+    // server hello is treated as a fresh login rather than a map change.
+    LogIn = 0;
+    CurrentProtocolState = REQUEST_JOIN_SERVER;
+    DeleteSocket();
+    CreateSocket(m_serverIp, m_serverPort);
+
+    if (IsSocketAlive())
+    {
+        g_bGameServerConnected = TRUE;
+        EnterPhase(Phase::Connecting);
+        return;
+    }
+
+    EnterPhase(Phase::Retrying);  // server not reachable this time; wait and retry
+}
+
+bool ReconnectManager::TrySelectCachedCharacter()
+{
+    if (m_characterName[0] == L'\0' || CharactersClient == nullptr)
+    {
+        return false;
+    }
+
+    for (int i = 0; i < MAX_CHARACTERS_PER_ACCOUNT; ++i)
+    {
+        if (wcscmp(CharactersClient[i].ID, m_characterName) == 0)
+        {
+            SelectedHero = i;
+            StartGame();   // -> LOADING_SCENE -> MAIN_SCENE (sends SelectCharacter)
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void ReconnectManager::Abort()
+{
+    m_active = false;
+    m_beginPending = false;
+    m_cancelRequested = false;
+    m_abortAfterTeardown = false;
+    m_phase = Phase::Idle;
+    CloseProbe();
+
+    // Begin() already released the in-game data, so this only needs to land on a
+    // usable login screen and reconnect to the server for a manual login. It
+    // runs from Update() (scene-update phase), so the light scene reset is safe.
+    DeleteSocket();
+    g_sceneInit.ResetForDisconnect();
+    SceneFlag = LOG_IN_SCENE;
+    LogIn = 0;
+    CurrentProtocolState = REQUEST_JOIN_SERVER;
+    CreateSocket(szServerIpAddress, g_ServerPort);
+}
+
+void ReconnectManager::EnterPhase(Phase phase)
+{
+    m_phase = phase;
+    m_phaseStartTime = WorldTime;
+}
+
+double ReconnectManager::ElapsedMs() const
+{
+    return WorldTime - m_phaseStartTime;
+}
+
+bool ReconnectManager::IsSocketAlive() const
+{
+    return SocketClient != nullptr && SocketClient->IsConnected();
+}
+
+int ReconnectManager::GetStepCount()
+{
+    return STEP_COUNT;
+}
+
+int ReconnectManager::GetStepIndex() const
+{
+    switch (m_phase)
+    {
+    // Probing/Retrying/Connecting share a step so the bar doesn't jump forward
+    // and snap back when a connect attempt fails and retries.
+    case Phase::Probing:        return 1;
+    case Phase::Retrying:       return 1;
+    case Phase::Connecting:     return 1;
+    case Phase::LoggingIn:      return 2;
+    case Phase::SelectingChar:  return 3;
+    case Phase::Joining:        return 4;
+    default:                    return 0;
+    }
+}
+
+int ReconnectManager::GetCountdownSeconds() const
+{
+    // Seconds until the next attempt, for the dialog's "retrying in N" text.
+    double interval = 0.0;
+    if (m_phase == Phase::Probing && m_probeSocket == NO_PROBE)
+    {
+        interval = PROBE_INTERVAL_MS;
+    }
+    else if (m_phase == Phase::Retrying)
+    {
+        interval = RETRY_INTERVAL_MS;
+    }
+    else
+    {
+        return 0;
+    }
+
+    const double remainingMs = interval - ElapsedMs();
+    if (remainingMs <= 0.0)
+    {
+        return 0;
+    }
+
+    return static_cast<int>(std::ceil(remainingMs / 1000.0));
+}

--- a/src/source/Network/Reconnect/ReconnectManager.h
+++ b/src/source/Network/Reconnect/ReconnectManager.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdint>
+
+#include "Core/Globals/_define.h"  // MAX_USERNAME_SIZE, MAX_PASSWORD_SIZE
+
+// Drives automatic reconnection after an in-game disconnect (issue #338).
+//
+// When the connection to the game server drops while playing, the client caches
+// the data needed to resume the session (game-server address, account
+// credentials, selected character) and replays the normal
+// connect -> login -> character-list -> select-character -> join sequence,
+// retrying the probe every few seconds until the server is back. Because the
+// server persists character state, re-entering the game restores the player
+// exactly where they left off.
+//
+// The manager only injects the two steps the scene loops cannot do on their own
+// (sending the login and picking the character). Everything else flows through
+// the existing per-frame scene state machine (NewMoveLogInScene /
+// NewMoveCharacterScene / StartGame), which advances on CurrentProtocolState.
+class ReconnectManager
+{
+public:
+    enum class Phase
+    {
+        Idle,           // not reconnecting
+        Probing,        // in-game, world still rendered; probing the server for life
+        Connecting,     // socket opened, waiting for the server hello
+        LoggingIn,      // login sent, login/character scene loops are driving
+        SelectingChar,  // character list arrived, selecting the cached character
+        Joining,        // loading into the world
+        Retrying,       // post-teardown: re-connect + re-login attempt failed, retry
+        Done,           // back in game; dialog dismissed next frame
+    };
+
+    static ReconnectManager& Instance();
+
+    // Session cache, populated during normal play.
+    void CacheServer(const wchar_t* ip, unsigned short port);
+    void CacheCredentials(const wchar_t* username, const wchar_t* password);
+    void CacheCharacter(const wchar_t* characterName);
+    void ClearSession();
+    bool HasSession() const { return m_hasSession; }
+
+    // Lifecycle.
+    void RequestBegin();  // detector asks to start reconnect (posts WM_START_RECONNECT)
+    void Begin();         // performs the teardown; runs in the window-proc context
+    void Update();        // per-frame driver (runs in the scene-update phase)
+    void RequestCancel(); // dialog's Cancel button; processed by Update()
+
+    // Read by ReconnectDialog.
+    bool IsActive() const { return m_active || m_beginPending; }
+    Phase GetPhase() const { return m_phase; }
+    int GetStepIndex() const;        // 1-based progress step for the bar
+    static int GetStepCount();       // total steps the bar represents
+    int GetCountdownSeconds() const; // seconds until the next probe (Waiting only)
+
+private:
+    ReconnectManager() = default;
+
+    void EnterPhase(Phase phase);
+    void Abort();                     // give up -> back to the login screen
+    double ElapsedMs() const;         // time spent in the current phase
+    bool IsSocketAlive() const;
+    bool TrySelectCachedCharacter();
+
+    void UpdateProbing();
+    void UpdateConnecting();
+    void UpdateLoggingIn();
+    void UpdateSelectingChar();
+    void UpdateJoining();
+    void UpdateRetrying();
+
+    // Background TCP reachability probe (keeps the game rendered while waiting).
+    void StartProbe();
+    void PollProbe();
+    void CloseProbe();
+
+    bool m_active = false;
+    bool m_beginPending = false;       // RequestBegin posted, Begin not yet run
+    bool m_cancelRequested = false;    // Cancel clicked, Abort not yet run
+    bool m_abortAfterTeardown = false; // cancel during Probing: tear down, then abort
+    bool m_hasSession = false;
+    bool m_muHelperWasActive = false; // MU Helper state to restore after reconnect
+    Phase m_phase = Phase::Idle;
+    double m_phaseStartTime = 0.0;
+
+    // Background probe socket (uintptr_t holds a winsock SOCKET; ~0 = none).
+    uintptr_t m_probeSocket = static_cast<uintptr_t>(~0ull);
+    double m_probeStartTime = 0.0;
+
+    wchar_t m_serverIp[256] = {};  // IPv4 literal or hostname
+    unsigned short m_serverPort = 0;
+    wchar_t m_username[MAX_USERNAME_SIZE + 1] = {};
+    wchar_t m_password[MAX_PASSWORD_SIZE + 1] = {};
+    wchar_t m_characterName[MAX_USERNAME_SIZE + 1] = {};
+};

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -16,6 +16,7 @@
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Engine/Object/ZzzOpenData.h"
 #include "Scenes/SceneCore.h"
+#include "Network/Reconnect/ReconnectManager.h"
 #include "I18N/All.h"
 
 #include "Audio/DSPlaySound.h"
@@ -358,9 +359,22 @@ BOOL CreateSocket(const wchar_t* IpAddr, unsigned short Port)
         bResult = FALSE;
         g_ErrorReport.Write(L"Failed to connect. ");
         g_ErrorReport.WriteCurrentTime();
-        free(SocketClient);
+        delete SocketClient;
         SocketClient = nullptr;
-        CUIMng::Instance().PopUpMsgWin(MESSAGE_SERVER_LOST);
+
+        // While auto-reconnecting we probe the server repeatedly; the reconnect
+        // dialog already shows the status, so don't stack "server lost" popups.
+        if (!ReconnectManager::Instance().IsActive())
+        {
+            CUIMng::Instance().PopUpMsgWin(MESSAGE_SERVER_LOST);
+        }
+    }
+    else
+    {
+        // Remember the address we actually connected to so auto-reconnect can
+        // probe it directly. This covers both the connect-server flow and a
+        // direct game-server connection (where ReceiveServerConnect never runs).
+        ReconnectManager::Instance().CacheServer(IpAddr, Port);
     }
 
     return bResult;
@@ -526,7 +540,12 @@ void ReceiveJoinServer(const BYTE* ReceiveBuffer)
         switch (Data2->Result)
         {
         case 0x01:
-            rUIMng.ShowWin(&rUIMng.m_LoginWin);
+            // Auto-reconnect logs in on its own and keeps its dialog on top, so
+            // don't surface the manual login window underneath it.
+            if (!ReconnectManager::Instance().IsActive())
+            {
+                rUIMng.ShowWin(&rUIMng.m_LoginWin);
+            }
             HeroKey = ((int)(Data2->NumberH) << 8) + Data2->NumberL;
             CurrentProtocolState = RECEIVE_JOIN_SERVER_SUCCESS;
             break;
@@ -927,6 +946,45 @@ BOOL ReceiveLogOut(const BYTE* ReceiveBuffer, BOOL bEncrypted)
     g_ConsoleDebug->Write(MCD_RECEIVE, L"0x02 [ReceiveServerList(%d)]", Data->Value);
 
     return (TRUE);
+}
+
+void ResetClientToLoginScene()
+{
+    // Mirror of the in-game logout path (see ReceiveLogOut, case 2): release the
+    // active game session and return to a clean login scene. The auto-reconnect
+    // flow always runs this from MAIN_SCENE, so the teardown is unconditional.
+    CryWolfMVPInit();
+    StopMusic();
+    AllStopSound();
+    SEASON3B::CNewUIInventoryCtrl::BackupPickedItem();
+    ReleaseMainData();
+
+    g_GuildCache.Reset();
+    memset(GuildMark[MARK_EDIT].Mark, 0, sizeof(GuildMark[MARK_EDIT].Mark));
+    memset(GuildMark[MARK_EDIT].GuildName, 0, sizeof(GuildMark[MARK_EDIT].GuildName));
+    SelectMarkColor = 0;
+
+    if (SocketClient != nullptr)
+    {
+        // Close but do NOT null the pointer: lots of code (and queued packet
+        // handlers) dereference SocketClient unconditionally, and Send/Close
+        // safely no-op on a closed connection. Nulling it here crashes them.
+        // The reconnect's Waiting phase calls DeleteSocket() before reconnecting.
+        SocketClient->Close();
+        g_bGameServerConnected = false;
+    }
+
+    ReleaseCharacterSceneData();
+    SceneFlag = LOG_IN_SCENE;
+    g_sceneInit.ResetForDisconnect();
+    CurrentProtocolState = REQUEST_JOIN_SERVER;
+    LogIn = 0;
+    g_csMapServer.Init();
+    InitGame();
+
+    g_pWindowMgr->Reset();
+    g_pFriendList->ClearFriendList();
+    g_pLetterList->ClearLetterList();
 }
 
 int HeroIndex;

--- a/src/source/Network/Server/WSclient.h
+++ b/src/source/Network/Server/WSclient.h
@@ -3571,6 +3571,11 @@ extern bool SoccerObserver;
 
 BOOL CreateSocket(const wchar_t* IpAddr, unsigned short Port);
 void DeleteSocket();
+
+// Tears the live game session down to a clean login-scene state (matching the
+// in-game logout path). Used by the auto-reconnect flow before it replays login.
+void ResetClientToLoginScene();
+
 void ReceiveMovePosition(const BYTE* ReceiveBuffer);
 
 struct PacketInfo

--- a/src/source/Platform/Windows/Winmain.cpp
+++ b/src/source/Platform/Windows/Winmain.cpp
@@ -14,6 +14,7 @@
 #include "Render/Textures/ZzzTexture.h"
 #include "Engine/Object/ZzzOpenData.h"
 #include "Scenes/SceneCore.h"
+#include "Network/Reconnect/ReconnectManager.h"
 #include "Render/Models/ZzzBMD.h"
 #include "Engine/Object/ZzzInfomation.h"
 #include "Engine/Object/ZzzObject.h"
@@ -521,6 +522,11 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         ProcessPacketCallback(Packet.release());
         break;
     }
+    case WM_START_RECONNECT:
+        // Runs the in-game teardown in the window-proc context (like packet
+        // handlers), where releasing world data is safe.
+        ReconnectManager::Instance().Begin();
+        break;
     case WM_NPROTECT_EXIT_TWO:
         SocketClient->ToGameServer()->SendLogOutByCheatDetection(0);
         SetTimer(g_hWnd, WINDOWMINIMIZED_TIMER, 1 * 1000, nullptr);

--- a/src/source/Platform/Windows/Winmain.h
+++ b/src/source/Platform/Windows/Winmain.h
@@ -50,6 +50,9 @@
 
 
 #define WM_RECEIVE_BUFFER	( WM_USER + 2)
+// Posted by the auto-reconnect detector so the heavy session teardown runs in
+// the window-proc context (like packet handlers) instead of mid-render.
+#define WM_START_RECONNECT	( WM_USER + 3)
 #define WM_NPROTECT_EXIT_TWO  (WM_USER + 10001)
 
 extern bool ashies;

--- a/src/source/Scenes/LoadingScene.cpp
+++ b/src/source/Scenes/LoadingScene.cpp
@@ -13,6 +13,7 @@
 #include "SceneCore.h"
 #include "Engine/Object/ZzzInterface.h"
 #include "SceneCommon.h"
+#include "UI/NewUI/Dialogs/ReconnectDialog.h"
 
 
 #ifdef _EDITOR
@@ -109,6 +110,7 @@ void LoadingScene(HDC hDC)
         EndBitmap();
     }
 #endif
+    UI::Reconnect::RenderDialog();
     ::SwapBuffers(hDC);
 
     SAFE_DELETE(rUIMng.m_pLoadingScene);

--- a/src/source/Scenes/MainScene.cpp
+++ b/src/source/Scenes/MainScene.cpp
@@ -21,6 +21,7 @@
 #include "Core/Utilities/Log/muConsoleDebug.h"
 #include "Core/Utilities/FrameProfiler.h"
 #include "Network/Server/WSclient.h"
+#include "Network/Reconnect/ReconnectManager.h"
 #include "Engine/AI/GOBoid.h"
 #include "GameLogic/Items/PersonalShopTitleImp.h"
 #include "UI/Legacy/UIManager.h"
@@ -132,6 +133,9 @@ static void InitializeMainScene()
 
     CurrentProtocolState = REQUEST_JOIN_MAP_SERVER;
     SocketClient->ToGameServer()->SendSelectCharacter(CharactersClient[SelectedHero].ID);
+
+    // Remember which character is in play so auto-reconnect can re-select it.
+    ReconnectManager::Instance().CacheCharacter(CharactersClient[SelectedHero].ID);
 
     CUIMng::Instance().CreateMainScene();
 
@@ -319,6 +323,12 @@ void MoveMainScene()
     }
 
     InitializeSceneFrame();
+
+    // While the reconnect dialog is up it's modal: block world clicks so they
+    // don't move the hero and instead reach the dialog's Cancel button.
+    if (ReconnectManager::Instance().IsActive())
+        MouseOnWindow = true;
+
     UpdateUIAndInput();
 
     if (ErrorMessage != 0)

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -32,6 +32,8 @@ FrameTimingState g_frameTiming;
 #include "Core/Input/Input.h"
 #include "UI/Legacy/UIMng.h"
 #include "Network/Server/WSclient.h"
+#include "Network/Reconnect/ReconnectManager.h"
+#include "UI/NewUI/Dialogs/ReconnectDialog.h"
 #include "GameLogic/Events/w_CursedTemple.h"
 #include "Network/Server/ServerListManager.h"
 #include "UI/NewUI/NewUISystem.h"
@@ -607,17 +609,39 @@ static void RenderFpsCounter()
  */
 static void CheckServerConnection()
 {
-    if (SocketClient == nullptr || !SocketClient->IsConnected())
+    if (SocketClient != nullptr && SocketClient->IsConnected())
     {
-        static BOOL s_bClosed = FALSE;
-        if (!s_bClosed)
-        {
-            s_bClosed = TRUE;
-            g_ErrorReport.Write(L"> Connection closed. ");
-            g_ErrorReport.WriteCurrentTime();
-            g_ConsoleDebug->Write(MCD_NORMAL, L"Connection closed");
-            CUIMng::Instance().PopUpMsgWin(MESSAGE_SERVER_LOST);
-        }
+        return;
+    }
+
+    // A reconnect already in progress manages its own connection attempts.
+    if (ReconnectManager::Instance().IsActive())
+    {
+        return;
+    }
+
+    // Auto-reconnect only makes sense in-game, where the server restores the
+    // character's saved position. Other scenes keep the original behaviour.
+    if (SceneFlag == MAIN_SCENE && ReconnectManager::Instance().HasSession())
+    {
+        g_ErrorReport.Write(L"> Connection lost in game - starting auto-reconnect. ");
+        g_ErrorReport.WriteCurrentTime();
+        g_ConsoleDebug->Write(MCD_NORMAL, L"Connection lost in game - starting auto-reconnect");
+        // Grab the clean game frame now (front buffer, dialog not yet drawn) so
+        // the brief re-login phase shows it frozen instead of a black screen.
+        UI::Reconnect::CaptureBackground();
+        ReconnectManager::Instance().RequestBegin();
+        return;
+    }
+
+    static BOOL s_bClosed = FALSE;
+    if (!s_bClosed)
+    {
+        s_bClosed = TRUE;
+        g_ErrorReport.Write(L"> Connection closed. ");
+        g_ErrorReport.WriteCurrentTime();
+        g_ConsoleDebug->Write(MCD_NORMAL, L"Connection closed");
+        CUIMng::Instance().PopUpMsgWin(MESSAGE_SERVER_LOST);
     }
 }
 
@@ -983,6 +1007,7 @@ void MainScene(HDC hDC)
         Success = RenderCurrentScene(hDC);
         RenderDebugInfo();
         RenderFpsCounter();
+        UI::Reconnect::RenderDialog();
 
         if (Success)
         {
@@ -1018,6 +1043,11 @@ void RenderScene(HDC hDC)
 {
     CalcFPS();
     UpdateSceneState();
+
+    // Drive auto-reconnect after the scene loops have advanced this frame. It
+    // runs across all scenes because reconnect passes through the login,
+    // character and loading scenes on its way back into the game.
+    ReconnectManager::Instance().Update();
 
     g_frameTiming.MarkFrameRendered();
 

--- a/src/source/UI/NewUI/Dialogs/ReconnectDialog.cpp
+++ b/src/source/UI/NewUI/Dialogs/ReconnectDialog.cpp
@@ -1,0 +1,293 @@
+#include "stdafx.h"
+#include "ReconnectDialog.h"
+
+#include "Network/Reconnect/ReconnectManager.h"
+#include "Render/Textures/ZzzOpenglUtil.h"   // RenderColor, BeginBitmap/EndBitmap, Mouse*
+#include "Render/Sprites/GlobalBitmap.h"     // Bitmaps (texture-loaded check)
+#include "UI/Legacy/UIControls.h"            // g_pRenderText, CheckMouseIn, RT3_SORT_CENTER
+#include "UI/NewUI/NewUICommon.h"            // SEASON3B::RenderImage
+#include "UI/NewUI/Dialogs/NewUIMessageBox.h"// CNewUIMessageBoxMng::IMAGE_MSGBOX_*
+#include "Platform/Windows/Winmain.h"        // g_hFont, g_hFontBold
+#include "I18N/All.h"
+
+namespace UI::Reconnect
+{
+namespace
+{
+    using MsgBox = SEASON3B::CNewUIMessageBoxMng;
+
+    // Frozen game frame captured at disconnect, shown during the re-login phase.
+    GLuint s_backgroundTex = 0;
+    bool s_hasBackground = false;
+
+    // Native message-box frame slice sizes (match CNewUICommonMessageBox).
+    constexpr float MSGBOX_WIDTH = 230.0f;
+    constexpr float TOP_H = 67.0f;
+    constexpr float BOTTOM_H = 50.0f;
+    constexpr float BACK_BLANK_W = 8.0f;
+    constexpr float BACK_BLANK_H = 10.0f;
+    // Layout in the 640x480 reference space the 2D render helpers use. The
+    // frame's top/bottom slices are fixed; the middle slice is stretched to make
+    // up the rest, so the panel height can be set freely.
+    constexpr float PANEL_W = MSGBOX_WIDTH;
+    constexpr float PANEL_H = 122.0f;
+    constexpr float PANEL_X = (REFERENCE_WIDTH - PANEL_W) / 2.0f;
+    constexpr float PANEL_Y = (REFERENCE_HEIGHT - PANEL_H) / 2.0f + 100.0f;
+    constexpr float MIDDLE_FILL_H = PANEL_H - TOP_H - BOTTOM_H;
+
+    constexpr float TITLE_Y = PANEL_Y + 12.0f;
+    constexpr float STEP_Y = PANEL_Y + 30.0f;
+    constexpr float COUNTDOWN_Y = PANEL_Y + 48.0f;
+
+    constexpr float PROG_W = 160.0f;
+    constexpr float PROG_H = 18.0f;
+    constexpr float PROG_X = PANEL_X + (PANEL_W - PROG_W) / 2.0f;
+    constexpr float PROG_Y = PANEL_Y + 66.0f;
+    // The fill bar is smaller than the trough; inset it so it sits centred.
+    constexpr float PROG_BAR_MAX_W = 150.0f;
+    constexpr float PROG_BAR_H = 8.0f;
+    constexpr float PROG_BAR_INSET = 5.0f;
+    constexpr float PROG_BAR_X = PROG_X + PROG_BAR_INSET;
+    constexpr float PROG_BAR_Y = PROG_Y + PROG_BAR_INSET;
+
+    constexpr float CANCEL_W = 54.0f;        // native cancel button size
+    constexpr float CANCEL_H = 30.0f;
+    constexpr float CANCEL_X = PANEL_X + (PANEL_W - CANCEL_W) / 2.0f;
+    constexpr float CANCEL_Y = PANEL_Y + PANEL_H - CANCEL_H - 6.0f;
+
+    // The cancel button texture stacks three 30px states in a 64x128 sheet.
+    constexpr float BTN_SHEET_W = 64.0f;
+    constexpr float BTN_SHEET_H = 128.0f;
+
+    // Text colour (light parchment, matching the in-game message boxes).
+    constexpr BYTE TEXT_R = 230;
+    constexpr BYTE TEXT_G = 220;
+    constexpr BYTE TEXT_B = 200;
+    constexpr BYTE TEXT_A = 255;
+
+    // Backdrop / fallback-panel opacities.
+    constexpr float DIM_ALPHA = 0.45f;          // dim over the live game / snapshot
+    constexpr float OPAQUE_ALPHA = 1.0f;        // full cover when no frame is shown
+    constexpr float FB_BORDER_ALPHA = 0.5f;     // fallback panel border
+    constexpr float FB_PANEL_ALPHA = 0.92f;     // fallback panel fill
+    constexpr float FB_BORDER = 2.0f;           // fallback panel border thickness
+    constexpr float FB_BAR_BG_ALPHA = 0.7f;     // fallback progress trough
+    constexpr float FB_BAR_FILL_ALPHA = 0.9f;   // fallback progress fill
+    constexpr float FB_CANCEL_ALPHA = 0.25f;    // fallback cancel button
+    constexpr float FB_CANCEL_HOVER_ALPHA = 0.45f;
+
+    const wchar_t* StepLabel(ReconnectManager::Phase phase)
+    {
+        using Phase = ReconnectManager::Phase;
+        switch (phase)
+        {
+        case Phase::Probing:       return I18N::Game::CheckingServerAvailability;
+        case Phase::Retrying:      return I18N::Game::ConnectingToTheServer;
+        case Phase::Connecting:    return I18N::Game::ConnectingToTheServer;
+        case Phase::LoggingIn:     return I18N::Game::LoggingIn;
+        case Phase::SelectingChar: return I18N::Game::LoadingCharacterList;
+        case Phase::Joining:       return I18N::Game::EnteringTheGame;
+        default:                   return L"";
+        }
+    }
+
+    // True when the in-game message-box textures are resident (they are while
+    // we're still in the main scene - i.e. the long probing wait). During the
+    // brief re-login the UI is torn down and they may be gone, so we fall back.
+    bool NativeSkinAvailable()
+    {
+        return Bitmaps[MsgBox::IMAGE_MSGBOX_TOP].TextureNumber != 0
+            && Bitmaps[MsgBox::IMAGE_MSGBOX_PROGRESS_BG].TextureNumber != 0
+            && Bitmaps[MsgBox::IMAGE_MSGBOX_BTN_CANCEL].TextureNumber != 0;
+    }
+
+    void FillWhite(float x, float y, float w, float h, float alpha)
+    {
+        RenderColor(x, y, w, h, alpha, 0);
+    }
+
+    void FillBlack(float x, float y, float w, float h, float alpha)
+    {
+        RenderColor(x, y, w, h, alpha, 1);
+    }
+
+    void DrawCenteredText(float x, float y, float width, HFONT font, const wchar_t* text)
+    {
+        g_pRenderText->SetFont(font);
+        g_pRenderText->SetBgColor(0, 0, 0, 0);
+        g_pRenderText->SetTextColor(TEXT_R, TEXT_G, TEXT_B, TEXT_A);
+        g_pRenderText->RenderText(static_cast<int>(x), static_cast<int>(y), text,
+            static_cast<int>(width), 0, RT3_SORT_CENTER);
+    }
+
+    void DrawBackdrop()
+    {
+        // While probing we're still in the main scene: dim the live game lightly
+        // and let it show through.
+        if (ReconnectManager::Instance().GetPhase() == ReconnectManager::Phase::Probing)
+        {
+            FillBlack(0.0f, 0.0f, REFERENCE_WIDTH, REFERENCE_HEIGHT, DIM_ALPHA);
+            return;
+        }
+
+        // Re-login: the world is torn down. Show the frozen disconnect frame
+        // (BindTexture takes a negative id as a raw GL texture; the framebuffer
+        // is bottom-up so V is flipped) so the player doesn't see a black screen
+        // or the login world.
+        if (s_hasBackground && s_backgroundTex != 0)
+        {
+            glEnable(GL_TEXTURE_2D);
+            RenderColorBitmap(-static_cast<int>(s_backgroundTex), 0.0f, 0.0f,
+                REFERENCE_WIDTH, REFERENCE_HEIGHT, 0.0f, 1.0f, 1.0f, -1.0f, 0xFFFFFFFF);
+            FillBlack(0.0f, 0.0f, REFERENCE_WIDTH, REFERENCE_HEIGHT, DIM_ALPHA);
+            return;
+        }
+
+        FillBlack(0.0f, 0.0f, REFERENCE_WIDTH, REFERENCE_HEIGHT, OPAQUE_ALPHA);
+    }
+
+    float Progress()
+    {
+        const int steps = ReconnectManager::GetStepCount();
+        const int current = ReconnectManager::Instance().GetStepIndex();
+        if (steps <= 0 || current <= 0)
+        {
+            return 0.0f;
+        }
+        return static_cast<float>(current) / static_cast<float>(steps);
+    }
+
+    void DrawStatusTexts()
+    {
+        ReconnectManager& mgr = ReconnectManager::Instance();
+
+        DrawCenteredText(PANEL_X, TITLE_Y, PANEL_W, g_hFontBold, I18N::Game::ConnectionLost);
+        DrawCenteredText(PANEL_X, STEP_Y, PANEL_W, g_hFont, StepLabel(mgr.GetPhase()));
+
+        const int seconds = mgr.GetCountdownSeconds();
+        if (seconds > 0)
+        {
+            wchar_t countdown[64];
+            mu_swprintf(countdown, I18N::Game::RetryingInSeconds, seconds);
+            DrawCenteredText(PANEL_X, COUNTDOWN_Y, PANEL_W, g_hFont, countdown);
+        }
+    }
+
+    // ---- Native (message-box textured) rendering ----------------------------
+
+    void DrawNative(bool cancelHovered)
+    {
+        glEnable(GL_TEXTURE_2D);
+
+        // Inner background, then the top/middle*n/bottom border frame on top.
+        SEASON3B::RenderImage(MsgBox::IMAGE_MSGBOX_BACK, PANEL_X, PANEL_Y + 2.0f,
+            MSGBOX_WIDTH - BACK_BLANK_W, PANEL_H - BACK_BLANK_H);
+
+        SEASON3B::RenderImage(MsgBox::IMAGE_MSGBOX_TOP, PANEL_X, PANEL_Y, MSGBOX_WIDTH, TOP_H);
+        SEASON3B::RenderImage(MsgBox::IMAGE_MSGBOX_MIDDLE, PANEL_X, PANEL_Y + TOP_H, MSGBOX_WIDTH,
+            MIDDLE_FILL_H, 0.0f, 0.0f, 1.0f, 1.0f);  // stretched to fill
+        SEASON3B::RenderImage(MsgBox::IMAGE_MSGBOX_BOTTOM, PANEL_X, PANEL_Y + TOP_H + MIDDLE_FILL_H,
+            MSGBOX_WIDTH, BOTTOM_H);
+
+        // Progress bar (native two-texture gauge), fill inset into the trough.
+        SEASON3B::RenderImage(MsgBox::IMAGE_MSGBOX_PROGRESS_BG, PROG_X, PROG_Y, PROG_W, PROG_H);
+        const float fraction = Progress();
+        if (fraction > 0.0f)
+        {
+            SEASON3B::RenderImage(MsgBox::IMAGE_MSGBOX_PROGRESS_BAR, PROG_BAR_X, PROG_BAR_Y,
+                PROG_BAR_MAX_W * fraction, PROG_BAR_H);
+        }
+
+        // Cancel button: pick the normal / hover row from the button sheet.
+        const float sv = cancelHovered ? (CANCEL_H / BTN_SHEET_H) : 0.0f;
+        SEASON3B::RenderImage(MsgBox::IMAGE_MSGBOX_BTN_CANCEL, CANCEL_X, CANCEL_Y, CANCEL_W, CANCEL_H,
+            0.0f, sv, CANCEL_W / BTN_SHEET_W, CANCEL_H / BTN_SHEET_H);
+
+        DrawStatusTexts();
+    }
+
+    // ---- Fallback (flat-colour) rendering, used when the skin is unloaded ----
+
+    void DrawFallback(bool cancelHovered)
+    {
+        FillWhite(PANEL_X - FB_BORDER, PANEL_Y - FB_BORDER,
+            PANEL_W + 2 * FB_BORDER, PANEL_H + 2 * FB_BORDER, FB_BORDER_ALPHA);
+        FillBlack(PANEL_X, PANEL_Y, PANEL_W, PANEL_H, FB_PANEL_ALPHA);
+
+        FillBlack(PROG_X, PROG_Y, PROG_W, PROG_H, FB_BAR_BG_ALPHA);
+        const float fraction = Progress();
+        if (fraction > 0.0f)
+        {
+            FillWhite(PROG_BAR_X, PROG_BAR_Y, PROG_BAR_MAX_W * fraction, PROG_BAR_H, FB_BAR_FILL_ALPHA);
+        }
+
+        FillWhite(CANCEL_X, CANCEL_Y, CANCEL_W, CANCEL_H,
+            cancelHovered ? FB_CANCEL_HOVER_ALPHA : FB_CANCEL_ALPHA);
+
+        EndRenderColor();  // restore texturing for the glyphs
+
+        DrawStatusTexts();
+        DrawCenteredText(CANCEL_X, CANCEL_Y + 8.0f, CANCEL_W, g_hFont, I18N::Game::Cancel);
+    }
+}
+
+void CaptureBackground()
+{
+    if (WindowWidth == 0 || WindowHeight == 0)
+    {
+        return;
+    }
+
+    if (s_backgroundTex == 0)
+    {
+        glGenTextures(1, &s_backgroundTex);
+    }
+
+    glBindTexture(GL_TEXTURE_2D, s_backgroundTex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    // Read the displayed (front) buffer - this runs right after the frame was
+    // presented and before the dialog draws, so it's a clean game frame.
+    glReadBuffer(GL_FRONT);
+    glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 0, 0,
+        static_cast<GLsizei>(WindowWidth), static_cast<GLsizei>(WindowHeight), 0);
+    glReadBuffer(GL_BACK);
+
+    s_hasBackground = true;
+}
+
+void RenderDialog()
+{
+    ReconnectManager& mgr = ReconnectManager::Instance();
+    if (!mgr.IsActive())
+    {
+        return;
+    }
+
+    const bool cancelHovered = CheckMouseIn(static_cast<int>(CANCEL_X), static_cast<int>(CANCEL_Y),
+        static_cast<int>(CANCEL_W), static_cast<int>(CANCEL_H)) == TRUE;
+
+    BeginBitmap();
+
+    DrawBackdrop();
+
+    if (NativeSkinAvailable())
+    {
+        DrawNative(cancelHovered);
+    }
+    else
+    {
+        DrawFallback(cancelHovered);
+    }
+
+    EndBitmap();
+
+    if (cancelHovered && MouseLButtonPush)
+    {
+        mgr.RequestCancel();
+    }
+}
+}

--- a/src/source/UI/NewUI/Dialogs/ReconnectDialog.h
+++ b/src/source/UI/NewUI/Dialogs/ReconnectDialog.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Modal overlay shown while ReconnectManager is auto-reconnecting after an
+// in-game disconnect (issue #338). Reads its state from ReconnectManager and
+// renders a dimmed backdrop, a status panel with the current step and a
+// progress bar, and a Cancel button. A no-op when no reconnect is in progress.
+namespace UI::Reconnect
+{
+    // Captures the current (clean) game frame into a texture. Called at the
+    // moment of disconnect so the brief re-login phase - when the world is torn
+    // down and can't render - shows the frozen game instead of a black screen.
+    void CaptureBackground();
+
+    void RenderDialog();
+}

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -11,6 +11,7 @@
 #include "Engine/Object/ZzzObject.h"
 #include "Engine/Object/ZzzCharacter.h"
 #include "Engine/Object/ZzzInterface.h"
+#include "Network/Reconnect/ReconnectManager.h"
 #include "UI/Legacy/UIControls.h"
 #include "Scenes/SceneCore.h"
 #include "I18N/All.h"
@@ -268,6 +269,10 @@ void CLoginWin::RequestLogin()
             CurrentProtocolState = REQUEST_LOG_IN;
 
             SocketClient->ToGameServer()->SendLogin(m_Username, m_Password, Version, Serial);
+
+            // Keep the credentials in memory so auto-reconnect can re-login
+            // without prompting after an in-game disconnect.
+            ReconnectManager::Instance().CacheCredentials(m_Username, m_Password);
 
             g_pSystemLogBox->AddText(I18N::Game::VerifyingYourAccount, SEASON3B::TYPE_SYSTEM_MESSAGE);
             g_pSystemLogBox->AddText(I18N::Game::PleaseWait, SEASON3B::TYPE_SYSTEM_MESSAGE);


### PR DESCRIPTION
On an in-game disconnect the client now keeps the world rendered, probes the game server in the background, and once it is reachable re-logs in and rejoins the same character at its saved position instead of dropping to the login screen. A native-styled dialog shows the progress with a cancel button.

- ReconnectManager owns the probe/teardown/login/select/join state machine and caches the session (server address, credentials, character) during play.
- TCP keep-alive and send-failure teardown in the client library so dead or half-open connections are detected within ~10 seconds.
- MU Helper stop works after reconnect: the client-side toggle stops the bot immediately rather than waiting for a server reply.

Implements #338.