### PR TITLE
Stub the debug console on non-Windows

### DIFF
--- a/src/source/Core/Utilities/Log/WindowsConsole.cpp
+++ b/src/source/Core/Utilities/Log/WindowsConsole.cpp
@@ -4,6 +4,8 @@
 
 #include "WindowsConsole.h"
 
+#ifdef _WIN32
+
 bool leaf::OpenConsoleWindow(const std::wstring& title)
 {
     return CConsoleWindow::GetInstance()->Open(title);
@@ -73,7 +75,7 @@ CConsoleWindow::CConsoleWindow()
     m_bActiveCloseButton = false;
     m_started = false;
 
-    m_LimitTimer.SetTimer(12000);	//. 12ÃÊ
+    m_LimitTimer.SetTimer(12000);	//. 12ï¿½ï¿½
 }
 CConsoleWindow::~CConsoleWindow() {}
 
@@ -304,3 +306,36 @@ BOOL CALLBACK CConsoleWindow::EnumChildProc(HWND hWnd, LPARAM lParam)
     }
     return TRUE;
 }
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+// The separate debug console is a Win32 concept (a spawned console window with
+// colored text attributes); on Linux stdout is already the terminal. Provide
+// no-op implementations of the public API so the engine builds and links;
+// diagnostic text still flows through the normal logging path.
+namespace leaf {
+
+bool OpenConsoleWindow(const std::wstring& /*title*/)        { return true; }
+void CloseConsoleWindow()                                    {}
+
+bool SetConsoleTitle(const std::wstring& /*title*/)          { return true; }
+const std::wstring& GetConsoleTitle()                        { static const std::wstring s; return s; }
+
+HWND GetConsoleWndHandle()                                   { return nullptr; }
+
+bool IsConsoleVisible()                                      { return false; }
+void ShowConsole(bool /*bShow*/)                             {}
+
+void ClearConsoleScreen()                                    {}
+
+WORD GetConsoleTextColorIndex(WORD* pwBgColorIndex)          { if (pwBgColorIndex) *pwBgColorIndex = 0; return 0; }
+void SetConsoleTextColor(WORD /*text*/, WORD /*bg*/)         {}
+
+void ActivateCloseButton(bool /*bActive*/)                   {}
+bool IsActiveCloseButton()                                   { return false; }
+
+bool SaveConsoleScreenBuffer(const std::wstring& /*file*/)   { return true; }
+
+}  // namespace leaf
+
+#endif // _WIN32

--- a/src/source/Core/Utilities/Log/WindowsConsole.h
+++ b/src/source/Core/Utilities/Log/WindowsConsole.h
@@ -2,6 +2,9 @@
 #define _WINDOWSCONSOLE_H_
 
 #pragma once
+// Self-contained: this header declares HWND/WORD/FOREGROUND_* in its interface,
+// so pull the Win32 types in directly instead of relying on include order.
+#include "Core/Platform/WinCompat.h"
 #include "Core/Time/Timer.h"
 
 #pragma warning(disable : 4786)


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3: the Win32 debug console.

## Change

`WindowsConsole` spawns a Win32 console window and drives it through console APIs (`AllocConsole`, `SetConsoleMode`, `SetConsoleTextAttribute`, `GetConsoleScreenBufferInfo`, `EnumChildWindows`, `GetSystemMenu`, ...), none of which exist off Windows, where stdout is already the terminal.

Guard the Win32 implementation behind `_WIN32` and provide no-op implementations of the public `leaf::` console API so the engine builds and links. Diagnostic text still flows through the normal logging path.

## Result

Linux `MuClient` compile errors drop from **195 to 128**. The whole file also used `ShowWindow`/`COORD`/`SMALL_RECT`/`CHAR_INFO`/`ENABLE_*`, so guarding it clears more than just the console calls.

The change is non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.