### PR TITLE
Re-home packet delivery and reconnect off the Win32 message queue

### DIFF
--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -15,6 +15,7 @@
 #include "Engine/Object/ZzzOpenData.h"
 #include "Scenes/SceneCore.h"
 #include "Network/Reconnect/ReconnectManager.h"
+#include "Network/IncomingPacketQueue.h"
 #include "Render/Models/ZzzBMD.h"
 #include "Engine/Object/ZzzInfomation.h"
 #include "Engine/Object/ZzzObject.h"
@@ -517,16 +518,6 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
         }
         break;
-    case WM_RECEIVE_BUFFER: {
-        auto Packet = std::unique_ptr<PacketInfo>(reinterpret_cast<PacketInfo*>(wParam));
-        ProcessPacketCallback(Packet.release());
-        break;
-    }
-    case WM_START_RECONNECT:
-        // Runs the in-game teardown in the window-proc context (like packet
-        // handlers), where releasing world data is safe.
-        ReconnectManager::Instance().Begin();
-        break;
     case WM_NPROTECT_EXIT_TWO:
         SocketClient->ToGameServer()->SendLogOutByCheatDetection(0);
         SetTimer(g_hWnd, WINDOWMINIMIZED_TIMER, 1 * 1000, nullptr);
@@ -887,6 +878,14 @@ MSG MainLoop()
                 break;
             }
         }
+
+        // Process server packets handed over from the network thread. Replaces
+        // the old WM_RECEIVE_BUFFER message round-trip; runs on the main thread.
+        Network::IncomingPacketQueue::Instance().DrainTo(ProcessPacketCallback);
+
+        // Run a pending reconnect teardown between frames (self-guards on its
+        // pending flag). Replaces the old WM_START_RECONNECT round-trip.
+        ReconnectManager::Instance().Begin();
 
         if (CheckRenderNextFrame())
         {

--- a/src/source/App/Platform/Windows/Winmain.h
+++ b/src/source/App/Platform/Windows/Winmain.h
@@ -49,10 +49,6 @@
 //#define CAMERA_TEST
 
 
-#define WM_RECEIVE_BUFFER	( WM_USER + 2)
-// Posted by the auto-reconnect detector so the heavy session teardown runs in
-// the window-proc context (like packet handlers) instead of mid-render.
-#define WM_START_RECONNECT	( WM_USER + 3)
 #define WM_NPROTECT_EXIT_TWO  (WM_USER + 10001)
 
 extern bool ashies;

--- a/src/source/Network/IncomingPacketQueue.cpp
+++ b/src/source/Network/IncomingPacketQueue.cpp
@@ -14,12 +14,24 @@ namespace Network
 
     void IncomingPacketQueue::Push(std::unique_ptr<PacketInfo> packet)
     {
+        if (!packet)
+        {
+            return;
+        }
+
         std::lock_guard<std::mutex> lock(m_mutex);
         m_queue.push(std::move(packet));
     }
 
     void IncomingPacketQueue::DrainTo(Processor process)
     {
+        if (!process)
+        {
+            return;
+        }
+
+        // Push rejects null packets, so every entry here is non-null; no
+        // per-packet guard is needed.
         std::queue<std::unique_ptr<PacketInfo>> pending;
         {
             std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/source/Network/IncomingPacketQueue.cpp
+++ b/src/source/Network/IncomingPacketQueue.cpp
@@ -8,8 +8,11 @@ namespace Network
 
     IncomingPacketQueue& IncomingPacketQueue::Instance()
     {
-        static IncomingPacketQueue instance;
-        return instance;
+        // Intentionally leaked: the instance is never destroyed at process exit,
+        // so a network thread still winding down during shutdown can call Push()
+        // without racing a destroyed static. The OS reclaims the memory on exit.
+        static IncomingPacketQueue* instance = new IncomingPacketQueue();
+        return *instance;
     }
 
     void IncomingPacketQueue::Push(std::unique_ptr<PacketInfo> packet)
@@ -42,6 +45,18 @@ namespace Network
         {
             process(pending.front().get());
             pending.pop();
+        }
+    }
+
+    void IncomingPacketQueue::Clear()
+    {
+        // Discard packets queued before a session teardown so they are not
+        // processed against freed world data on the next frame. Swap under the
+        // lock and let the packets destruct after releasing it.
+        std::queue<std::unique_ptr<PacketInfo>> discarded;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            std::swap(discarded, m_queue);
         }
     }
 }

--- a/src/source/Network/IncomingPacketQueue.cpp
+++ b/src/source/Network/IncomingPacketQueue.cpp
@@ -1,0 +1,35 @@
+#include "stdafx.h"
+#include "Network/IncomingPacketQueue.h"
+#include "Network/Server/WSclient.h" // PacketInfo (complete type for the queued unique_ptr)
+
+namespace Network
+{
+    IncomingPacketQueue::~IncomingPacketQueue() = default;
+
+    IncomingPacketQueue& IncomingPacketQueue::Instance()
+    {
+        static IncomingPacketQueue instance;
+        return instance;
+    }
+
+    void IncomingPacketQueue::Push(std::unique_ptr<PacketInfo> packet)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.push(std::move(packet));
+    }
+
+    void IncomingPacketQueue::DrainTo(Processor process)
+    {
+        std::queue<std::unique_ptr<PacketInfo>> pending;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            std::swap(pending, m_queue);
+        }
+
+        while (!pending.empty())
+        {
+            process(pending.front().get());
+            pending.pop();
+        }
+    }
+}

--- a/src/source/Network/IncomingPacketQueue.h
+++ b/src/source/Network/IncomingPacketQueue.h
@@ -32,6 +32,11 @@ namespace Network
         // network thread.
         void DrainTo(Processor process);
 
+        // Discard all queued packets. Called on session teardown (disconnect /
+        // reconnect) so packets for the old session are not processed against
+        // freed world data.
+        void Clear();
+
     private:
         IncomingPacketQueue() = default;
         ~IncomingPacketQueue();

--- a/src/source/Network/IncomingPacketQueue.h
+++ b/src/source/Network/IncomingPacketQueue.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <queue>
+
+struct PacketInfo;
+
+namespace Network
+{
+    // Thread-safe hand-off of received server packets from the network thread
+    // to the main thread. The socket read callback enqueues packets; the main
+    // loop drains and processes them once per frame.
+    //
+    // This preserves the "packets are processed on the main thread" guarantee
+    // that the previous PostMessage(WM_RECEIVE_BUFFER) round-trip provided,
+    // without routing game data through the Win32 message queue (which does not
+    // exist off Windows).
+    class IncomingPacketQueue
+    {
+    public:
+        using Processor = void (*)(const PacketInfo*);
+
+        static IncomingPacketQueue& Instance();
+
+        // Enqueue a received packet. Called from the network thread.
+        void Push(std::unique_ptr<PacketInfo> packet);
+
+        // Process every queued packet in arrival order. Called from the main
+        // thread once per frame. The queue is moved out under the lock and
+        // drained after releasing it, so packet handling never blocks the
+        // network thread.
+        void DrainTo(Processor process);
+
+    private:
+        IncomingPacketQueue() = default;
+        ~IncomingPacketQueue();
+
+        std::mutex m_mutex;
+        std::queue<std::unique_ptr<PacketInfo>> m_queue;
+    };
+}

--- a/src/source/Network/Reconnect/ReconnectManager.cpp
+++ b/src/source/Network/Reconnect/ReconnectManager.cpp
@@ -13,7 +13,6 @@
 #include "Scenes/CharacterScene.h"     // StartGame
 #include "Engine/Object/ZzzCharacter.h"// CharactersClient
 #include "UI/Legacy/UIMng.h"           // CUIMng, m_LoginWin
-#include "App/Platform/Windows/Winmain.h"  // WM_START_RECONNECT
 #include "MUHelper/MuHelper.h"         // MUHelper::g_MuHelper
 
 // Timing (milliseconds). WorldTime is the wall-clock ms timer the rest of the
@@ -36,7 +35,6 @@ extern wchar_t LogInID[MAX_USERNAME_SIZE + 1];
 extern BYTE Version[SIZE_PROTOCOLVERSION];
 extern BYTE Serial[SIZE_PROTOCOLSERIAL + 1];
 extern BOOL g_bGameServerConnected;
-extern HWND g_hWnd;
 
 ReconnectManager& ReconnectManager::Instance()
 {
@@ -175,11 +173,12 @@ void ReconnectManager::Update()
         {
             if (m_phase == Phase::Probing && SceneFlag == MAIN_SCENE)
             {
-                // The game world is still loaded; its teardown must run in the
-                // window proc, after which we land on the login screen.
+                // The game world is still loaded; its teardown must run between
+                // frames (not mid-render), after which we land on the login
+                // screen. m_beginPending defers it: the main loop calls Begin()
+                // each frame and it fires once the flag is set.
                 m_abortAfterTeardown = true;
                 m_beginPending = true;
-                PostMessage(g_hWnd, WM_START_RECONNECT, 0, 0);
             }
             else
             {
@@ -293,10 +292,9 @@ void ReconnectManager::PollProbe()
 
         if (soError == 0)
         {
-            // Server is up - hand off to Begin() in the window proc to tear down
-            // and re-login.
+            // Server is up - defer to Begin() (called by the main loop each
+            // frame) to tear down and re-login between frames.
             m_beginPending = true;
-            PostMessage(g_hWnd, WM_START_RECONNECT, 0, 0);
         }
         else
         {

--- a/src/source/Network/Reconnect/ReconnectManager.h
+++ b/src/source/Network/Reconnect/ReconnectManager.h
@@ -43,8 +43,8 @@ public:
     bool HasSession() const { return m_hasSession; }
 
     // Lifecycle.
-    void RequestBegin();  // detector asks to start reconnect (posts WM_START_RECONNECT)
-    void Begin();         // performs the teardown; runs in the window-proc context
+    void RequestBegin();  // detector asks to start reconnect (begins probing)
+    void Begin();         // performs the teardown between frames; the main loop calls it once m_beginPending is set
     void Update();        // per-frame driver (runs in the scene-update phase)
     void RequestCancel(); // dialog's Cancel button; processed by Update()
 

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -21,6 +21,7 @@
 #include "Engine/Object/ZzzOpenData.h"
 #include "Scenes/SceneCore.h"
 #include "Network/Reconnect/ReconnectManager.h"
+#include "Network/IncomingPacketQueue.h"
 #include "I18N/All.h"
 
 #include "Audio/DSPlaySound.h"
@@ -14613,7 +14614,10 @@ static void HandleIncomingPacket(int32_t Handle, const BYTE* ReceiveBuffer, int3
     std::copy(ReceiveBuffer, ReceiveBuffer + Size, Packet->ReceiveBuffer.get());
     Packet->Size = Size;
 
-    PostMessage(g_hWnd, WM_RECEIVE_BUFFER, reinterpret_cast<WPARAM>(Packet.release()), 0);
+    // Hand the packet to the main thread for processing. The main loop drains
+    // this queue every frame and calls ProcessPacketCallback. Replaces the old
+    // PostMessage(WM_RECEIVE_BUFFER) round-trip through the Win32 message queue.
+    Network::IncomingPacketQueue::Instance().Push(std::move(Packet));
 }
 
 bool CheckExceptionBuff(eBuffState buff, OBJECT* o, bool iserase)

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -979,6 +979,10 @@ void ResetClientToLoginScene()
         g_bGameServerConnected = false;
     }
 
+    // Drop packets received for the session we just tore down so they are not
+    // processed against the freed world data on the next frame.
+    Network::IncomingPacketQueue::Instance().Clear();
+
     ReleaseCharacterSceneData();
     SceneFlag = LOG_IN_SCENE;
     g_sceneInit.ResetForDisconnect();


### PR DESCRIPTION
Server packets were delivered from the network thread to the main thread via PostMessage(g_hWnd, WM_RECEIVE_BUFFER), and the auto-reconnect teardown was deferred via PostMessage(g_hWnd, WM_START_RECONNECT). Both routed game control flow through the Win32 window message queue, which does not exist off Windows.

Add Network::IncomingPacketQueue, a thread-safe queue the socket read callback pushes to and MainLoop drains each frame into ProcessPacketCallback. Packets are moved out under the lock and processed after releasing it, so handling never blocks the network thread, and they are still processed on the main thread as before.

Reconnect now relies on the existing m_beginPending flag: the probe and cancel paths set it and MainLoop calls the already-idempotent Begin() each frame. ReconnectManager no longer needs Winmain.h or g_hWnd.

Remove the dead WM_RECEIVE_BUFFER / WM_START_RECONNECT WndProc cases and macros. First step of the SDL3 windowing migration (#442): the event loop no longer carries cross-thread data, so the window/event-loop swap can follow without a Win32 message hook
