### PR TITLE
Add a portable crtdbg shim for _ASSERT

### DIFF
--- a/src/source/Core/Platform/CrtDbg.h
+++ b/src/source/Core/Platform/CrtDbg.h
@@ -1,0 +1,23 @@
+// Portable shim for the MSVC debug-CRT header (issue #462, Phase 3).
+//
+// The engine includes <crtdbg.h> only for the _ASSERT/_ASSERTE macros. On
+// Windows that header is used unchanged; elsewhere the macros map onto the
+// standard assert (a no-op under NDEBUG, exactly as on a Windows release build).
+#pragma once
+
+#ifdef _WIN32
+
+#include <crtdbg.h>
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include <cassert>
+
+#ifndef _ASSERT
+#define _ASSERT(expr)  assert(expr)
+#endif
+#ifndef _ASSERTE
+#define _ASSERTE(expr) assert(expr)
+#endif
+
+#endif // _WIN32

--- a/src/source/Core/Platform/CrtDbg.h
+++ b/src/source/Core/Platform/CrtDbg.h
@@ -1,17 +1,18 @@
 // Portable shim for the MSVC debug-CRT header (issue #462, Phase 3).
 //
-// The engine includes <crtdbg.h> only for the _ASSERT/_ASSERTE macros. On
-// Windows that header is used unchanged; elsewhere the macros map onto the
-// standard assert (a no-op under NDEBUG, exactly as on a Windows release build).
+// The engine includes <crtdbg.h> only for the _ASSERT/_ASSERTE macros. <crtdbg.h>
+// is MSVC-specific, so only MSVC uses it; every other compiler (MinGW, Clang,
+// Linux GCC) maps the macros onto the standard assert (a no-op under NDEBUG,
+// exactly as on a Windows release build).
 #pragma once
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 #include <crtdbg.h>
 
-#else  // ---- non-Windows ----------------------------------------------------
+#else  // ---- non-MSVC -------------------------------------------------------
 
-#include <cassert>
+#include <assert.h>
 
 #ifndef _ASSERT
 #define _ASSERT(expr)  assert(expr)
@@ -20,4 +21,4 @@
 #define _ASSERTE(expr) assert(expr)
 #endif
 
-#endif // _WIN32
+#endif // _MSC_VER

--- a/src/source/GameLogic/Quests/QuestMng.cpp
+++ b/src/source/GameLogic/Quests/QuestMng.cpp
@@ -8,7 +8,7 @@
 
 
 
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 
 #include "UI/NewUI/NewUISystem.h"
 #include "Core/Utilities/UsefulDef.h"

--- a/src/source/GameShop/FileDownloader/Include.h
+++ b/src/source/GameShop/FileDownloader/Include.h
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <wininet.h>
 
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 #include <tchar.h>
 #include <strsafe.h>
 

--- a/src/source/GameShop/ShopListManager/Include.h
+++ b/src/source/GameShop/ShopListManager/Include.h
@@ -38,7 +38,7 @@
 #include <vector>
 #include <string>
 #include <tchar.h>
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 #include <strsafe.h>
 #include "GameShop/ShopListManager/interface/WZResult/WZResult.h"
 #include "GameShop/ShopListManager/interface/DownloadInfo.h"

--- a/src/source/GameShop/ShopListManager/interface/Include.h
+++ b/src/source/GameShop/ShopListManager/interface/Include.h
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <wininet.h>
 
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 #include <tchar.h>
 #include <strsafe.h>
 

--- a/src/source/GameShop/ShopListManager/interface/PathMethod/Path.cpp
+++ b/src/source/GameShop/ShopListManager/interface/PathMethod/Path.cpp
@@ -13,7 +13,7 @@
 #include "Path.h"
 
 #include <fstream>
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 #include <strsafe.h>
 
 TCHAR* Path::GetCurrentFullPath(TCHAR* szPath)

--- a/src/source/GameShop/ShopListManager/interface/WZResult/WZResult.cpp
+++ b/src/source/GameShop/ShopListManager/interface/WZResult/WZResult.cpp
@@ -11,7 +11,7 @@
 #include "stdafx.h"
 #ifdef KJH_ADD_INGAMESHOP_UI_SYSTEM
 #include "WZResult.h"
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 #include <strsafe.h>
 
 WZResult::WZResult() // OK

--- a/src/source/Render/Sprites/Sprite.cpp
+++ b/src/source/Render/Sprites/Sprite.cpp
@@ -9,7 +9,7 @@
 
 #include "Render/Textures/ZzzOpenglUtil.h"
 
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 
 CSprite::CSprite()
 {

--- a/src/source/UI/NewUI/NPCs/NewUINPCDialogue.cpp
+++ b/src/source/UI/NewUI/NPCs/NewUINPCDialogue.cpp
@@ -6,7 +6,7 @@
 #include "UI/NewUI/NPCs/NewUINPCDialogue.h"
 #include "I18N/All.h"
 
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 #include "Audio/DSPlaySound.h"
 #include "UI/NewUI/NewUISystem.h"
 

--- a/src/source/UI/Windows/MsgWin.cpp
+++ b/src/source/UI/Windows/MsgWin.cpp
@@ -6,7 +6,7 @@
 #include "UI/Windows/MsgWin.h"
 #include "Core/Input/Input.h"
 #include "UI/Legacy/UIMng.h"
-#include <crtdbg.h>
+#include "Core/Platform/CrtDbg.h"
 #include "Render/Models/ZzzBMD.h"
 #include "Engine/Object/ZzzInfomation.h"
 #include "Engine/Object/ZzzObject.h"


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3: the `<crtdbg.h>` fatal-include category.

## Change

The engine includes `<crtdbg.h>` only for the `_ASSERT`/`_ASSERTE` macros, which are unavailable off Windows.

New `Core/Platform/CrtDbg.h` maps them onto the standard `assert` (a no-op under `NDEBUG`, exactly as on a Windows release build), and the nine `<crtdbg.h>` includes are redirected to it.

## Result

The `crtdbg.h` fatal-include category goes from 6 to 0, letting four game files (`Sprite`, `QuestMng`, `MsgWin`, `NewUINPCDialogue`) compile with no new errors. The redirect also covers the in-game-shop headers, which remain blocked on `wininet`/`strsafe` (a separate subsystem) for now.

The shim is non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.