### PR TITLE
Add a portable IMM (IME) shim

### DIFF
--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -30,7 +30,7 @@
 #include "Audio/DSPlaySound.h"
 
 #include "App/Platform/Windows/resource.h"
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "Engine/Pathing/ZzzPath.h"
 #include "App/Platform/Windows/Local.h"
 #include "GameLogic/Items/PersonalShopTitleImp.h"

--- a/src/source/Core/Input/ImeInput.cpp
+++ b/src/source/Core/Input/ImeInput.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "Core/Input/ImeInput.h"
 
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "App/Platform/Windows/Winmain.h"   // g_hWnd, WindowWidth/Height
 #include "UI/Legacy/UIControls.h"       // g_pRenderText
 #include "Engine/Object/ZzzInterface.h" // LockInputStatus

--- a/src/source/Core/Platform/Imm.h
+++ b/src/source/Core/Platform/Imm.h
@@ -1,0 +1,56 @@
+// Portable IMM (Windows IME) shim (issue #462, Phase 3).
+//
+// On Windows the IME is driven through <imm.h>. On Linux SDL owns IME (the
+// portable text field, #447), so the legacy Win32 IMM calls become no-ops: there
+// is no IMM context to fetch, and conversion-mode control belongs to the platform
+// IME. These stubs just let the legacy IME code paths compile.
+#pragma once
+
+#ifdef _WIN32
+
+#include <imm.h>
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include "Core/Platform/WinCompat.h"  // HWND, HIMC, DWORD, LPDWORD, POINT, RECT, BOOL
+
+// Composition-window form + conversion-mode flags (imm.h).
+#ifndef CFS_POINT
+#define CFS_POINT 0x0002
+#endif
+#ifndef IMC_SETCOMPOSITIONWINDOW
+#define IMC_SETCOMPOSITIONWINDOW 0x000B
+#endif
+#ifndef IME_CMODE_ALPHANUMERIC
+#define IME_CMODE_ALPHANUMERIC 0x0000
+#endif
+#ifndef IME_CMODE_NATIVE
+#define IME_CMODE_NATIVE 0x0001
+#endif
+#ifndef IME_SMODE_NONE
+#define IME_SMODE_NONE 0x0000
+#endif
+#ifndef IME_SMODE_AUTOMATIC
+#define IME_SMODE_AUTOMATIC 0x0004
+#endif
+
+typedef struct tagCOMPOSITIONFORM {
+    DWORD dwStyle;
+    POINT ptCurrentPos;
+    RECT  rcArea;
+} COMPOSITIONFORM, * LPCOMPOSITIONFORM;
+
+// No IMM context exists off Windows; SDL handles composition and conversion.
+inline HIMC ImmGetContext(HWND)              { return nullptr; }
+inline BOOL ImmReleaseContext(HWND, HIMC)    { return TRUE; }
+inline HWND ImmGetDefaultIMEWnd(HWND)        { return nullptr; }
+
+inline BOOL ImmGetConversionStatus(HIMC, LPDWORD lpfdwConversion, LPDWORD lpfdwSentence)
+{
+    if (lpfdwConversion) *lpfdwConversion = 0;
+    if (lpfdwSentence)   *lpfdwSentence = 0;
+    return TRUE;
+}
+inline BOOL ImmSetConversionStatus(HIMC, DWORD, DWORD) { return TRUE; }
+
+#endif // _WIN32

--- a/src/source/Engine/Object/EditObjects.cpp
+++ b/src/source/Engine/Object/EditObjects.cpp
@@ -3,7 +3,7 @@
 #include "Engine/Object/EditObjects.h"
 
 // Includes mirror ZzzInterface.cpp, the unit this was extracted from.
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"

--- a/src/source/Engine/Object/ZzzInterface.cpp
+++ b/src/source/Engine/Object/ZzzInterface.cpp
@@ -3,7 +3,7 @@
 
 #include "stdafx.h"
 #include "Core/Input/KeyState.h"
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"

--- a/src/source/GameLogic/Combat/ClassAttack.cpp
+++ b/src/source/GameLogic/Combat/ClassAttack.cpp
@@ -6,7 +6,7 @@
 #include "GameLogic/Buffs/w_Buff.h"     // UnRegisterBuff
 
 // Includes mirror ZzzInterface.cpp, the unit these functions were extracted from.
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"

--- a/src/source/GameLogic/Combat/CombatTarget.cpp
+++ b/src/source/GameLogic/Combat/CombatTarget.cpp
@@ -2,7 +2,7 @@
 #include "GameLogic/Combat/CombatTarget.h"
 
 // Includes mirror ZzzInterface.cpp, the unit this was extracted from.
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"

--- a/src/source/GameLogic/Combat/SkillCast.cpp
+++ b/src/source/GameLogic/Combat/SkillCast.cpp
@@ -4,7 +4,7 @@
 #include "GameLogic/Social/MonkSystem.h" // g_CMonkSystem
 
 // Includes mirror ZzzInterface.cpp, the unit these were extracted from.
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"

--- a/src/source/GameLogic/Combat/SkillExecution.cpp
+++ b/src/source/GameLogic/Combat/SkillExecution.cpp
@@ -6,7 +6,7 @@
 #include "Character/CharacterManager.h"   // gCharacterManager
 
 // Includes mirror ZzzInterface.cpp, the unit this was extracted from.
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"

--- a/src/source/Input/Selection.cpp
+++ b/src/source/Input/Selection.cpp
@@ -4,7 +4,7 @@
 #include "Character/CharacterManager.h" // gCharacterManager
 
 // Includes mirror ZzzInterface.cpp, the unit this was extracted from.
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"

--- a/src/source/UI/Chat/Chat.cpp
+++ b/src/source/UI/Chat/Chat.cpp
@@ -5,7 +5,7 @@
 #include "Camera/CameraProjection.h" // CameraProjection
 
 // Includes mirror ZzzInterface.cpp, the unit these were extracted from.
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"

--- a/src/source/UI/Chat/ChatInput.cpp
+++ b/src/source/UI/Chat/ChatInput.cpp
@@ -2,7 +2,7 @@
 #include "UI/Chat/ChatInput.h"
 
 // Includes mirror ZzzInterface.cpp, the unit this was extracted from.
-#include <imm.h>
+#include "Core/Platform/Imm.h"
 #include "UI/Legacy/UIManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Models/ZzzBMD.h"


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3: the `<imm.h>` fatal-include category.

## Change

The legacy Win32 IME code uses `<imm.h>` (`ImmGetContext`/`ImmReleaseContext`, `ImmGet/SetConversionStatus`, `ImmGetDefaultIMEWnd`, `COMPOSITIONFORM`), which is unavailable off Windows. On Linux SDL owns IME (the portable text field, #447), so the Win32 IMM calls become no-ops: there is no IMM context to fetch and conversion-mode control belongs to the platform IME.

New `Core/Platform/Imm.h` provides those no-op stubs plus `COMPOSITIONFORM` and the `CFS_*`/`IME_CMODE_*`/`IME_SMODE_*`/`IMC_*` constants, and the eleven `<imm.h>` includes are redirected to it.

## Result

The `imm.h` fatal-include category goes from 10 to 0. `ImeInput.cpp` and `Winmain.cpp` (the only real IMM users) compile, and nine files that only carried a stray `<imm.h>` include unblock too. No new errors are exposed.

The shim is non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.