### PR TITLE
Guard the PCH's Win32-only includes behind _WIN32

### DIFF
--- a/src/source/App/stdafx.h
+++ b/src/source/App/stdafx.h
@@ -47,6 +47,12 @@
 
 #pragma warning( push, 3 )
 
+// Win32-only system headers. Guarded behind _WIN32 so the PCH can be parsed by
+// non-Windows toolchains. On Windows _WIN32 is always defined (for both 32-bit
+// and 64-bit targets), so every include below is taken and the build stays
+// unchanged. Win32 types/macros still referenced by portable code past the PCH
+// (e.g. the project headers further down) are a separate, case-by-case follow-up.
+#ifdef _WIN32
 #include <windows.h>
 
 // MinGW workaround: Allow swprintf usage
@@ -54,23 +60,23 @@
 #undef swprintf
 #endif
 
-//windows
 #include <winsock2.h>
 #include <mmsystem.h>
 #include <shellapi.h>
+#include <tchar.h>
+#include <mbstring.h>
+#include <conio.h>
+#endif // _WIN32
 
 //c runtime
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
 #include <memory.h>
-#include <tchar.h>
 #include <assert.h>
-#include <mbstring.h>
 #include <time.h>
 #include <math.h>
 #include <stdarg.h>
-#include <conio.h>
 
 #include <string>
 #include <list>


### PR DESCRIPTION
The precompiled header (included by every translation unit) pulled Win32-only system headers unconditionally, so the PCH could not be parsed by a non-Windows toolchain.

Group windows.h, winsock2.h, mmsystem.h, shellapi.h, tchar.h, mbstring.h and conio.h into a single #ifdef _WIN32 section. On Windows _WIN32 is always defined (32- and 64-bit), so the includes are taken as before and the build is unchanged; on Linux/macOS the PCH now parses past these includes and fails only on real platform gaps.

Closes #440 