### PR TITLE
Route VSync, buffer swap, and refresh rate through SDL

### DIFF
--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -201,9 +201,18 @@ int GetFPSLimit()
     constexpr int DEFAULT_REFRESH_HZ = 60;
     if (g_sdlWindow)
     {
-        const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(SDL_GetDisplayForWindow(g_sdlWindow));
-        if (mode && mode->refresh_rate > 0.0f)
-            return static_cast<int>(mode->refresh_rate + 0.5f);
+        // Before the window is mapped to a display, SDL_GetDisplayForWindow
+        // returns 0; fall back to the primary display so a high-refresh monitor
+        // isn't capped at the default 60 Hz.
+        SDL_DisplayID displayID = SDL_GetDisplayForWindow(g_sdlWindow);
+        if (displayID == 0)
+            displayID = SDL_GetPrimaryDisplay();
+        if (displayID != 0)
+        {
+            const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayID);
+            if (mode && mode->refresh_rate > 0.0f)
+                return static_cast<int>(mode->refresh_rate + 0.5f);
+        }
     }
     return DEFAULT_REFRESH_HZ;
 }

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -186,6 +186,28 @@ GLvoid KillGLWindow(GLvoid)
     }
 }
 
+// Present the current GL frame. SDL owns the window/context, so swapping goes
+// through SDL_GL_SwapWindow instead of the Win32 ::SwapBuffers (issue #442).
+void PlatformSwapBuffers()
+{
+    if (g_sdlWindow)
+        SDL_GL_SwapWindow(g_sdlWindow);
+}
+
+// Monitor refresh rate (Hz) for the display the window is on, via SDL instead
+// of the Win32 GetDeviceCaps(VREFRESH) (issue #442). Falls back to 60.
+int GetFPSLimit()
+{
+    constexpr int DEFAULT_REFRESH_HZ = 60;
+    if (g_sdlWindow)
+    {
+        const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(SDL_GetDisplayForWindow(g_sdlWindow));
+        if (mode && mode->refresh_rate > 0.0f)
+            return static_cast<int>(mode->refresh_rate + 0.5f);
+    }
+    return DEFAULT_REFRESH_HZ;
+}
+
 BOOL GetFileNameOfFilePath(wchar_t* lpszFile, wchar_t* lpszPath)
 {
     auto iFind = (int)'\\';

--- a/src/source/Render/Textures/ZzzOpenglUtil.cpp
+++ b/src/source/Render/Textures/ZzzOpenglUtil.cpp
@@ -9,7 +9,10 @@
 #include "Engine/Object/ZzzObject.h"
 #include "Engine/Object/ZzzCharacter.h"
 #include "UI/NewUI/NewUISystem.h"
-#include "wglext.h"
+#include <SDL3/SDL.h>
+#ifdef LDS_ADD_MULTISAMPLEANTIALIASING
+#include "wglext.h"  // legacy WGL multisample pixel-format path (disabled by default)
+#endif
 #include "Camera/CameraProjection.h"
 #include "Camera/CameraManager.h"
 #include "Camera/CameraMode.h"
@@ -34,7 +37,6 @@ GLfloat FogColor[4] = { 30 / 256.f,20 / 256.f,10 / 256.f, };
 
 bool _isVSyncAvailable = false;
 bool _isVSyncEnabled = false;
-PFNWGLSWAPINTERVALEXTPROC       wglSwapIntervalEXT = nullptr;
 
 
 unsigned int WindowWidth = 1024;
@@ -634,6 +636,7 @@ void UpdateMousePositionn()
     VectorIRotate(vPos, g_Camera.Matrix, MousePosition);
 }
 
+#ifdef LDS_ADD_MULTISAMPLEANTIALIASING
 BOOL IsGLExtensionSupported(const wchar_t* extension)
 {
     const size_t extlen = wcslen(extension);
@@ -667,37 +670,13 @@ BOOL IsGLExtensionSupported(const wchar_t* extension)
     }
 }
 
-bool WGLExtensionSupported(const char* extension_name)
-{
-    // this is pointer to function which returns pointer to string with list of all wgl extensions
-     PFNWGLGETEXTENSIONSSTRINGEXTPROC _wglGetExtensionsStringEXT = reinterpret_cast<PFNWGLGETEXTENSIONSSTRINGEXTPROC>(wglGetProcAddress("wglGetExtensionsStringEXT"));
-
-    if (strstr(_wglGetExtensionsStringEXT(), extension_name) == nullptr)
-    {
-        // string was not found
-        return false;
-    }
-
-    // extension is supported
-    return true;
-}
+#endif // LDS_ADD_MULTISAMPLEANTIALIASING
 
 void InitVSync()
 {
-    _isVSyncAvailable = WGLExtensionSupported("WGL_EXT_swap_control");
-    if (_isVSyncAvailable)
-    {
-        // Extension is supported, init pointers.
-        wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
-
-        // this is another function from WGL_EXT_swap_control extension
-        // wglGetSwapIntervalEXT = (PFNWGLGETSWAPINTERVALEXTPROC)wglGetProcAddress("wglGetSwapIntervalEXT");
-    }
-
-    if (wglSwapIntervalEXT == nullptr)
-    {
-        _isVSyncAvailable = false;
-    }
+    // SDL controls the swap interval on the current GL context on every platform;
+    // EnableVSync/DisableVSync just toggle it. No WGL extension probing needed.
+    _isVSyncAvailable = true;
 }
 
 bool IsVSyncAvailable()
@@ -712,30 +691,18 @@ bool IsVSyncEnabled()
 
 void EnableVSync()
 {
-    if (!_isVSyncAvailable)
-    {
-        return;
-    }
-
-    wglSwapIntervalEXT(1);
-    _isVSyncEnabled = true;
+    if (SDL_GL_SetSwapInterval(1))
+        _isVSyncEnabled = true;
 }
 
 void DisableVSync()
 {
-    if (!_isVSyncAvailable)
-    {
-        return;
-    }
-
-    wglSwapIntervalEXT(0);
-    _isVSyncEnabled = false;
+    if (SDL_GL_SetSwapInterval(0))
+        _isVSyncEnabled = false;
 }
 
-int GetFPSLimit()
-{
-    return GetDeviceCaps(g_hDC, VREFRESH);
-}
+// GetFPSLimit() lives in the platform layer (Winmain.cpp): it queries the
+// monitor refresh rate, which SDL exposes per display (issue #442).
 
 #ifdef LDS_ADD_MULTISAMPLEANTIALIASING
 BOOL InitGLMultisample(HINSTANCE hInstance, HWND hWnd, PIXELFORMATDESCRIPTOR pfd, int iRequestMSAAValue, int& OutiPixelFormat)

--- a/src/source/Render/Textures/ZzzOpenglUtil.h
+++ b/src/source/Render/Textures/ZzzOpenglUtil.h
@@ -82,6 +82,9 @@ void EnableVSync();
 void DisableVSync();
 int GetFPSLimit();
 
+// Present the current GL frame via SDL (replaces the Win32 ::SwapBuffers, #442).
+void PlatformSwapBuffers();
+
 void UpdateMousePositionn();
 inline void TEXCOORD(float* c, float u, float v)
 {

--- a/src/source/Scenes/LoadingScene.cpp
+++ b/src/source/Scenes/LoadingScene.cpp
@@ -111,7 +111,7 @@ void LoadingScene(HDC hDC)
     }
 #endif
     UI::Reconnect::RenderDialog();
-    ::SwapBuffers(hDC);
+    PlatformSwapBuffers();
 
     SAFE_DELETE(rUIMng.m_pLoadingScene);
 

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -1026,7 +1026,7 @@ void MainScene(HDC hDC)
                 EndBitmap();
             }
 #endif
-            SwapBuffers(hDC);
+            PlatformSwapBuffers();
         }
 
         CheckServerConnection();

--- a/src/source/UI/Legacy/UIMng.cpp
+++ b/src/source/UI/Legacy/UIMng.cpp
@@ -159,7 +159,7 @@ void CUIMng::RenderTitleSceneUI(HDC hDC, DWORD dwNow, DWORD dwTotal)
     // Always render ImGui (shows "Open Editor" button when closed, or full UI when open)
     g_MuEditorCore.Render();
 #endif
-    ::SwapBuffers(hDC);
+    PlatformSwapBuffers();
 }
 
 void CUIMng::Create()


### PR DESCRIPTION
Replaces the remaining WGL/GDI GL-context calls with their SDL equivalents so the present path is portable. Advances the "GL loader / VSync / MSAA" item of #442.

## Changes
- VSync uses `SDL_GL_SetSwapInterval` instead of `wglSwapIntervalEXT`; the WGL extension probing is removed.
- A new `PlatformSwapBuffers()` calls `SDL_GL_SwapWindow`, replacing the three Win32 `::SwapBuffers(hDC)` call sites (loading scene, scene manager, UI manager).
- `GetFPSLimit()` reads the monitor refresh rate from `SDL_GetCurrentDisplayMode` instead of `GetDeviceCaps(VREFRESH)`.

## Notes
- The renderer is fixed-function linked against `opengl32`, so there is no GL loader to migrate.
- The legacy WGL multisample path was already disabled by default; it and its `wglext.h` include are now wrapped under the `LDS_ADD_MULTISAMPLEANTIALIASING` macro so the live path has no WGL dependency. If MSAA is ever enabled it would use `SDL_GL_SetAttribute` at context creation.