### PR TITLE
Fix x64 client crashes on login scene load

### DIFF
--- a/src/source/Camera/CameraMove.cpp
+++ b/src/source/Camera/CameraMove.cpp
@@ -194,14 +194,14 @@ bool CCameraMove::LoadCameraWalkScript(const std::wstring& filename)
         return false;
     }
 
-    size_t waypointCount = 0;
-    if (fread(&waypointCount, sizeof(size_t), 1, fileHandle.get()) != 1)
+    DWORD waypointCount = 0;
+    if (fread(&waypointCount, sizeof(DWORD), 1, fileHandle.get()) != 1)
     {
         return false;
     }
 
     m_listWayPoint.reserve(waypointCount);
-    for (size_t index = 0; index < waypointCount; ++index)
+    for (DWORD index = 0; index < waypointCount; ++index)
     {
         auto waypoint = std::make_unique<WAYPOINT>();
         if (fread(waypoint.get(), sizeof(WAYPOINT), 1, fileHandle.get()) != 1)

--- a/src/source/GameLogic/Pets/w_PetProcess.cpp
+++ b/src/source/GameLogic/Pets/w_PetProcess.cpp
@@ -42,17 +42,21 @@ void PetInfo::Destroy()
 
 void PetInfo::SetActions(int count, int* actions, float* speeds)
 {
-    if (NULL == actions || 0 >= count || NULL == speeds)
+    constexpr int MAX_PET_ACTIONS = 100;
+
+    if (NULL == actions || NULL == speeds || count <= 0 || count > MAX_PET_ACTIONS)
     {
         return;
     }
+
+    Destroy();
 
     m_count = count;
     m_actions = new int[count]();
     memcpy(m_actions, actions, sizeof(int) * m_count);
 
     m_speeds = new float[count];
-    memcpy(m_speeds, speeds, sizeof(int) * m_count);
+    memcpy(m_speeds, speeds, sizeof(float) * m_count);
 }
 
 PetProcessPtr g_petProcess;
@@ -198,7 +202,7 @@ bool PetProcess::LoadData()
     float _scale;
     int _count;
     int* _action = new int[_array];
-    auto* _speed = new float[_array];
+    float* _speed = new float[_array];
 
     int _listSize = 0;
     fread(&_listSize, sizeof(DWORD), 1, fp);
@@ -250,8 +254,14 @@ bool PetProcess::LoadData()
             memcpy(_action, pSeek, sizeof(int) * _array);
             pSeek += sizeof(int) * _array;
 
-            memcpy(_speed, pSeek, sizeof(_speed) * _array);
-            pSeek += sizeof(_speed) * _array;
+            memcpy(_speed, pSeek, sizeof(float) * _array);
+            pSeek += sizeof(float) * _array;
+
+            constexpr int MAX_PET_ACTIONS = 100;
+            if (_type < 0 || _type > 10000 || _count <= 0 || _count > _array || _count > MAX_PET_ACTIONS)
+            {
+                continue;
+            }
 
             PetInfoPtr petInfo = PetInfo::Make();
             petInfo->SetBlendMesh(_blendMesh);


### PR DESCRIPTION
- PetProcess::LoadData: copy pet speed data with sizeof(float) instead of sizeof(pointer), which corrupted the heap on x64.
- PetInfo::SetActions: reject invalid action counts to avoid allocating gigabytes of memory on malformed pet.bmd entries.
- CameraMove::LoadCameraWalkScript: read waypoint count as DWORD (4 bytes) because .cws files are x86 format; size_t on x64 reads 8 bytes and caused bad_alloc/abort when loading the login scene camera script.

<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

<!-- What does this PR do, and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Checklist

- [ ] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [ ] I have built the project locally (see [`docs/build-guide.md`](docs/build-guide.md)).
- [ ] Changes are focused on one concern; the diff is as small as it reasonably can be.
