### PR TITLE
Portable Win32 timer/string/path shims for non-Windows (#462 Phase 3)

### DIFF
--- a/src/source/App/stdafx.h
+++ b/src/source/App/stdafx.h
@@ -72,6 +72,7 @@
 // (issue #462, Phase 1).
 #include "Core/Platform/WinCompat.h"
 #include "Core/Platform/SecureCrt.h"
+#include "Core/Platform/WinApiShims.h"
 #endif // _WIN32
 
 //c runtime

--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -1,0 +1,91 @@
+// Portable shims for the Win32 timer / wide-string / path helpers the engine
+// calls (issue #462, Phase 3). On Windows these come from the SDK/CRT, so this
+// header is empty there; elsewhere it maps them onto the standard library.
+#pragma once
+
+#ifndef _WIN32
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cwchar>
+#include <cwctype>
+#include <strings.h>  // strcasecmp
+#include "Core/Platform/WinCompat.h"  // DWORD, FILE handle types
+
+namespace mu_detail
+{
+    // Shared monotonic epoch so GetTickCount() and timeGetTime() agree.
+    inline std::chrono::steady_clock::time_point tickEpoch()
+    {
+        static const std::chrono::steady_clock::time_point epoch = std::chrono::steady_clock::now();
+        return epoch;
+    }
+}
+
+// Milliseconds since first use (relative timing; matches how the engine uses it).
+inline DWORD GetTickCount()
+{
+    using namespace std::chrono;
+    return static_cast<DWORD>(duration_cast<milliseconds>(steady_clock::now() - mu_detail::tickEpoch()).count());
+}
+inline DWORD timeGetTime() { return GetTickCount(); }
+
+// Case-insensitive compares.
+inline int _wcsicmp(const wchar_t* a, const wchar_t* b) { return wcscasecmp(a, b); }
+inline int wcsicmp(const wchar_t* a, const wchar_t* b) { return wcscasecmp(a, b); }
+inline int _stricmp(const char* a, const char* b) { return strcasecmp(a, b); }
+
+// In-place wide upper-case.
+inline wchar_t* _wcsupr(wchar_t* s)
+{
+    for (wchar_t* p = s; *p; ++p) *p = static_cast<wchar_t>(towupper(*p));
+    return s;
+}
+
+// Wide fopen: convert the path/mode to the locale encoding and open.
+inline FILE* _wfopen(const wchar_t* path, const wchar_t* mode)
+{
+    char narrowPath[4096] = { 0 };
+    char narrowMode[16] = { 0 };
+    if (wcstombs(narrowPath, path, sizeof(narrowPath) - 1) == static_cast<size_t>(-1)) return nullptr;
+    if (wcstombs(narrowMode, mode, sizeof(narrowMode) - 1) == static_cast<size_t>(-1)) return nullptr;
+    return fopen(narrowPath, narrowMode);
+}
+
+// Split a wide path into components (POSIX has no drive). Matches MSVC's
+// _wsplitpath: any output may be null; `ext` keeps its leading dot.
+inline void _wsplitpath(const wchar_t* path, wchar_t* drive, wchar_t* dir, wchar_t* fname, wchar_t* ext)
+{
+    if (drive) drive[0] = L'\0';
+
+    const wchar_t* lastSep = nullptr;
+    for (const wchar_t* p = path; *p; ++p)
+        if (*p == L'/' || *p == L'\\') lastSep = p;
+    const wchar_t* nameStart = lastSep ? lastSep + 1 : path;
+
+    if (dir)
+    {
+        const size_t dlen = static_cast<size_t>(nameStart - path);
+        wmemcpy(dir, path, dlen);
+        dir[dlen] = L'\0';
+    }
+
+    const wchar_t* dot = nullptr;
+    for (const wchar_t* p = nameStart; *p; ++p)
+        if (*p == L'.') dot = p;
+
+    if (fname)
+    {
+        const size_t flen = dot ? static_cast<size_t>(dot - nameStart) : wcslen(nameStart);
+        wmemcpy(fname, nameStart, flen);
+        fname[flen] = L'\0';
+    }
+    if (ext)
+    {
+        if (dot) wcscpy(ext, dot);
+        else ext[0] = L'\0';
+    }
+}
+
+#endif // !_WIN32

--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -39,6 +39,7 @@ inline int _stricmp(const char* a, const char* b) { return strcasecmp(a, b); }
 // In-place wide upper-case.
 inline wchar_t* _wcsupr(wchar_t* s)
 {
+    if (!s) return nullptr;
     for (wchar_t* p = s; *p; ++p) *p = static_cast<wchar_t>(towupper(*p));
     return s;
 }
@@ -46,6 +47,7 @@ inline wchar_t* _wcsupr(wchar_t* s)
 // Wide fopen: convert the path/mode to the locale encoding and open.
 inline FILE* _wfopen(const wchar_t* path, const wchar_t* mode)
 {
+    if (!path || !mode) return nullptr;
     char narrowPath[4096] = { 0 };
     char narrowMode[16] = { 0 };
     if (wcstombs(narrowPath, path, sizeof(narrowPath) - 1) == static_cast<size_t>(-1)) return nullptr;
@@ -57,6 +59,7 @@ inline FILE* _wfopen(const wchar_t* path, const wchar_t* mode)
 // _wsplitpath: any output may be null; `ext` keeps its leading dot.
 inline void _wsplitpath(const wchar_t* path, wchar_t* drive, wchar_t* dir, wchar_t* fname, wchar_t* ext)
 {
+    if (!path) return;
     if (drive) drive[0] = L'\0';
 
     const wchar_t* lastSep = nullptr;


### PR DESCRIPTION
Part of #462 (native Linux build). A self-contained set of Win32 API shims, independent of the constants PR (#466).

## Change
- New `src/source/Core/Platform/WinApiShims.h` (empty on Windows): maps the Win32 timer/string/path helpers the engine calls onto the standard library -
  - `GetTickCount` / `timeGetTime` -> a shared `std::chrono::steady_clock` epoch (relative timing, as the engine uses them),
  - `_wcsicmp` / `wcsicmp` / `_stricmp` -> the case-folding compares,
  - `_wcsupr` -> in-place `towupper`,
  - `_wfopen` -> `wcstombs` + `fopen`,
  - `_wsplitpath` -> a POSIX implementation (no drive; `ext` keeps its dot).
- Pulled in through the PCH (`stdafx.h`) on non-Windows.

## Effect
- **Windows:** unchanged (header empty there). Verified the MinGW build still builds clean.
- **Linux:** all `GetTickCount`/`timeGetTime`/`_wfopen`/`_wcsicmp`/`wcsicmp`/`_wsplitpath`/`_wcsupr`/`_stricmp` errors are resolved.

## Not in scope
The remaining Win32 API subsystems (wininet shop downloader, IME, winsock, MessageBox/SendMessage, GDI text, audio) and the wchar_t migration are separate #462 PRs.