### PR TITLE
Fix/portable input stuck focus

### DIFF
--- a/src/source/UI/Legacy/UIControls.cpp
+++ b/src/source/UI/Legacy/UIControls.cpp
@@ -3135,6 +3135,15 @@ void CUITextInputBox::GiveFocus(BOOL SelectText)
     }
 }
 
+// Symmetric counterpart to GiveFocus(): drops keyboard focus from the focused
+// portable text field without hiding or destroying it. Clears the same static
+// the destructor and SetState(UISTATE_HIDE) already clear, so a field can give
+// focus back to the game window while staying visible.
+void CUITextInputBox::ReleaseFocus()
+{
+    s_pFocusedPortable = nullptr;
+}
+
 void CUITextInputBox::Render()
 {
     if (m_iState == UISTATE_HIDE) return;

--- a/src/source/UI/Legacy/UIControls.cpp
+++ b/src/source/UI/Legacy/UIControls.cpp
@@ -3136,12 +3136,21 @@ void CUITextInputBox::GiveFocus(BOOL SelectText)
 }
 
 // Symmetric counterpart to GiveFocus(): drops keyboard focus from the focused
-// portable text field without hiding or destroying it. Clears the same static
-// the destructor and SetState(UISTATE_HIDE) already clear, so a field can give
-// focus back to the game window while staying visible.
+// portable text field without hiding or destroying it. GiveFocus() sets both
+// s_pFocusedPortable and g_dwKeyFocusUIID, so release both here (clearing the
+// key-focus id only while it still points at this field, to avoid stomping
+// another widget), letting the field hand focus back to the game window while
+// staying visible.
 void CUITextInputBox::ReleaseFocus()
 {
-    s_pFocusedPortable = nullptr;
+    if (s_pFocusedPortable != nullptr)
+    {
+        if (g_dwKeyFocusUIID == s_pFocusedPortable->GetUIID())
+        {
+            g_dwKeyFocusUIID = 0;
+        }
+        s_pFocusedPortable = nullptr;
+    }
 }
 
 void CUITextInputBox::Render()

--- a/src/source/UI/Legacy/UIControls.h
+++ b/src/source/UI/Legacy/UIControls.h
@@ -881,6 +881,10 @@ public:
     // based on whether one is focused (issue #447).
     static CUITextInputBox* GetFocusedPortable() { return s_pFocusedPortable; }
 
+    // Release keyboard focus from the focused portable field (counterpart to
+    // GiveFocus()); the field stays visible. Defined in the .cpp.
+    static void ReleaseFocus();
+
     // Input fed from the SDL event loop.
     void OnTextInput(const wchar_t* pszText);            // committed characters
     void OnTextEditing(const wchar_t* pszText);          // IME composition preview (uncommitted)

--- a/src/source/UI/Legacy/UIWindows.cpp
+++ b/src/source/UI/Legacy/UIWindows.cpp
@@ -424,6 +424,7 @@ void CUIWindowMgr::HideAllWindow(BOOL bHide, BOOL bMainClose)
     {
         SetWindowsEnable(FALSE);
         SetFocus(g_hWnd);
+        CUITextInputBox::ReleaseFocus();
     }
 }
 
@@ -522,6 +523,7 @@ void CUIWindowMgr::HandleMessage()
                     SaveIMEStatus();
 
                 SetFocus(g_hWnd);
+                CUITextInputBox::ReleaseFocus();
             }
             if (GetWindow(m_WorkMessage.m_iParam1)->GetState() == UISTATE_HIDE)
                 ShowHideWindow(m_WorkMessage.m_iParam1, TRUE);
@@ -564,6 +566,7 @@ void CUIWindowMgr::HandleMessage()
                     {
                         g_pWindowMgr->SetWindowsEnable(FALSE);
                         SetFocus(g_hWnd);
+                        CUITextInputBox::ReleaseFocus();
                     }
                 }
             }
@@ -571,6 +574,7 @@ void CUIWindowMgr::HandleMessage()
             {
                 g_pWindowMgr->SetWindowsEnable(FALSE);
                 SetFocus(g_hWnd);
+                CUITextInputBox::ReleaseFocus();
             }
         }
         break;
@@ -608,6 +612,7 @@ void CUIWindowMgr::HandleMessage()
                     {
                         g_pWindowMgr->SetWindowsEnable(FALSE);
                         SetFocus(g_hWnd);
+                        CUITextInputBox::ReleaseFocus();
                     }
                 }
             }
@@ -615,6 +620,7 @@ void CUIWindowMgr::HandleMessage()
             {
                 g_pWindowMgr->SetWindowsEnable(FALSE);
                 SetFocus(g_hWnd);
+                CUITextInputBox::ReleaseFocus();
             }
         }
         break;

--- a/src/source/UI/NewUI/Inventory/NewUIMyShopInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMyShopInventory.cpp
@@ -410,6 +410,7 @@ bool SEASON3B::CNewUIMyShopInventory::UpdateMouseEvent()
             && CheckMouseIn(m_EditBox->GetPosition_x(), m_EditBox->GetPosition_y(), m_EditBox->GetWidth(), m_EditBox->GetHeight()) == false)
         {
             SetFocus(g_hWnd);
+            CUITextInputBox::ReleaseFocus();
         }
     }
 
@@ -584,6 +585,7 @@ void SEASON3B::CNewUIMyShopInventory::ClosingProcess()
     CNewUIInventoryCtrl::BackupPickedItem();
     g_pMyInventory->ChangeMyShopButtonStateOpen();
     SetFocus(g_hWnd);
+    CUITextInputBox::ReleaseFocus();
 }
 
 int SEASON3B::CNewUIMyShopInventory::GetPointedItemIndex()

--- a/src/source/UI/NewUI/NewUIMuHelper.cpp
+++ b/src/source/UI/NewUI/NewUIMuHelper.cpp
@@ -547,6 +547,7 @@ bool CNewUIMuHelper::UpdateMouseEvent()
         {
             g_pNewUISystem->Hide(INTERFACE_MUHELPER);
             SetFocus(g_hWnd);
+            CUITextInputBox::ReleaseFocus();
         }
         else if (iButtonId == BUTTON_ID_INIT_CONFIG)
         {
@@ -557,6 +558,7 @@ bool CNewUIMuHelper::UpdateMouseEvent()
             SaveConfig();
             g_pNewUISystem->Hide(INTERFACE_MUHELPER);
             SetFocus(g_hWnd);
+            CUITextInputBox::ReleaseFocus();
         }
 
         return false;
@@ -688,6 +690,7 @@ bool CNewUIMuHelper::UpdateMouseEvent()
         else
         {
             SetFocus(g_hWnd);
+            CUITextInputBox::ReleaseFocus();
         }
 
         POINT ptExitBtn = { m_Pos.x + 169, m_Pos.y + 7 };
@@ -733,6 +736,7 @@ bool CNewUIMuHelper::UpdateKeyEvent()
             g_pNewUISystem->Hide(INTERFACE_MUHELPER_SKILL_LIST);
             //PlayBuffer(SOUND_CLICK01);
             SetFocus(g_hWnd);
+            CUITextInputBox::ReleaseFocus();
 
             return false;
         }
@@ -959,6 +963,7 @@ void CNewUIMuHelper::SaveExtraItem()
 
     m_ItemInput.SetText(L"");
     SetFocus(g_hWnd);
+    CUITextInputBox::ReleaseFocus();
 }
 
 void CNewUIMuHelper::RemoveExtraItem()
@@ -1157,6 +1162,7 @@ void CNewUIMuHelper::Show(bool bShow)
     }
 
     SetFocus(g_hWnd);
+    CUITextInputBox::ReleaseFocus();
 }
 
 bool CNewUIMuHelper::Render()
@@ -1910,6 +1916,7 @@ bool CNewUIMuHelperSkillList::UpdateKeyEvent()
         {
             g_pNewUISystem->Hide(INTERFACE_MUHELPER_SKILL_LIST);
             SetFocus(g_hWnd);
+            CUITextInputBox::ReleaseFocus();
             //PlayBuffer(SOUND_CLICK01);
 
             return false;
@@ -2850,6 +2857,7 @@ bool CNewUIMuHelperExt::UpdateMouseEvent()
         else
         {
             SetFocus(g_hWnd);
+            CUITextInputBox::ReleaseFocus();
         }
     }
     else if (m_iCurrentPage == SUB_PAGE_PARTY_CONFIG)
@@ -2861,6 +2869,7 @@ bool CNewUIMuHelperExt::UpdateMouseEvent()
         else
         {
             SetFocus(g_hWnd);
+            CUITextInputBox::ReleaseFocus();
         }
     }
 


### PR DESCRIPTION
Fix stuck keyboard focus in portable text fields

Problem

After the migration to portable (SDL) text fields (#447), text inputs keep capturing the keyboard after the user is done with them. In MuHelper, typing in a delay field and clicking Save settings leaves the field focused — the caret keeps blinking and keystrokes still go into the field (and are swallowed from the game) even after the panel is hidden. The same happens in the My Shop title field and in legacy windows (letter writer, chat).

Root cause

CUITextInputBox tracks keyboard focus in the static s_pFocusedPortable, which is set by GiveFocus() and cleared only by the destructor and SetState(UISTATE_HIDE). The portable field no longer takes Win32 focus, so the existing SetFocus(g_hWnd) calls (which previously moved focus off the Win32 EDIT control) no longer release it — s_pFocusedPortable stays pointing at the field. Hiding the surrounding panel does not hide the field itself, so it keeps owning the keyboard while invisible.

There was no public counterpart to GiveFocus() to release focus while keeping the field visible.

Fix

Add CUITextInputBox::ReleaseFocus(), a static counterpart to GiveFocus(). It clears s_pFocusedPortable exactly as the destructor and the UISTATE_HIDE path already do — no new mechanism, no hiding/destroying the field. It is called alongside the SetFocus(g_hWnd) sites that hand focus back to the game.

Scope

Applied where a portable field stays visible after handing focus back to the game:
- MuHelper — all 9 SetFocus(g_hWnd) sites (save / exit / escape / add-item / click-outside).
- My Shop — clicking outside the shop-title field, and ClosingProcess().
- CUIWindowMgr (HideAllWindow / HandleMessage close & dismiss paths) — centrally covers legacy windows with fields (letter writer, chat).

Intentionally not touched (focus self-clears via destructor / UISTATE_HIDE on close, or no portable field is involved): the chat input box, the custom message box, the photo viewer and friend-menu SetFocus sites, and dialogs that destroy/hide their fields on close (login, send-gift, guild-make, serial input).

Testing

On the Windows (mingw i686) build:
1. Open MuHelper, type in a delay field, click Save settings → caret stops blinking; pressing keys no longer types into the field.
2. Same for the My Shop title field (click outside / close the shop) and the letter/chat windows.