### PR TITLE
Win32 type compatibility shim for non-Windows builds (#462 Phase 1)

### DIFF
--- a/src/source/App/stdafx.h
+++ b/src/source/App/stdafx.h
@@ -66,6 +66,10 @@
 #include <tchar.h>
 #include <mbstring.h>
 #include <conio.h>
+#else // !_WIN32
+// Provide the Win32 scalar/handle types the engine declarations use, so the
+// ~350 PCH consumers parse on non-Windows toolchains (issue #462, Phase 1).
+#include "Core/Platform/WinCompat.h"
 #endif // _WIN32
 
 //c runtime

--- a/src/source/Audio/DSWaveIO.cpp
+++ b/src/source/Audio/DSWaveIO.cpp
@@ -4,7 +4,7 @@
 #include <cwchar>
 #include <cstring>
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include <mmsystem.h>
 
 // Undefine the editor redirect macro so we can use std::fwprintf directly

--- a/src/source/Audio/DSWaveIO.cpp
+++ b/src/source/Audio/DSWaveIO.cpp
@@ -5,7 +5,9 @@
 #include <cstring>
 
 #include "Core/Platform/WinCompat.h"
+#ifdef _WIN32
 #include <mmsystem.h>
+#endif
 
 // Undefine the editor redirect macro so we can use std::fwprintf directly
 // to log to both stderr and the in-game editor console.

--- a/src/source/Audio/DSWaveIO.h
+++ b/src/source/Audio/DSWaveIO.h
@@ -1,7 +1,33 @@
 #pragma once
 
 #include "Core/Platform/WinCompat.h"
+#ifdef _WIN32
 #include <mmsystem.h>
+#else
+// Minimal multimedia-IO types so this header parses off Windows (the DirectSound
+// implementation in the .cpp is a Win32 audio subsystem ported later, #462).
+typedef void* HMMIO;
+typedef struct waveformat_tag {
+    WORD  wFormatTag;
+    WORD  nChannels;
+    DWORD nSamplesPerSec;
+    DWORD nAvgBytesPerSec;
+    WORD  nBlockAlign;
+} WAVEFORMAT;
+typedef struct pcmwaveformat_tag {
+    WAVEFORMAT wf;
+    WORD       wBitsPerSample;
+} PCMWAVEFORMAT;
+typedef struct tWAVEFORMATEX {
+    WORD  wFormatTag;
+    WORD  nChannels;
+    DWORD nSamplesPerSec;
+    DWORD nAvgBytesPerSec;
+    WORD  nBlockAlign;
+    WORD  wBitsPerSample;
+    WORD  cbSize;
+} WAVEFORMATEX;
+#endif
 #include <cstdint>
 
 class waveIO

--- a/src/source/Audio/DSWaveIO.h
+++ b/src/source/Audio/DSWaveIO.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include <mmsystem.h>
 #include <cstdint>
 

--- a/src/source/Core/Platform/WinCompat.h
+++ b/src/source/Core/Platform/WinCompat.h
@@ -1,0 +1,142 @@
+// Win32 type compatibility shim (issue #462, Phase 1).
+//
+// A handful of widely-included engine headers reference Win32 scalar types,
+// handles and small structs in their declarations. On Windows this comes from
+// <windows.h>; this header funnels that through one place so the engine can be
+// parsed by a non-Windows toolchain.
+//
+//   - On Windows: include <windows.h> unchanged (zero behavioral change).
+//   - Elsewhere: provide just the Win32 *types* the engine declarations need.
+//
+// This only unblocks parsing. Win32 *function* calls and the wchar_t width
+// difference are handled in later phases of #462; this header deliberately does
+// not try to emulate the Win32 API.
+#pragma once
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#else  // ---- non-Windows: minimal Win32 type shims -------------------------
+
+#include <cstdint>
+#include <cstddef>
+
+// Fixed-width scalar aliases. Widths match the Windows definitions (DWORD/LONG
+// are 32-bit there, unlike `long` on LP64 Linux) so struct layouts stay stable.
+typedef uint8_t   BYTE;
+typedef uint16_t  WORD;
+typedef uint32_t  DWORD;
+typedef uint32_t  UINT;
+typedef int32_t   INT;
+typedef int32_t   LONG;
+typedef uint32_t  ULONG;
+typedef int16_t   SHORT;
+typedef uint16_t  USHORT;
+typedef int64_t   LONGLONG;
+typedef uint64_t  ULONGLONG;
+typedef uint64_t  DWORDLONG;
+typedef int       BOOL;
+typedef float     FLOAT;
+typedef char      CHAR;
+typedef unsigned char UCHAR;
+typedef wchar_t   WCHAR;  // NOTE: 32-bit here vs 16-bit on Windows; the wchar_t width migration is Phase 2.
+typedef void      VOID;
+typedef DWORD     COLORREF;
+
+// MSVC fixed-width keyword aliases (gcc/clang on Linux lack these).
+typedef int64_t   __int64;
+typedef int32_t   __int32;
+typedef int16_t   __int16;
+typedef int8_t    __int8;
+
+// Pointer-sized message/param/int types.
+typedef uintptr_t UINT_PTR;
+typedef intptr_t  INT_PTR;
+typedef intptr_t  LONG_PTR;
+typedef uintptr_t ULONG_PTR;
+typedef uintptr_t DWORD_PTR;
+typedef uintptr_t WPARAM;
+typedef intptr_t  LPARAM;
+typedef intptr_t  LRESULT;
+typedef LONG      HRESULT;
+typedef BYTE      BOOLEAN;
+
+// TCHAR maps to the wide character set (the engine builds UNICODE).
+typedef WCHAR     TCHAR;
+typedef WCHAR*    LPTSTR;
+typedef const WCHAR* LPCTSTR;
+#ifndef _T
+#define _T(x) L##x
+#endif
+#ifndef TEXT
+#define TEXT(x) L##x
+#endif
+
+// Opaque handles. Real identity is irrelevant to the portable declarations that
+// only store or pass them through.
+typedef void* HANDLE;
+typedef void* HWND;
+typedef void* HDC;
+typedef void* HGLRC;
+typedef void* HINSTANCE;
+typedef void* HMODULE;
+typedef void* HMENU;
+typedef void* HICON;
+typedef void* HCURSOR;
+typedef void* HBRUSH;
+typedef void* HFONT;
+typedef void* HBITMAP;
+typedef void* HGDIOBJ;
+typedef void* HKEY;
+typedef void* HIMC;
+
+// Pointer aliases.
+typedef void*           LPVOID;
+typedef const void*     LPCVOID;
+typedef CHAR*           LPSTR;
+typedef const CHAR*     LPCSTR;
+typedef WCHAR*          LPWSTR;
+typedef const WCHAR*    LPCWSTR;
+typedef BYTE*           LPBYTE;
+typedef WORD*           LPWORD;
+typedef DWORD*          LPDWORD;
+typedef LONG*           LPLONG;
+typedef BOOL*           LPBOOL;
+
+// Small structs used in declarations.
+typedef struct tagPOINT { LONG x, y; } POINT, * LPPOINT;
+typedef struct tagSIZE { LONG cx, cy; } SIZE, * LPSIZE;
+typedef struct tagRECT { LONG left, top, right, bottom; } RECT, * LPRECT;
+
+// Calling-convention / annotation macros: no-ops off Windows.
+#ifndef WINAPI
+#define WINAPI
+#endif
+#ifndef APIENTRY
+#define APIENTRY
+#endif
+#ifndef CALLBACK
+#define CALLBACK
+#endif
+#ifndef CONST
+#define CONST const
+#endif
+#ifndef IN
+#define IN
+#endif
+#ifndef OUT
+#define OUT
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+#ifndef MAX_PATH
+#define MAX_PATH 260
+#endif
+
+#endif  // _WIN32

--- a/src/source/Core/Platform/WinCompat.h
+++ b/src/source/Core/Platform/WinCompat.h
@@ -44,11 +44,20 @@ typedef wchar_t   WCHAR;  // NOTE: 32-bit here vs 16-bit on Windows; the wchar_t
 typedef void      VOID;
 typedef DWORD     COLORREF;
 
-// MSVC fixed-width keyword aliases (gcc/clang on Linux lack these).
-typedef int64_t   __int64;
-typedef int32_t   __int32;
-typedef int16_t   __int16;
-typedef int8_t    __int8;
+// MSVC fixed-width keyword aliases (gcc/clang lack these). Defined as macros,
+// not typedefs, so the common `unsigned __int64` form stays valid.
+#ifndef __int64
+#define __int64 long long
+#endif
+#ifndef __int32
+#define __int32 int
+#endif
+#ifndef __int16
+#define __int16 short
+#endif
+#ifndef __int8
+#define __int8 char
+#endif
 
 // Pointer-sized message/param/int types.
 typedef uintptr_t UINT_PTR;
@@ -73,23 +82,24 @@ typedef const WCHAR* LPCTSTR;
 #define TEXT(x) L##x
 #endif
 
-// Opaque handles. Real identity is irrelevant to the portable declarations that
-// only store or pass them through.
+// Opaque handles. Each is a distinct incompatible pointer type (as on Windows
+// via DECLARE_HANDLE) so overloads on different handle types don't collapse.
+#define DECLARE_HANDLE(name) struct name##__ { int unused; }; typedef struct name##__ *name
 typedef void* HANDLE;
-typedef void* HWND;
-typedef void* HDC;
-typedef void* HGLRC;
-typedef void* HINSTANCE;
-typedef void* HMODULE;
-typedef void* HMENU;
-typedef void* HICON;
-typedef void* HCURSOR;
-typedef void* HBRUSH;
-typedef void* HFONT;
-typedef void* HBITMAP;
-typedef void* HGDIOBJ;
-typedef void* HKEY;
-typedef void* HIMC;
+DECLARE_HANDLE(HWND);
+DECLARE_HANDLE(HDC);
+DECLARE_HANDLE(HGLRC);
+DECLARE_HANDLE(HINSTANCE);
+DECLARE_HANDLE(HMODULE);
+DECLARE_HANDLE(HMENU);
+DECLARE_HANDLE(HICON);
+DECLARE_HANDLE(HCURSOR);
+DECLARE_HANDLE(HBRUSH);
+DECLARE_HANDLE(HFONT);
+DECLARE_HANDLE(HBITMAP);
+DECLARE_HANDLE(HGDIOBJ);
+DECLARE_HANDLE(HKEY);
+DECLARE_HANDLE(HIMC);
 
 // Pointer aliases.
 typedef void*           LPVOID;
@@ -106,8 +116,10 @@ typedef BOOL*           LPBOOL;
 
 // Small structs used in declarations.
 typedef struct tagPOINT { LONG x, y; } POINT, * LPPOINT;
+typedef const POINT* LPCPOINT;
 typedef struct tagSIZE { LONG cx, cy; } SIZE, * LPSIZE;
 typedef struct tagRECT { LONG left, top, right, bottom; } RECT, * LPRECT;
+typedef const RECT* LPCRECT;
 
 // Calling-convention / annotation macros: no-ops off Windows.
 #ifndef WINAPI

--- a/src/source/Core/Utilities/StringUtils.h
+++ b/src/source/Core/Utilities/StringUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 namespace StringUtils
 {

--- a/src/source/Data/DataHandler/DataFileIO.cpp
+++ b/src/source/Data/DataHandler/DataFileIO.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "DataFileIO.h"
 #include "Engine/Object/ZzzInfomation.h"
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 extern HWND g_hWnd;
 

--- a/src/source/Data/DataHandler/DataFileIO.h
+++ b/src/source/Data/DataHandler/DataFileIO.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include <memory>
 #include <functional>
 

--- a/src/source/Data/GameConfig/GameConfig.cpp
+++ b/src/source/Data/GameConfig/GameConfig.cpp
@@ -1,7 +1,9 @@
 #include "stdafx.h"
 #include "GameConfig.h"
 
+#ifdef _WIN32
 #include <imagehlp.h>
+#endif
 
 #include "GameConfigConstants.h"
 #include "Core/Platform/WinCompat.h"

--- a/src/source/Data/GameConfig/GameConfig.cpp
+++ b/src/source/Data/GameConfig/GameConfig.cpp
@@ -4,7 +4,7 @@
 #include <imagehlp.h>
 
 #include "GameConfigConstants.h"
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 GameConfig& GameConfig::GetInstance()
 {

--- a/src/source/Data/GameConfig/GameConfig.h
+++ b/src/source/Data/GameConfig/GameConfig.h
@@ -3,7 +3,7 @@
 #include <filesystem>
 #include <string>
 #include <vector>
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 class GameConfig
 {

--- a/src/source/Data/GameData/Common/FieldMetadataHelper.h
+++ b/src/source/Data/GameData/Common/FieldMetadataHelper.h
@@ -2,7 +2,7 @@
 
 #ifdef _EDITOR
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include "I18N/All.h"
 
 // ============================================================================

--- a/src/source/Data/GameData/ItemData/ItemFieldMetadata.h
+++ b/src/source/Data/GameData/ItemData/ItemFieldMetadata.h
@@ -2,7 +2,7 @@
 
 #ifdef _EDITOR
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include "ItemStructs.h"
 #include "ItemFieldDefs.h"
 #include "Data/GameData/Common/FieldMetadataHelper.h"

--- a/src/source/Data/GameData/ItemData/ItemStructs.h
+++ b/src/source/Data/GameData/ItemData/ItemStructs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include "Data/Translation/MultiLanguage.h"
 
 // Forward declarations for constants

--- a/src/source/Data/GameData/SkillData/SkillFieldDefs.h
+++ b/src/source/Data/GameData/SkillData/SkillFieldDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 // X-Macro definition for all SKILL_ATTRIBUTE fields (except Name which is special)
 // Format: X(FieldName, TypeEnum, ArraySize, DefaultColumnWidth, I18nMetadataName)

--- a/src/source/Data/GameData/SkillData/SkillFieldMetadata.h
+++ b/src/source/Data/GameData/SkillData/SkillFieldMetadata.h
@@ -2,7 +2,7 @@
 
 #ifdef _EDITOR
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include "SkillStructs.h"
 #include "SkillFieldDefs.h"
 #include "Data/GameData/Common/FieldMetadataHelper.h"

--- a/src/source/Data/GameData/SkillData/SkillStructs.h
+++ b/src/source/Data/GameData/SkillData/SkillStructs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 // Forward declarations for constants
 #ifndef MAX_CLASS

--- a/src/source/Dotnet/Connection.h
+++ b/src/source/Dotnet/Connection.h
@@ -11,7 +11,7 @@
 #include <cwchar>
 
 #ifdef _WIN32
-#include "windows.h"
+#include "Core/Platform/WinCompat.h"
 #define symLoad GetProcAddress
 #else
 #include "dlfcn.h"

--- a/src/source/Scenes/CharacterScene.h
+++ b/src/source/Scenes/CharacterScene.h
@@ -2,7 +2,7 @@
 
 // CharacterScene.h - Character selection scene
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 // Character scene lifecycle
 void CreateCharacterScene();

--- a/src/source/Scenes/LoginScene.h
+++ b/src/source/Scenes/LoginScene.h
@@ -2,7 +2,7 @@
 
 // LoginScene.h - Login scene management
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include "Render/Textures/ZzzOpenglUtil.h"  // For vec3_t
 
 // Login scene lifecycle

--- a/src/source/Scenes/MainScene.h
+++ b/src/source/Scenes/MainScene.h
@@ -2,7 +2,7 @@
 
 // MainScene.h - Main game scene
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 // Main scene lifecycle
 void MoveMainScene();

--- a/src/source/Scenes/SceneCommon.h
+++ b/src/source/Scenes/SceneCommon.h
@@ -2,7 +2,7 @@
 
 // SceneCommon.h - Shared utilities used by multiple scenes
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 #include "Engine/Object/ZzzInfomation.h"  // For MAX_CHARACTERS_PER_ACCOUNT
 
 //=============================================================================

--- a/src/source/Scenes/SceneManager.h
+++ b/src/source/Scenes/SceneManager.h
@@ -2,7 +2,7 @@
 
 // SceneManager.h - Top-level scene orchestration
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 //=============================================================================
 // Frame Timing State

--- a/src/source/Scenes/WebzenScene.h
+++ b/src/source/Scenes/WebzenScene.h
@@ -2,7 +2,7 @@
 
 // WebzenScene.h - Splash screen scene
 
-#include <windows.h>
+#include "Core/Platform/WinCompat.h"
 
 // Splash screen scene
 void WebzenScene(HDC hDC);


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 1: the `Core/Platform` seam.

## Change
- New `src/source/Core/Platform/WinCompat.h`: on Windows it includes `windows.h` unchanged; on other platforms it defines the Win32 types the engine's declarations use - fixed-width scalars (`BYTE`/`WORD`/`DWORD`/`LONG`/...), handles (`HWND`/`HDC`/...), small structs (`POINT`/`RECT`/`SIZE`), pointer-width ints, `HRESULT`/`TCHAR`, the MSVC `__int64` keyword, and the `WINAPI`/`TEXT()` etc. macros. Widths match Windows so struct layouts stay stable.
- Funnel it through the PCH (`stdafx.h`) on non-Windows, and point the headers that included `<windows.h>` directly at the shim.

## Effect
- **Windows:** unchanged - the shim just includes `windows.h`, and the PCH `#else` branch is not taken. Verified the MinGW build still builds clean.
- **Linux:** clears the `windows.h: No such file` wall (21 unguarded headers -> ~352 transitively) and the resulting cascade of undefined Win32 types. Native engine compile errors drop from ~25k to ~3.3k.

## Not in scope (later #462 phases)
The remaining errors are Win32 API *calls* and per-subsystem headers - `wininet`/`urlmon` (shop downloader), IME, winsock, `MessageBox`, `timeGetTime`, `ZeroMemory`, `VK_*`/`WM_*` constants, secure-CRT `_s` funcs - plus the `wchar_t` width migration (Phase 2). This PR only removes the type wall.