### PR TITLE
Port the reconnect probe off Winsock to BSD sockets

### DIFF
--- a/src/source/Core/Platform/WinCompat.h
+++ b/src/source/Core/Platform/WinCompat.h
@@ -311,9 +311,11 @@ inline constexpr ENUMTYPE operator ~ (ENUMTYPE a) { using T = std::underlying_ty
 #define ZeroMemory(dst, len) std::memset((dst), 0, (len))
 #endif
 
-// Element count of a stack array (MSVC _countof).
+// Element count of a stack array (MSVC _countof). Type-safe: a pointer argument
+// fails to match the array helper and is a compile error, not a silent miscount.
 #ifndef _countof
-#define _countof(a) (sizeof(a) / sizeof((a)[0]))
+template <typename T, std::size_t N> char (&mu_countof_helper(T (&)[N]))[N];
+#define _countof(arr) (sizeof(mu_countof_helper(arr)))
 #endif
 
 // ---- GDI rect/point helpers (winuser.h) -------------------------------------

--- a/src/source/Core/Platform/WinCompat.h
+++ b/src/source/Core/Platform/WinCompat.h
@@ -311,6 +311,11 @@ inline constexpr ENUMTYPE operator ~ (ENUMTYPE a) { using T = std::underlying_ty
 #define ZeroMemory(dst, len) std::memset((dst), 0, (len))
 #endif
 
+// Element count of a stack array (MSVC _countof).
+#ifndef _countof
+#define _countof(a) (sizeof(a) / sizeof((a)[0]))
+#endif
+
 // ---- GDI rect/point helpers (winuser.h) -------------------------------------
 // Pure value-type helpers with no platform dependency; same semantics as Win32.
 

--- a/src/source/Core/Platform/WinSock.h
+++ b/src/source/Core/Platform/WinSock.h
@@ -44,14 +44,25 @@ inline int WSACleanup() { return 0; }
 inline int WSAGetLastError() { return errno; }
 
 inline int closesocket(SOCKET s) { return ::close(s); }
-inline int ioctlsocket(SOCKET s, long cmd, u_long* argp) { return ::ioctl(s, static_cast<unsigned long>(cmd), argp); }
+
+inline int ioctlsocket(SOCKET s, long cmd, u_long* argp)
+{
+    // Linux ioctl(FIONBIO) expects an int*, not Winsock's u_long*; convert so
+    // the flag is read correctly (size/endianness safe).
+    if (cmd == FIONBIO)
+    {
+        int val = argp ? static_cast<int>(*argp) : 0;
+        return ::ioctl(s, FIONBIO, &val);
+    }
+    return ::ioctl(s, static_cast<unsigned long>(cmd), argp);
+}
 
 // Wide name resolution. The probe only reads ai_addr/ai_family, so map the wide
 // addrinfo onto POSIX addrinfo and convert the node/service to the locale bytes.
 typedef struct addrinfo addrinfoW, ADDRINFOW, * PADDRINFOW;
 
 inline int GetAddrInfoW(const wchar_t* node, const wchar_t* service,
-                        const addrinfo* hints, addrinfo** result)
+                        const addrinfoW* hints, addrinfoW** result)
 {
     char n[256] = { 0 };
     char sv[64] = { 0 };

--- a/src/source/Core/Platform/WinSock.h
+++ b/src/source/Core/Platform/WinSock.h
@@ -1,0 +1,64 @@
+// Portable Winsock shim (issue #462, Phase 3).
+//
+// The reconnect reachability probe is the only Winsock user. Most of what it
+// needs (socket/connect/getsockopt/select/sockaddr_in/AF_INET/...) is standard
+// on POSIX, so on Windows this includes <ws2tcpip.h> and elsewhere it provides
+// just the Winsock-specific names mapped onto BSD sockets.
+#pragma once
+
+#ifdef _WIN32
+
+#include <ws2tcpip.h>
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>    // htons
+#include <netdb.h>        // getaddrinfo / addrinfo
+#include <unistd.h>       // close
+#include <sys/ioctl.h>    // ioctl, FIONBIO
+#include <sys/select.h>   // select, fd_set
+#include <cerrno>
+#include <cwchar>         // wcstombs
+
+#include "Core/Platform/WinCompat.h"  // WORD, MAKEWORD
+
+typedef int SOCKET;
+
+#ifndef INVALID_SOCKET
+#define INVALID_SOCKET (-1)
+#endif
+#ifndef SOCKET_ERROR
+#define SOCKET_ERROR (-1)
+#endif
+#ifndef WSAEWOULDBLOCK
+#define WSAEWOULDBLOCK EWOULDBLOCK
+#endif
+
+// Winsock startup is a no-op on BSD sockets.
+typedef struct { WORD wVersion; } WSADATA, * LPWSADATA;
+inline int WSAStartup(WORD, LPWSADATA) { return 0; }
+inline int WSACleanup() { return 0; }
+inline int WSAGetLastError() { return errno; }
+
+inline int closesocket(SOCKET s) { return ::close(s); }
+inline int ioctlsocket(SOCKET s, long cmd, u_long* argp) { return ::ioctl(s, static_cast<unsigned long>(cmd), argp); }
+
+// Wide name resolution. The probe only reads ai_addr/ai_family, so map the wide
+// addrinfo onto POSIX addrinfo and convert the node/service to the locale bytes.
+typedef struct addrinfo addrinfoW, ADDRINFOW, * PADDRINFOW;
+
+inline int GetAddrInfoW(const wchar_t* node, const wchar_t* service,
+                        const addrinfo* hints, addrinfo** result)
+{
+    char n[256] = { 0 };
+    char sv[64] = { 0 };
+    if (node && wcstombs(n, node, sizeof(n) - 1) == static_cast<size_t>(-1)) return EAI_FAIL;
+    if (service && wcstombs(sv, service, sizeof(sv) - 1) == static_cast<size_t>(-1)) return EAI_FAIL;
+    return ::getaddrinfo(node ? n : nullptr, service ? sv : nullptr, hints, result);
+}
+inline void FreeAddrInfoW(addrinfo* p) { ::freeaddrinfo(p); }
+
+#endif // _WIN32

--- a/src/source/Network/Reconnect/ReconnectManager.cpp
+++ b/src/source/Network/Reconnect/ReconnectManager.cpp
@@ -281,7 +281,8 @@ void ReconnectManager::PollProbe()
     FD_SET(probe, &errorSet);
 
     timeval immediate = {};
-    select(0, nullptr, &writeSet, &errorSet, &immediate);
+    // POSIX needs nfds = highest fd + 1; Windows ignores the first argument.
+    select(static_cast<int>(probe + 1), nullptr, &writeSet, &errorSet, &immediate);
 
     if (FD_ISSET(probe, &writeSet))
     {

--- a/src/source/Network/Reconnect/ReconnectManager.cpp
+++ b/src/source/Network/Reconnect/ReconnectManager.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "ReconnectManager.h"
 
-#include <ws2tcpip.h>  // GetAddrInfoW for the reachability probe (IPs + hostnames)
+#include "Core/Platform/WinSock.h"  // GetAddrInfoW + BSD-socket shims for the reachability probe
 
 #include <cmath>
 #include <cwchar>
@@ -286,7 +286,7 @@ void ReconnectManager::PollProbe()
     if (FD_ISSET(probe, &writeSet))
     {
         int soError = 0;
-        int len = sizeof(soError);
+        socklen_t len = sizeof(soError);
         getsockopt(probe, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&soError), &len);
         CloseProbe();
 


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3: `winsock -> BSD-socket abstraction`.

## Change

The reconnect reachability probe (`ReconnectManager`) is the engine's only Winsock user (the actual networking goes through the managed client library). Most of the API it uses (`socket`/`connect`/`getsockopt`/`select`/`sockaddr_in`/`AF_INET`/...) is standard on POSIX, so:

- New `Core/Platform/WinSock.h` maps only the Winsock-specific names onto BSD sockets: `SOCKET` -> `int`, `INVALID_SOCKET`, `WSAStartup`/`WSACleanup` no-ops, `closesocket` -> `close`, `ioctlsocket` -> `ioctl`, and `GetAddrInfoW`/`FreeAddrInfoW` over `getaddrinfo` (the wide `addrinfo` maps to POSIX `addrinfo`). `ReconnectManager` includes it instead of `<ws2tcpip.h>`.
- Added the `_countof` macro to `WinCompat`.
- Gave the `getsockopt` length a `socklen_t` type (`int` on Winsock, `unsigned int` on Linux) so it compiles on both.

## Result

Clears the `ws2tcpip` fatal-include category; `ReconnectManager` compiles on Linux and the portable surface stays at zero non-fatal errors.

The shim and macro are non-Windows-only and `socklen_t` exists on both platforms, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.