### PR TITLE
Add portable SendMessage/PostMessage that route quit to SDL

### DIFF
--- a/src/source/Core/Platform/WinCompat.h
+++ b/src/source/Core/Platform/WinCompat.h
@@ -220,6 +220,7 @@ inline constexpr ENUMTYPE operator ~ (ENUMTYPE a) { using T = std::underlying_ty
 #define WM_ACTIVATE      0x0006
 #define WM_PAINT         0x000F
 #define WM_CLOSE         0x0010
+#define WM_QUIT          0x0012
 #define WM_ERASEBKGND    0x0014
 #define WM_SETCURSOR     0x0020
 #define WM_CHAR          0x0102

--- a/src/source/Core/Platform/WinUser.cpp
+++ b/src/source/Core/Platform/WinUser.cpp
@@ -84,4 +84,29 @@ int MessageBoxW(HWND /*owner*/, LPCWSTR text, LPCWSTR caption, UINT type)
     return IDOK;
 }
 
+namespace
+{
+    bool IsQuitMessage(UINT msg) { return msg == WM_DESTROY || msg == WM_CLOSE || msg == WM_QUIT; }
+
+    void RequestQuit()
+    {
+        SDL_Event quit;
+        SDL_zero(quit);
+        quit.type = SDL_EVENT_QUIT;
+        SDL_PushEvent(&quit);
+    }
+}
+
+LRESULT SendMessage(HWND /*hWnd*/, UINT Msg, WPARAM /*wParam*/, LPARAM /*lParam*/)
+{
+    if (IsQuitMessage(Msg)) RequestQuit();
+    return 0;
+}
+
+BOOL PostMessage(HWND /*hWnd*/, UINT Msg, WPARAM /*wParam*/, LPARAM /*lParam*/)
+{
+    if (IsQuitMessage(Msg)) RequestQuit();
+    return TRUE;
+}
+
 #endif // !_WIN32

--- a/src/source/Core/Platform/WinUser.cpp
+++ b/src/source/Core/Platform/WinUser.cpp
@@ -88,12 +88,17 @@ namespace
 {
     bool IsQuitMessage(UINT msg) { return msg == WM_DESTROY || msg == WM_CLOSE || msg == WM_QUIT; }
 
-    void RequestQuit()
+    bool RequestQuit()
     {
         SDL_Event quit;
         SDL_zero(quit);
         quit.type = SDL_EVENT_QUIT;
-        SDL_PushEvent(&quit);
+        if (!SDL_PushEvent(&quit))
+        {
+            SDL_Log("Failed to push quit event: %s", SDL_GetError());
+            return false;
+        }
+        return true;
     }
 }
 
@@ -105,7 +110,7 @@ LRESULT SendMessage(HWND /*hWnd*/, UINT Msg, WPARAM /*wParam*/, LPARAM /*lParam*
 
 BOOL PostMessage(HWND /*hWnd*/, UINT Msg, WPARAM /*wParam*/, LPARAM /*lParam*/)
 {
-    if (IsQuitMessage(Msg)) RequestQuit();
+    if (IsQuitMessage(Msg)) return RequestQuit() ? TRUE : FALSE;
     return TRUE;
 }
 

--- a/src/source/Core/Platform/WinUser.h
+++ b/src/source/Core/Platform/WinUser.h
@@ -34,4 +34,12 @@ int MessageBoxW(HWND owner, LPCWSTR text, LPCWSTR caption, UINT type);
 #define MessageBox MessageBoxW
 #endif
 
+// Window messaging. The engine only ever sends WM_DESTROY/WM_CLOSE (a request to
+// quit) and one WM_IME_CONTROL (IME, which SDL owns on Linux). The portable
+// versions turn the quit messages into an SDL quit and ignore the rest, so the
+// main loop's existing SDL_EVENT_QUIT handling stops the game. Implemented in
+// WinUser.cpp.
+LRESULT SendMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+BOOL    PostMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+
 #endif // _WIN32


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3: window messaging.

## Change

Across the engine, `SendMessage`/`PostMessage` are used only to request shutdown (`WM_DESTROY` / `WM_CLOSE`, 49 sites) plus one `WM_IME_CONTROL` (IME, which SDL owns on Linux). Off Windows these are unavailable.

Add portable `SendMessage`/`PostMessage` in `WinUser` that push an `SDL_EVENT_QUIT` for the quit messages -- which the main loop already turns into its `Destroy` flag -- and ignore everything else. This preserves the existing quit behavior rather than just stubbing the calls. Adds the `WM_QUIT` constant to `WinCompat`.

## Result

Linux `MuClient` compile errors drop from **122 to 101**.

The shims are non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.