### PR TITLE
Add portable lstrlen/_wtoi/_itow/_mbclen shims

### DIFF
--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -58,7 +58,9 @@ inline wchar_t* _itow(int value, wchar_t* buffer, int radix)
     if (radix < 2 || radix > 36) { buffer[0] = L'\0'; return buffer; }
 
     const bool negative = (value < 0 && radix == 10);
-    unsigned int v = negative ? static_cast<unsigned int>(-static_cast<long>(value))
+    // Unsigned negation is well-defined and yields the correct magnitude even
+    // for INT_MIN, unlike negating through a (possibly 32-bit) signed long.
+    unsigned int v = negative ? -static_cast<unsigned int>(value)
                               : static_cast<unsigned int>(value);
 
     wchar_t digits[33];

--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>    // strlen
 #include <cwchar>
 #include <cwctype>
 #include <strings.h>  // strcasecmp
@@ -30,6 +31,50 @@ inline DWORD GetTickCount()
     return static_cast<DWORD>(duration_cast<milliseconds>(steady_clock::now() - mu_detail::tickEpoch()).count());
 }
 inline DWORD timeGetTime() { return GetTickCount(); }
+
+// String length (Win32 lstrlen; the engine builds UNICODE, hence the wide form).
+inline int lstrlen(const wchar_t* s) { return s ? static_cast<int>(wcslen(s)) : 0; }
+inline int lstrlen(const char* s)    { return s ? static_cast<int>(strlen(s)) : 0; }
+
+// Wide string -> int.
+inline int _wtoi(const wchar_t* s) { return s ? static_cast<int>(wcstol(s, nullptr, 10)) : 0; }
+
+// Bytes in the multibyte character at c. Narrow strings are UTF-8 on Linux, so
+// this is the UTF-8 sequence length taken from the lead byte.
+inline size_t _mbclen(const unsigned char* c)
+{
+    if (!c || *c < 0x80)      return 1;
+    if ((*c & 0xE0) == 0xC0)  return 2;
+    if ((*c & 0xF0) == 0xE0)  return 3;
+    if ((*c & 0xF8) == 0xF0)  return 4;
+    return 1;
+}
+
+// Int -> wide string in the given radix (MSVC _itow). A leading '-' is emitted
+// only for base 10, matching MSVC; the caller's buffer must be large enough.
+inline wchar_t* _itow(int value, wchar_t* buffer, int radix)
+{
+    if (!buffer) return buffer;
+    if (radix < 2 || radix > 36) { buffer[0] = L'\0'; return buffer; }
+
+    const bool negative = (value < 0 && radix == 10);
+    unsigned int v = negative ? static_cast<unsigned int>(-static_cast<long>(value))
+                              : static_cast<unsigned int>(value);
+
+    wchar_t digits[33];
+    int n = 0;
+    do {
+        const unsigned int d = v % static_cast<unsigned int>(radix);
+        digits[n++] = static_cast<wchar_t>(d < 10 ? L'0' + d : L'a' + (d - 10));
+        v /= static_cast<unsigned int>(radix);
+    } while (v != 0);
+
+    int j = 0;
+    if (negative) buffer[j++] = L'-';
+    while (n > 0) buffer[j++] = digits[--n];
+    buffer[j] = L'\0';
+    return buffer;
+}
 
 // Case-insensitive compares.
 inline int _wcsicmp(const wchar_t* a, const wchar_t* b) { return wcscasecmp(a, b); }


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3.

## Change

The engine uses these Win32/MSVC string helpers widely (`lstrlen` and `_wtoi` in particular), and they are unavailable off Windows. Add portable versions to `WinApiShims`:

- `lstrlen` -> `wcslen`/`strlen` (wide + narrow overloads).
- `_wtoi`  -> `wcstol` base 10.
- `_itow`  -> int to wide string in a given radix (MSVC semantics: a leading `-` only for base 10).
- `_mbclen` -> UTF-8 lead-byte length (narrow strings are UTF-8 on Linux).

## Result

Linux `MuClient` compile errors drop from **48 to 45**. The small delta is because most of the 63 `_wtoi` / 29 `lstrlen` call sites live in files still behind the in-game-shop include wall; this shim pre-clears them.

The shims are non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.