### PR TITLE
Move the editor ImGui backend from Win32 to SDL3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,7 +128,7 @@ if(ENABLE_EDITOR)
     "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/imgui_draw.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/imgui_tables.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/imgui_widgets.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/backends/imgui_impl_win32.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/backends/imgui_impl_sdl3.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/backends/imgui_impl_opengl2.cpp"
   )
 
@@ -136,6 +136,10 @@ if(ENABLE_EDITOR)
     "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui"
     "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/imgui/backends"
   )
+
+  # The SDL3 ImGui backend (imgui_impl_sdl3.cpp) needs the SDL3 headers; link the
+  # target so its include dirs propagate (issue #442).
+  target_link_libraries(imgui PUBLIC SDL3::SDL3)
 
   # The Win32 + OpenGL2 backends call straight into opengl32 (glOrtho,
   # glShadeModel, ...) and dwmapi. Declaring them as PUBLIC dependencies of

--- a/src/MuEditor/Core/MuEditorCore.cpp
+++ b/src/MuEditor/Core/MuEditorCore.cpp
@@ -4,7 +4,7 @@
 
 #include "MuEditorCore.h"
 #include "imgui.h"
-#include "imgui_impl_win32.h"
+#include "imgui_impl_sdl3.h"
 #include "imgui_impl_opengl2.h"
 #include "MuInputBlockerCore.h"
 #include "../Config/MuEditorConfig.h"
@@ -52,7 +52,7 @@ CMuEditorCore& CMuEditorCore::GetInstance()
     return instance;
 }
 
-void CMuEditorCore::Initialize(HWND hwnd, HDC hdc)
+void CMuEditorCore::Initialize(SDL_Window* window, void* glContext)
 {
     if (m_bInitialized)
         return;
@@ -240,7 +240,7 @@ void CMuEditorCore::Initialize(HWND hwnd, HDC hdc)
     style.WindowRounding = 0.0f;
     style.Colors[ImGuiCol_WindowBg] = ImVec4(0.12f, 0.12f, 0.12f, 1.0f);
 
-    ImGui_ImplWin32_Init(hwnd);
+    ImGui_ImplSDL3_InitForOpenGL(window, glContext);
     ImGui_ImplOpenGL2_Init();
 
     fwprintf(stderr, L"[MuEditor] ImGui backends initialized\n");
@@ -272,7 +272,7 @@ void CMuEditorCore::Shutdown()
     g_MuSkillEditorUI.SaveColumnPreferences();
 
     ImGui_ImplOpenGL2_Shutdown();
-    ImGui_ImplWin32_Shutdown();
+    ImGui_ImplSDL3_Shutdown();
     ImGui::DestroyContext();
 
     m_bInitialized = false;
@@ -288,35 +288,11 @@ void CMuEditorCore::Update()
     {
         ImGui_ImplOpenGL2_NewFrame();
 
-        // Only let Win32 backend update mouse when editor is open
-        if (m_bEditorMode)
-        {
-            ImGui_ImplWin32_NewFrame();
-        }
-        else
-        {
-            // When closed, manually create a minimal frame and update mouse position
-            ImGuiIO& io = ImGui::GetIO();
-
-            // Get window size
-            extern HWND g_hWnd;
-            RECT rect;
-            GetClientRect(g_hWnd, &rect);
-            io.DisplaySize = ImVec2((float)(rect.right - rect.left), (float)(rect.bottom - rect.top));
-            io.DeltaTime = 1.0f / 60.0f;
-
-            // Manually update mouse position for button detection
-            POINT mousePos;
-            if (GetCursorPos(&mousePos))
-            {
-                ScreenToClient(g_hWnd, &mousePos);
-                io.MousePos = ImVec2((float)mousePos.x, (float)mousePos.y);
-            }
-
-            // Update mouse button states
-            extern bool MouseLButton;
-            io.MouseDown[0] = MouseLButton;
-        }
+        // The SDL3 backend fills display size and mouse/keyboard from the SDL
+        // events fed via ImGui_ImplSDL3_ProcessEvent, so it works the same
+        // whether the editor is open or only the "Open Editor" button is shown
+        // (issue #442) - no manual Win32 frame setup needed.
+        ImGui_ImplSDL3_NewFrame();
 
         ImGui::NewFrame();
         m_bFrameStarted = true;

--- a/src/MuEditor/Core/MuEditorCore.cpp
+++ b/src/MuEditor/Core/MuEditorCore.cpp
@@ -57,6 +57,13 @@ void CMuEditorCore::Initialize(SDL_Window* window, void* glContext)
     if (m_bInitialized)
         return;
 
+    if (window == nullptr || glContext == nullptr)
+    {
+        fwprintf(stderr, L"[MuEditor] Initialize failed: window or glContext is null\n");
+        fflush(stderr);
+        return;
+    }
+
     fwprintf(stderr, L"[MuEditor] Initialize() called\n");
     fflush(stderr);
 
@@ -240,8 +247,21 @@ void CMuEditorCore::Initialize(SDL_Window* window, void* glContext)
     style.WindowRounding = 0.0f;
     style.Colors[ImGuiCol_WindowBg] = ImVec4(0.12f, 0.12f, 0.12f, 1.0f);
 
-    ImGui_ImplSDL3_InitForOpenGL(window, glContext);
-    ImGui_ImplOpenGL2_Init();
+    if (!ImGui_ImplSDL3_InitForOpenGL(window, glContext))
+    {
+        fwprintf(stderr, L"[MuEditor] ImGui_ImplSDL3_InitForOpenGL failed\n");
+        fflush(stderr);
+        ImGui::DestroyContext();
+        return;
+    }
+    if (!ImGui_ImplOpenGL2_Init())
+    {
+        fwprintf(stderr, L"[MuEditor] ImGui_ImplOpenGL2_Init failed\n");
+        fflush(stderr);
+        ImGui_ImplSDL3_Shutdown();
+        ImGui::DestroyContext();
+        return;
+    }
 
     fwprintf(stderr, L"[MuEditor] ImGui backends initialized\n");
     fflush(stderr);

--- a/src/MuEditor/Core/MuEditorCore.h
+++ b/src/MuEditor/Core/MuEditorCore.h
@@ -4,12 +4,16 @@
 
 #include "stdafx.h"
 
+struct SDL_Window;
+
 class CMuEditorCore
 {
 public:
     static CMuEditorCore& GetInstance();
 
-    void Initialize(HWND hwnd, HDC hdc);
+    // window/glContext are the SDL window and GL context for the ImGui SDL3
+    // backend (issue #442).
+    void Initialize(SDL_Window* window, void* glContext);
     void Shutdown();
     void Update();
     void Render();

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -67,7 +67,6 @@
 #include "imgui.h"
 #include "imgui_impl_sdl3.h"
 #include "../MuEditor/Config/MuEditorConfig.h"
-#include "../MuEditor/Core/MuEditorCore.h"
 #endif
 
 CUIMercenaryInputBox* g_pMercenaryInputBox = nullptr;
@@ -1001,7 +1000,9 @@ MSG MainLoop()
         {
 #ifdef _EDITOR
             // Feed every event to the editor's ImGui SDL3 backend (issue #442).
-            ImGui_ImplSDL3_ProcessEvent(&event);
+            // Guard on an active context: editor init can fail or be shut down.
+            if (ImGui::GetCurrentContext() != nullptr)
+                ImGui_ImplSDL3_ProcessEvent(&event);
 #endif
             switch (event.type)
             {
@@ -1580,6 +1581,11 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLin
     // Teardown that used to run in WM_DESTROY, now after the loop exits (SDL owns
     // the window/GL context, so they must not be destroyed from a message).
     DestroySound();
+#ifdef _EDITOR
+    // Shut the editor's ImGui backends down while the GL context and SDL window
+    // are still alive; the static destructor runs too late (after KillGLWindow).
+    g_MuEditorCore.Shutdown();
+#endif
     KillGLWindow();
     DestroyWindow();
 

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -65,11 +65,9 @@
 #ifdef _EDITOR
 #include "../MuEditor/Core/MuEditorCore.h"
 #include "imgui.h"
-#include "imgui_impl_win32.h"
+#include "imgui_impl_sdl3.h"
 #include "../MuEditor/Config/MuEditorConfig.h"
 #include "../MuEditor/Core/MuEditorCore.h"
-// Forward declare ImGui WndProc handler
-extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 #endif
 
 CUIMercenaryInputBox* g_pMercenaryInputBox = nullptr;
@@ -471,15 +469,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         return 0;
     }
 
-#ifdef _EDITOR
-    // Only forward messages to ImGui when editor is open
-    // When editor is closed, we handle button clicks manually in RenderToolbarOpen
-    if (g_MuEditorCore.IsEnabled())
-    {
-        if (ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
-            return true;
-    }
-#endif
+    // ImGui (editor) now consumes input from the SDL event loop via
+    // ImGui_ImplSDL3_ProcessEvent, not from Win32 messages (issue #442).
 
     switch (msg)
     {
@@ -1008,6 +999,10 @@ MSG MainLoop()
         // events are handled here, off the hook.
         while (SDL_PollEvent(&event))
         {
+#ifdef _EDITOR
+            // Feed every event to the editor's ImGui SDL3 backend (issue #442).
+            ImGui_ImplSDL3_ProcessEvent(&event);
+#endif
             switch (event.type)
             {
             case SDL_EVENT_QUIT:
@@ -1463,8 +1458,8 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLin
     }
 
 #ifdef _EDITOR
-    // Initialize MU Editor
-    g_MuEditorCore.Initialize(g_hWnd, g_hDC);
+    // Initialize MU Editor (ImGui SDL3 backend needs the SDL window + GL context).
+    g_MuEditorCore.Initialize(g_sdlWindow, g_sdlGLContext);
 
     // Check for --editor command line flag
     if (szCmdLine && wcsstr(GetCommandLineW(), L"--editor"))


### PR DESCRIPTION
Build imgui_impl_sdl3 instead of imgui_impl_win32 and drive ImGui from the SDL event loop, so the editor input path is portable.

- The imgui library compiles the SDL3 backend and links SDL3 for its headers.
- The editor initializes the backend with the SDL window and GL context (ImGui_ImplSDL3_InitForOpenGL) and starts each frame with ImGui_ImplSDL3_NewFrame, dropping the Win32 manual mouse/size handling used while the editor was closed.
- The main loop forwards every SDL event to ImGui_ImplSDL3_ProcessEvent; the old ImGui_ImplWin32_WndProcHandler forwarding is removed.