### PR TITLE
Disable DirectSound on non-Windows

### DIFF
--- a/src/source/Audio/DSPlaySound.cpp
+++ b/src/source/Audio/DSPlaySound.cpp
@@ -25,11 +25,15 @@
 #include <thread>
 #include <vector>
 
+#ifdef _WIN32
 #include <objbase.h>
 #include <dsound.h>
+#endif
 #include "Audio/DSWaveIO.h"
 #include "Engine/Object/ZzzCharacter.h"
 #include "Audio/DSPlaySound.h"
+
+#ifdef _WIN32  // ---- Windows: the DirectSound implementation ----------------
 
 namespace
 {
@@ -775,3 +779,23 @@ void Set3DSoundPosition()
 {
     Manager().Update3DPositions();
 }
+
+#else  // ---- non-Windows: DirectSound is unavailable ------------------------
+
+// Sound effects run on DirectSound, which has no portable equivalent yet
+// (issue #462). Until an SDL_mixer port, the public API is a silent no-op so
+// every caller still builds and runs. Music already plays through SDL_mixer.
+HRESULT InitDirectSound(HWND) { return S_OK; }
+void    SetEnableSound(bool) {}
+void    FreeDirectSound() {}
+void    LoadWaveFile(ESound, const wchar_t*, int, bool) {}
+HRESULT PlayBuffer(ESound, OBJECT*, BOOL) { return S_OK; }
+void    StopBuffer(ESound, BOOL) {}
+void    AllStopSound(void) {}
+void    Set3DSoundPosition() {}
+HRESULT ReleaseBuffer(int) { return S_OK; }
+HRESULT RestoreBuffers(int, int) { return S_OK; }
+void    SetVolume(int, long) {}
+void    SetMasterVolume(long) {}
+
+#endif // _WIN32


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3.

## Change

The sound-effects engine is built on DirectSound/COM (`<objbase.h>` / `<dsound.h>`), which has no portable equivalent yet. Guard the whole DirectSound implementation behind `_WIN32` and provide `#else` no-op definitions of the public audio API (`InitDirectSound`, `PlayBuffer`, `LoadWaveFile`, `StopBuffer`, `SetVolume`, ...) so every caller still builds and runs.

Sound effects are silent on Linux for now; music already plays through SDL_mixer, and an SDL_mixer SFX port is a follow-up.

## Result

Clears the `objbase.h` fatal-include category; `DSPlaySound.cpp` compiles on Linux and the portable surface stays at zero non-fatal errors.

Non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.