### PR TITLE
Bugfix: fallback atk speed

### DIFF
--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -955,6 +955,11 @@ namespace MUHelper
             return 0;
         }
 
+        if (Hero->AttackTime > 0.0f)
+        {
+            return 0;
+        }
+
         const int iCharIndex = FindCharacterIndex(iTarget);
         if (iCharIndex == MAX_CHARACTERS_CLIENT)
         {
@@ -1019,11 +1024,6 @@ namespace MUHelper
             Hero->Path.Lock.unlock();
 
             SendMove(Hero, &Hero->Object);
-            return 0;
-        }
-
-        if (Hero->AttackTime > 0.0f)
-        {
             return 0;
         }
 

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -1022,6 +1022,11 @@ namespace MUHelper
             return 0;
         }
 
+        if (Hero->AttackTime > 0.0f)
+        {
+            return 0;
+        }
+
         Hero->MovementType = MOVEMENT_ATTACK;
         ActionTarget = iCharIndex;
         Attacking = 1;


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

SimulateBasicAttack is sending SendHitRequest on every helper loop tick when the target was in range, ignoring whether the character's attack animation was still playing. This caused the fallback to hit ~2–3× faster than a normal manual basic attack, since the manual path is naturally rate-limited by the animation frame counter.

## Related issues

Closes #430 

## Checklist

- [X] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [X] I have built the project locally (see [`docs/build-guide.md`](docs/build-guide.md)).
- [X] Changes are focused on one concern; the diff is as small as it reasonably can be.
