### PR TITLE
Port ErrorReport to Linux: file-API shim + guard the system info

### DIFF
--- a/src/source/App/stdafx.h
+++ b/src/source/App/stdafx.h
@@ -76,6 +76,7 @@
 #include "Core/Platform/WinUser.h"
 #include "Core/Platform/WinNls.h"
 #include "Core/Platform/WinGdi.h"
+#include "Core/Platform/WinFile.h"
 #endif // _WIN32
 
 //c runtime

--- a/src/source/Core/Platform/WinFile.h
+++ b/src/source/Core/Platform/WinFile.h
@@ -18,6 +18,7 @@
 #include <ctime>
 #include <cstdint>
 #include "Core/Platform/WinCompat.h"  // HANDLE, DWORD, BOOL, LPCWSTR, WORD, INVALID_HANDLE_VALUE
+#include "Core/Platform/WinNls.h"     // WideCharToMultiByte / CP_UTF8 (locale-independent paths)
 
 // dwDesiredAccess
 #ifndef GENERIC_READ
@@ -78,7 +79,7 @@ inline HANDLE CreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD /*sha
     }
 
     char path[4096] = { 0 };
-    if (!lpFileName || std::wcstombs(path, lpFileName, sizeof(path) - 1) == static_cast<size_t>(-1))
+    if (!lpFileName || WideCharToMultiByte(CP_UTF8, 0, lpFileName, -1, path, sizeof(path) - 1, nullptr, nullptr) == 0)
         return INVALID_HANDLE_VALUE;
 
     const int fd = ::open(path, oflag, 0644);
@@ -88,8 +89,13 @@ inline HANDLE CreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD /*sha
 #define CreateFile CreateFileW
 #endif
 
+// A null HANDLE maps to fd 0 (stdin), so guard it: reading/writing/closing it
+// would hang on or clobber standard input.
+inline bool MuFileHandleValid(HANDLE h) { return h != nullptr && h != INVALID_HANDLE_VALUE; }
+
 inline BOOL ReadFile(HANDLE hFile, void* buffer, DWORD count, LPDWORD bytesRead, void* /*ovl*/)
 {
+    if (!MuFileHandleValid(hFile)) { if (bytesRead) *bytesRead = 0; return FALSE; }
     const ssize_t r = ::read(mu_detail::HandleToFd(hFile), buffer, count);
     if (r < 0) { if (bytesRead) *bytesRead = 0; return FALSE; }
     if (bytesRead) *bytesRead = static_cast<DWORD>(r);
@@ -98,6 +104,7 @@ inline BOOL ReadFile(HANDLE hFile, void* buffer, DWORD count, LPDWORD bytesRead,
 
 inline BOOL WriteFile(HANDLE hFile, const void* buffer, DWORD count, LPDWORD bytesWritten, void* /*ovl*/)
 {
+    if (!MuFileHandleValid(hFile)) { if (bytesWritten) *bytesWritten = 0; return FALSE; }
     const ssize_t w = ::write(mu_detail::HandleToFd(hFile), buffer, count);
     if (w < 0) { if (bytesWritten) *bytesWritten = 0; return FALSE; }
     if (bytesWritten) *bytesWritten = static_cast<DWORD>(w);
@@ -106,22 +113,31 @@ inline BOOL WriteFile(HANDLE hFile, const void* buffer, DWORD count, LPDWORD byt
 
 inline BOOL CloseHandle(HANDLE hObject)
 {
-    if (hObject == INVALID_HANDLE_VALUE) return FALSE;
+    if (!MuFileHandleValid(hObject)) return FALSE;
     return (::close(mu_detail::HandleToFd(hObject)) == 0) ? TRUE : FALSE;
 }
 
-inline DWORD SetFilePointer(HANDLE hFile, LONG distance, LONG* /*distanceHigh*/, DWORD moveMethod)
+inline DWORD SetFilePointer(HANDLE hFile, LONG distance, LONG* distanceHigh, DWORD moveMethod)
 {
+    if (!MuFileHandleValid(hFile)) return INVALID_SET_FILE_POINTER;
     const int whence = (moveMethod == FILE_END) ? SEEK_END
                      : (moveMethod == FILE_CURRENT) ? SEEK_CUR : SEEK_SET;
-    const off_t pos = ::lseek(mu_detail::HandleToFd(hFile), distance, whence);
-    return (pos == static_cast<off_t>(-1)) ? INVALID_SET_FILE_POINTER : static_cast<DWORD>(pos);
+
+    // Combine the optional high dword for offsets past 2GB.
+    std::int64_t offset = distance;
+    if (distanceHigh)
+        offset = (static_cast<std::int64_t>(*distanceHigh) << 32) | static_cast<std::uint32_t>(distance);
+
+    const off_t pos = ::lseek(mu_detail::HandleToFd(hFile), static_cast<off_t>(offset), whence);
+    if (pos == static_cast<off_t>(-1)) return INVALID_SET_FILE_POINTER;
+    if (distanceHigh) *distanceHigh = static_cast<LONG>(pos >> 32);
+    return static_cast<DWORD>(pos & 0xFFFFFFFF);
 }
 
 inline BOOL DeleteFileW(LPCWSTR lpFileName)
 {
     char path[4096] = { 0 };
-    if (!lpFileName || std::wcstombs(path, lpFileName, sizeof(path) - 1) == static_cast<size_t>(-1))
+    if (!lpFileName || WideCharToMultiByte(CP_UTF8, 0, lpFileName, -1, path, sizeof(path) - 1, nullptr, nullptr) == 0)
         return FALSE;
     return (::unlink(path) == 0) ? TRUE : FALSE;
 }

--- a/src/source/Core/Platform/WinFile.h
+++ b/src/source/Core/Platform/WinFile.h
@@ -1,0 +1,152 @@
+// Portable Win32 file-API shim (issue #462, Phase 3).
+//
+// A few subsystems do file I/O through the Win32 HANDLE API (CreateFile/ReadFile/
+// WriteFile/CloseHandle/SetFilePointer/DeleteFile) and read the clock through
+// GetLocalTime. On Windows these come from <windows.h>; elsewhere this maps them
+// onto POSIX file descriptors and the C clock. A HANDLE carries the fd value.
+#pragma once
+
+#ifdef _WIN32
+
+// File API + SYSTEMTIME come from <windows.h>.
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstdlib>   // wcstombs
+#include <ctime>
+#include <cstdint>
+#include "Core/Platform/WinCompat.h"  // HANDLE, DWORD, BOOL, LPCWSTR, WORD, INVALID_HANDLE_VALUE
+
+// dwDesiredAccess
+#ifndef GENERIC_READ
+#define GENERIC_READ  0x80000000u
+#endif
+#ifndef GENERIC_WRITE
+#define GENERIC_WRITE 0x40000000u
+#endif
+// dwShareMode (advisory only on POSIX, ignored here)
+#ifndef FILE_SHARE_READ
+#define FILE_SHARE_READ   0x00000001
+#endif
+#ifndef FILE_SHARE_WRITE
+#define FILE_SHARE_WRITE  0x00000002
+#endif
+// dwCreationDisposition
+#ifndef CREATE_NEW
+#define CREATE_NEW        1
+#define CREATE_ALWAYS     2
+#define OPEN_EXISTING     3
+#define OPEN_ALWAYS       4
+#define TRUNCATE_EXISTING 5
+#endif
+#ifndef FILE_ATTRIBUTE_NORMAL
+#define FILE_ATTRIBUTE_NORMAL 0x00000080
+#endif
+// SetFilePointer move method
+#ifndef FILE_BEGIN
+#define FILE_BEGIN   0
+#define FILE_CURRENT 1
+#define FILE_END     2
+#endif
+#ifndef INVALID_SET_FILE_POINTER
+#define INVALID_SET_FILE_POINTER (static_cast<DWORD>(-1))
+#endif
+
+namespace mu_detail
+{
+    inline int    HandleToFd(HANDLE h) { return static_cast<int>(reinterpret_cast<std::intptr_t>(h)); }
+    inline HANDLE FdToHandle(int fd)   { return reinterpret_cast<HANDLE>(static_cast<std::intptr_t>(fd)); }
+}
+
+inline HANDLE CreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD /*share*/, void* /*sec*/,
+                          DWORD dwCreationDisposition, DWORD /*flags*/, HANDLE /*tmpl*/)
+{
+    const bool wantRead  = (dwDesiredAccess & GENERIC_READ) != 0;
+    const bool wantWrite = (dwDesiredAccess & GENERIC_WRITE) != 0;
+    int oflag = wantRead && wantWrite ? O_RDWR : (wantWrite ? O_WRONLY : O_RDONLY);
+
+    switch (dwCreationDisposition)
+    {
+        case CREATE_ALWAYS:     oflag |= O_CREAT | O_TRUNC; break;
+        case CREATE_NEW:        oflag |= O_CREAT | O_EXCL;  break;
+        case OPEN_ALWAYS:       oflag |= O_CREAT;           break;
+        case TRUNCATE_EXISTING: oflag |= O_TRUNC;           break;
+        case OPEN_EXISTING:
+        default:                                            break;
+    }
+
+    char path[4096] = { 0 };
+    if (!lpFileName || std::wcstombs(path, lpFileName, sizeof(path) - 1) == static_cast<size_t>(-1))
+        return INVALID_HANDLE_VALUE;
+
+    const int fd = ::open(path, oflag, 0644);
+    return (fd < 0) ? INVALID_HANDLE_VALUE : mu_detail::FdToHandle(fd);
+}
+#ifndef CreateFile
+#define CreateFile CreateFileW
+#endif
+
+inline BOOL ReadFile(HANDLE hFile, void* buffer, DWORD count, LPDWORD bytesRead, void* /*ovl*/)
+{
+    const ssize_t r = ::read(mu_detail::HandleToFd(hFile), buffer, count);
+    if (r < 0) { if (bytesRead) *bytesRead = 0; return FALSE; }
+    if (bytesRead) *bytesRead = static_cast<DWORD>(r);
+    return TRUE;
+}
+
+inline BOOL WriteFile(HANDLE hFile, const void* buffer, DWORD count, LPDWORD bytesWritten, void* /*ovl*/)
+{
+    const ssize_t w = ::write(mu_detail::HandleToFd(hFile), buffer, count);
+    if (w < 0) { if (bytesWritten) *bytesWritten = 0; return FALSE; }
+    if (bytesWritten) *bytesWritten = static_cast<DWORD>(w);
+    return TRUE;
+}
+
+inline BOOL CloseHandle(HANDLE hObject)
+{
+    if (hObject == INVALID_HANDLE_VALUE) return FALSE;
+    return (::close(mu_detail::HandleToFd(hObject)) == 0) ? TRUE : FALSE;
+}
+
+inline DWORD SetFilePointer(HANDLE hFile, LONG distance, LONG* /*distanceHigh*/, DWORD moveMethod)
+{
+    const int whence = (moveMethod == FILE_END) ? SEEK_END
+                     : (moveMethod == FILE_CURRENT) ? SEEK_CUR : SEEK_SET;
+    const off_t pos = ::lseek(mu_detail::HandleToFd(hFile), distance, whence);
+    return (pos == static_cast<off_t>(-1)) ? INVALID_SET_FILE_POINTER : static_cast<DWORD>(pos);
+}
+
+inline BOOL DeleteFileW(LPCWSTR lpFileName)
+{
+    char path[4096] = { 0 };
+    if (!lpFileName || std::wcstombs(path, lpFileName, sizeof(path) - 1) == static_cast<size_t>(-1))
+        return FALSE;
+    return (::unlink(path) == 0) ? TRUE : FALSE;
+}
+#ifndef DeleteFile
+#define DeleteFile DeleteFileW
+#endif
+
+typedef struct _SYSTEMTIME {
+    WORD wYear, wMonth, wDayOfWeek, wDay, wHour, wMinute, wSecond, wMilliseconds;
+} SYSTEMTIME, * LPSYSTEMTIME, * PSYSTEMTIME;
+
+inline void GetLocalTime(LPSYSTEMTIME st)
+{
+    if (!st) return;
+    const time_t t = ::time(nullptr);
+    struct tm lt {};
+    ::localtime_r(&t, &lt);
+    st->wYear         = static_cast<WORD>(lt.tm_year + 1900);
+    st->wMonth        = static_cast<WORD>(lt.tm_mon + 1);
+    st->wDayOfWeek    = static_cast<WORD>(lt.tm_wday);
+    st->wDay          = static_cast<WORD>(lt.tm_mday);
+    st->wHour         = static_cast<WORD>(lt.tm_hour);
+    st->wMinute       = static_cast<WORD>(lt.tm_min);
+    st->wSecond       = static_cast<WORD>(lt.tm_sec);
+    st->wMilliseconds = 0;
+}
+
+#endif // _WIN32

--- a/src/source/Core/Utilities/Log/ErrorReport.cpp
+++ b/src/source/Core/Utilities/Log/ErrorReport.cpp
@@ -3,11 +3,13 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#ifdef _WIN32
 #include <ddraw.h>
 #include <dinput.h>
 #include <dmusicc.h>
 #include <eh.h>
 #include <imagehlp.h>
+#endif
 #include "ErrorReport.h"
 
 // Max UTF-8 bytes for a single log line. Source buffer is wchar_t[1024]; UTF-8 needs
@@ -226,6 +228,12 @@ void CErrorReport::WriteOpenGLInfo(void)
     glGetIntegerv(GL_MAX_VIEWPORT_DIMS, iResult);
     Write(L"Max Viewport size\t: %d x %d\r\n", iResult[0], iResult[1]);
 }
+
+// ---- Win32 crash-report system info -----------------------------------------
+// IME / sound-card / OS / CPU / DirectX details for the crash log. These pull in
+// DirectX and other Win32 APIs and are only invoked from the Windows entry point
+// (Winmain), so guard the whole section off on non-Windows (issue #462).
+#ifdef _WIN32
 
 void CErrorReport::WriteImeInfo(HWND hWnd)
 {
@@ -714,3 +722,4 @@ void GetSystemInfo(ER_SystemInfo* si)
     DWORD dwDX = GetDXVersion();
     mu_swprintf(si->m_lpszDxVersion, L"Direct-X %d.%d", dwDX >> 8, dwDX & 0xFF);
 }
+#endif // _WIN32 (Win32 crash-report system info)


### PR DESCRIPTION
Part of #462 (native Linux build), Phase 3. This clears the second-to-last fatal-include dam; after it, only the in-game shop (`wininet`) remains.

## Change

Unblocking the crash reporter (`ErrorReport`) revealed two things: its DirectX/Win32 includes and system-info collector, and the Win32 HANDLE file API it logs through.

- New `Core/Platform/WinFile.h`: `CreateFile`/`ReadFile`/`WriteFile`/`CloseHandle`/`SetFilePointer`/`DeleteFile` mapped onto POSIX file descriptors (a `HANDLE` carries the fd), plus `SYSTEMTIME`/`GetLocalTime` over the C clock. Wired into the PCH, so the other HANDLE-file-API users get it too (the `Win32 file API -> std::fstream/POSIX` checklist item).
- Guard `ErrorReport`'s DirectX includes (`ddraw`/`dinput`/`dmusicc`/`eh`/`imagehlp`) and the whole IME / sound-card / OS / CPU / DirectX system-info section behind `_WIN32` -- it is only ever called from the Windows entry point (`Winmain`). The portable logging (`Write`/`HexWrite`/`AddSeparator`/...) stays.

## Result

Clears the `ddraw.h` fatal-include category; `ErrorReport.cpp` compiles on Linux, and the portable surface stays at zero non-fatal errors. The only remaining fatal dam is the in-game shop (`wininet`/`strsafe`).

Non-Windows-only, so the Windows build is unchanged. Verified by building the full Windows `Main.exe` (MinGW): compiles and links clean, zero errors.