### PR TITLE
Add a portable MessageBox backed by SDL

### DIFF
--- a/src/source/App/stdafx.h
+++ b/src/source/App/stdafx.h
@@ -73,6 +73,7 @@
 #include "Core/Platform/WinCompat.h"
 #include "Core/Platform/SecureCrt.h"
 #include "Core/Platform/WinApiShims.h"
+#include "Core/Platform/WinUser.h"
 #endif // _WIN32
 
 //c runtime

--- a/src/source/Core/Platform/WinUser.cpp
+++ b/src/source/Core/Platform/WinUser.cpp
@@ -17,7 +17,11 @@ namespace
         if (s == nullptr) return out;
         for (const wchar_t* p = s; *p; ++p)
         {
-            const unsigned int c = static_cast<unsigned int>(*p);
+            unsigned int c = static_cast<unsigned int>(*p);
+            // Map surrogates and out-of-range values to U+FFFD so we never emit
+            // invalid UTF-8 to SDL / the font renderer.
+            if ((c >= 0xD800 && c <= 0xDFFF) || c > 0x10FFFF) c = 0xFFFD;
+
             if (c < 0x80)
             {
                 out.push_back(static_cast<char>(c));
@@ -57,6 +61,10 @@ int MessageBoxW(HWND /*owner*/, LPCWSTR text, LPCWSTR caption, UINT type)
     const std::string message = ToUtf8(text);
     const std::string title   = caption ? ToUtf8(caption) : std::string("MU");
 
+    // Parent the dialog to the focused window so it stays in front and modal to
+    // the game; a null parent can spawn behind the window on some Linux WMs.
+    SDL_Window* parent = SDL_GetKeyboardFocus();
+
     if ((type & MB_YESNO) == MB_YESNO)
     {
         const SDL_MessageBoxButtonData buttons[2] = {
@@ -64,7 +72,7 @@ int MessageBoxW(HWND /*owner*/, LPCWSTR text, LPCWSTR caption, UINT type)
             { SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, IDNO,  "No"  },
         };
         const SDL_MessageBoxData data = {
-            IconFlags(type), nullptr, title.c_str(), message.c_str(),
+            IconFlags(type), parent, title.c_str(), message.c_str(),
             2, buttons, nullptr
         };
         int buttonId = IDNO;
@@ -72,7 +80,7 @@ int MessageBoxW(HWND /*owner*/, LPCWSTR text, LPCWSTR caption, UINT type)
         return (buttonId == IDYES) ? IDYES : IDNO;
     }
 
-    SDL_ShowSimpleMessageBox(IconFlags(type), title.c_str(), message.c_str(), nullptr);
+    SDL_ShowSimpleMessageBox(IconFlags(type), title.c_str(), message.c_str(), parent);
     return IDOK;
 }
 

--- a/src/source/Core/Platform/WinUser.cpp
+++ b/src/source/Core/Platform/WinUser.cpp
@@ -1,0 +1,79 @@
+// Non-Windows implementation of the MessageBox shim declared in WinUser.h.
+// Routes the engine's error/info dialogs through SDL's message box.
+#ifndef _WIN32
+
+#include "Core/Platform/WinUser.h"
+
+#include <SDL3/SDL.h>
+#include <string>
+
+namespace
+{
+    // wchar_t is UTF-32 on Linux; SDL wants UTF-8. Encode directly so non-ASCII
+    // (e.g. Korean) text survives instead of relying on the C locale.
+    std::string ToUtf8(LPCWSTR s)
+    {
+        std::string out;
+        if (s == nullptr) return out;
+        for (const wchar_t* p = s; *p; ++p)
+        {
+            const unsigned int c = static_cast<unsigned int>(*p);
+            if (c < 0x80)
+            {
+                out.push_back(static_cast<char>(c));
+            }
+            else if (c < 0x800)
+            {
+                out.push_back(static_cast<char>(0xC0 | (c >> 6)));
+                out.push_back(static_cast<char>(0x80 | (c & 0x3F)));
+            }
+            else if (c < 0x10000)
+            {
+                out.push_back(static_cast<char>(0xE0 | (c >> 12)));
+                out.push_back(static_cast<char>(0x80 | ((c >> 6) & 0x3F)));
+                out.push_back(static_cast<char>(0x80 | (c & 0x3F)));
+            }
+            else
+            {
+                out.push_back(static_cast<char>(0xF0 | (c >> 18)));
+                out.push_back(static_cast<char>(0x80 | ((c >> 12) & 0x3F)));
+                out.push_back(static_cast<char>(0x80 | ((c >> 6) & 0x3F)));
+                out.push_back(static_cast<char>(0x80 | (c & 0x3F)));
+            }
+        }
+        return out;
+    }
+
+    Uint32 IconFlags(UINT type)
+    {
+        if (type & (MB_ICONERROR | MB_ICONSTOP)) return SDL_MESSAGEBOX_ERROR;
+        if (type & MB_ICONEXCLAMATION)           return SDL_MESSAGEBOX_WARNING;
+        return SDL_MESSAGEBOX_INFORMATION;
+    }
+}
+
+int MessageBoxW(HWND /*owner*/, LPCWSTR text, LPCWSTR caption, UINT type)
+{
+    const std::string message = ToUtf8(text);
+    const std::string title   = caption ? ToUtf8(caption) : std::string("MU");
+
+    if ((type & MB_YESNO) == MB_YESNO)
+    {
+        const SDL_MessageBoxButtonData buttons[2] = {
+            { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, IDYES, "Yes" },
+            { SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, IDNO,  "No"  },
+        };
+        const SDL_MessageBoxData data = {
+            IconFlags(type), nullptr, title.c_str(), message.c_str(),
+            2, buttons, nullptr
+        };
+        int buttonId = IDNO;
+        if (!SDL_ShowMessageBox(&data, &buttonId)) return IDNO;  // dialog failed/dismissed
+        return (buttonId == IDYES) ? IDYES : IDNO;
+    }
+
+    SDL_ShowSimpleMessageBox(IconFlags(type), title.c_str(), message.c_str(), nullptr);
+    return IDOK;
+}
+
+#endif // !_WIN32

--- a/src/source/Core/Platform/WinUser.h
+++ b/src/source/Core/Platform/WinUser.h
@@ -1,0 +1,37 @@
+// Portable MessageBox shim (issue #462, Phase 3).
+//
+// On Windows MessageBox comes from <windows.h>; elsewhere we route it through
+// SDL's message box so the engine's error/info dialogs work on Linux. Only the
+// MessageBox surface the engine actually uses is provided.
+#pragma once
+
+#ifdef _WIN32
+
+// Real MessageBox is in <windows.h> (pulled in via the PCH on Windows).
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include "Core/Platform/WinCompat.h"  // HWND, UINT, LPCWSTR, MB_* flags
+
+// MessageBox return values (winuser.h).
+#ifndef IDOK
+#define IDOK     1
+#define IDCANCEL 2
+#define IDABORT  3
+#define IDRETRY  4
+#define IDIGNORE 5
+#define IDYES    6
+#define IDNO     7
+#endif
+
+// Shows a modal dialog and returns one of the ID* values above. Implemented in
+// WinUser.cpp on top of SDL_ShowMessageBox.
+int MessageBoxW(HWND owner, LPCWSTR text, LPCWSTR caption, UINT type);
+
+// The engine builds UNICODE, so unqualified MessageBox maps to the wide form
+// (exactly as <winuser.h> does on Windows).
+#ifndef MessageBox
+#define MessageBox MessageBoxW
+#endif
+
+#endif // _WIN32

--- a/src/source/UI/Windows/CBTMessageBox.cpp
+++ b/src/source/UI/Windows/CBTMessageBox.cpp
@@ -3,6 +3,9 @@
 
 #include <algorithm>
 
+// Win32 CBT-hook implementation; non-Windows builds use the SDL MessageBox.
+#ifdef _WIN32
+
 int leaf::CBTMessageBox(HWND hWnd, const std::wstring& text, const std::wstring& caption, UINT uType, bool bAlwaysOnTop)
 {
     return CCBTMessageBox::GetInstance()->OpenMessageBox(hWnd, text.c_str(), caption.c_str(), uType, bAlwaysOnTop);
@@ -154,3 +157,4 @@ LRESULT CALLBACK leaf::CCBTMessageBox::CBTProc(INT nCode, WPARAM wParam, LPARAM 
 
     return 0;
 }
+#endif // _WIN32

--- a/src/source/UI/Windows/CBTMessageBox.h
+++ b/src/source/UI/Windows/CBTMessageBox.h
@@ -1,5 +1,9 @@
 #include <string>
 
+// Centers/raises the native Win32 MessageBox via a CBT hook. Windows-only and
+// currently unused; portable code uses the SDL-backed MessageBox (WinUser.h).
+#ifdef _WIN32
+
 namespace leaf {
     int CBTMessageBox(HWND hWnd, const std::wstring& text, const std::wstring& caption, UINT uType, bool bAlwaysOnTop = false);
 
@@ -27,3 +31,5 @@ namespace leaf {
         static LRESULT CALLBACK CBTProc(INT nCode, WPARAM wParam, LPARAM lParam);
     };
 }
+
+#endif // _WIN32


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3: `MessageBox` -> portable message box (SDL).

## Changes

- New `Core/Platform/WinUser.{h,cpp}`: a portable `MessageBox`/`MessageBoxW` that routes through `SDL_ShowMessageBox`. Simple OK boxes use `SDL_ShowSimpleMessageBox`; `MB_YESNO` uses a two-button dialog returning `IDYES`/`IDNO`. Icon flags map to SDL's error/warning/information styles. `wchar_t` text is encoded directly to UTF-8 (Linux `wchar_t` is UTF-32) so non-ASCII text survives. On Windows the header is empty and the real `MessageBox` from `<windows.h>` is used unchanged.
- Guard the unused `leaf::CCBTMessageBox` helper behind `_WIN32`. It is a Win32 CBT hook that re-centers the native dialog; it has no callers, and the SDL message box positions itself.

## Result

Linux `MuClient` compile errors drop from **277 to 226**.

The shim and the guard are non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.