### PR TITLE
Poll keyboard and mouse-button state through SDL

### DIFF
--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -1,6 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 
 #define WIN32_LEAN_AND_MEAN
 #define WIN32_EXTRA_LEAN
@@ -947,7 +948,7 @@ MSG MainLoop()
 #ifdef _EDITOR
                 // F12 key toggle for editor
                 static bool wasF12Pressed = false;
-                if (GetAsyncKeyState(VK_F12) & 0x8000)
+                if (Core::Input::IsKeyDown(VK_F12))
                 {
                     if (!wasF12Pressed)
                     {

--- a/src/source/Camera/CameraUtility.cpp
+++ b/src/source/Camera/CameraUtility.cpp
@@ -31,8 +31,8 @@ namespace
  */
 static void HandleCameraHotkeys()
 {
-    const bool bF9Down  = (Core::Input::IsKeyDown(VK_F9)) != 0;
-    const bool bF11Down = (Core::Input::IsKeyDown(VK_F11)) != 0;
+    const bool bF9Down  = Core::Input::IsKeyDown(VK_F9);
+    const bool bF11Down = Core::Input::IsKeyDown(VK_F11);
 
     if (bF9Down && !s_bF9KeyPressed)
         CameraManager::Instance().CycleToNextMode();

--- a/src/source/Camera/CameraUtility.cpp
+++ b/src/source/Camera/CameraUtility.cpp
@@ -2,6 +2,7 @@
 // Extracted from ZzzScene.cpp as part of scene refactoring
 
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 #include "CameraUtility.h"
 #include "CameraManager.h"
 #include "Camera/CameraMove.h"
@@ -30,8 +31,8 @@ namespace
  */
 static void HandleCameraHotkeys()
 {
-    const bool bF9Down  = (GetAsyncKeyState(VK_F9)  & 0x8000) != 0;
-    const bool bF11Down = (GetAsyncKeyState(VK_F11) & 0x8000) != 0;
+    const bool bF9Down  = (Core::Input::IsKeyDown(VK_F9)) != 0;
+    const bool bF11Down = (Core::Input::IsKeyDown(VK_F11)) != 0;
 
     if (bF9Down && !s_bF9KeyPressed)
         CameraManager::Instance().CycleToNextMode();

--- a/src/source/Camera/DefaultCamera.cpp
+++ b/src/source/Camera/DefaultCamera.cpp
@@ -2,6 +2,7 @@
 // Extracted from CameraUtility.cpp
 
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 
 #include <iterator>
 
@@ -802,11 +803,11 @@ void DefaultCamera::HandleEditorMode()
     if (!g_pUIManager->IsInputEnable())
     {
         // Handle camera angle rotation
-        if (HIBYTE(GetAsyncKeyState(VK_INSERT)) == 128)
+        if (Core::Input::IsKeyDown(VK_INSERT))
             m_State.Angle[2] += 15;
-        if (HIBYTE(GetAsyncKeyState(VK_DELETE)) == 128)
+        if (Core::Input::IsKeyDown(VK_DELETE))
             m_State.Angle[2] -= 15;
-        if (HIBYTE(GetAsyncKeyState(VK_HOME)) == 128)
+        if (Core::Input::IsKeyDown(VK_HOME))
             m_State.Angle[2] = -45;
 
         m_State.Angle[2] = fmodf(m_State.Angle[2] + 360.0f, 360.0f) - 360.0f;
@@ -831,7 +832,7 @@ void DefaultCamera::HandleEditorMode()
 
         for (const auto& mapping : keyMappings)
         {
-            if (HIBYTE(GetAsyncKeyState(mapping.vKey)) == 128)
+            if (Core::Input::IsKeyDown(mapping.vKey))
             {
                 Vector(mapping.x, mapping.y, 0.f, p1);
                 EditMove = true;

--- a/src/source/Camera/FreeFlyCamera.cpp
+++ b/src/source/Camera/FreeFlyCamera.cpp
@@ -1,6 +1,7 @@
 // FreeFlyCamera.cpp - Free-fly camera for editor mode (spectator tool)
 
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 
 #ifdef _EDITOR
 
@@ -171,14 +172,14 @@ void FreeFlyCamera::ReadMovementInput(float& outForward, float& outStrafe, float
     outStrafe = 0.0f;
     outVertical = 0.0f;
 
-    if (GetAsyncKeyState(VK_UP) & 0x8000)    outForward += 1.0f;
-    if (GetAsyncKeyState(VK_DOWN) & 0x8000)  outForward -= 1.0f;
-    if (GetAsyncKeyState(VK_LEFT) & 0x8000)  outStrafe -= 1.0f;
-    if (GetAsyncKeyState(VK_RIGHT) & 0x8000) outStrafe += 1.0f;
+    if (Core::Input::IsKeyDown(VK_UP))    outForward += 1.0f;
+    if (Core::Input::IsKeyDown(VK_DOWN))  outForward -= 1.0f;
+    if (Core::Input::IsKeyDown(VK_LEFT))  outStrafe -= 1.0f;
+    if (Core::Input::IsKeyDown(VK_RIGHT)) outStrafe += 1.0f;
 
     // PageUp/PageDown for vertical movement
-    if (GetAsyncKeyState(VK_PRIOR) & 0x8000) outVertical += 1.0f;
-    if (GetAsyncKeyState(VK_NEXT)  & 0x8000) outVertical -= 1.0f;
+    if (Core::Input::IsKeyDown(VK_PRIOR)) outVertical += 1.0f;
+    if (Core::Input::IsKeyDown(VK_NEXT)) outVertical -= 1.0f;
 }
 
 void FreeFlyCamera::HandleMovement()
@@ -196,7 +197,7 @@ void FreeFlyCamera::HandleMovement()
     vertical /= inputLength;
 
     float speed = BASE_SPEED;
-    if (GetAsyncKeyState(VK_SHIFT) & 0x8000)
+    if (Core::Input::IsKeyDown(VK_SHIFT))
         speed *= SPRINT_MULTIPLIER;
     speed *= FPS_ANIMATION_FACTOR;
 

--- a/src/source/Core/Input/KeyState.cpp
+++ b/src/source/Core/Input/KeyState.cpp
@@ -1,0 +1,80 @@
+#include "stdafx.h"
+#include "Core/Input/KeyState.h"
+#include <SDL3/SDL.h>
+
+namespace Core::Input
+{
+    namespace
+    {
+        // Map a Win32 virtual-key code (or ASCII letter/digit) to an SDL
+        // scancode. Returns SDL_SCANCODE_UNKNOWN for keys we don't translate.
+        SDL_Scancode VkToScancode(int vk)
+        {
+            // ASCII letters and digits: VK codes equal their ASCII values.
+            if (vk >= 'A' && vk <= 'Z') return static_cast<SDL_Scancode>(SDL_SCANCODE_A + (vk - 'A'));
+            if (vk >= '1' && vk <= '9') return static_cast<SDL_Scancode>(SDL_SCANCODE_1 + (vk - '1'));
+            if (vk == '0') return SDL_SCANCODE_0;
+
+            switch (vk)
+            {
+            case VK_UP:      return SDL_SCANCODE_UP;
+            case VK_DOWN:    return SDL_SCANCODE_DOWN;
+            case VK_LEFT:    return SDL_SCANCODE_LEFT;
+            case VK_RIGHT:   return SDL_SCANCODE_RIGHT;
+            case VK_INSERT:  return SDL_SCANCODE_INSERT;
+            case VK_DELETE:  return SDL_SCANCODE_DELETE;
+            case VK_HOME:    return SDL_SCANCODE_HOME;
+            case VK_END:     return SDL_SCANCODE_END;
+            case VK_PRIOR:   return SDL_SCANCODE_PAGEUP;
+            case VK_NEXT:    return SDL_SCANCODE_PAGEDOWN;
+            case VK_SPACE:   return SDL_SCANCODE_SPACE;
+            case VK_RETURN:  return SDL_SCANCODE_RETURN;
+            case VK_ESCAPE:  return SDL_SCANCODE_ESCAPE;
+            case VK_TAB:     return SDL_SCANCODE_TAB;
+            case VK_BACK:    return SDL_SCANCODE_BACKSPACE;
+            case VK_F1:      return SDL_SCANCODE_F1;
+            case VK_F2:      return SDL_SCANCODE_F2;
+            case VK_F3:      return SDL_SCANCODE_F3;
+            case VK_F4:      return SDL_SCANCODE_F4;
+            case VK_F5:      return SDL_SCANCODE_F5;
+            case VK_F6:      return SDL_SCANCODE_F6;
+            case VK_F7:      return SDL_SCANCODE_F7;
+            case VK_F8:      return SDL_SCANCODE_F8;
+            case VK_F9:      return SDL_SCANCODE_F9;
+            case VK_F10:     return SDL_SCANCODE_F10;
+            case VK_F11:     return SDL_SCANCODE_F11;
+            case VK_F12:     return SDL_SCANCODE_F12;
+            default:         return SDL_SCANCODE_UNKNOWN;
+            }
+        }
+    }
+
+    bool IsKeyDown(int virtualKey)
+    {
+        // Mouse buttons: GetAsyncKeyState(VK_LBUTTON/...) reported these too, and
+        // CInput / CNewKeyInput poll them through this path, so honor them via the
+        // SDL mouse state.
+        switch (virtualKey)
+        {
+        case VK_LBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_LMASK) != 0;
+        case VK_RBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_RMASK) != 0;
+        case VK_MBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_MMASK) != 0;
+        default: break;
+        }
+
+        // Modifier keys aggregate left and right via the mod state.
+        switch (virtualKey)
+        {
+        case VK_SHIFT:   return (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
+        case VK_CONTROL: return (SDL_GetModState() & SDL_KMOD_CTRL) != 0;
+        case VK_MENU:    return (SDL_GetModState() & SDL_KMOD_ALT) != 0;
+        default: break;
+        }
+
+        const SDL_Scancode sc = VkToScancode(virtualKey);
+        if (sc == SDL_SCANCODE_UNKNOWN) return false;
+
+        const bool* state = SDL_GetKeyboardState(nullptr);
+        return state != nullptr && state[sc];
+    }
+}

--- a/src/source/Core/Input/KeyState.cpp
+++ b/src/source/Core/Input/KeyState.cpp
@@ -48,6 +48,7 @@ namespace Core::Input
             case VK_F10:     return SDL_SCANCODE_F10;
             case VK_F11:     return SDL_SCANCODE_F11;
             case VK_F12:     return SDL_SCANCODE_F12;
+            case VK_SNAPSHOT: return SDL_SCANCODE_PRINTSCREEN;
             default:         return SDL_SCANCODE_UNKNOWN;
             }
         }
@@ -69,9 +70,9 @@ namespace Core::Input
         // Mouse buttons and modifiers come from the SDL mouse / mod state.
         switch (virtualKey)
         {
-        case VK_LBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_LMASK) != 0;
-        case VK_RBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_RMASK) != 0;
-        case VK_MBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_MMASK) != 0;
+        case VK_LBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_MASK(SDL_BUTTON_LEFT)) != 0;
+        case VK_RBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_MASK(SDL_BUTTON_RIGHT)) != 0;
+        case VK_MBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_MASK(SDL_BUTTON_MIDDLE)) != 0;
         case VK_SHIFT:   return (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
         case VK_CONTROL: return (SDL_GetModState() & SDL_KMOD_CTRL) != 0;
         case VK_MENU:    return (SDL_GetModState() & SDL_KMOD_ALT) != 0;

--- a/src/source/Core/Input/KeyState.cpp
+++ b/src/source/Core/Input/KeyState.cpp
@@ -1,9 +1,13 @@
 #include "stdafx.h"
 #include "Core/Input/KeyState.h"
+
+#ifndef _WIN32
 #include <SDL3/SDL.h>
+#endif
 
 namespace Core::Input
 {
+#ifndef _WIN32
     namespace
     {
         // Map a Win32 virtual-key code (or ASCII letter/digit) to an SDL
@@ -48,23 +52,26 @@ namespace Core::Input
             }
         }
     }
+#endif // !_WIN32
 
     bool IsKeyDown(int virtualKey)
     {
-        // Mouse buttons: GetAsyncKeyState(VK_LBUTTON/...) reported these too, and
-        // CInput / CNewKeyInput poll them through this path, so honor them via the
-        // SDL mouse state.
+#ifdef _WIN32
+        // On Windows the legacy UI polls global key/mouse-button state that must
+        // keep working while a Win32 child EDIT control holds keyboard focus.
+        // SDL_GetKeyboardState only reflects keys delivered to the SDL window, so
+        // it goes blind whenever an EDIT box is focused (e.g. the login screen).
+        // Keep the global async query here; switch to the SDL path below once the
+        // EDIT controls are replaced (issue #447). GetAsyncKeyState reports the
+        // mouse buttons (VK_LBUTTON/...) and modifiers too, matching the original.
+        return (GetAsyncKeyState(virtualKey) & 0x8000) != 0;
+#else
+        // Mouse buttons and modifiers come from the SDL mouse / mod state.
         switch (virtualKey)
         {
         case VK_LBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_LMASK) != 0;
         case VK_RBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_RMASK) != 0;
         case VK_MBUTTON: return (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON_MMASK) != 0;
-        default: break;
-        }
-
-        // Modifier keys aggregate left and right via the mod state.
-        switch (virtualKey)
-        {
         case VK_SHIFT:   return (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
         case VK_CONTROL: return (SDL_GetModState() & SDL_KMOD_CTRL) != 0;
         case VK_MENU:    return (SDL_GetModState() & SDL_KMOD_ALT) != 0;
@@ -76,5 +83,6 @@ namespace Core::Input
 
         const bool* state = SDL_GetKeyboardState(nullptr);
         return state != nullptr && state[sc];
+#endif // _WIN32
     }
 }

--- a/src/source/Core/Input/KeyState.h
+++ b/src/source/Core/Input/KeyState.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Core::Input
+{
+    // Portable replacement for the Win32 "is this key currently down" check
+    // (HIBYTE(GetAsyncKeyState(vk)) == 128 / & 0x8000), backed by SDL keyboard
+    // state. The argument is a Win32 virtual-key code (VK_*) or an ASCII letter
+    // or digit, matching what the existing call sites already pass.
+    bool IsKeyDown(int virtualKey);
+}

--- a/src/source/Engine/Object/EditObjects.cpp
+++ b/src/source/Engine/Object/EditObjects.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 #include "Engine/Object/EditObjects.h"
 
 // Includes mirror ZzzInterface.cpp, the unit this was extracted from.
@@ -131,21 +132,21 @@ void EditObjects()
                     else
                         PickObject->Position[2] += PickObjectHeight;
                 }
-                if (HIBYTE(GetAsyncKeyState('Q')) == 128)
+                if (Core::Input::IsKeyDown('Q'))
                     PickObject->Angle[0] -= 5.f;
-                if (HIBYTE(GetAsyncKeyState('E')) == 128)
+                if (Core::Input::IsKeyDown('E'))
                     PickObject->Angle[0] += 5.f;
-                if (HIBYTE(GetAsyncKeyState('A')) == 128)
+                if (Core::Input::IsKeyDown('A'))
                     PickObject->Angle[2] += 30.f;
-                if (HIBYTE(GetAsyncKeyState('D')) == 128)
+                if (Core::Input::IsKeyDown('D'))
                     PickObject->Angle[2] -= 30.f;
-                if (HIBYTE(GetAsyncKeyState('W')) == 128)
+                if (Core::Input::IsKeyDown('W'))
                     PickObjectHeight += 5.f;
-                if (HIBYTE(GetAsyncKeyState('S')) == 128)
+                if (Core::Input::IsKeyDown('S'))
                     PickObjectHeight -= 5.f;
-                if (HIBYTE(GetAsyncKeyState('R')) == 128)
+                if (Core::Input::IsKeyDown('R'))
                     PickObject->Scale += 0.02f;
-                if (HIBYTE(GetAsyncKeyState('F')) == 128)
+                if (Core::Input::IsKeyDown('F'))
                     PickObject->Scale -= 0.02f;
                 if (MouseX >= REFERENCE_WIDTH - 100 && MouseY < 100)
                 {

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -2,6 +2,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 #include <imm.h>
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
@@ -224,7 +225,7 @@ void PrintPKLog(CHARACTER* pCha)
 
 bool PressKey(int Key)
 {
-    if (HIBYTE(GetAsyncKeyState(Key)) == 128)
+    if (Core::Input::IsKeyDown(Key))
     {
         if (KeyState[Key] == false)
         {
@@ -547,7 +548,7 @@ bool CheckAttack_Fenrir(CHARACTER* c)
     }
     else if (::IsStrifeMap(gMapManager.WorldActive) && c != Hero && c->m_byGensInfluence != Hero->m_byGensInfluence)
     {
-        if (((wcscmp(GuildMark[Hero->GuildMarkIndex].GuildName, GuildMark[c->GuildMarkIndex].GuildName) == 0) || (g_pPartyManager->IsPartyMember(SelectedCharacter))) && (HIBYTE(GetAsyncKeyState(VK_CONTROL)) == 128))
+        if (((wcscmp(GuildMark[Hero->GuildMarkIndex].GuildName, GuildMark[c->GuildMarkIndex].GuildName) == 0) || (g_pPartyManager->IsPartyMember(SelectedCharacter))) && (Core::Input::IsKeyDown(VK_CONTROL)))
         {
             return true;
         }
@@ -674,7 +675,7 @@ bool CheckAttack_Fenrir(CHARACTER* c)
                 return false;
             }
         }
-        else if (c->PK >= PVP_MURDERER2 || (HIBYTE(GetAsyncKeyState(VK_CONTROL)) == 128 && c != Hero))
+        else if (c->PK >= PVP_MURDERER2 || (Core::Input::IsKeyDown(VK_CONTROL) && c != Hero))
         {
             return true;
         }
@@ -729,12 +730,12 @@ bool CheckAttack()
         {
             return false;
         }
-        if (HIBYTE(GetAsyncKeyState(VK_MENU)) == 128)
+        if (Core::Input::IsKeyDown(VK_MENU))
         {
             return false;
         }
 
-        if (HIBYTE(GetAsyncKeyState(VK_CONTROL)) == 128)
+        if (Core::Input::IsKeyDown(VK_CONTROL))
         {
             if (EnableGuildWar)
             {
@@ -913,7 +914,7 @@ bool CheckAttack()
                 return false;
             }
         }
-        else if (c->PK >= PVP_MURDERER2 || (HIBYTE(GetAsyncKeyState(VK_CONTROL)) == 128 && c != Hero))
+        else if (c->PK >= PVP_MURDERER2 || (Core::Input::IsKeyDown(VK_CONTROL) && c != Hero))
         {
             return true;
         }
@@ -988,7 +989,7 @@ int	getTargetCharacterKey(CHARACTER* c, int selected)
         return -1;
     }
 
-    if (::IsStrifeMap(gMapManager.WorldActive) && sc != Hero && sc->m_byGensInfluence != Hero->m_byGensInfluence && HIBYTE(GetAsyncKeyState(VK_MENU)) != 128)
+    if (::IsStrifeMap(gMapManager.WorldActive) && sc != Hero && sc->m_byGensInfluence != Hero->m_byGensInfluence && !Core::Input::IsKeyDown(VK_MENU))
     {
         if (sc->GuildRelationShip == GR_NONE && !g_pPartyManager->IsPartyMember(SelectedCharacter))
         {
@@ -998,7 +999,7 @@ int	getTargetCharacterKey(CHARACTER* c, int selected)
         if ((wcscmp(GuildMark[Hero->GuildMarkIndex].GuildName, GuildMark[c->GuildMarkIndex].GuildName) == 0) ||
             g_pPartyManager->IsPartyMember(SelectedCharacter))
         {
-            if (HIBYTE(GetAsyncKeyState(VK_CONTROL)) == 128)
+            if (Core::Input::IsKeyDown(VK_CONTROL))
             {
                 return sc->Key;
             }
@@ -1007,7 +1008,7 @@ int	getTargetCharacterKey(CHARACTER* c, int selected)
         }
     }
 
-    if ((sc->PK >= PVP_MURDERER2 && sc->Object.Kind == KIND_PLAYER) || (HIBYTE(GetAsyncKeyState(VK_CONTROL)) == 128 && sc != Hero))
+    if ((sc->PK >= PVP_MURDERER2 && sc->Object.Kind == KIND_PLAYER) || (Core::Input::IsKeyDown(VK_CONTROL) && sc != Hero))
     {
         return sc->Key;
     }
@@ -3301,7 +3302,7 @@ void MoveHero()
                     c->MovementType = MOVEMENT_MOVE;
                 }
             }
-            else if (HIBYTE(GetAsyncKeyState(VK_SHIFT)) != 128)
+            else if (!Core::Input::IsKeyDown(VK_SHIFT))
             {
                 RenderTerrain(true);
 
@@ -3428,16 +3429,16 @@ void MoveInterface()
     {
         if (gMapManager.InChaosCastle() == false)
         {
-            if (HIBYTE(GetAsyncKeyState(VK_MENU)))
+            if (Core::Input::IsKeyDown(VK_MENU))
             {
                 for (int i = 0; i < 9; i++)
                 {
-                    if (HIBYTE(GetAsyncKeyState('1' + i)))
+                    if (Core::Input::IsKeyDown('1' + i))
                     {
                         SendMacroChat(MacroText[i]);
                     }
                 }
-                if (HIBYTE(GetAsyncKeyState('0')))
+                if (Core::Input::IsKeyDown('0'))
                 {
                     SendMacroChat(MacroText[9]);
                 }

--- a/src/source/Guild/UIGuildInfo.cpp
+++ b/src/source/Guild/UIGuildInfo.cpp
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Engine/Object/ZzzInterface.h"
 #include "Render/Textures/ZzzTexture.h"
@@ -811,7 +812,7 @@ void UseBattleMasterSkill(void)
 
     if (Hero->GuildMasterKillCount >= MaxKillCount)
     {
-        if (HIBYTE(GetAsyncKeyState(VK_SHIFT)))
+        if (Core::Input::IsKeyDown(VK_SHIFT))
         {
             if (Hero->BackupCurrentSkill == 255)
             {

--- a/src/source/Input/Selection.cpp
+++ b/src/source/Input/Selection.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 #include "Input/Selection.h"
 #include "Character/CharacterManager.h" // gCharacterManager
 
@@ -308,7 +309,7 @@ void SelectObjects()
 
     if (!MouseOnWindow && false == g_pNewUISystem->CheckMouseUse() && SEASON3B::CheckMouseIn(0, 0, GetScreenWidth(), 429))
     {
-        if (HIBYTE(GetAsyncKeyState(VK_MENU)) == 128)
+        if (Core::Input::IsKeyDown(VK_MENU))
         {
             if (SEASON3B::CNewUIInventoryCtrl::GetPickedItem() == NULL)
                 SelectedItem = SelectItem();

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -3,6 +3,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 #include <vector>
 #include <algorithm>
 #include <numeric>
@@ -233,7 +234,7 @@ static void HandleScreenshotCapture()
         return;
     }
 
-    const bool addTimeStampToCapture = !HIBYTE(GetAsyncKeyState(VK_SHIFT));
+    const bool addTimeStampToCapture = !Core::Input::IsKeyDown(VK_SHIFT);
     wchar_t screenshotText[256];
 
     GenerateScreenshotFilename(GrabFileName, screenshotText);

--- a/src/source/UI/Legacy/UIControls.cpp
+++ b/src/source/UI/Legacy/UIControls.cpp
@@ -2,6 +2,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 #include "Core/Time/FrameTimerScheduler.h"
 #include "GameLogic/Items/CComGem.h"
 #include "UIControls.h"
@@ -803,13 +804,13 @@ BOOL CUITextListBox<T>::DoMouseAction()
     {
         BOOL bKeyPress = FALSE;
 
-        if (HIBYTE(GetAsyncKeyState(VK_LEFT)) == 128)
+        if (Core::Input::IsKeyDown(VK_LEFT))
         {
         }
-        if (HIBYTE(GetAsyncKeyState(VK_RIGHT)) == 128)
+        if (Core::Input::IsKeyDown(VK_RIGHT))
         {
         }
-        if (HIBYTE(GetAsyncKeyState(VK_UP)) == 128)
+        if (Core::Input::IsKeyDown(VK_UP))
         {
             bKeyPress = TRUE;
             if (m_bPressCursorKey == 0)
@@ -822,7 +823,7 @@ BOOL CUITextListBox<T>::DoMouseAction()
             else
                 ++m_bPressCursorKey;
         }
-        if (HIBYTE(GetAsyncKeyState(VK_DOWN)) == 128)
+        if (Core::Input::IsKeyDown(VK_DOWN))
         {
             bKeyPress = TRUE;
             if (m_bPressCursorKey == 0)
@@ -3112,10 +3113,10 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
     if (pTextInputBox == nullptr)
         return 0;
 
-    if (HIBYTE(GetAsyncKeyState(VK_UP)) == 128
-        || HIBYTE(GetAsyncKeyState(VK_DOWN)) == 128
-        || HIBYTE(GetAsyncKeyState(VK_LEFT)) == 128
-        || HIBYTE(GetAsyncKeyState(VK_RIGHT)) == 128)
+    if (Core::Input::IsKeyDown(VK_UP)
+        || Core::Input::IsKeyDown(VK_DOWN)
+        || Core::Input::IsKeyDown(VK_LEFT)
+        || Core::Input::IsKeyDown(VK_RIGHT))
     {
         pTextInputBox->m_caretTimer.ResetTimer();
     }

--- a/src/source/UI/NewUI/NewUICommon.cpp
+++ b/src/source/UI/NewUI/NewUICommon.cpp
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include "Core/Input/KeyState.h"
 
 #include "UI/NewUI/NewUICommon.h"
 #include "UI/NewUI/Widgets/NewUIRenderNumber.h"
@@ -174,7 +175,7 @@ void SEASON3B::CNewKeyInput::ScanAsyncKeyState()
 
     for (int key = 0; key < 256; key++)
     {
-        if (HIBYTE(GetAsyncKeyState(key)) & 0x80)
+        if (Core::Input::IsKeyDown(key))
         {
             if (m_pInputInfo[key].byKeyState == KEY_NONE || m_pInputInfo[key].byKeyState == KEY_RELEASE)
             {


### PR DESCRIPTION
Replace ~50 GetAsyncKeyState 'is this key down' checks across the camera, interface, edit-object, UI, and scene code with a portable Core::Input::IsKeyDown helper backed by SDL_GetKeyboardState / SDL_GetModState and a VK-to-scancode map.

IsKeyDown also resolves VK_LBUTTON/VK_RBUTTON/VK_MBUTTON via SDL_GetMouseState and VK_SHIFT/CONTROL/MENU via the mod state, matching what GetAsyncKeyState reported: CInput and CNewKeyInput poll the mouse buttons through this same 0-255 key scan, so the legacy CWin/CButton UI keeps working.

Step 5 of the SDL3 windowing migration (#442).