### PR TITLE
Add a native Linux CI portability guard (#462 Phase 0)

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -1,0 +1,66 @@
+name: Linux Portability Smoke Test
+
+# Builds (and runs) the portable SDL shell smoke test natively on Linux as a
+# guard for issue #462: it ensures the platform-neutral window/GL/event-loop
+# layer keeps compiling and running on Linux even though the full client is
+# still Windows-bound. Only the mu_sdl_smoke target is built (it links SDL3,
+# not the engine), so this stays fast and does not depend on the Win32 code.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  linux-smoke:
+    name: linux-smoke (native)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build tools and SDL3 Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake ninja-build pkg-config \
+            libx11-dev libxext-dev libxrandr-dev libxi-dev libxcursor-dev \
+            libxfixes-dev libxrender-dev libxss-dev libxtst-dev libxkbcommon-dev \
+            libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev \
+            libwayland-dev libdecor-0-dev wayland-protocols \
+            libasound2-dev libpulse-dev libdbus-1-dev libudev-dev \
+            libgl1-mesa-dri xvfb
+
+      - name: Install .NET SDK 10
+        # Needed at configure time to restore the OpenMU packet XML NuGet
+        # package that the wire-size codegen reads.
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Configure CMake (native Linux)
+        run: |
+          cmake -S . -B build-linux -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_EDITOR=OFF
+
+      - name: Build the SDL shell smoke test
+        run: |
+          cmake --build build-linux --target mu_sdl_smoke -j"$(nproc)"
+
+      - name: Run the smoke test (headless via Xvfb, best effort)
+        # Running needs a display and a GL driver; Xvfb + Mesa software GL
+        # cover that on CI. Don't fail the job if the runner can't provide GL -
+        # the build above is the hard portability guard.
+        continue-on-error: true
+        run: |
+          xvfb-run -a ./build-linux/src/mu_sdl_smoke
+
+      - name: Upload smoke-test binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: mu_sdl_smoke-linux
+          path: build-linux/src/mu_sdl_smoke
+          if-no-files-found: error


### PR DESCRIPTION
First step of #462 (native Linux build). The portable SDL shell from #442 already builds and runs natively on Linux with no code changes; this adds CI to keep it that way.

## Change
- `.github/workflows/linux-smoke.yml`: a native `ubuntu-latest` job that installs the SDL3 Linux dependencies and .NET, configures with `-DENABLE_EDITOR=OFF`, builds only the `mu_sdl_smoke` target (it links SDL3, not the engine), runs it best-effort under Xvfb, and uploads the binary.

## Why this works without engine changes
- The native Linux configure already succeeds: the static-turbojpeg requirement is `WIN32`-gated, Python and .NET cover the wire-size codegen, and the smoke target depends only on SDL3.
- Building `mu_sdl_smoke` does not compile the still-Windows-bound engine, so it stays fast and green.

## Verified
Built and ran `mu_sdl_smoke` natively (window + GL context + event loop, exit 0) on a Linux host. The workflow mirrors the existing CI jobs; its first run on Actions will confirm the runner specifics.

## Not in scope
The full Linux client (wide-char portability, registry/DPAPI/wininet, message-hook removal) is the rest of #462.