### PR TITLE
Unblock muConsoleDebug on Linux (io.h guard + _vsnwprintf)

### DIFF
--- a/src/source/Core/Platform/SecureCrt.h
+++ b/src/source/Core/Platform/SecureCrt.h
@@ -96,11 +96,15 @@ inline int _vsnwprintf_s(wchar_t* buf, size_t count, size_t maxcount, const wcha
     return r;
 }
 
-// Non-secure _vsnwprintf(buf, count, fmt, args) -> bounded C99 vswprintf.
+// Non-secure _vsnwprintf(buf, count, fmt, args) -> bounded C99 vswprintf. On
+// failure vswprintf leaves the buffer indeterminate, so null-terminate it
+// (callers don't check the return value) to keep later reads in bounds.
 inline int _vsnwprintf(wchar_t* buf, size_t count, const wchar_t* fmt, va_list argptr)
 {
     if (buf == nullptr || count == 0 || fmt == nullptr) return -1;
-    return vswprintf(buf, count, fmt, argptr);
+    const int r = vswprintf(buf, count, fmt, argptr);
+    if (r < 0) buf[count - 1] = L'\0';
+    return r;
 }
 
 // ---- swprintf_s --------------------------------------------------------------

--- a/src/source/Core/Platform/SecureCrt.h
+++ b/src/source/Core/Platform/SecureCrt.h
@@ -96,6 +96,13 @@ inline int _vsnwprintf_s(wchar_t* buf, size_t count, size_t maxcount, const wcha
     return r;
 }
 
+// Non-secure _vsnwprintf(buf, count, fmt, args) -> bounded C99 vswprintf.
+inline int _vsnwprintf(wchar_t* buf, size_t count, const wchar_t* fmt, va_list argptr)
+{
+    if (buf == nullptr || count == 0 || fmt == nullptr) return -1;
+    return vswprintf(buf, count, fmt, argptr);
+}
+
 // ---- swprintf_s --------------------------------------------------------------
 inline int swprintf_s(wchar_t* buf, size_t count, const wchar_t* fmt, ...)
 {

--- a/src/source/Core/Utilities/Log/muConsoleDebug.cpp
+++ b/src/source/Core/Utilities/Log/muConsoleDebug.cpp
@@ -5,7 +5,9 @@
 
 #include "muConsoleDebug.h"	// self
 
+#ifdef _WIN32
 #include <io.h>
+#endif
 #include <fcntl.h>
 #include <iostream>
 #include "Engine/Object/ZzzInterface.h"


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3.

## Change

`muConsoleDebug.cpp` pulled in `<io.h>` (an MSVC-only header, with no functions from it actually used) and called `_vsnwprintf`.

- Guard the `<io.h>` include behind `_WIN32`.
- Add a portable `_vsnwprintf` shim (-> bounded C99 `vswprintf`) in `SecureCrt`.

## Result

Clears the `io.h` fatal-include category; `muConsoleDebug.cpp` now compiles on Linux. The portable engine surface remains at zero non-fatal errors.

Non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.