### PR TITLE
Fix stack buffer overflow in MuHelper text-field reads

### DIFF
--- a/src/source/UI/NewUI/NewUIMuHelper.cpp
+++ b/src/source/UI/NewUI/NewUIMuHelper.cpp
@@ -941,7 +941,7 @@ void CNewUIMuHelper::SaveExtraItem()
 {
     wchar_t wsExtraItem[MAX_ITEM_NAME + 1] = { 0 };
 
-    m_ItemInput.GetText(wsExtraItem, sizeof(wsExtraItem));
+    m_ItemInput.GetText(wsExtraItem, MAX_ITEM_NAME + 1);
 
     if (wcscmp(wsExtraItem, L"") != 0)
     {
@@ -1114,13 +1114,13 @@ void CNewUIMuHelper::SaveConfig()
 {
     wchar_t wsNumberInput[MAX_NUMBER_DIGITS + 1]{};
 
-    m_DistanceTimeInput.GetText(wsNumberInput, sizeof(wsNumberInput));
+    m_DistanceTimeInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
     _TempConfig.iMaxSecondsAway = GetIntFromTextInput(wsNumberInput);
 
-    m_Skill2DelayInput.GetText(wsNumberInput, sizeof(wsNumberInput));
+    m_Skill2DelayInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
     _TempConfig.aiSkillInterval[1] = GetIntFromTextInput(wsNumberInput);
 
-    m_Skill3DelayInput.GetText(wsNumberInput, sizeof(wsNumberInput));
+    m_Skill3DelayInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
     _TempConfig.aiSkillInterval[2] = GetIntFromTextInput(wsNumberInput);
 
     _TempConfig.aiSkill[0] = m_aiSelectedSkills[0] > 0 ? m_aiSelectedSkills[0] : 0;
@@ -2951,7 +2951,7 @@ void CNewUIMuHelperExt::Save()
 {
     wchar_t wsNumberInput[MAX_NUMBER_DIGITS + 1]{};
 
-    m_BuffTimeInput.GetText(wsNumberInput, sizeof(wsNumberInput));
+    m_BuffTimeInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
     _TempConfig.iBuffCastInterval = CNewUIMuHelper::GetIntFromTextInput(wsNumberInput);
 
     _TempConfig.iPotionThreshold = m_iCurrentPotionThreshold * 10;

--- a/src/source/UI/NewUI/NewUIMuHelper.cpp
+++ b/src/source/UI/NewUI/NewUIMuHelper.cpp
@@ -941,7 +941,7 @@ void CNewUIMuHelper::SaveExtraItem()
 {
     wchar_t wsExtraItem[MAX_ITEM_NAME + 1] = { 0 };
 
-    m_ItemInput.GetText(wsExtraItem, MAX_ITEM_NAME + 1);
+    m_ItemInput.GetText(wsExtraItem, std::size(wsExtraItem));
 
     if (wcscmp(wsExtraItem, L"") != 0)
     {
@@ -1114,13 +1114,13 @@ void CNewUIMuHelper::SaveConfig()
 {
     wchar_t wsNumberInput[MAX_NUMBER_DIGITS + 1]{};
 
-    m_DistanceTimeInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
+    m_DistanceTimeInput.GetText(wsNumberInput, std::size(wsNumberInput));
     _TempConfig.iMaxSecondsAway = GetIntFromTextInput(wsNumberInput);
 
-    m_Skill2DelayInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
+    m_Skill2DelayInput.GetText(wsNumberInput, std::size(wsNumberInput));
     _TempConfig.aiSkillInterval[1] = GetIntFromTextInput(wsNumberInput);
 
-    m_Skill3DelayInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
+    m_Skill3DelayInput.GetText(wsNumberInput, std::size(wsNumberInput));
     _TempConfig.aiSkillInterval[2] = GetIntFromTextInput(wsNumberInput);
 
     _TempConfig.aiSkill[0] = m_aiSelectedSkills[0] > 0 ? m_aiSelectedSkills[0] : 0;
@@ -2951,7 +2951,7 @@ void CNewUIMuHelperExt::Save()
 {
     wchar_t wsNumberInput[MAX_NUMBER_DIGITS + 1]{};
 
-    m_BuffTimeInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
+    m_BuffTimeInput.GetText(wsNumberInput, std::size(wsNumberInput));
     _TempConfig.iBuffCastInterval = CNewUIMuHelper::GetIntFromTextInput(wsNumberInput);
 
     _TempConfig.iPotionThreshold = m_iCurrentPotionThreshold * 10;


### PR DESCRIPTION
Fix stack buffer overflow in MuHelper text-field reads

Problem

The client crashes when adding an item in MuHelper: enabling Add extra item, typing a name and clicking Add reliably crashes. The numeric config fields (distance time, skill 2/3 delay, buff interval) corrupt the stack the same way when settings are saved.

Root cause

CUITextInputBox::GetText(wchar_t* buf, int len) treats len as a character count (buf[len - 1] = L'\0'). The MuHelper call sites passed sizeof(buf), i.e. a byte count — (N + 1) * sizeof(wchar_t), so the length is 2× too large. The unconditional terminator write then lands well past the end of the stack buffer:

wchar_t wsExtraItem[MAX_ITEM_NAME + 1] = { 0 };          // 51 wchars
m_ItemInput.GetText(wsExtraItem, sizeof(wsExtraItem));    // passes 102, not 51

For the 51-wchar extra-item buffer this overruns by ~100 bytes → reliable crash. For the 4-wchar numeric buffers it overruns by a few zeroed bytes → silent stack corruption (UB) that happens not to crash with the current layout, but is still wrong.

This was latent since the sizeof was introduced; it became a hard crash once GetText dropped the Win32 GetWindowText path (which tolerated an oversized length) and always took the portable wcsncpy branch.

Fix

Pass the buffer element count instead of sizeof, using the same constants the buffers are declared with (matches the existing convention, e.g. GetText(m_szID, MAX_USERNAME_SIZE + 1)):

m_ItemInput.GetText(wsExtraItem, MAX_ITEM_NAME + 1);
m_DistanceTimeInput.GetText(wsNumberInput, MAX_NUMBER_DIGITS + 1);
// …and the remaining numeric fields

All 5 affected sites in NewUIMuHelper.cpp are fixed (lines for extra-item, distance time, skill 2 delay, skill 3 delay, buff interval). No other GetText(..., sizeof(...)) remain in the tree.

Testing

On the Windows (mingw i686) build: open MuHelper, enable Add extra item, type a name, click Add → item is added, no crash. Saving the numeric config fields no longer corrupts the stack.