### PR TITLE
Add a POSIX CpuUsage implementation

### DIFF
--- a/src/source/Core/Utilities/CpuUsage.cpp
+++ b/src/source/Core/Utilities/CpuUsage.cpp
@@ -3,8 +3,10 @@
 #include <stdexcept>
 #include "CpuUsage.h"
 
+#ifdef _WIN32
+
 // Implementation for Windows
-class CpuUsage::Impl 
+class CpuUsage::Impl
 {
 public:
     Impl()
@@ -73,7 +75,66 @@ private:
     }
 };
 
-CpuUsage* CpuUsage::Instance() 
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include <sys/resource.h>  // getrusage
+#include <thread>          // hardware_concurrency
+
+// POSIX implementation: process CPU time (user + system) from getrusage against
+// wall-clock time, scaled by the processor count -- the same ratio the Windows
+// path computes from GetProcessTimes.
+class CpuUsage::Impl
+{
+public:
+    Impl()
+        : m_numProcessors(std::max(1u, std::thread::hardware_concurrency()))
+        , m_lastCheckTime(std::chrono::steady_clock::now())
+        , m_lastProcessTime(0)
+    {
+    }
+
+    double GetUsage()
+    {
+        rusage ru{};
+        if (getrusage(RUSAGE_SELF, &ru) != 0)
+            return 0.0;
+
+        const unsigned long long currentProcessTime =
+            (static_cast<unsigned long long>(ru.ru_utime.tv_sec + ru.ru_stime.tv_sec) * 1000000ULL) +
+            static_cast<unsigned long long>(ru.ru_utime.tv_usec + ru.ru_stime.tv_usec);
+
+        const auto now = std::chrono::steady_clock::now();
+        const long long elapsedWallTime =
+            std::chrono::duration_cast<std::chrono::microseconds>(now - m_lastCheckTime).count();
+
+        // First call: seed the baselines, no usage yet.
+        if (m_lastProcessTime == 0)
+        {
+            m_lastProcessTime = currentProcessTime;
+            m_lastCheckTime = now;
+            return 0.0;
+        }
+
+        const unsigned long long processTimeElapsed = currentProcessTime - m_lastProcessTime;
+        m_lastProcessTime = currentProcessTime;
+        m_lastCheckTime = now;
+
+        if (elapsedWallTime <= 0 || m_numProcessors == 0)
+            return 0.0;
+
+        return std::max<double>(0.0, (100.0 * processTimeElapsed) /
+                                     (static_cast<double>(elapsedWallTime) * m_numProcessors));
+    }
+
+private:
+    unsigned int m_numProcessors;
+    std::chrono::steady_clock::time_point m_lastCheckTime;
+    unsigned long long m_lastProcessTime;
+};
+
+#endif // _WIN32
+
+CpuUsage* CpuUsage::Instance()
 {
     static CpuUsage instance;
     return &instance;

--- a/src/source/Core/Utilities/CpuUsage.cpp
+++ b/src/source/Core/Utilities/CpuUsage.cpp
@@ -77,6 +77,7 @@ private:
 
 #else  // ---- non-Windows ----------------------------------------------------
 
+#include <algorithm>       // std::max
 #include <sys/resource.h>  // getrusage
 #include <thread>          // hardware_concurrency
 
@@ -89,7 +90,7 @@ public:
     Impl()
         : m_numProcessors(std::max(1u, std::thread::hardware_concurrency()))
         , m_lastCheckTime(std::chrono::steady_clock::now())
-        , m_lastProcessTime(0)
+        , m_lastProcessTime(~0ULL)  // sentinel: "no baseline yet" (0 is a valid CPU time)
     {
     }
 
@@ -100,15 +101,17 @@ public:
             return 0.0;
 
         const unsigned long long currentProcessTime =
-            (static_cast<unsigned long long>(ru.ru_utime.tv_sec + ru.ru_stime.tv_sec) * 1000000ULL) +
-            static_cast<unsigned long long>(ru.ru_utime.tv_usec + ru.ru_stime.tv_usec);
+            (static_cast<unsigned long long>(ru.ru_utime.tv_sec) +
+             static_cast<unsigned long long>(ru.ru_stime.tv_sec)) * 1000000ULL +
+            static_cast<unsigned long long>(ru.ru_utime.tv_usec) +
+            static_cast<unsigned long long>(ru.ru_stime.tv_usec);
 
         const auto now = std::chrono::steady_clock::now();
         const long long elapsedWallTime =
             std::chrono::duration_cast<std::chrono::microseconds>(now - m_lastCheckTime).count();
 
         // First call: seed the baselines, no usage yet.
-        if (m_lastProcessTime == 0)
+        if (m_lastProcessTime == ~0ULL)
         {
             m_lastProcessTime = currentProcessTime;
             m_lastCheckTime = now;


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3.

## Change

`CpuUsage` measures the process's CPU load with the Win32 `GetProcessTimes` / `SYSTEM_INFO` / `FILETIME`, which are unavailable off Windows.

Guard the Windows `Impl` behind `_WIN32` and add a POSIX `Impl` that derives the same ratio from `getrusage` (user + system CPU time) over wall-clock time, scaled by the processor count (`std::thread::hardware_concurrency`).

## Result

Linux `MuClient` compile errors drop from **69 to 55** (`CpuUsage.cpp` compiles).

The new code is non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.