### PR TITLE
Add portable Win32 rect/point helper shims

### DIFF
--- a/src/source/Core/Platform/WinCompat.h
+++ b/src/source/Core/Platform/WinCompat.h
@@ -310,4 +310,44 @@ inline constexpr ENUMTYPE operator ~ (ENUMTYPE a) { using T = std::underlying_ty
 #define ZeroMemory(dst, len) std::memset((dst), 0, (len))
 #endif
 
+// ---- GDI rect/point helpers (winuser.h) -------------------------------------
+// Pure value-type helpers with no platform dependency; same semantics as Win32.
+
+inline BOOL SetRect(RECT* lprc, int left, int top, int right, int bottom)
+{
+    if (!lprc) return FALSE;
+    lprc->left = left; lprc->top = top; lprc->right = right; lprc->bottom = bottom;
+    return TRUE;
+}
+
+// Point is inside the rectangle's [left,right) x [top,bottom) half-open range.
+inline BOOL PtInRect(const RECT* lprc, POINT pt)
+{
+    if (!lprc) return FALSE;
+    return (pt.x >= lprc->left && pt.x < lprc->right &&
+            pt.y >= lprc->top  && pt.y < lprc->bottom) ? TRUE : FALSE;
+}
+
+// Intersection of two rects into dst; returns FALSE (and empties dst) if none.
+inline BOOL IntersectRect(RECT* dst, const RECT* a, const RECT* b)
+{
+    if (!dst || !a || !b) return FALSE;
+    const LONG left   = (a->left   > b->left)   ? a->left   : b->left;
+    const LONG top    = (a->top    > b->top)    ? a->top    : b->top;
+    const LONG right  = (a->right  < b->right)  ? a->right  : b->right;
+    const LONG bottom = (a->bottom < b->bottom) ? a->bottom : b->bottom;
+    if (left < right && top < bottom)
+    {
+        dst->left = left; dst->top = top; dst->right = right; dst->bottom = bottom;
+        return TRUE;
+    }
+    dst->left = dst->top = dst->right = dst->bottom = 0;
+    return FALSE;
+}
+
+// Legacy Win32 pointer-validity probe. There is no portable equivalent, and the
+// API is deprecated even on Windows; the realistic failure the callers guard
+// against is a null pointer, so report only that as "bad".
+inline BOOL IsBadReadPtr(const void* lp, UINT_PTR /*ucb*/) { return lp ? FALSE : TRUE; }
+
 #endif  // _WIN32


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3: portable shims for the Win32 GDI rect/point helpers the engine's UI hit-testing and layout code uses.

## Changes

Added portable inlines to `Core/Platform/WinCompat.h` (non-Windows branch) with the same semantics as Win32:

- `SetRect`, `PtInRect` (half-open `[left,right) x [top,bottom)` range), and `IntersectRect`.
- `IsBadReadPtr`: there is no portable pointer-validity probe, and the API is deprecated even on Windows. The realistic failure the callers guard against is a null pointer, so the shim reports only null as "bad".

## Result

Linux `MuClient` compile errors drop from **226 to 195**.

The shims are non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.