### PR TITLE
Add test ensuring MuEditor is excluded when ENABLE_EDITOR=OFF

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,3 +51,5 @@ function(mu_add_test)
 endfunction()
 
 add_subdirectory(text)
+
+add_subdirectory(editor)

--- a/tests/editor/CMakeLists.txt
+++ b/tests/editor/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Editor-specific tests only.
+# Shared test harness setup (doctest include, wine setup, mu_test_main,
+# and mu_add_test) lives in the top-level tests/CMakeLists.txt.
+
+# Guard against the editor leaking into a non-editor build (issue #359).
+# When ENABLE_EDITOR=OFF, nothing under MuEditor/ should be compiled in. The
+# editor sources are added to the MuClient library (Main is just the
+# entry-point executable that links it), so MuClient is the target to inspect
+# -- Main's own SOURCES never list them.
+if(NOT ENABLE_EDITOR)
+    # file(GENERATE) resolves the SOURCES generator expression at generate
+    # time and writes one absolute path per line.
+    file(GENERATE
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/muclient_sources.txt"
+        CONTENT "$<JOIN:$<TARGET_PROPERTY:MuClient,SOURCES>,\n>")
+
+    # Pure-CMake check: no Python or other interpreter to find, so the test
+    # always runs wherever this project builds (CMake is always present),
+    # instead of silently skipping when an interpreter is missing.
+    # PROJECT_SOURCE_DIR (not CMAKE_SOURCE_DIR) so the editor path stays
+    # correct even if MuMain is ever pulled in as a subdirectory of a larger
+    # CMake project. Arguments are quoted to survive paths containing spaces.
+    add_test(
+        NAME editor_leak
+        COMMAND ${CMAKE_COMMAND}
+            "-DSOURCES_FILE=${CMAKE_CURRENT_BINARY_DIR}/muclient_sources.txt"
+            "-DEDITOR_DIR=${PROJECT_SOURCE_DIR}/src/MuEditor"
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/test_leak.cmake")
+endif()

--- a/tests/editor/test_leak.cmake
+++ b/tests/editor/test_leak.cmake
@@ -1,0 +1,34 @@
+# Fails (non-zero exit via FATAL_ERROR) if any source under the editor
+# directory was compiled into the client while ENABLE_EDITOR=OFF. Run by
+# CTest as:
+#   cmake -DSOURCES_FILE=<file> -DEDITOR_DIR=<dir> -P test_leak.cmake
+# SOURCES_FILE is produced by file(GENERATE) and holds one source path per
+# line: the resolved SOURCES list of the target that owns the editor code.
+# EDITOR_DIR is the absolute path of the editor source directory.
+
+foreach(var SOURCES_FILE EDITOR_DIR)
+    if(NOT DEFINED ${var})
+        message(FATAL_ERROR "${var} must be passed with -D${var}=<path>")
+    endif()
+endforeach()
+
+file(STRINGS "${SOURCES_FILE}" sources)
+
+set(leaked "")
+foreach(src IN LISTS sources)
+    # A path-segment containment test (not a substring match), so it flags
+    # files inside EDITOR_DIR without false-positiving when the repository
+    # itself is checked out under an unrelated directory named "MuEditor".
+    cmake_path(IS_PREFIX EDITOR_DIR "${src}" NORMALIZE inside)
+    if(inside)
+        list(APPEND leaked "${src}")
+    endif()
+endforeach()
+
+if(leaked)
+    string(REPLACE ";" "\n  - " leaked "${leaked}")
+    message(FATAL_ERROR
+        "MuEditor leaked into the build with ENABLE_EDITOR=OFF:\n  - ${leaked}")
+endif()
+
+message(STATUS "PASS: no MuEditor sources compiled with ENABLE_EDITOR=OFF.")


### PR DESCRIPTION
Adds a CTest that fails the build if any source under src/MuEditor is compiled into the client while ENABLE_EDITOR=OFF (issue #359).

The editor sources are compiled into the MuClient library, so the check inspects MuClient's SOURCES property (dumped at generate time via file(GENERATE)); Main is only the entry-point executable that links MuClient and never lists those sources itself.

The check is a pure-CMake script run via cmake -P, so it needs no Python or other interpreter and always runs wherever the project builds. It uses cmake_path(IS_PREFIX) for a path-segment containment test rather than a substring match, so it does not false-positive when the repository is checked out under a directory named MuEditor.

Closes #359