### PR TITLE
 Fix basic weapon skill: attack-speed scaling and missing blade trail

### DIFF
--- a/src/source/Engine/Object/ZzzCharacter.cpp
+++ b/src/source/Engine/Object/ZzzCharacter.cpp
@@ -3780,8 +3780,10 @@ void CreateWeaponBlur(CHARACTER* c, OBJECT* o, BMD* b)
                 BlurType = 1;
                 BlurMapping = 2;
             }
-            else if (o->CurrentAction == PLAYER_ATTACK_SKILL_SWORD2 || o->CurrentAction == PLAYER_ATTACK_SKILL_SWORD3 || o->CurrentAction == PLAYER_ATTACK_SKILL_SWORD4)
+            else if (o->CurrentAction == PLAYER_ATTACK_SKILL_SWORD1 || o->CurrentAction == PLAYER_ATTACK_SKILL_SWORD2 || o->CurrentAction == PLAYER_ATTACK_SKILL_SWORD3 || o->CurrentAction == PLAYER_ATTACK_SKILL_SWORD4)
             {
+                // SWORD1 is Falling Slash: it was missing here, so a sword-wielder's Falling Slash
+                // got no trail while Lunge/Uppercut/Cyclone (SWORD2/3/4) and Slash (SWORD5, below) did.
                 BlurType = 1;
                 if (Type == MODEL_LIGHTING_SWORD || Type == MODEL_DARK_REIGN_BLADE || Type == MODEL_RUNE_BLADE)
                     BlurMapping = 1;
@@ -3982,7 +3984,11 @@ void CreateWeaponBlur(CHARACTER* c, OBJECT* o, BMD* b)
             else
             {
                 constexpr float inter = 10.f;
-                const float playSpeed = b->Actions[b->CurrentAction].PlaySpeed * FPS_ANIMATION_FACTOR;
+                // The trail spans backward over one animation slice and lays its points along it.
+                // Scaling that slice by FPS_ANIMATION_FACTOR (REFERENCE_FPS / FPS) collapses it at
+                // high frame rates - the points pile onto a single weapon position and the streak
+                // disappears. Span a fixed PlaySpeed slice so the trail renders the same at any FPS.
+                const float playSpeed = b->Actions[b->CurrentAction].PlaySpeed;
                 float animationFrame = o->AnimationFrame - playSpeed;
                 const float priorAnimationFrame = o->PriorAnimationFrame;
                 const float animationSpeed = playSpeed / inter;

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -7399,6 +7399,15 @@ void MoveHero()
 
     if (c->JumpTime > 0)
     {
+        // The hero is sliding to a server-set position (the basic weapon skills reposition the
+        // hero on every cast). Returning here freezes all input for the whole slide, which
+        // capped those skills' auto-attack cadence below the player's attack speed (issue #350).
+        // Keep the auto-attack re-cast running through the slide; only manual input stays
+        // suppressed, and the slide itself still animates smoothly.
+        if (g_pOption->IsAutoAttack() && Attacking != -1 && SelectedCharacter != -1)
+        {
+            Attack(Hero);
+        }
         return;
     }
 

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -7360,6 +7360,29 @@ void CheckGate()
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 void MoveEffect(OBJECT* o, int iIndex);
 
+namespace
+{
+    // While the hero slides to a server-set position (the basic weapon skills reposition the
+    // hero on every cast), MoveHero would freeze all input until the slide ended, which capped
+    // those skills' auto-attack cadence below the player's attack speed (issue #350). Keep the
+    // auto-attack re-cast running through the slide; the slide still animates smoothly and only
+    // manual move/click input stays suppressed. Returns true when the hero is mid-slide, in
+    // which case MoveHero should stop after this.
+    bool HandleHeroPositionSlide(CHARACTER* c)
+    {
+        if (c->JumpTime <= 0)
+        {
+            return false;
+        }
+
+        if (g_pOption->IsAutoAttack() && Attacking != -1 && SelectedCharacter != -1)
+        {
+            Attack(Hero);
+        }
+        return true;
+    }
+}
+
 void MoveHero()
 {
     CHARACTER* c = Hero;
@@ -7397,17 +7420,8 @@ void MoveHero()
     if (c->Object.Live == 0)
         return;
 
-    if (c->JumpTime > 0)
+    if (HandleHeroPositionSlide(c))
     {
-        // The hero is sliding to a server-set position (the basic weapon skills reposition the
-        // hero on every cast). Returning here freezes all input for the whole slide, which
-        // capped those skills' auto-attack cadence below the player's attack speed (issue #350).
-        // Keep the auto-attack re-cast running through the slide; only manual input stays
-        // suppressed, and the slide itself still animates smoothly.
-        if (g_pOption->IsAutoAttack() && Attacking != -1 && SelectedCharacter != -1)
-        {
-            Attack(Hero);
-        }
         return;
     }
 


### PR DESCRIPTION
### Two small fixes for the basic weapon skills (Falling Slash, Lunge, Uppercut, Cyclone, Slash).

### Attack speed
These skills auto-attacked at a fixed cadence no matter how much Attack Speed the player had, unlike
normal attacks and Death Stab. The server repositions the hero on every cast, which started a fixed-length
slide that froze input until it finished. The auto-attack re-cast now keeps running during the slide, so
the cadence is paced by the swing animation and scales with attack speed. Movement stays smooth.

### Blade trail
The weapon trail effect was invisible on the skill swings. Its length was scaled by the frame-rate factor,
so above the reference frame rate it collapsed to a point and drew nothing. It now spans a fixed slice
and renders at any frame rate. Also added Falling Slash to the sword trail branch, which was the only
swing missing one.

Closes #350 