### PR TITLE
Fix equipped weapon shadows

### DIFF
--- a/src/source/Engine/Object/ZzzCharacter.cpp
+++ b/src/source/Engine/Object/ZzzCharacter.cpp
@@ -6575,6 +6575,9 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
 
     Object->Type = Type;
     ItemObjectAttribute(Object);
+    Object->EnableShadow = o->EnableShadow;
+    Object->m_bRenderShadow = o->m_bRenderShadow;
+    Object->m_bySkillCount = o->m_bySkillCount;
     b->LightEnable = Object->LightEnable;
     b->LightEnable = false;
 
@@ -6922,6 +6925,11 @@ void RenderLinkObject(float x, float y, float z, CHARACTER* c, PART_t* f, int Ty
         )
     {
         RenderPartObjectEffect(Object, Type, c->Light, o->Alpha, Level, Option1, false, 0, RenderType | ((c->MonsterIndex == MONSTER_METAL_BALROG || c->MonsterIndex == MONSTER_ORC_ARCHER_OF_DOOM) ? (RENDER_EXTRA | RENDER_TEXTURE) : RENDER_TEXTURE));
+    }
+
+    if (Object->EnableShadow)
+    {
+        return;
     }
 
     float Luminosity;
@@ -8528,8 +8536,9 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                 if (p->Type != -1 && c->SafeZone == false)
                 {
                     int Type = p->Type;
+                    PART_t ShadowPart = *p;
 
-                    RenderPartObject(&c->Object, Type, p, c->Light, o->Alpha, 0, 0, 0, false, false, Translate);
+                    RenderLinkObject(0.f, 0.f, 0.f, c, &ShadowPart, Type, 0, 0, false, Translate);
                 }
             }
             o->EnableShadow = false;


### PR DESCRIPTION
Render weapon shadows through the linked item path instead of the body-part path.

Weapons are separate item models attached to the character with RenderLinkObject. The old shadow pass used RenderPartObject, which is meant for body parts, so weapon shadows used the wrong position and rotation math and appeared detached from the player.

This keeps detailed weapon shadows, but makes them follow the same attachment logic as the visible weapon.

Fixes issue https://github.com/sven-n/MuMain/issues/396

<img width="490" height="465" alt="image" src="https://github.com/user-attachments/assets/0d627591-ed76-4717-b859-a7c5469157fb" />
