### PR TITLE
Fix auto-reconnect connecting to the wrong server endpoint

### DIFF
--- a/src/source/Network/Reconnect/ReconnectManager.cpp
+++ b/src/source/Network/Reconnect/ReconnectManager.cpp
@@ -125,6 +125,15 @@ void ReconnectManager::Begin()
         return;
     }
 
+    // Point the login scene at the cached game server before tearing down.
+    // ResetClientToLoginScene() switches to LOG_IN_SCENE, and the next frame
+    // NewMoveLogInScene() -> CreateLogInScene() reconnects to
+    // szServerIpAddress/g_ServerPort. Left at the connect-server endpoint that
+    // reconnect hijacks the game-server socket we open below, so the first
+    // attempt connects to the wrong endpoint and only the retry recovers.
+    szServerIpAddress = m_serverIp;
+    g_ServerPort = m_serverPort;
+
     // Tear the live session down to a clean login state.
     ResetClientToLoginScene();
 

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -374,11 +374,17 @@ BOOL CreateSocket(const wchar_t* IpAddr, unsigned short Port)
             CUIMng::Instance().PopUpMsgWin(MESSAGE_SERVER_LOST);
         }
     }
-    else
+    else if (isEncrypted)
     {
         // Remember the address we actually connected to so auto-reconnect can
-        // probe it directly. This covers both the connect-server flow and a
-        // direct game-server connection (where ReceiveServerConnect never runs).
+        // probe it directly. Only cache game-server endpoints: a reconnect
+        // re-runs the login/character/join sequence, which the connect server
+        // can't answer. The connect server is the only unencrypted endpoint
+        // (see the port heuristic above), so caching when isEncrypted captures
+        // both the redirected game server (ReceiveServerConnect), a map-server
+        // change, and a direct game-server connection (where ReceiveServerConnect
+        // never runs), while skipping the connect server that would otherwise
+        // poison the cache and break reconnection (issue #68).
         ReconnectManager::Instance().CacheServer(IpAddr, Port);
     }
 


### PR DESCRIPTION
Two bugs caused auto-reconnect to target the connect server instead of the game server. Together they made reconnection fail or only succeed on the second attempt. Reported in Mosch0512/MuMain#68.

Auto-reconnect probes a cached endpoint and replays `login -> character list -> select -> join`, which only a game server can answer.

## 1. Cache only game-server endpoints

`CreateSocket()` cached **every** connection into the reconnect manager, including the initial connection to the **connect server** (`szServerIpAddress`/`g_ServerPort`). If the connect-server endpoint was the one held in the cache when the in-game connection dropped, reconnection silently failed - the connect server cannot handle a game login.

Fix: only cache **game-server** endpoints. The connect server is the single unencrypted endpoint, which `CreateSocket()` already distinguishes via its port heuristic (`isEncrypted`). Gating the cache on `isEncrypted` keeps caching the redirected game server (`ReceiveServerConnect`), a map-server change (`CSMapServer`), and a direct game-server connection, while skipping the connect server.

## 2. Reconnect to the cached game server from the login scene

In `ReconnectManager::Begin()`, `ResetClientToLoginScene()` switches to `LOG_IN_SCENE`. The next frame, `NewMoveLogInScene() -> CreateLogInScene()` reconnects to `szServerIpAddress`/`g_ServerPort` - still the connect-server endpoint - which replaced the game-server socket `Begin()` had just opened. The `Connecting` phase then waited for a game-server hello that never arrived, timed out, and only the `Retrying` pass recovered, so reconnection only worked on the second try.

Fix: point `szServerIpAddress`/`g_ServerPort` at the cached game-server endpoint before the teardown, so the login-scene reconnect targets the game server and reconnection succeeds on the first attempt.