### PR TITLE
Add portable window/cursor query shims (SDL)

### DIFF
--- a/src/source/Core/Platform/WinUser.cpp
+++ b/src/source/Core/Platform/WinUser.cpp
@@ -132,7 +132,7 @@ BOOL GetCursorPos(LPPOINT lpPoint)
 // GetCursorPos already returns client-space coordinates, so this is the identity.
 BOOL ScreenToClient(HWND /*hWnd*/, LPPOINT lpPoint)
 {
-    return lpPoint != nullptr;
+    return lpPoint ? TRUE : FALSE;
 }
 
 HWND GetActiveWindow()

--- a/src/source/Core/Platform/WinUser.cpp
+++ b/src/source/Core/Platform/WinUser.cpp
@@ -114,4 +114,35 @@ BOOL PostMessage(HWND /*hWnd*/, UINT Msg, WPARAM /*wParam*/, LPARAM /*lParam*/)
     return TRUE;
 }
 
+void PostQuitMessage(int /*nExitCode*/)
+{
+    RequestQuit();
+}
+
+BOOL GetCursorPos(LPPOINT lpPoint)
+{
+    if (!lpPoint) return FALSE;
+    float x = 0.0f, y = 0.0f;
+    SDL_GetMouseState(&x, &y);  // already window-relative
+    lpPoint->x = static_cast<LONG>(x);
+    lpPoint->y = static_cast<LONG>(y);
+    return TRUE;
+}
+
+// GetCursorPos already returns client-space coordinates, so this is the identity.
+BOOL ScreenToClient(HWND /*hWnd*/, LPPOINT lpPoint)
+{
+    return lpPoint != nullptr;
+}
+
+HWND GetActiveWindow()
+{
+    return reinterpret_cast<HWND>(SDL_GetKeyboardFocus());  // null when unfocused
+}
+
+UINT GetDoubleClickTime()
+{
+    return 500;  // the Win32 default
+}
+
 #endif // !_WIN32

--- a/src/source/Core/Platform/WinUser.h
+++ b/src/source/Core/Platform/WinUser.h
@@ -41,5 +41,16 @@ int MessageBoxW(HWND owner, LPCWSTR text, LPCWSTR caption, UINT type);
 // WinUser.cpp.
 LRESULT SendMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 BOOL    PostMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+void    PostQuitMessage(int nExitCode);
+
+// Window / cursor queries, backed by SDL. The engine reads the cursor as
+// GetCursorPos followed by ScreenToClient(window); SDL_GetMouseState already
+// returns window-relative coordinates, so GetCursorPos yields those directly and
+// ScreenToClient is the identity. GetActiveWindow reports the focused window (so
+// `== NULL` means the game is unfocused). Implemented in WinUser.cpp.
+BOOL GetCursorPos(LPPOINT lpPoint);
+BOOL ScreenToClient(HWND hWnd, LPPOINT lpPoint);
+HWND GetActiveWindow();
+UINT GetDoubleClickTime();
 
 #endif // _WIN32


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3.

## Change

The input layer reads the cursor (`GetCursorPos` + `ScreenToClient`), checks focus (`GetActiveWindow`) and the double-click interval (`GetDoubleClickTime`), and some code requests shutdown via `PostQuitMessage`. These Win32 calls are unavailable off Windows.

Add SDL-backed versions in `WinUser`:
- `GetCursorPos` returns SDL's window-relative mouse position, so `ScreenToClient` (which the engine always applies next) is the identity.
- `GetActiveWindow` reports SDL's keyboard-focus window (null when the game is unfocused).
- `GetDoubleClickTime` returns the Win32 default of 500 ms.
- `PostQuitMessage` routes to the same SDL quit as `PostMessage(WM_QUIT)`.

None of these depend on `g_hWnd`.

## Result

Linux `MuClient` compile errors drop from **55 to 48** (`Input.cpp` compiles).

The shims are non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.