### PR TITLE
feat(inventory): right-click & drag always-equip with conflict resolution

### DIFF
--- a/docs/inventory-equip.md
+++ b/docs/inventory-equip.md
@@ -1,0 +1,44 @@
+# Equipping from the inventory
+
+How items move from the bag onto the character. Covers right-click and
+drag-drop equipping and how occupied slots are handled.
+
+## Right-click to equip
+
+Right-clicking an equippable item in the inventory equips it immediately,
+choosing the slot for you:
+
+- **One-handed weapon** — goes to the main hand. If the main hand is taken
+  but the off-hand is free (dual-wield classes), it fills the off-hand
+  instead. If both hands are full, it replaces the main-hand weapon.
+- **Shield / off-hand** — goes to the off-hand, replacing whatever is there.
+- **Ring** — fills a free ring slot; if both are full, replaces the first.
+- **Two-handed weapon** — needs both hands, so it unequips **both** the
+  main-hand weapon and the off-hand/shield, then equips.
+- Equipping a shield (or any off-hand item) while a two-handed weapon is
+  held unequips the two-handed weapon.
+
+Anything it replaces is moved back into the inventory.
+
+## Drag-drop to equip
+
+Dragging an item onto an equipment slot equips it into **that exact slot**.
+Dropping onto an already-occupied slot now **replaces** the occupant
+(previously it did nothing): the occupant returns to the bag and the dropped
+item is equipped. The two-handed rules above apply here too.
+
+## When the bag is full
+
+Replacing an item only works if the inventory has room for everything being
+taken off. The whole action is all-or-nothing: if a two-handed weapon would
+displace two items but only one fits, **nothing** is unequipped and a "not
+enough space" message is shown. The item you were equipping is never lost.
+
+## Why it works this way
+
+The server only moves an item onto an **empty** equipment slot, one move at a
+time, and confirms each move before the next. A direct slot-to-slot swap is
+not possible, so the client unequips the conflicting item(s) to the bag first
+and equips the new item once every required slot is free. In the original S6
+client an occupied slot simply rejected the equip; here it resolves the
+conflict for you.

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -44,6 +44,7 @@
 #include "UI/NewUI/Dialogs/NewUICommonMessageBox.h"
 #include "UI/NewUI/Dialogs/NewUICustomMessageBox.h"
 #include "UI/NewUI/Inventory/NewUIInventoryCtrl.h"
+#include "UI/NewUI/Inventory/NewUIInventoryActionController.h"
 #include "GameLogic/Events/w_CursedTemple.h"
 #include "GameLogic/Skills/SummonSystem.h"
 #include "GameLogic/Skills/SkillManager.h"
@@ -6138,9 +6139,13 @@ BOOL ReceiveEquipmentItemExtended(std::span<const BYTE> ReceiveBuffer)
         }
 
         PlayBuffer(SOUND_GET_ITEM01);
+
+        // If a right-click "always equip" unequipped an occupant first, equip the new item now.
+        SEASON3B::ProcessPendingEquipAfterMove();
     }
     else
     {
+        SEASON3B::CancelPendingEquipSwap();
         SEASON3B::CNewUIInventoryCtrl::BackupPickedItem();
         if (g_pStorageInventory->IsItemAutoMove())
         {

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -780,6 +780,8 @@ extern void StopMusic();
 
 void InitGame()
 {
+    SEASON3B::CancelPendingEquipSwap();   // drop any half-finished equip swap from a prior session
+
     EnableUse = 0;
     SendGetItem = -1;
     SummonLife = 0;

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
@@ -41,6 +41,7 @@ namespace
         int   dstEquipSlot = -1;                              // where the new item will be equipped
         DWORD newItemKey   = 0;                               // identifies the new inventory item
         int   freeSlots[MAX_EQUIP_BLOCKERS] = { -1, -1 };     // equipment slots still to unequip
+        int   freeDest[MAX_EQUIP_BLOCKERS]  = { -1, -1 };     // reserved inventory slot for each
         int   freeCount    = 0;
     };
 
@@ -78,9 +79,10 @@ namespace
         return true;
     }
 
-    // Pick the item in an equipment slot and request the server to move it to a free inventory slot.
-    // Returns false when there is no inventory space (caller must abort without touching anything).
-    bool UnequipToInventory(int nEquipSlot)
+    // Pick the item in an equipment slot and request the server to move it to a pre-reserved
+    // inventory slot. The destination was reserved up front so the whole multi-item swap is
+    // all-or-nothing (see SwapEquipItem); -1 falls back to a fresh search as a safety net.
+    bool UnequipToInventory(int nEquipSlot, int nReservedDest)
     {
         if (g_pMyInventory == nullptr || nEquipSlot < 0 || nEquipSlot >= MAX_EQUIPMENT_INDEX)
         {
@@ -88,7 +90,7 @@ namespace
         }
 
         ITEM* pEquipped = &CharacterMachine->Equipment[nEquipSlot];
-        const int iTempSlot = g_pMyInventory->FindEmptySlot(pEquipped);
+        const int iTempSlot = (nReservedDest != -1) ? nReservedDest : g_pMyInventory->FindEmptySlot(pEquipped);
         if (iTempSlot == -1)
         {
             return false;
@@ -107,6 +109,61 @@ namespace
         SendRequestEquipmentItem(STORAGE_TYPE::INVENTORY, nEquipSlot, pEquipped, STORAGE_TYPE::INVENTORY, iTempSlot);
         return true;
     }
+
+    bool EquippedSlotItemSize(int nSlot, int& outWidth, int& outHeight)
+    {
+        if (nSlot < 0 || nSlot >= MAX_EQUIPMENT_INDEX)
+        {
+            return false;
+        }
+
+        const ITEM* pItem = &CharacterMachine->Equipment[nSlot];
+        if (pItem->Type == -1)
+        {
+            return false;
+        }
+
+        const ITEM_ATTRIBUTE* pAttr = &ItemAttribute[pItem->Type];
+        outWidth  = pAttr->Width;
+        outHeight = pAttr->Height;
+        return true;
+    }
+
+    // Reserve a distinct inventory slot for every blocking equipment item, all at once. Returns
+    // false (reserving nothing) unless ALL of them fit, so the caller can abort atomically and
+    // leave the character untouched (mirrors WoW: a 2H swap fails cleanly when the bag is full).
+    bool ReserveSlotsForBlockers(CNewUIInventoryCtrl* pInvenCtrl, const int* blockers, int nBlockers, int* outDest)
+    {
+        if (pInvenCtrl == nullptr || nBlockers <= 0)
+        {
+            return false;
+        }
+
+        int wA, hA;
+        if (!EquippedSlotItemSize(blockers[0], wA, hA))
+        {
+            return false;
+        }
+
+        int wB, hB;
+        const bool bSecond = (nBlockers >= 2) && EquippedSlotItemSize(blockers[1], wB, hB);
+
+        // Only the first slot holds a movable item: a single free slot is enough.
+        if (!bSecond)
+        {
+            const int slot = pInvenCtrl->FindEmptySlot(wA, hA);
+            if (slot == -1)
+            {
+                return false;
+            }
+            outDest[0] = slot;
+            outDest[1] = -1;
+            return true;
+        }
+
+        // Both items must fit at once in non-overlapping space.
+        return pInvenCtrl->FindTwoEmptySlots(wA, hA, wB, hB, outDest[0], outDest[1]);
+    }
 }
 
 void CancelPendingEquipSwap()
@@ -124,7 +181,9 @@ void ProcessPendingEquipAfterMove()
     // Unequip the next still-occupied blocking slot, one per move ack, before the final equip.
     while (s_pendingEquip.freeCount > 0)
     {
-        const int nSlot = s_pendingEquip.freeSlots[--s_pendingEquip.freeCount];
+        const int nIdx  = --s_pendingEquip.freeCount;
+        const int nSlot = s_pendingEquip.freeSlots[nIdx];
+        const int nDest = s_pendingEquip.freeDest[nIdx];
         if (nSlot < 0 || nSlot >= MAX_EQUIPMENT_INDEX)
         {
             continue;
@@ -135,7 +194,7 @@ void ProcessPendingEquipAfterMove()
             continue;   // already empty -> nothing to move, skip to the next blocker
         }
 
-        if (!UnequipToInventory(nSlot))
+        if (!UnequipToInventory(nSlot, nDest))
         {
             ClearPendingEquip();   // no inventory space: stop safely, the new item is untouched
             return;
@@ -581,9 +640,24 @@ int CNewUIInventoryActionController::CollectEquipBlockers(ITEM* pItem, int nDstI
 
 bool CNewUIInventoryActionController::SwapEquipItem(ITEM* pItem, int nDstSlot, const int* blockers, int nBlockers) const
 {
-    // Queue the blocking slots to unequip, then drive the sequence. The new item is only equipped
-    // once every blocker has been cleared (see ProcessPendingEquipAfterMove), so it is never lost
-    // even if the server would reject an intermediate state.
+    CNewUIInventoryCtrl* pInvenCtrl = (g_pMyInventory != nullptr) ? g_pMyInventory->GetInventoryCtrl() : nullptr;
+    if (pInvenCtrl == nullptr || nBlockers <= 0)
+    {
+        return true;
+    }
+
+    // Reserve an inventory slot for EVERY item we are about to displace, up front. If they do not
+    // all fit at once, abort and unequip nothing — the swap is all-or-nothing, like WoW.
+    int dest[MAX_EQUIP_BLOCKERS] = { -1, -1 };
+    if (!ReserveSlotsForBlockers(pInvenCtrl, blockers, nBlockers, dest))
+    {
+        g_pSystemLogBox->AddText(GlobalText[1815], TYPE_ERROR_MESSAGE);   // not enough inventory space
+        return true;
+    }
+
+    // Queue the blocking slots to unequip into their reserved destinations, then drive the
+    // sequence. The new item is only equipped once every blocker has been cleared (see
+    // ProcessPendingEquipAfterMove), so it is never lost even on an intermediate server rejection.
     s_pendingEquip.active       = true;
     s_pendingEquip.dstEquipSlot = nDstSlot;
     s_pendingEquip.newItemKey   = pItem->Key;
@@ -591,7 +665,9 @@ bool CNewUIInventoryActionController::SwapEquipItem(ITEM* pItem, int nDstSlot, c
 
     for (int i = 0; i < nBlockers && i < MAX_EQUIP_BLOCKERS; ++i)
     {
-        s_pendingEquip.freeSlots[s_pendingEquip.freeCount++] = blockers[i];
+        s_pendingEquip.freeSlots[s_pendingEquip.freeCount] = blockers[i];
+        s_pendingEquip.freeDest[s_pendingEquip.freeCount]  = dest[i];
+        s_pendingEquip.freeCount++;
     }
 
     ProcessPendingEquipAfterMove();   // performs the first unequip

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
@@ -674,6 +674,49 @@ bool CNewUIInventoryActionController::SwapEquipItem(ITEM* pItem, int nDstSlot, c
     return true;
 }
 
+bool CNewUIInventoryActionController::EquipToSlotReplacing(DWORD dwItemKey, int nDstSlot) const
+{
+    if (m_pContext == nullptr || g_pMyInventory == nullptr
+        || nDstSlot < 0 || nDstSlot >= MAX_EQUIPMENT_INDEX)
+    {
+        return false;
+    }
+
+    CNewUIInventoryCtrl* pInvenCtrl = g_pMyInventory->GetInventoryCtrl();
+    if (pInvenCtrl == nullptr)
+    {
+        return false;
+    }
+
+    ITEM* pItem = pInvenCtrl->FindItemByKey(dwItemKey);
+    if (pItem == nullptr)
+    {
+        return false;   // not in the main inventory; leave it where it was restored
+    }
+
+    if (!m_pContext->IsEquipable(nDstSlot, pItem))
+    {
+        return true;
+    }
+
+    const int iSrcIndex = pInvenCtrl->GetIndexByItem(pItem);
+    if (iSrcIndex < 0)
+    {
+        return false;
+    }
+
+    // Same unequip-then-equip path as right-click, but into the exact slot the item was dropped on.
+    int blockers[MAX_EQUIP_BLOCKERS];
+    const int nBlockers = CollectEquipBlockers(pItem, nDstSlot, blockers);
+
+    if (nBlockers == 0)
+    {
+        return EquipFromInventory(pInvenCtrl, pItem, iSrcIndex, nDstSlot);
+    }
+
+    return SwapEquipItem(pItem, nDstSlot, blockers, nBlockers);
+}
+
 bool CNewUIInventoryActionController::TryDropItem(CNewUIInventoryCtrl* targetControl, ITEM* pItem) const
 {
     if (Hero->Dead != 0)

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
@@ -25,6 +25,169 @@
 namespace SEASON3B
 {
 
+namespace
+{
+    // A two-handed weapon can require BOTH hands freed (its slot + the off-hand shield).
+    constexpr int MAX_EQUIP_BLOCKERS = 2;
+
+    // Right-click "always equip": the server only moves an item onto an EMPTY equipment slot, one
+    // move at a time, and acks asynchronously. So when the target slot — or a conflicting off-hand
+    // (e.g. equipping a two-handed weapon over a shield) — is occupied, we unequip each blocking
+    // item to inventory first and only equip the new item once every required slot is free. This
+    // record carries that multi-step sequence across ReceiveEquipmentItemExtended.
+    struct PendingEquip
+    {
+        bool  active       = false;
+        int   dstEquipSlot = -1;                              // where the new item will be equipped
+        DWORD newItemKey   = 0;                               // identifies the new inventory item
+        int   freeSlots[MAX_EQUIP_BLOCKERS] = { -1, -1 };     // equipment slots still to unequip
+        int   freeCount    = 0;
+    };
+
+    PendingEquip s_pendingEquip{};
+
+    void ClearPendingEquip()
+    {
+        s_pendingEquip.active    = false;
+        s_pendingEquip.freeCount = 0;
+    }
+
+    // Pick an inventory item and request the server to move it to an equipment slot.
+    bool EquipFromInventory(CNewUIInventoryCtrl* targetControl, ITEM* pItem, int iSrcIndex, int iDstSlot)
+    {
+        if (targetControl == nullptr || pItem == nullptr)
+        {
+            return false;
+        }
+
+        if (!CNewUIInventoryCtrl::CreatePickedItem(nullptr, pItem))
+        {
+            return false;
+        }
+
+        CNewUIPickedItem* pPickedItem = CNewUIInventoryCtrl::GetPickedItem();
+        if (pPickedItem == nullptr)
+        {
+            return false;
+        }
+
+        targetControl->RemoveItem(pItem);
+        pPickedItem->HidePickedItem();
+
+        SendRequestEquipmentItem(STORAGE_TYPE::INVENTORY, iSrcIndex, pItem, STORAGE_TYPE::INVENTORY, iDstSlot);
+        return true;
+    }
+
+    // Pick the item in an equipment slot and request the server to move it to a free inventory slot.
+    // Returns false when there is no inventory space (caller must abort without touching anything).
+    bool UnequipToInventory(int nEquipSlot)
+    {
+        if (g_pMyInventory == nullptr || nEquipSlot < 0 || nEquipSlot >= MAX_EQUIPMENT_INDEX)
+        {
+            return false;
+        }
+
+        ITEM* pEquipped = &CharacterMachine->Equipment[nEquipSlot];
+        const int iTempSlot = g_pMyInventory->FindEmptySlot(pEquipped);
+        if (iTempSlot == -1)
+        {
+            return false;
+        }
+
+        if (CNewUIInventoryCtrl::CreatePickedItem(nullptr, pEquipped))
+        {
+            CNewUIPickedItem* pPickedItem = CNewUIInventoryCtrl::GetPickedItem();
+            g_pMyInventory->UnequipItem(nEquipSlot);
+            if (pPickedItem != nullptr)
+            {
+                pPickedItem->HidePickedItem();
+            }
+        }
+
+        SendRequestEquipmentItem(STORAGE_TYPE::INVENTORY, nEquipSlot, pEquipped, STORAGE_TYPE::INVENTORY, iTempSlot);
+        return true;
+    }
+}
+
+void CancelPendingEquipSwap()
+{
+    ClearPendingEquip();
+}
+
+void ProcessPendingEquipAfterMove()
+{
+    if (!s_pendingEquip.active)
+    {
+        return;
+    }
+
+    // Unequip the next still-occupied blocking slot, one per move ack, before the final equip.
+    while (s_pendingEquip.freeCount > 0)
+    {
+        const int nSlot = s_pendingEquip.freeSlots[--s_pendingEquip.freeCount];
+        if (nSlot < 0 || nSlot >= MAX_EQUIPMENT_INDEX)
+        {
+            continue;
+        }
+
+        if (CharacterMachine->Equipment[nSlot].Type == -1)
+        {
+            continue;   // already empty -> nothing to move, skip to the next blocker
+        }
+
+        if (!UnequipToInventory(nSlot))
+        {
+            ClearPendingEquip();   // no inventory space: stop safely, the new item is untouched
+            return;
+        }
+
+        return;   // wait for this unequip's ack before handling the next step
+    }
+
+    // Every blocking slot is now free: equip the new item.
+    const int   iDstSlot  = s_pendingEquip.dstEquipSlot;
+    const DWORD dwItemKey = s_pendingEquip.newItemKey;
+    ClearPendingEquip();
+
+    if (g_pMyInventory == nullptr)
+    {
+        return;
+    }
+
+    CNewUIInventoryCtrl* pInvenCtrl = g_pMyInventory->GetInventoryCtrl();
+    if (pInvenCtrl == nullptr)
+    {
+        return;
+    }
+
+    ITEM* pNewItem = pInvenCtrl->FindItemByKey(dwItemKey);
+    if (pNewItem == nullptr)
+    {
+        return;   // item moved/changed since we queued the swap; abort safely
+    }
+
+    // Final guards: never pick the item unless the destination is genuinely equippable now.
+    if (iDstSlot < 0 || iDstSlot >= MAX_EQUIPMENT_INDEX || CharacterMachine->Equipment[iDstSlot].Type != -1)
+    {
+        return;
+    }
+
+    const ITEM_ATTRIBUTE* pNewAttr = &ItemAttribute[pNewItem->Type];
+    if (pNewAttr->TwoHand && iDstSlot == EQUIPMENT_WEAPON_RIGHT
+        && CharacterMachine->Equipment[EQUIPMENT_WEAPON_LEFT].Type != -1)
+    {
+        return;   // two-handed weapon still blocked by the off-hand; do not lose the item
+    }
+
+    const int iSrcIndex = pInvenCtrl->GetIndexByItem(pNewItem);
+    if (iSrcIndex < 0)
+    {
+        return;
+    }
+
+    EquipFromInventory(pInvenCtrl, pNewItem, iSrcIndex, iDstSlot);
+}
+
 CNewUIInventoryActionController::CNewUIInventoryActionController()
     : m_pContext(nullptr)
 {
@@ -358,6 +521,7 @@ bool CNewUIInventoryActionController::TryEquipItem(CNewUIInventoryCtrl* targetCo
         return true;
     }
 
+    // Prefer an empty alternate hand/ring (e.g. equip a 1H weapon to the free off-hand).
     if (IsSlotOccupied(nDstIndex))
     {
         const int nAltSlot = FindAlternateEquipSlot(nDstIndex, pItem);
@@ -366,10 +530,6 @@ bool CNewUIInventoryActionController::TryEquipItem(CNewUIInventoryCtrl* targetCo
         {
             nDstIndex = nAltSlot;
         }
-        else
-        {
-            return true;
-        }
     }
 
     if (!m_pContext->IsEquipable(nDstIndex, pItem))
@@ -377,21 +537,64 @@ bool CNewUIInventoryActionController::TryEquipItem(CNewUIInventoryCtrl* targetCo
         return true;
     }
 
-    if (!CNewUIInventoryCtrl::CreatePickedItem(nullptr, pItem))
+    // Find every equipment slot that must be emptied before this equip can succeed: the target
+    // slot itself plus any two-handed-weapon hand conflict (which IsEquipable does not check).
+    int blockers[MAX_EQUIP_BLOCKERS];
+    const int nBlockers = CollectEquipBlockers(pItem, nDstIndex, blockers);
+
+    if (nBlockers == 0)
     {
-        return false;
+        return EquipFromInventory(targetControl, pItem, iSrcIndex, nDstIndex);
     }
 
-    CNewUIPickedItem* pPickedItem = CNewUIInventoryCtrl::GetPickedItem();
-    if (pPickedItem == nullptr)
+    return SwapEquipItem(pItem, nDstIndex, blockers, nBlockers);
+}
+
+int CNewUIInventoryActionController::CollectEquipBlockers(ITEM* pItem, int nDstIndex, int* outSlots) const
+{
+    int nCount = 0;
+    const ITEM_ATTRIBUTE* pItemAttr = &ItemAttribute[pItem->Type];
+
+    if (IsSlotOccupied(nDstIndex))
     {
-        return false;
+        outSlots[nCount++] = nDstIndex;
     }
 
-    targetControl->RemoveItem(pItem);
-    pPickedItem->HidePickedItem();
+    // A two-handed weapon needs the off-hand empty too.
+    if (pItemAttr->TwoHand && nDstIndex == EQUIPMENT_WEAPON_RIGHT && IsSlotOccupied(EQUIPMENT_WEAPON_LEFT))
+    {
+        outSlots[nCount++] = EQUIPMENT_WEAPON_LEFT;
+    }
 
-    SendRequestEquipmentItem(STORAGE_TYPE::INVENTORY, iSrcIndex, pItem, STORAGE_TYPE::INVENTORY, nDstIndex);
+    // Equipping into the off-hand while the main hand holds a two-handed weapon: free that weapon.
+    if (nDstIndex == EQUIPMENT_WEAPON_LEFT)
+    {
+        const ITEM* pRight = &CharacterMachine->Equipment[EQUIPMENT_WEAPON_RIGHT];
+        if (pRight->Type != -1 && ItemAttribute[pRight->Type].TwoHand && nCount < MAX_EQUIP_BLOCKERS)
+        {
+            outSlots[nCount++] = EQUIPMENT_WEAPON_RIGHT;
+        }
+    }
+
+    return nCount;
+}
+
+bool CNewUIInventoryActionController::SwapEquipItem(ITEM* pItem, int nDstSlot, const int* blockers, int nBlockers) const
+{
+    // Queue the blocking slots to unequip, then drive the sequence. The new item is only equipped
+    // once every blocker has been cleared (see ProcessPendingEquipAfterMove), so it is never lost
+    // even if the server would reject an intermediate state.
+    s_pendingEquip.active       = true;
+    s_pendingEquip.dstEquipSlot = nDstSlot;
+    s_pendingEquip.newItemKey   = pItem->Key;
+    s_pendingEquip.freeCount    = 0;
+
+    for (int i = 0; i < nBlockers && i < MAX_EQUIP_BLOCKERS; ++i)
+    {
+        s_pendingEquip.freeSlots[s_pendingEquip.freeCount++] = blockers[i];
+    }
+
+    ProcessPendingEquipAfterMove();   // performs the first unequip
     return true;
 }
 

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
@@ -38,6 +38,7 @@ namespace
     struct PendingEquip
     {
         bool  active       = false;
+        CNewUIInventoryCtrl* pNewItemInvenCtrl = nullptr;     // control holding the item to equip (main or extended)
         int   dstEquipSlot = -1;                              // where the new item will be equipped
         DWORD newItemKey   = 0;                               // identifies the new inventory item
         int   freeSlots[MAX_EQUIP_BLOCKERS] = { -1, -1 };     // equipment slots still to unequip
@@ -49,8 +50,9 @@ namespace
 
     void ClearPendingEquip()
     {
-        s_pendingEquip.active    = false;
-        s_pendingEquip.freeCount = 0;
+        s_pendingEquip.active            = false;
+        s_pendingEquip.pNewItemInvenCtrl = nullptr;
+        s_pendingEquip.freeCount         = 0;
     }
 
     // Pick an inventory item and request the server to move it to an equipment slot.
@@ -203,17 +205,12 @@ void ProcessPendingEquipAfterMove()
         return;   // wait for this unequip's ack before handling the next step
     }
 
-    // Every blocking slot is now free: equip the new item.
+    // Every blocking slot is now free: equip the new item from the control it lives in.
     const int   iDstSlot  = s_pendingEquip.dstEquipSlot;
     const DWORD dwItemKey = s_pendingEquip.newItemKey;
+    CNewUIInventoryCtrl* pInvenCtrl = s_pendingEquip.pNewItemInvenCtrl;
     ClearPendingEquip();
 
-    if (g_pMyInventory == nullptr)
-    {
-        return;
-    }
-
-    CNewUIInventoryCtrl* pInvenCtrl = g_pMyInventory->GetInventoryCtrl();
     if (pInvenCtrl == nullptr)
     {
         return;
@@ -606,7 +603,7 @@ bool CNewUIInventoryActionController::TryEquipItem(CNewUIInventoryCtrl* targetCo
         return EquipFromInventory(targetControl, pItem, iSrcIndex, nDstIndex);
     }
 
-    return SwapEquipItem(pItem, nDstIndex, blockers, nBlockers);
+    return SwapEquipItem(targetControl, pItem, nDstIndex, blockers, nBlockers);
 }
 
 int CNewUIInventoryActionController::CollectEquipBlockers(ITEM* pItem, int nDstIndex, int* outSlots) const
@@ -638,10 +635,11 @@ int CNewUIInventoryActionController::CollectEquipBlockers(ITEM* pItem, int nDstI
     return nCount;
 }
 
-bool CNewUIInventoryActionController::SwapEquipItem(ITEM* pItem, int nDstSlot, const int* blockers, int nBlockers) const
+bool CNewUIInventoryActionController::SwapEquipItem(CNewUIInventoryCtrl* pNewItemInvenCtrl, ITEM* pItem, int nDstSlot, const int* blockers, int nBlockers) const
 {
+    // Displaced equipment always returns to the main inventory, so reserve space there.
     CNewUIInventoryCtrl* pInvenCtrl = (g_pMyInventory != nullptr) ? g_pMyInventory->GetInventoryCtrl() : nullptr;
-    if (pInvenCtrl == nullptr || nBlockers <= 0)
+    if (pInvenCtrl == nullptr || pNewItemInvenCtrl == nullptr || nBlockers <= 0)
     {
         return true;
     }
@@ -651,17 +649,18 @@ bool CNewUIInventoryActionController::SwapEquipItem(ITEM* pItem, int nDstSlot, c
     int dest[MAX_EQUIP_BLOCKERS] = { -1, -1 };
     if (!ReserveSlotsForBlockers(pInvenCtrl, blockers, nBlockers, dest))
     {
-        g_pSystemLogBox->AddText(GlobalText[1815], TYPE_ERROR_MESSAGE);   // not enough inventory space
+        g_pSystemLogBox->AddText(I18N::Game::InventorySpaceIsInsufficient, TYPE_ERROR_MESSAGE);
         return true;
     }
 
     // Queue the blocking slots to unequip into their reserved destinations, then drive the
     // sequence. The new item is only equipped once every blocker has been cleared (see
     // ProcessPendingEquipAfterMove), so it is never lost even on an intermediate server rejection.
-    s_pendingEquip.active       = true;
-    s_pendingEquip.dstEquipSlot = nDstSlot;
-    s_pendingEquip.newItemKey   = pItem->Key;
-    s_pendingEquip.freeCount    = 0;
+    s_pendingEquip.active            = true;
+    s_pendingEquip.pNewItemInvenCtrl = pNewItemInvenCtrl;
+    s_pendingEquip.dstEquipSlot      = nDstSlot;
+    s_pendingEquip.newItemKey        = pItem->Key;
+    s_pendingEquip.freeCount         = 0;
 
     for (int i = 0; i < nBlockers && i < MAX_EQUIP_BLOCKERS; ++i)
     {
@@ -674,16 +673,10 @@ bool CNewUIInventoryActionController::SwapEquipItem(ITEM* pItem, int nDstSlot, c
     return true;
 }
 
-bool CNewUIInventoryActionController::EquipToSlotReplacing(DWORD dwItemKey, int nDstSlot) const
+bool CNewUIInventoryActionController::EquipToSlotReplacing(CNewUIInventoryCtrl* pInvenCtrl, DWORD dwItemKey, int nDstSlot) const
 {
-    if (m_pContext == nullptr || g_pMyInventory == nullptr
+    if (m_pContext == nullptr || pInvenCtrl == nullptr
         || nDstSlot < 0 || nDstSlot >= MAX_EQUIPMENT_INDEX)
-    {
-        return false;
-    }
-
-    CNewUIInventoryCtrl* pInvenCtrl = g_pMyInventory->GetInventoryCtrl();
-    if (pInvenCtrl == nullptr)
     {
         return false;
     }
@@ -691,7 +684,7 @@ bool CNewUIInventoryActionController::EquipToSlotReplacing(DWORD dwItemKey, int 
     ITEM* pItem = pInvenCtrl->FindItemByKey(dwItemKey);
     if (pItem == nullptr)
     {
-        return false;   // not in the main inventory; leave it where it was restored
+        return false;   // not in this inventory; leave it where it was restored
     }
 
     if (!m_pContext->IsEquipable(nDstSlot, pItem))
@@ -714,7 +707,7 @@ bool CNewUIInventoryActionController::EquipToSlotReplacing(DWORD dwItemKey, int 
         return EquipFromInventory(pInvenCtrl, pItem, iSrcIndex, nDstSlot);
     }
 
-    return SwapEquipItem(pItem, nDstSlot, blockers, nBlockers);
+    return SwapEquipItem(pInvenCtrl, pItem, nDstSlot, blockers, nBlockers);
 }
 
 bool CNewUIInventoryActionController::TryDropItem(CNewUIInventoryCtrl* targetControl, ITEM* pItem) const

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.h
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.h
@@ -21,9 +21,10 @@ public:
     void SetContext(IInventoryActionContext* pContext);
     bool HandleInventoryActions(CNewUIInventoryCtrl* targetControl) const;
 
-    // Equip an inventory item (identified by key) into a specific equipment slot, unequipping any
-    // occupant first (and freeing a two-handed conflict). Used by drag-drop to replace on drop.
-    bool EquipToSlotReplacing(DWORD dwItemKey, int nDstSlot) const;
+    // Equip an inventory item (identified by key, in the given control — main or extended) into a
+    // specific equipment slot, unequipping any occupant first (and freeing a two-handed conflict).
+    // Used by drag-drop to replace on drop.
+    bool EquipToSlotReplacing(CNewUIInventoryCtrl* pInvenCtrl, DWORD dwItemKey, int nDstSlot) const;
 
 private:
     bool HandlePickedItemPlacement(CNewUIInventoryCtrl* targetControl) const;
@@ -39,7 +40,7 @@ private:
     bool HandleInventoryRightClickActions(CNewUIInventoryCtrl* targetControl) const;
     bool TryEquipItem(CNewUIInventoryCtrl* targetControl, ITEM* pItem, int iSrcIndex) const;
     int  CollectEquipBlockers(ITEM* pItem, int nDstIndex, int* outSlots) const;
-    bool SwapEquipItem(ITEM* pItem, int nDstSlot, const int* blockers, int nBlockers) const;
+    bool SwapEquipItem(CNewUIInventoryCtrl* pNewItemInvenCtrl, ITEM* pItem, int nDstSlot, const int* blockers, int nBlockers) const;
     bool TryDropItem(CNewUIInventoryCtrl* targetControl, ITEM* pItem) const;
 
     int  FindAlternateEquipSlot(int nOriginalSlot, ITEM* pItem) const;

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.h
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.h
@@ -21,6 +21,10 @@ public:
     void SetContext(IInventoryActionContext* pContext);
     bool HandleInventoryActions(CNewUIInventoryCtrl* targetControl) const;
 
+    // Equip an inventory item (identified by key) into a specific equipment slot, unequipping any
+    // occupant first (and freeing a two-handed conflict). Used by drag-drop to replace on drop.
+    bool EquipToSlotReplacing(DWORD dwItemKey, int nDstSlot) const;
+
 private:
     bool HandlePickedItemPlacement(CNewUIInventoryCtrl* targetControl) const;
     bool TryApplyJewel(CNewUIInventoryCtrl* targetControl, CNewUIPickedItem* pPickedItem, ITEM* pPickItem, int iSourceIndex, int iTargetIndex) const;

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.h
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.h
@@ -34,6 +34,8 @@ private:
     bool HandleSellToNPC(CNewUIInventoryCtrl* targetControl) const;
     bool HandleInventoryRightClickActions(CNewUIInventoryCtrl* targetControl) const;
     bool TryEquipItem(CNewUIInventoryCtrl* targetControl, ITEM* pItem, int iSrcIndex) const;
+    int  CollectEquipBlockers(ITEM* pItem, int nDstIndex, int* outSlots) const;
+    bool SwapEquipItem(ITEM* pItem, int nDstSlot, const int* blockers, int nBlockers) const;
     bool TryDropItem(CNewUIInventoryCtrl* targetControl, ITEM* pItem) const;
 
     int  FindAlternateEquipSlot(int nOriginalSlot, ITEM* pItem) const;
@@ -47,6 +49,10 @@ private:
 
     IInventoryActionContext* m_pContext;
 };
+
+// Sequences the deferred "equip after unequip" step on the inventory move ack.
+void ProcessPendingEquipAfterMove();
+void CancelPendingEquipSwap();
 
 } // namespace SEASON3B
 

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryCtrl.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryCtrl.cpp
@@ -1347,6 +1347,58 @@ bool SEASON3B::CNewUIInventoryCtrl::CheckSlot(int iColumnX, int iRowY, int width
     return CheckSlot(iIndex, width, height);
 }
 
+bool SEASON3B::CNewUIInventoryCtrl::IsRectEmpty(int startIndex, int width, int height) const
+{
+    const int gridSize = m_nColumn * m_nRow;
+    if (startIndex < 0 || width <= 0 || height <= 0) return false;
+    if (startIndex % m_nColumn > m_nColumn - width) return false;
+
+    for (int y = 0; y < height; y++)
+    {
+        for (int x = 0; x < width; x++)
+        {
+            const int iIndex = startIndex + (y * m_nColumn) + x;
+            if (iIndex >= gridSize) return false;
+            if (m_pdwItemCheckBox[iIndex] != 0) return false;
+        }
+    }
+    return true;
+}
+
+bool SEASON3B::CNewUIInventoryCtrl::FindTwoEmptySlots(int wA, int hA, int wB, int hB, int& outSlotA, int& outSlotB) const
+{
+    if (wA <= 0 || hA <= 0 || wB <= 0 || hB <= 0) return false;
+
+    const int totalCells = m_nColumn * m_nRow;
+    for (int a = 0; a < totalCells; a++)
+    {
+        if (!IsRectEmpty(a, wA, hA)) continue;
+
+        const int ax = a % m_nColumn;
+        const int ay = a / m_nColumn;
+
+        for (int b = 0; b < totalCells; b++)
+        {
+            if (!IsRectEmpty(b, wB, hB)) continue;
+
+            const int bx = b % m_nColumn;
+            const int by = b / m_nColumn;
+
+            // Both placements are individually empty; accept the first non-overlapping pair.
+            const bool bOverlap =
+                !(ax + wA <= bx || bx + wB <= ax || ay + hA <= by || by + hB <= ay);
+            if (!bOverlap)
+            {
+                outSlotA = a + m_nIndexOffset;
+                outSlotB = b + m_nIndexOffset;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 int CNewUIInventoryCtrl::GetIndex(int column, int row)
 {
     return column + row * m_nColumn + m_nIndexOffset;

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryCtrl.h
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryCtrl.h
@@ -165,7 +165,12 @@ namespace SEASON3B
 
         bool CheckSlot(int startIndex, int width, int height);
         bool CheckSlot(int iColumnX, int iRowY, int width, int height);
+        bool IsRectEmpty(int startIndex, int width, int height) const;
     public:
+        // Find two non-overlapping empty placements for items of the given sizes. Output indices
+        // include the storage offset (like FindEmptySlot). Used for atomic all-or-nothing equip
+        // swaps that displace two items. Returns false if both cannot fit at once.
+        bool FindTwoEmptySlots(int wA, int hA, int wB, int hB, int& outSlotA, int& outSlotB) const;
         CNewUIInventoryCtrl();
         virtual ~CNewUIInventoryCtrl();
 

--- a/src/source/UI/NewUI/Inventory/NewUIMyInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMyInventory.cpp
@@ -1424,6 +1424,20 @@ bool CNewUIMyInventory::EquipmentWindowProcess()
             ITEM* pEquipmentItemSlot = &CharacterMachine->Equipment[iTargetIndex];
             if (pEquipmentItemSlot && pEquipmentItemSlot->Type != -1)
             {
+                // Dropping an equippable inventory item onto an occupied slot replaces it: the
+                // occupant is unequipped to the bag, then the dropped item is equipped. Change
+                // rings keep their dedicated handling and are not auto-replaced here.
+                const STORAGE_TYPE sourceType = pPickedItem->GetSourceStorageType();
+                if (sourceType == STORAGE_TYPE::INVENTORY
+                    && IsEquipable(iTargetIndex, pItemObj)
+                    && !g_ChangeRingMgr->CheckChangeRing(pItemObj->Type))
+                {
+                    const DWORD dwItemKey = pItemObj->Key;
+                    CNewUIInventoryCtrl::BackupPickedItem();
+                    m_ActionController.EquipToSlotReplacing(dwItemKey, iTargetIndex);
+                    return true;
+                }
+
                 return true;
             }
 

--- a/src/source/UI/NewUI/Inventory/NewUIMyInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMyInventory.cpp
@@ -1433,8 +1433,9 @@ bool CNewUIMyInventory::EquipmentWindowProcess()
                     && !g_ChangeRingMgr->CheckChangeRing(pItemObj->Type))
                 {
                     const DWORD dwItemKey = pItemObj->Key;
+                    CNewUIInventoryCtrl* pOwner = pPickedItem->GetOwnerInventory();
                     CNewUIInventoryCtrl::BackupPickedItem();
-                    m_ActionController.EquipToSlotReplacing(dwItemKey, iTargetIndex);
+                    m_ActionController.EquipToSlotReplacing(pOwner, dwItemKey, iTargetIndex);
                     return true;
                 }
 


### PR DESCRIPTION
## Summary

Makes equipping items from the inventory "always equip", replacing whatever
occupies the target slot — for both **right-click** and **drag-drop** —
resolving slot conflicts for the player instead of rejecting the action.

The server only moves an item onto an **empty** equipment slot, one move at a
time, acked asynchronously, so a direct slot-to-slot swap isn't possible. The
client unequips the conflicting item(s) to the bag first and equips the new
item once every required slot is free, sequencing the steps across the move
acks in `ReceiveEquipmentItemExtended`.

## Behavior

- **Right-click** an equippable item → equips it, replacing the occupant.
  - 1H weapon: fills a free hand, otherwise replaces the main hand.
  - Shield: targets the off-hand.
  - Ring: fills a free ring slot, otherwise replaces the primary.
  - **Two-handed weapon**: frees **both** hands (weapon + shield) before equipping.
  - Equipping an off-hand/shield while a 2H weapon is held frees the 2H weapon.
- **Drag-drop** onto an occupied slot now replaces it (previously a no-op),
  into the exact slot dropped on.
- **All-or-nothing**: if the bag can't hold every displaced item at once,
  nothing is unequipped and a "not enough space" message is shown. The item
  being equipped is never lost.

## Implementation notes

- `NewUIInventoryActionController` gains the unequip-then-equip sequencing
  (`SwapEquipItem`, `CollectEquipBlockers`, `EquipToSlotReplacing`) plus a
  small pending-state record driven by the move ack.
- `NewUIInventoryCtrl::FindTwoEmptySlots` locates two non-overlapping empty
  placements so the two-item case can be reserved up front; backed by a new
  read-only `IsRectEmpty` helper (no side effects, unlike `CheckSlot`).
- Drag-drop replace is a small hook in `EquipmentWindowProcess` that reuses
  the same path, honoring the dropped-on slot.

Follows the project coding rules (early-exit, named constants, reuse over
duplication). Usage-level behavior documented in `docs/inventory-equip.md`.

## Testing (manual)

- Right-click / drag a weapon, shield, ring onto an occupied slot → swaps, occupant to bag.
- 2H weapon over 1H + shield → both go to bag, 2H equips.
- Shield while a 2H is equipped → 2H to bag, shield equips.
- Same actions with a full bag → nothing unequips, "no space" message, item not lost.
