### PR TITLE
Port the config system (GameConfig) to Linux

### DIFF
--- a/src/source/Core/Platform/Dpapi.h
+++ b/src/source/Core/Platform/Dpapi.h
@@ -1,0 +1,36 @@
+// Portable DPAPI shim (issue #462, Phase 3).
+//
+// The config layer encrypts saved credentials with the Windows Data Protection
+// API. There is no portable equivalent, and on Windows the types come from the
+// platform SDK (pulled in via <imagehlp.h> where the config code uses them), so
+// this header only provides non-Windows stubs.
+//
+// The stubs report failure: CryptProtectData/CryptUnprotectData return FALSE, so
+// the caller never stores or reads credentials -- nothing is written in
+// plaintext. Wiring up a portable secret store (libsecret / Keychain) is a
+// follow-up.
+#pragma once
+
+#ifndef _WIN32
+
+#include "Core/Platform/WinCompat.h"  // BOOL, BYTE, DWORD, PVOID, LPCWSTR, LPWSTR
+
+typedef struct _CRYPTOAPI_BLOB {
+    DWORD cbData;
+    BYTE* pbData;
+} DATA_BLOB;
+
+inline BOOL CryptProtectData(DATA_BLOB*, LPCWSTR, DATA_BLOB*, PVOID, void*, DWORD, DATA_BLOB*)
+{
+    return FALSE;
+}
+inline BOOL CryptUnprotectData(DATA_BLOB*, LPWSTR*, DATA_BLOB*, PVOID, void*, DWORD, DATA_BLOB*)
+{
+    return FALSE;
+}
+
+// Never reached on Linux (only called on the success path of the Crypt* calls,
+// which always fail here), but needed so the call sites compile.
+inline void* LocalFree(void* hMem) { return hMem; }
+
+#endif // !_WIN32

--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -14,6 +14,7 @@
 #include <strings.h>  // strcasecmp
 #include <unistd.h>   // readlink
 #include "Core/Platform/WinCompat.h"  // DWORD, FILE handle types
+#include "Core/Platform/WinNls.h"     // MultiByteToWideChar / CP_UTF8
 
 namespace mu_detail
 {
@@ -41,13 +42,13 @@ inline DWORD GetModuleFileNameW(HMODULE /*hModule*/, LPWSTR lpFilename, DWORD nS
     char path[4096];
     const ssize_t n = readlink("/proc/self/exe", path, sizeof(path) - 1);
     if (n <= 0) { lpFilename[0] = L'\0'; return 0; }
-    path[n] = '\0';
-
-    const size_t converted = mbstowcs(lpFilename, path, nSize - 1);
-    if (converted == static_cast<size_t>(-1)) { lpFilename[0] = L'\0'; return 0; }
-    const DWORD len = (converted < static_cast<size_t>(nSize - 1)) ? static_cast<DWORD>(converted) : nSize - 1;
-    lpFilename[len] = L'\0';
-    return len;
+    // UTF-8 -> wide via the project's own converter (locale-independent, unlike
+    // mbstowcs which fails on non-ASCII paths in the default "C" locale).
+    const int converted = MultiByteToWideChar(CP_UTF8, 0, path, static_cast<int>(n),
+                                              lpFilename, static_cast<int>(nSize - 1));
+    if (converted <= 0) { lpFilename[0] = L'\0'; return 0; }
+    lpFilename[converted] = L'\0';
+    return static_cast<DWORD>(converted);
 }
 
 // String length (Win32 lstrlen; the engine builds UNICODE, hence the wide form).

--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -12,6 +12,7 @@
 #include <cwchar>
 #include <cwctype>
 #include <strings.h>  // strcasecmp
+#include <unistd.h>   // readlink
 #include "Core/Platform/WinCompat.h"  // DWORD, FILE handle types
 
 namespace mu_detail
@@ -31,6 +32,23 @@ inline DWORD GetTickCount()
     return static_cast<DWORD>(duration_cast<milliseconds>(steady_clock::now() - mu_detail::tickEpoch()).count());
 }
 inline DWORD timeGetTime() { return GetTickCount(); }
+
+// Path of the running executable (Win32 GetModuleFileNameW). The engine only
+// queries its own module (hModule == null), which maps to /proc/self/exe.
+inline DWORD GetModuleFileNameW(HMODULE /*hModule*/, LPWSTR lpFilename, DWORD nSize)
+{
+    if (!lpFilename || nSize == 0) return 0;
+    char path[4096];
+    const ssize_t n = readlink("/proc/self/exe", path, sizeof(path) - 1);
+    if (n <= 0) { lpFilename[0] = L'\0'; return 0; }
+    path[n] = '\0';
+
+    const size_t converted = mbstowcs(lpFilename, path, nSize - 1);
+    if (converted == static_cast<size_t>(-1)) { lpFilename[0] = L'\0'; return 0; }
+    const DWORD len = (converted < static_cast<size_t>(nSize - 1)) ? static_cast<DWORD>(converted) : nSize - 1;
+    lpFilename[len] = L'\0';
+    return len;
+}
 
 // String length (Win32 lstrlen; the engine builds UNICODE, hence the wide form).
 inline int lstrlen(const wchar_t* s) { return s ? static_cast<int>(wcslen(s)) : 0; }

--- a/src/source/Core/Platform/WinIni.cpp
+++ b/src/source/Core/Platform/WinIni.cpp
@@ -1,0 +1,196 @@
+// Non-Windows implementation of the .ini profile shim (WinIni.h).
+// Stores the file as UTF-8 on disk; sections/keys are matched case-insensitively.
+#ifndef _WIN32
+
+#include "Core/Platform/WinIni.h"
+#include "Core/Platform/WinNls.h"  // WideCharToMultiByte / MultiByteToWideChar
+
+#include <cstdio>
+#include <cstring>
+#include <cwchar>
+#include <string>
+#include <vector>
+
+namespace
+{
+    std::string Narrow(LPCWSTR s)
+    {
+        if (!s) return std::string();
+        const int n = WideCharToMultiByte(CP_UTF8, 0, s, -1, nullptr, 0, nullptr, nullptr);
+        if (n <= 1) return std::string();
+        std::string out(static_cast<size_t>(n - 1), '\0');
+        WideCharToMultiByte(CP_UTF8, 0, s, -1, out.data(), n, nullptr, nullptr);
+        return out;
+    }
+
+    std::wstring Widen(const std::string& s)
+    {
+        if (s.empty()) return std::wstring();
+        const int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
+        if (n <= 1) return std::wstring();
+        std::wstring out(static_cast<size_t>(n - 1), L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, out.data(), n);
+        return out;
+    }
+
+    std::string Trim(const std::string& s)
+    {
+        size_t a = 0, b = s.size();
+        while (a < b && (s[a] == ' ' || s[a] == '\t' || s[a] == '\r' || s[a] == '\n')) ++a;
+        while (b > a && (s[b - 1] == ' ' || s[b - 1] == '\t' || s[b - 1] == '\r' || s[b - 1] == '\n')) --b;
+        return s.substr(a, b - a);
+    }
+
+    bool IEquals(const std::string& a, const std::string& b)
+    {
+        if (a.size() != b.size()) return false;
+        for (size_t i = 0; i < a.size(); ++i)
+            if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(b[i])))
+                return false;
+        return true;
+    }
+
+    struct Entry   { std::string key, value; };
+    struct Section { std::string name; std::vector<Entry> entries; };
+
+    std::vector<Section> Load(const std::string& path)
+    {
+        std::vector<Section> sections;
+        FILE* fp = std::fopen(path.c_str(), "rb");
+        if (!fp) return sections;
+
+        std::string content;
+        char buf[4096];
+        size_t r;
+        while ((r = std::fread(buf, 1, sizeof(buf), fp)) > 0)
+            content.append(buf, r);
+        std::fclose(fp);
+
+        Section* current = nullptr;
+        size_t pos = 0;
+        while (pos <= content.size())
+        {
+            size_t nl = content.find('\n', pos);
+            const std::string raw = content.substr(pos, (nl == std::string::npos ? content.size() : nl) - pos);
+            const std::string line = Trim(raw);
+            if (nl == std::string::npos && line.empty()) break;
+            pos = (nl == std::string::npos) ? content.size() + 1 : nl + 1;
+
+            if (line.empty() || line[0] == ';' || line[0] == '#')
+                continue;
+
+            if (line.front() == '[' && line.back() == ']')
+            {
+                sections.push_back(Section{ line.substr(1, line.size() - 2), {} });
+                current = &sections.back();
+                continue;
+            }
+
+            const size_t eq = line.find('=');
+            if (eq == std::string::npos || !current)
+                continue;
+            current->entries.push_back(Entry{ Trim(line.substr(0, eq)), Trim(line.substr(eq + 1)) });
+        }
+        return sections;
+    }
+
+    bool Store(const std::string& path, const std::vector<Section>& sections)
+    {
+        FILE* fp = std::fopen(path.c_str(), "wb");
+        if (!fp) return false;
+        for (const Section& s : sections)
+        {
+            std::fprintf(fp, "[%s]\n", s.name.c_str());
+            for (const Entry& e : s.entries)
+                std::fprintf(fp, "%s=%s\n", e.key.c_str(), e.value.c_str());
+            std::fputc('\n', fp);
+        }
+        std::fclose(fp);
+        return true;
+    }
+
+    // Returns the value for app/key, or nullptr if absent.
+    const std::string* Find(const std::vector<Section>& sections, const std::string& app, const std::string& key)
+    {
+        for (const Section& s : sections)
+        {
+            if (!IEquals(s.name, app)) continue;
+            for (const Entry& e : s.entries)
+                if (IEquals(e.key, key)) return &e.value;
+        }
+        return nullptr;
+    }
+}
+
+DWORD GetPrivateProfileStringW(LPCWSTR lpAppName, LPCWSTR lpKeyName, LPCWSTR lpDefault,
+                               LPWSTR lpReturnedString, DWORD nSize, LPCWSTR lpFileName)
+{
+    if (!lpReturnedString || nSize == 0) return 0;
+
+    const std::vector<Section> sections = Load(Narrow(lpFileName));
+    const std::string* found = (lpAppName && lpKeyName)
+        ? Find(sections, Narrow(lpAppName), Narrow(lpKeyName)) : nullptr;
+
+    const std::wstring value = found ? Widen(*found) : (lpDefault ? std::wstring(lpDefault) : std::wstring());
+
+    DWORD copied = static_cast<DWORD>(value.size());
+    if (copied > nSize - 1) copied = nSize - 1;  // truncate, leaving room for the null
+    std::wmemcpy(lpReturnedString, value.c_str(), copied);
+    lpReturnedString[copied] = L'\0';
+    return copied;
+}
+
+UINT GetPrivateProfileIntW(LPCWSTR lpAppName, LPCWSTR lpKeyName, INT nDefault, LPCWSTR lpFileName)
+{
+    const std::vector<Section> sections = Load(Narrow(lpFileName));
+    const std::string* found = (lpAppName && lpKeyName)
+        ? Find(sections, Narrow(lpAppName), Narrow(lpKeyName)) : nullptr;
+    if (!found) return static_cast<UINT>(nDefault);
+    return static_cast<UINT>(std::strtol(found->c_str(), nullptr, 10));
+}
+
+BOOL WritePrivateProfileStringW(LPCWSTR lpAppName, LPCWSTR lpKeyName, LPCWSTR lpString, LPCWSTR lpFileName)
+{
+    if (!lpAppName) return FALSE;
+    const std::string path = Narrow(lpFileName);
+    const std::string app = Narrow(lpAppName);
+    std::vector<Section> sections = Load(path);
+
+    // Null key: delete the whole section.
+    if (!lpKeyName)
+    {
+        for (size_t i = 0; i < sections.size(); ++i)
+            if (IEquals(sections[i].name, app)) { sections.erase(sections.begin() + i); break; }
+        return Store(path, sections) ? TRUE : FALSE;
+    }
+
+    const std::string key = Narrow(lpKeyName);
+
+    Section* sec = nullptr;
+    for (Section& s : sections)
+        if (IEquals(s.name, app)) { sec = &s; break; }
+
+    // Null value: delete the key (if its section exists).
+    if (!lpString)
+    {
+        if (sec)
+            for (size_t i = 0; i < sec->entries.size(); ++i)
+                if (IEquals(sec->entries[i].key, key)) { sec->entries.erase(sec->entries.begin() + i); break; }
+        return Store(path, sections) ? TRUE : FALSE;
+    }
+
+    if (!sec)
+    {
+        sections.push_back(Section{ app, {} });
+        sec = &sections.back();
+    }
+
+    const std::string value = Narrow(lpString);
+    for (Entry& e : sec->entries)
+        if (IEquals(e.key, key)) { e.value = value; return Store(path, sections) ? TRUE : FALSE; }
+
+    sec->entries.push_back(Entry{ key, value });
+    return Store(path, sections) ? TRUE : FALSE;
+}
+
+#endif // !_WIN32

--- a/src/source/Core/Platform/WinIni.cpp
+++ b/src/source/Core/Platform/WinIni.cpp
@@ -13,23 +13,27 @@
 
 namespace
 {
+    // Convert with the source's explicit length (no trailing null), so the
+    // converters never write a terminator one past the string's logical end.
     std::string Narrow(LPCWSTR s)
     {
         if (!s) return std::string();
-        const int n = WideCharToMultiByte(CP_UTF8, 0, s, -1, nullptr, 0, nullptr, nullptr);
-        if (n <= 1) return std::string();
-        std::string out(static_cast<size_t>(n - 1), '\0');
-        WideCharToMultiByte(CP_UTF8, 0, s, -1, out.data(), n, nullptr, nullptr);
+        const int len = static_cast<int>(wcslen(s));
+        const int n = WideCharToMultiByte(CP_UTF8, 0, s, len, nullptr, 0, nullptr, nullptr);
+        if (n <= 0) return std::string();
+        std::string out(static_cast<size_t>(n), '\0');
+        WideCharToMultiByte(CP_UTF8, 0, s, len, out.data(), n, nullptr, nullptr);
         return out;
     }
 
     std::wstring Widen(const std::string& s)
     {
         if (s.empty()) return std::wstring();
-        const int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
-        if (n <= 1) return std::wstring();
-        std::wstring out(static_cast<size_t>(n - 1), L'\0');
-        MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, out.data(), n);
+        const int len = static_cast<int>(s.size());
+        const int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, nullptr, 0);
+        if (n <= 0) return std::wstring();
+        std::wstring out(static_cast<size_t>(n), L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, out.data(), n);
         return out;
     }
 

--- a/src/source/Core/Platform/WinIni.h
+++ b/src/source/Core/Platform/WinIni.h
@@ -1,0 +1,24 @@
+// Portable .ini profile shim (issue #462, Phase 3).
+//
+// The config layer persists settings with the Win32 private-profile API. On
+// Windows these come from <windows.h>; elsewhere this provides portable
+// implementations (WinIni.cpp) that read/write a UTF-8 .ini file with the same
+// contract (case-insensitive sections/keys; a null value deletes a key; a null
+// key deletes a section; a zero buffer size returns the required length).
+#pragma once
+
+#ifdef _WIN32
+
+// GetPrivateProfile*/WritePrivateProfile* come from <windows.h>.
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include "Core/Platform/WinCompat.h"  // UINT, DWORD, INT, LPCWSTR, LPWSTR, BOOL
+
+UINT  GetPrivateProfileIntW(LPCWSTR lpAppName, LPCWSTR lpKeyName, INT nDefault, LPCWSTR lpFileName);
+DWORD GetPrivateProfileStringW(LPCWSTR lpAppName, LPCWSTR lpKeyName, LPCWSTR lpDefault,
+                               LPWSTR lpReturnedString, DWORD nSize, LPCWSTR lpFileName);
+BOOL  WritePrivateProfileStringW(LPCWSTR lpAppName, LPCWSTR lpKeyName, LPCWSTR lpString,
+                                 LPCWSTR lpFileName);
+
+#endif // _WIN32

--- a/src/source/Data/GameConfig/GameConfig.cpp
+++ b/src/source/Data/GameConfig/GameConfig.cpp
@@ -7,6 +7,8 @@
 
 #include "GameConfigConstants.h"
 #include "Core/Platform/WinCompat.h"
+#include "Core/Platform/WinIni.h"  // private-profile (.ini) API
+#include "Core/Platform/Dpapi.h"   // DPAPI credential crypto (no-op off Windows)
 
 GameConfig& GameConfig::GetInstance()
 {
@@ -225,7 +227,7 @@ void GameConfig::DecryptCredentials(wchar_t* outUser, wchar_t* outPass, size_t u
 // Helper functions using Windows INI API
 int GameConfig::ReadInt(const wchar_t* section, const wchar_t* key, int defaultValue)
 {
-    return GetPrivateProfileIntW(section, key, defaultValue, m_configPath.c_str());
+    return GetPrivateProfileIntW(section, key, defaultValue, m_configPath.wstring().c_str());
 }
 
 void GameConfig::WriteInt(const wchar_t* section, const wchar_t* key, int value)
@@ -233,17 +235,17 @@ void GameConfig::WriteInt(const wchar_t* section, const wchar_t* key, int value)
     wchar_t buffer[32];
     swprintf_s(buffer, L"%d", value);
 
-    WritePrivateProfileStringW(section, key, buffer, m_configPath.c_str());
+    WritePrivateProfileStringW(section, key, buffer, m_configPath.wstring().c_str());
 }
 
 bool GameConfig::ReadBool(const wchar_t* section, const wchar_t* key, bool defaultValue)
 {
-    return GetPrivateProfileIntW(section, key, defaultValue ? 1 : 0, m_configPath.c_str()) != 0;
+    return GetPrivateProfileIntW(section, key, defaultValue ? 1 : 0, m_configPath.wstring().c_str()) != 0;
 }
 
 void GameConfig::WriteBool(const wchar_t* section, const wchar_t* key, bool value)
 {
-    WritePrivateProfileStringW(section, key, value ? L"1" : L"0", m_configPath.c_str());
+    WritePrivateProfileStringW(section, key, value ? L"1" : L"0", m_configPath.wstring().c_str());
 }
 
 std::wstring GameConfig::ReadString(const wchar_t* section, const wchar_t* key, const std::wstring& defaultValue)
@@ -251,7 +253,7 @@ std::wstring GameConfig::ReadString(const wchar_t* section, const wchar_t* key, 
     std::vector<wchar_t> buffer(2048);
     while (true)
     {
-        DWORD charsRead = GetPrivateProfileStringW(section, key, defaultValue.c_str(), buffer.data(), static_cast<DWORD>(buffer.size()), m_configPath.c_str());
+        DWORD charsRead = GetPrivateProfileStringW(section, key, defaultValue.c_str(), buffer.data(), static_cast<DWORD>(buffer.size()), m_configPath.wstring().c_str());
         if (charsRead < buffer.size() - 1)
         {
             return std::wstring(buffer.data());
@@ -262,19 +264,19 @@ std::wstring GameConfig::ReadString(const wchar_t* section, const wchar_t* key, 
 
 void GameConfig::WriteString(const wchar_t* section, const wchar_t* key, const std::wstring& value)
 {
-    WritePrivateProfileStringW(section, key, value.c_str(), m_configPath.c_str());
+    WritePrivateProfileStringW(section, key, value.c_str(), m_configPath.wstring().c_str());
 }
 
 void GameConfig::RemoveObsoleteKey(const wchar_t* section, const wchar_t* key)
 {
     // Passing nullptr as the value deletes the key (Windows INI API).
-    WritePrivateProfileStringW(section, key, nullptr, m_configPath.c_str());
+    WritePrivateProfileStringW(section, key, nullptr, m_configPath.wstring().c_str());
 }
 
 void GameConfig::RemoveObsoleteSection(const wchar_t* section)
 {
     // Passing nullptr as the key deletes the entire section.
-    WritePrivateProfileStringW(section, nullptr, nullptr, m_configPath.c_str());
+    WritePrivateProfileStringW(section, nullptr, nullptr, m_configPath.wstring().c_str());
 }
 
 std::wstring GameConfig::DecryptSetting(const std::wstring& hexInput)


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3.

## Change

`GameConfig` persisted settings via the Win32 private-profile (`.ini`) API, encrypted saved credentials with DPAPI, and located `config.ini` via `GetModuleFileNameW` -- all Windows-only. Add portable equivalents:

- **`Core/Platform/WinIni.{h,cpp}`** -- a real `.ini` reader/writer (UTF-8 on disk, case-insensitive sections/keys, null-value deletes a key, null-key deletes a section, zero buffer size returns the required length) implementing `GetPrivateProfileIntW`/`GetPrivateProfileStringW`/`WritePrivateProfileStringW`.
- **`Core/Platform/Dpapi.h`** -- `CryptProtectData`/`CryptUnprotectData` stubs that report failure, so saved credentials are never written in plaintext off Windows. A portable secret store (libsecret/Keychain) is a follow-up.
- **`GetModuleFileNameW`** via `/proc/self/exe` in `WinApiShims`.
- Pass the config path as a wide string (`std::filesystem::path::value_type` is `char` on POSIX), so the `.ini` calls receive `LPCWSTR` on both platforms.

## Result

Linux `MuClient` compile errors drop from **41 to 22** (`GameConfig.cpp` compiles).

The shims are non-Windows-only and the config path is wide on both platforms, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.

## Known follow-up (runtime, not compile)

`GameConfig` locates the config directory with `wcsrchr(exePath, L'\\')`, which won't match the forward slashes in a Linux exe path, so `config.ini` would currently land at the wrong path on Linux. This belongs with the Phase 4 "runnable client" work (one of several runtime path fixes) and is intentionally out of scope for this compile-focused change.