### PR TITLE
Add ExitProcess shim and fix a raw swprintf call

### DIFF
--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -51,8 +51,8 @@ inline DWORD GetModuleFileNameW(HMODULE /*hModule*/, LPWSTR lpFilename, DWORD nS
     return static_cast<DWORD>(converted);
 }
 
-// Terminate the process (Win32 ExitProcess).
-inline void ExitProcess(UINT uExitCode) { exit(static_cast<int>(uExitCode)); }
+// Terminate the process (Win32 ExitProcess). Never returns, like the real one.
+[[noreturn]] inline void ExitProcess(UINT uExitCode) { exit(static_cast<int>(uExitCode)); }
 
 // String length (Win32 lstrlen; the engine builds UNICODE, hence the wide form).
 inline int lstrlen(const wchar_t* s) { return s ? static_cast<int>(wcslen(s)) : 0; }

--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -51,6 +51,9 @@ inline DWORD GetModuleFileNameW(HMODULE /*hModule*/, LPWSTR lpFilename, DWORD nS
     return static_cast<DWORD>(converted);
 }
 
+// Terminate the process (Win32 ExitProcess).
+inline void ExitProcess(UINT uExitCode) { exit(static_cast<int>(uExitCode)); }
+
 // String length (Win32 lstrlen; the engine builds UNICODE, hence the wide form).
 inline int lstrlen(const wchar_t* s) { return s ? static_cast<int>(wcslen(s)) : 0; }
 inline int lstrlen(const char* s)    { return s ? static_cast<int>(strlen(s)) : 0; }

--- a/src/source/Data/DataHandler/SkillData/SkillDataLoader.cpp
+++ b/src/source/Data/DataHandler/SkillData/SkillDataLoader.cpp
@@ -24,7 +24,7 @@ bool SkillDataLoader::Load(wchar_t* fileName)
     if (fp == NULL)
     {
         wchar_t errorMsg[256];
-        swprintf(errorMsg, L"Skill file not found: %ls", fileName);
+        mu_swprintf(errorMsg, L"Skill file not found: %ls", fileName);
         DataFileIO::ShowErrorAndExit(errorMsg);
         return false;
     }


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3.

## Change

- `ExitProcess` -> `exit()` in `WinApiShims`.
- `SkillDataLoader` called the MSVC 2-argument `swprintf(buffer, format, ...)`, which the standard `swprintf` (which takes a buffer-size argument) rejects off Windows. Route it through the existing `mu_swprintf` wrapper.

## Result

Linux `MuClient` compile errors drop from **22 to 20**.

Non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.