### PR TITLE
Add portable GDI BMP/DIB struct shims

### DIFF
--- a/src/source/App/stdafx.h
+++ b/src/source/App/stdafx.h
@@ -75,6 +75,7 @@
 #include "Core/Platform/WinApiShims.h"
 #include "Core/Platform/WinUser.h"
 #include "Core/Platform/WinNls.h"
+#include "Core/Platform/WinGdi.h"
 #endif // _WIN32
 
 //c runtime

--- a/src/source/Core/Platform/WinGdi.h
+++ b/src/source/Core/Platform/WinGdi.h
@@ -1,0 +1,66 @@
+// Portable GDI struct shim (issue #462, Phase 3).
+//
+// The terrain/UI code reads and builds Windows DIB/BMP structures for file I/O
+// and texture uploads. On Windows these come from <wingdi.h> (via <windows.h>);
+// elsewhere this provides just the structs and constants used, laid out to match
+// the on-disk/in-memory Windows formats. GDI *functions* are a separate concern.
+#pragma once
+
+#ifdef _WIN32
+
+// BMP/DIB types come from <wingdi.h> (pulled in by <windows.h>).
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include "Core/Platform/WinCompat.h"  // WORD, DWORD, LONG, BYTE
+
+#ifndef BI_RGB
+#define BI_RGB 0
+#endif
+
+// The file header is read/written with sizeof == 14, so it must be packed (the
+// DWORD bfSize sits at offset 2, not 4).
+#pragma pack(push, 2)
+typedef struct tagBITMAPFILEHEADER {
+    WORD  bfType;
+    DWORD bfSize;
+    WORD  bfReserved1;
+    WORD  bfReserved2;
+    DWORD bfOffBits;
+} BITMAPFILEHEADER, * LPBITMAPFILEHEADER, * PBITMAPFILEHEADER;
+#pragma pack(pop)
+
+typedef struct tagBITMAPINFOHEADER {
+    DWORD biSize;
+    LONG  biWidth;
+    LONG  biHeight;
+    WORD  biPlanes;
+    WORD  biBitCount;
+    DWORD biCompression;
+    DWORD biSizeImage;
+    LONG  biXPelsPerMeter;
+    LONG  biYPelsPerMeter;
+    DWORD biClrUsed;
+    DWORD biClrImportant;
+} BITMAPINFOHEADER, * LPBITMAPINFOHEADER, * PBITMAPINFOHEADER;
+
+typedef struct tagRGBQUAD {
+    BYTE rgbBlue;
+    BYTE rgbGreen;
+    BYTE rgbRed;
+    BYTE rgbReserved;
+} RGBQUAD;
+
+typedef struct tagBITMAPINFO {
+    BITMAPINFOHEADER bmiHeader;
+    RGBQUAD          bmiColors[1];
+} BITMAPINFO, * LPBITMAPINFO, * PBITMAPINFO;
+
+typedef struct tagPALETTEENTRY {
+    BYTE peRed;
+    BYTE peGreen;
+    BYTE peBlue;
+    BYTE peFlags;
+} PALETTEENTRY, * LPPALETTEENTRY, * PPALETTEENTRY;
+
+#endif // _WIN32

--- a/src/source/Core/Platform/WinGdi.h
+++ b/src/source/Core/Platform/WinGdi.h
@@ -8,7 +8,7 @@
 
 #ifdef _WIN32
 
-// BMP/DIB types come from <wingdi.h> (pulled in by <windows.h>).
+#include <windows.h>  // BMP/DIB types (pulled in via <wingdi.h>)
 
 #else  // ---- non-Windows ----------------------------------------------------
 


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3.

## Change

The terrain loader (`ZzzLodTerrain`) and UI texture code read BMP files and build DIB structures with the Win32 `BITMAPFILEHEADER`/`BITMAPINFOHEADER`/`BITMAPINFO`/`RGBQUAD`/`PALETTEENTRY` types, which are unavailable off Windows.

New `Core/Platform/WinGdi.h` provides those structs and the `BI_RGB` constant, wired into the PCH. `BITMAPFILEHEADER` is packed to its 14-byte on-disk layout (the loader `memcpy`s it from a file buffer with `sizeof`). GDI *functions* remain a later concern (the text renderer is still HDC-based).

## Result

Linux `MuClient` compile errors drop from **45 to 41** (`ZzzLodTerrain.cpp` compiles).

The shim is non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.