### PR TITLE
Guard stray MSVC-only includes and add wcsnicmp

### DIFF
--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -100,6 +100,20 @@ inline wchar_t* _itow(int value, wchar_t* buffer, int radix)
     return buffer;
 }
 
+// Case-insensitive, length-limited wide compare (MSVC _wcsnicmp/wcsnicmp).
+inline int _wcsnicmp(const wchar_t* a, const wchar_t* b, size_t n)
+{
+    for (size_t i = 0; i < n; ++i)
+    {
+        const wint_t ca = towlower(static_cast<wint_t>(a[i]));
+        const wint_t cb = towlower(static_cast<wint_t>(b[i]));
+        if (ca != cb) return (ca < cb) ? -1 : 1;
+        if (a[i] == L'\0') break;
+    }
+    return 0;
+}
+inline int wcsnicmp(const wchar_t* a, const wchar_t* b, size_t n) { return _wcsnicmp(a, b, n); }
+
 // Case-insensitive compares.
 inline int _wcsicmp(const wchar_t* a, const wchar_t* b) { return wcscasecmp(a, b); }
 inline int wcsicmp(const wchar_t* a, const wchar_t* b) { return wcscasecmp(a, b); }

--- a/src/source/Data/DataHandler/LoadData.cpp
+++ b/src/source/Data/DataHandler/LoadData.cpp
@@ -6,7 +6,9 @@
 
 #include <codecvt>
 #include <locale>
+#ifdef _WIN32
 #include <shlwapi.h>
+#endif
 
 #include "Render/Sprites/GlobalBitmap.h"
 

--- a/src/source/Engine/Object/ZzzCharacter.cpp
+++ b/src/source/Engine/Object/ZzzCharacter.cpp
@@ -8,7 +8,9 @@
 #include "stdafx.h"
 #include "UI/Chat/Chat.h"
 #include "Core/Globals/_enum.h"
+#ifdef _WIN32
 #include <eh.h>
+#endif
 #include "UI/Legacy/UIManager.h"
 #include "Guild/GuildCache.h"
 #include "Render/Textures/ZzzOpenglUtil.h"

--- a/src/source/GameLogic/NPCs/npcBreeder.cpp
+++ b/src/source/GameLogic/NPCs/npcBreeder.cpp
@@ -2,7 +2,9 @@
 //  npcBreeder.cpp
 //////////////////////////////////////////////////////////////////////////
 #include "stdafx.h"
+#ifdef _WIN32
 #include <process.h>
+#endif
 #include "UI/Legacy/UIManager.h"
 #include "Render/Models/ZzzBMD.h"
 #include "Engine/Object/ZzzInfomation.h"


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3. Batches several small fatal-include fixes.

## Change

Three files pulled in MSVC-only headers without using anything from them:

- `<shlwapi.h>` in `LoadData.cpp`
- `<process.h>` in `npcBreeder.cpp`
- `<eh.h>` in `ZzzCharacter.cpp`

Guard each behind `_WIN32`. Once `LoadData` was unblocked it needed `wcsnicmp`, so add a portable `wcsnicmp`/`_wcsnicmp` (case-insensitive, length-limited wide compare) to `WinApiShims`.

## Result

Clears the `shlwapi.h` / `process.h` / `eh.h` fatal-include categories; all three files compile on Linux, and the portable surface stays at zero non-fatal errors.

Non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.