### PR TITLE
Add a portable mmio RIFF reader/writer for the WAV loader

### DIFF
--- a/src/source/Audio/DSWaveIO.h
+++ b/src/source/Audio/DSWaveIO.h
@@ -4,29 +4,8 @@
 #ifdef _WIN32
 #include <mmsystem.h>
 #else
-// Minimal multimedia-IO types so this header parses off Windows (the DirectSound
-// implementation in the .cpp is a Win32 audio subsystem ported later, #462).
-typedef void* HMMIO;
-typedef struct waveformat_tag {
-    WORD  wFormatTag;
-    WORD  nChannels;
-    DWORD nSamplesPerSec;
-    DWORD nAvgBytesPerSec;
-    WORD  nBlockAlign;
-} WAVEFORMAT;
-typedef struct pcmwaveformat_tag {
-    WAVEFORMAT wf;
-    WORD       wBitsPerSample;
-} PCMWAVEFORMAT;
-typedef struct tWAVEFORMATEX {
-    WORD  wFormatTag;
-    WORD  nChannels;
-    DWORD nSamplesPerSec;
-    DWORD nAvgBytesPerSec;
-    WORD  nBlockAlign;
-    WORD  wBitsPerSample;
-    WORD  cbSize;
-} WAVEFORMATEX;
+// mmio RIFF reader/writer + wave-format types used by the .cpp; see WinMM.h.
+#include "Core/Platform/WinMM.h"
 #endif
 #include <cstdint>
 

--- a/src/source/Core/Platform/WinMM.cpp
+++ b/src/source/Core/Platform/WinMM.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdio>
 #include <cstdlib>  // wcstombs
+#include <climits>  // LONG_MAX
 
 namespace
 {
@@ -29,7 +30,15 @@ HMMIO mmioOpenW(wchar_t* szFilename, void* /*lpmmioinfo*/, DWORD dwOpenFlags)
     FILE* fp = std::fopen(path, mode);
     if (!fp) return nullptr;
 
-    return static_cast<HMMIO>(new MuMmio{ fp });
+    try
+    {
+        return static_cast<HMMIO>(new MuMmio{ fp });
+    }
+    catch (...)  // don't leak the file if the (tiny) allocation throws
+    {
+        std::fclose(fp);
+        return nullptr;
+    }
 }
 
 int mmioClose(HMMIO hmmio, UINT /*wFlags*/)
@@ -65,15 +74,20 @@ int mmioDescend(HMMIO hmmio, MMCKINFO* lpck, const MMCKINFO* lpckParent, UINT wF
     const FOURCC wantId   = lpck->ckid;     // MMIO_FINDCHUNK
     const FOURCC wantType = lpck->fccType;  // MMIO_FINDRIFF
 
+    // Search limit: the end of the parent chunk's data, or unbounded at top level.
+    // All offset math below is unsigned 64-bit so corrupted chunk sizes can never
+    // overflow into a negative seek or skip a chunk backwards.
+    const unsigned long long parentEnd =
+        lpckParent ? static_cast<unsigned long long>(lpckParent->dwDataOffset) + lpckParent->cksize
+                   : ~0ull;
+
     for (;;)
     {
-        const long chunkStart = std::ftell(h->fp);
-        if (chunkStart < 0) return 1;
+        const long pos = std::ftell(h->fp);
+        if (pos < 0) return 1;
+        const unsigned long long start = static_cast<unsigned long long>(pos);
 
-        // Don't search past the end of the parent chunk's data.
-        if (lpckParent &&
-            static_cast<DWORD>(chunkStart) >= lpckParent->dwDataOffset + lpckParent->cksize)
-            return 1;
+        if (start + 8 > parentEnd) return 1;  // header must fit within the parent
 
         unsigned char header[8];
         if (std::fread(header, 1, sizeof(header), h->fp) != sizeof(header)) return 1;  // EOF
@@ -82,14 +96,15 @@ int mmioDescend(HMMIO hmmio, MMCKINFO* lpck, const MMCKINFO* lpckParent, UINT wF
         lpck->cksize       = ReadFourCC(header + 4);  // little-endian u32
         lpck->fccType      = 0;
         lpck->dwFlags      = 0;
-        lpck->dwDataOffset = static_cast<DWORD>(chunkStart + 8);
+        lpck->dwDataOffset = static_cast<DWORD>(start + 8);
 
         if (lpck->ckid == FOURCC_RIFF || lpck->ckid == FOURCC_LIST)
         {
+            if (start + 12 > parentEnd) return 1;  // form type must fit too
             unsigned char formType[4];
             if (std::fread(formType, 1, sizeof(formType), h->fp) != sizeof(formType)) return 1;
             lpck->fccType      = ReadFourCC(formType);
-            lpck->dwDataOffset = static_cast<DWORD>(chunkStart + 12);
+            lpck->dwDataOffset = static_cast<DWORD>(start + 12);
         }
 
         bool match;
@@ -104,9 +119,11 @@ int mmioDescend(HMMIO hmmio, MMCKINFO* lpck, const MMCKINFO* lpckParent, UINT wF
         }
 
         // Skip to the next chunk; RIFF chunks are word-aligned (pad byte if odd).
-        const long next = chunkStart + 8 + static_cast<long>(lpck->cksize) +
-                          static_cast<long>(lpck->cksize & 1u);
-        if (std::fseek(h->fp, next, SEEK_SET) != 0) return 1;
+        const unsigned long long aligned = static_cast<unsigned long long>(lpck->cksize) + (lpck->cksize & 1u);
+        const unsigned long long next = start + 8 + aligned;  // always advances by >= 8
+        if (next > parentEnd) return 1;                                       // runs past parent
+        if (next > static_cast<unsigned long long>(LONG_MAX)) return 1;       // beyond seekable range
+        if (std::fseek(h->fp, static_cast<long>(next), SEEK_SET) != 0) return 1;
     }
 }
 
@@ -117,10 +134,10 @@ int mmioAscend(HMMIO hmmio, MMCKINFO* lpck, UINT /*wFlags*/)
     auto* h = static_cast<MuMmio*>(hmmio);
     if (!h || !h->fp || !lpck) return 1;
 
-    const long end = static_cast<long>(lpck->dwDataOffset) +
-                     static_cast<long>(lpck->cksize) +
-                     static_cast<long>(lpck->cksize & 1u);
-    return (std::fseek(h->fp, end, SEEK_SET) == 0) ? 0 : 1;
+    const unsigned long long aligned = static_cast<unsigned long long>(lpck->cksize) + (lpck->cksize & 1u);
+    const unsigned long long end = static_cast<unsigned long long>(lpck->dwDataOffset) + aligned;
+    if (end > static_cast<unsigned long long>(LONG_MAX)) return 1;
+    return (std::fseek(h->fp, static_cast<long>(end), SEEK_SET) == 0) ? 0 : 1;
 }
 
 #endif // !_WIN32

--- a/src/source/Core/Platform/WinMM.cpp
+++ b/src/source/Core/Platform/WinMM.cpp
@@ -1,0 +1,126 @@
+// Non-Windows implementation of the mmio RIFF reader/writer (WinMM.h).
+// Backs the WAV loader with buffered stdio file access.
+#ifndef _WIN32
+
+#include "Core/Platform/WinMM.h"
+
+#include <cstdio>
+#include <cstdlib>  // wcstombs
+
+namespace
+{
+    struct MuMmio { FILE* fp; };
+
+    FOURCC ReadFourCC(const unsigned char* p)
+    {
+        return static_cast<FOURCC>(p[0]) | (static_cast<FOURCC>(p[1]) << 8) |
+               (static_cast<FOURCC>(p[2]) << 16) | (static_cast<FOURCC>(p[3]) << 24);
+    }
+}
+
+HMMIO mmioOpenW(wchar_t* szFilename, void* /*lpmmioinfo*/, DWORD dwOpenFlags)
+{
+    if (!szFilename) return nullptr;
+
+    char path[4096] = { 0 };
+    if (std::wcstombs(path, szFilename, sizeof(path) - 1) == static_cast<size_t>(-1)) return nullptr;
+
+    const char* mode = (dwOpenFlags & MMIO_WRITE) ? "wb" : "rb";
+    FILE* fp = std::fopen(path, mode);
+    if (!fp) return nullptr;
+
+    return static_cast<HMMIO>(new MuMmio{ fp });
+}
+
+int mmioClose(HMMIO hmmio, UINT /*wFlags*/)
+{
+    auto* h = static_cast<MuMmio*>(hmmio);
+    if (!h) return 0;
+    if (h->fp) std::fclose(h->fp);
+    delete h;
+    return 0;
+}
+
+int mmioRead(HMMIO hmmio, char* pch, int cch)
+{
+    auto* h = static_cast<MuMmio*>(hmmio);
+    if (!h || !h->fp || !pch || cch < 0) return -1;
+    return static_cast<int>(std::fread(pch, 1, static_cast<size_t>(cch), h->fp));
+}
+
+int mmioWrite(HMMIO hmmio, const char* pch, int cch)
+{
+    auto* h = static_cast<MuMmio*>(hmmio);
+    if (!h || !h->fp || !pch || cch < 0) return -1;
+    return static_cast<int>(std::fwrite(pch, 1, static_cast<size_t>(cch), h->fp));
+}
+
+// Read the next chunk header (or search for a specific chunk with MMIO_FINDCHUNK
+// / MMIO_FINDRIFF), leaving the file positioned at the start of the chunk data.
+int mmioDescend(HMMIO hmmio, MMCKINFO* lpck, const MMCKINFO* lpckParent, UINT wFlags)
+{
+    auto* h = static_cast<MuMmio*>(hmmio);
+    if (!h || !h->fp || !lpck) return 1;
+
+    const FOURCC wantId   = lpck->ckid;     // MMIO_FINDCHUNK
+    const FOURCC wantType = lpck->fccType;  // MMIO_FINDRIFF
+
+    for (;;)
+    {
+        const long chunkStart = std::ftell(h->fp);
+        if (chunkStart < 0) return 1;
+
+        // Don't search past the end of the parent chunk's data.
+        if (lpckParent &&
+            static_cast<DWORD>(chunkStart) >= lpckParent->dwDataOffset + lpckParent->cksize)
+            return 1;
+
+        unsigned char header[8];
+        if (std::fread(header, 1, sizeof(header), h->fp) != sizeof(header)) return 1;  // EOF
+
+        lpck->ckid         = ReadFourCC(header);
+        lpck->cksize       = ReadFourCC(header + 4);  // little-endian u32
+        lpck->fccType      = 0;
+        lpck->dwFlags      = 0;
+        lpck->dwDataOffset = static_cast<DWORD>(chunkStart + 8);
+
+        if (lpck->ckid == FOURCC_RIFF || lpck->ckid == FOURCC_LIST)
+        {
+            unsigned char formType[4];
+            if (std::fread(formType, 1, sizeof(formType), h->fp) != sizeof(formType)) return 1;
+            lpck->fccType      = ReadFourCC(formType);
+            lpck->dwDataOffset = static_cast<DWORD>(chunkStart + 12);
+        }
+
+        bool match;
+        if (wFlags & MMIO_FINDCHUNK)      match = (lpck->ckid == wantId);
+        else if (wFlags & MMIO_FINDRIFF)  match = (lpck->ckid == FOURCC_RIFF && lpck->fccType == wantType);
+        else                              match = true;
+
+        if (match)
+        {
+            std::fseek(h->fp, static_cast<long>(lpck->dwDataOffset), SEEK_SET);
+            return 0;
+        }
+
+        // Skip to the next chunk; RIFF chunks are word-aligned (pad byte if odd).
+        const long next = chunkStart + 8 + static_cast<long>(lpck->cksize) +
+                          static_cast<long>(lpck->cksize & 1u);
+        if (std::fseek(h->fp, next, SEEK_SET) != 0) return 1;
+    }
+}
+
+// Seek past the end of the current chunk's data (word-aligned). Used on plain
+// data chunks (the fmt chunk), not on the RIFF container.
+int mmioAscend(HMMIO hmmio, MMCKINFO* lpck, UINT /*wFlags*/)
+{
+    auto* h = static_cast<MuMmio*>(hmmio);
+    if (!h || !h->fp || !lpck) return 1;
+
+    const long end = static_cast<long>(lpck->dwDataOffset) +
+                     static_cast<long>(lpck->cksize) +
+                     static_cast<long>(lpck->cksize & 1u);
+    return (std::fseek(h->fp, end, SEEK_SET) == 0) ? 0 : 1;
+}
+
+#endif // !_WIN32

--- a/src/source/Core/Platform/WinMM.h
+++ b/src/source/Core/Platform/WinMM.h
@@ -1,0 +1,89 @@
+// Portable multimedia-IO shim (issue #462, Phase 3).
+//
+// The WAV file loader (waveIO) uses the Win32 mmio RIFF reader/writer and the
+// wave-format structs from <mmsystem.h>/<mmreg.h>. On Windows those headers are
+// used unchanged; elsewhere this provides the small subset the loader needs.
+#pragma once
+
+#ifdef _WIN32
+
+// mmio + wave-format types come from <mmsystem.h>.
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include "Core/Platform/WinCompat.h"  // WORD, DWORD, BYTE
+
+typedef DWORD FOURCC;
+
+// Build a four-character-code from four chars (little-endian, as on disk).
+#define mmioFOURCC(c0, c1, c2, c3)                                       \
+    ((DWORD)(BYTE)(c0)        | ((DWORD)(BYTE)(c1) << 8) |               \
+     ((DWORD)(BYTE)(c2) << 16) | ((DWORD)(BYTE)(c3) << 24))
+
+#ifndef FOURCC_RIFF
+#define FOURCC_RIFF mmioFOURCC('R', 'I', 'F', 'F')
+#endif
+#ifndef FOURCC_LIST
+#define FOURCC_LIST mmioFOURCC('L', 'I', 'S', 'T')
+#endif
+
+// mmioOpen flags.
+#define MMIO_READ      0x00000000
+#define MMIO_WRITE     0x00000001
+#define MMIO_CREATE    0x00001000
+#define MMIO_ALLOCBUF  0x00010000
+// mmioDescend search flags.
+#define MMIO_FINDCHUNK 0x0010
+#define MMIO_FINDRIFF  0x0020
+
+#ifndef WAVE_FORMAT_PCM
+#define WAVE_FORMAT_PCM 1
+#endif
+
+// Wave-format structs map directly onto file bytes, so pack them tightly:
+// sizeof(PCMWAVEFORMAT) must be 16 and sizeof(WAVEFORMATEX) 18.
+#pragma pack(push, 1)
+typedef struct waveformat_tag {
+    WORD  wFormatTag;
+    WORD  nChannels;
+    DWORD nSamplesPerSec;
+    DWORD nAvgBytesPerSec;
+    WORD  nBlockAlign;
+} WAVEFORMAT;
+typedef struct pcmwaveformat_tag {
+    WAVEFORMAT wf;
+    WORD       wBitsPerSample;
+} PCMWAVEFORMAT;
+typedef struct tWAVEFORMATEX {
+    WORD  wFormatTag;
+    WORD  nChannels;
+    DWORD nSamplesPerSec;
+    DWORD nAvgBytesPerSec;
+    WORD  nBlockAlign;
+    WORD  wBitsPerSample;
+    WORD  cbSize;
+} WAVEFORMATEX;
+#pragma pack(pop)
+
+// In-memory RIFF chunk descriptor (no packing needed).
+typedef struct _MMCKINFO {
+    FOURCC ckid;          // chunk id
+    DWORD  cksize;        // chunk size (bytes after the 8-byte header)
+    FOURCC fccType;       // form/list type (for RIFF/LIST chunks)
+    DWORD  dwDataOffset;  // file offset of the chunk data
+    DWORD  dwFlags;
+} MMCKINFO, * LPMMCKINFO;
+
+typedef void* HMMIO;
+
+// mmio subset used by the WAV loader. mmioDescend/mmioAscend return 0 on
+// success (MMSYSERR_NOERROR), non-zero on failure; mmioRead/mmioWrite return
+// the byte count (-1 on error), as on Windows. Implemented in WinMM.cpp.
+HMMIO mmioOpenW(wchar_t* szFilename, void* lpmmioinfo, DWORD dwOpenFlags);
+int   mmioClose(HMMIO hmmio, UINT wFlags);
+int   mmioRead(HMMIO hmmio, char* pch, int cch);
+int   mmioWrite(HMMIO hmmio, const char* pch, int cch);
+int   mmioDescend(HMMIO hmmio, MMCKINFO* lpck, const MMCKINFO* lpckParent, UINT wFlags);
+int   mmioAscend(HMMIO hmmio, MMCKINFO* lpck, UINT wFlags);
+
+#endif // _WIN32


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3: the Win32 mmio WAV loader.

## Change

The WAV loader (`waveIO` in `DSWaveIO.cpp`) uses the Win32 mmio API to read and write RIFF/WAVE files, which is unavailable off Windows.

New `Core/Platform/WinMM.{h,cpp}` provides a portable mmio subset backed by stdio:

- `mmioOpenW`/`mmioClose`/`mmioRead`/`mmioWrite` plus `mmioDescend`/`mmioAscend` with real RIFF chunk navigation (`MMIO_FINDCHUNK`, parent-bounded search, word-aligned chunk skipping), and the `mmioFOURCC` macro, `MMCKINFO`, and the `MMIO_*`/`FOURCC_RIFF`/`WAVE_FORMAT_PCM` constants.
- The wave-format structs (`WAVEFORMAT`/`PCMWAVEFORMAT`/`WAVEFORMATEX`), previously inlined in `DSWaveIO.h`, move here and are packed (`#pragma pack(1)`) so they map onto the on-disk layout byte-for-byte (`sizeof(PCMWAVEFORMAT) == 16`), which the `mmioRead` calls rely on. This fixes a latent size mismatch in the prior unpacked definitions. `DSWaveIO.h` now includes `WinMM.h`.

## Result

Linux `MuClient` compile errors drop from **101 to 69** (`DSWaveIO.cpp` fully compiles).

The shim is non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.