### PR TITLE
Add a portable SDL shell and a cross-platform smoke test

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,6 +219,17 @@ if (NOT MSVC)
   target_link_options(Main PRIVATE "-Wl,-Map,${MU_MAIN_MAP_FILE}")
 endif()
 
+# Minimal cross-platform smoke test for the portable SDL shell: opens a window,
+# creates a GL context, and runs the event loop (issue #442). It links only
+# SDL3 - not the engine, which is still Win32-bound - so it builds and runs on
+# Linux/macOS/Windows as a CI portability guard for the platform-neutral shell.
+add_executable(mu_sdl_smoke
+  "${CMAKE_CURRENT_SOURCE_DIR}/source/App/Platform/SdlShell.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/source/App/Platform/Linux/main.cpp"
+)
+target_compile_features(mu_sdl_smoke PRIVATE cxx_std_20)
+target_link_libraries(mu_sdl_smoke PRIVATE SDL3::SDL3)
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
   # Build as a Windows GUI application (no console window) and let CMake
   # add the default system libraries like kernel32, user32, gdi32, etc.

--- a/src/source/App/Platform/Linux/main.cpp
+++ b/src/source/App/Platform/Linux/main.cpp
@@ -1,0 +1,12 @@
+// Linux entry point (issue #442, the per-platform entry seam from #441).
+//
+// The engine is still largely Win32-bound, so the full game cannot link here
+// yet. For now this entry runs the portable SDL shell smoke test, which proves
+// the window/GL/event-loop path works on Linux. It is replaced with the real
+// game bootstrap once the engine is platform-neutral.
+#include "../SdlShell.h"
+
+int main(int /*argc*/, char* /*argv*/[])
+{
+    return Platform::RunSmokeTest();
+}

--- a/src/source/App/Platform/SdlShell.cpp
+++ b/src/source/App/Platform/SdlShell.cpp
@@ -30,7 +30,12 @@ namespace Platform
             return false;
         }
 
-        SDL_GL_MakeCurrent(window, static_cast<SDL_GLContext>(glContext));
+        if (!SDL_GL_MakeCurrent(window, static_cast<SDL_GLContext>(glContext)))
+        {
+            std::fprintf(stderr, "[SdlShell] SDL_GL_MakeCurrent failed: %s\n", SDL_GetError());
+            Destroy();
+            return false;
+        }
         return true;
     }
 

--- a/src/source/App/Platform/SdlShell.cpp
+++ b/src/source/App/Platform/SdlShell.cpp
@@ -1,0 +1,87 @@
+// Portable SDL window + OpenGL-context shell (issue #442). No Win32 here.
+#include "SdlShell.h"
+
+#include <SDL3/SDL.h>
+#include <cstdio>
+
+namespace Platform
+{
+    bool SdlShell::Create(const char* title, int width, int height)
+    {
+        // The fixed-function renderer needs a compatibility-profile context,
+        // matching what the Windows bootstrap requests.
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
+        SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+        SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 16);
+
+        window = SDL_CreateWindow(title, width, height, SDL_WINDOW_OPENGL);
+        if (window == nullptr)
+        {
+            std::fprintf(stderr, "[SdlShell] SDL_CreateWindow failed: %s\n", SDL_GetError());
+            return false;
+        }
+
+        glContext = SDL_GL_CreateContext(window);
+        if (glContext == nullptr)
+        {
+            std::fprintf(stderr, "[SdlShell] SDL_GL_CreateContext failed: %s\n", SDL_GetError());
+            SDL_DestroyWindow(window);
+            window = nullptr;
+            return false;
+        }
+
+        SDL_GL_MakeCurrent(window, static_cast<SDL_GLContext>(glContext));
+        return true;
+    }
+
+    void SdlShell::Destroy()
+    {
+        if (glContext != nullptr)
+        {
+            SDL_GL_DestroyContext(static_cast<SDL_GLContext>(glContext));
+            glContext = nullptr;
+        }
+        if (window != nullptr)
+        {
+            SDL_DestroyWindow(window);
+            window = nullptr;
+        }
+    }
+
+    int RunSmokeTest()
+    {
+        if (!SDL_Init(SDL_INIT_VIDEO))
+        {
+            std::fprintf(stderr, "[SdlShell] SDL_Init(VIDEO) failed: %s\n", SDL_GetError());
+            return 1;
+        }
+
+        SdlShell shell;
+        if (!shell.Create("MU SDL shell smoke test", 320, 240))
+        {
+            SDL_Quit();
+            return 2;
+        }
+
+        // A few non-interactive frames: drain events and swap, then exit so the
+        // test terminates on its own under CI.
+        constexpr int kFrames = 3;
+        bool running = true;
+        for (int frame = 0; frame < kFrames && running; ++frame)
+        {
+            SDL_Event event;
+            while (SDL_PollEvent(&event))
+            {
+                if (event.type == SDL_EVENT_QUIT)
+                    running = false;
+            }
+            SDL_GL_SwapWindow(shell.window);
+            SDL_Delay(16);
+        }
+
+        shell.Destroy();
+        SDL_Quit();
+        std::fprintf(stderr, "[SdlShell] smoke test OK\n");
+        return 0;
+    }
+}

--- a/src/source/App/Platform/SdlShell.h
+++ b/src/source/App/Platform/SdlShell.h
@@ -1,0 +1,31 @@
+// Portable SDL window + OpenGL-context shell (issue #442).
+//
+// This is the platform-neutral core of the client's window/GL/event bootstrap,
+// with no Win32 dependency, so it compiles and runs on Windows, Linux and
+// macOS. The Windows entry point still drives the full game through Winmain for
+// now; this unit backs the cross-platform smoke test (and the Linux entry) that
+// guards the portable path until the rest of the engine is platform-neutral.
+#pragma once
+
+struct SDL_Window;
+
+namespace Platform
+{
+    // Owns an SDL window and a compatibility-profile OpenGL context (the
+    // renderer is fixed-function). Create() returns false on failure and leaves
+    // the shell empty; Destroy() is idempotent.
+    struct SdlShell
+    {
+        SDL_Window* window = nullptr;
+        void* glContext = nullptr;  // SDL_GLContext (opaque)
+
+        bool Create(const char* title, int width, int height);
+        void Destroy();
+    };
+
+    // Minimal portability smoke test: initialize SDL video, open a window with a
+    // GL context, pump the event loop for a few frames (swapping buffers), then
+    // tear everything down. Returns 0 on success, non-zero on failure. Used by
+    // the cross-platform smoke-test target as a CI guard for the portable shell.
+    int RunSmokeTest();
+}


### PR DESCRIPTION
Completes the "portable shell + Linux entry" item of #442 at the windowing layer.

## Changes
- `Platform::SdlShell` (`src/source/App/Platform/SdlShell.{h,cpp}`): a Win32-free unit that creates an SDL window + compatibility-profile OpenGL context and tears it down, plus `RunSmokeTest()` (init video, open window/GL, pump the event loop a few frames swapping buffers, shut down).
- `src/source/App/Platform/Linux/main.cpp`: the Linux entry point (the per-platform seam from #441), running the smoke test for now.
- A `mu_sdl_smoke` CMake executable that links only SDL3 (not the engine) so it builds and runs on Linux/macOS/Windows as a portability guard for the shell.

## Scope
- Verified on Windows (MinGW): the smoke target builds, links, and runs (window + GL context + event loop); the existing `Main` build is unaffected.
- The Windows entry point still drives the full game through `Winmain`. The rest of the engine is still Windows-bound (wide-char width, registry, wininet/urlmon, DPAPI, etc., all out of scope for #442), so this guards the portable windowing path rather than producing a full Linux client.
- A native-Linux CI job is a follow-up: the CMake configure currently requires Windows-oriented dependencies (static turbojpeg, the .NET ClientLibrary, GenWireSizes) and needs to be made Linux-tolerant first.