### PR TITLE
Show runtime OS name and version in the $details overlay

### DIFF
--- a/src/source/Core/Utilities/PlatformInfo.cpp
+++ b/src/source/Core/Utilities/PlatformInfo.cpp
@@ -5,12 +5,22 @@
 // Intentionally not including <winternl.h>: it redeclares types already in
 // <windows.h> and conflicts under MinGW. OSVERSIONINFOW (from windows.h) is
 // layout-identical to RTL_OSVERSIONINFOW, so RtlGetVersion can write into it.
+#elif defined(__ANDROID__)
+#include <sys/system_properties.h>  // __system_property_get
+#elif defined(__APPLE__)
+#include <TargetConditionals.h>     // TARGET_OS_IPHONE
+#include <sys/sysctl.h>             // sysctlbyname
 #else
 #include <sys/utsname.h>
 #include <cstdio>       // sscanf
 #endif
 
 #include <cwchar>       // swprintf
+#include <iterator>     // std::size
+
+// The OS name and version are fixed for the process lifetime, so each platform
+// computes the string once into a function-local static. GetOSVersionString is
+// called every frame from the debug overlay; caching keeps it off the hot path.
 
 namespace Core::Platform
 {
@@ -19,49 +29,102 @@ namespace Core::Platform
 
 std::wstring GetOSVersionString()
 {
-    // GetVersionEx is intercepted by the application-compatibility manifest and
-    // caps at 6.2 (Windows 8) for unmanifested apps. RtlGetVersion bypasses that
-    // shim and reports the true OS version, so resolve it dynamically from ntdll.
-    using RtlGetVersionPtr = LONG(WINAPI*)(OSVERSIONINFOW*);
+    static const std::wstring osVersion = []() -> std::wstring
+    {
+        // GetVersionEx is intercepted by the application-compatibility manifest
+        // and caps at 6.2 (Windows 8) for unmanifested apps. RtlGetVersion
+        // bypasses that shim and reports the true OS version, so resolve it
+        // dynamically from ntdll.
+        using RtlGetVersionPtr = LONG(WINAPI*)(OSVERSIONINFOW*);
 
-    HMODULE hNtdll = GetModuleHandleW(L"ntdll.dll");
-    if (hNtdll == nullptr)
-        return L"Windows (unknown)";
+        HMODULE hNtdll = GetModuleHandleW(L"ntdll.dll");
+        if (hNtdll == nullptr)
+            return L"Windows (unknown)";
 
-    auto pRtlGetVersion =
-        reinterpret_cast<RtlGetVersionPtr>(GetProcAddress(hNtdll, "RtlGetVersion"));
-    if (pRtlGetVersion == nullptr)
-        return L"Windows (unknown)";
+        auto pRtlGetVersion =
+            reinterpret_cast<RtlGetVersionPtr>(GetProcAddress(hNtdll, "RtlGetVersion"));
+        if (pRtlGetVersion == nullptr)
+            return L"Windows (unknown)";
 
-    OSVERSIONINFOW info = {};
-    info.dwOSVersionInfoSize = sizeof(info);
-    if (pRtlGetVersion(&info) != 0)  // 0 == STATUS_SUCCESS
-        return L"Windows (unknown)";
+        OSVERSIONINFOW info = {};
+        info.dwOSVersionInfoSize = sizeof(info);
+        if (pRtlGetVersion(&info) != 0)  // 0 == STATUS_SUCCESS
+            return L"Windows (unknown)";
 
-    wchar_t buf[64];
-    swprintf(buf, std::size(buf), L"Windows %lu.%lu",
-             info.dwMajorVersion, info.dwMinorVersion);
-    return buf;
+        wchar_t buf[64];
+        swprintf(buf, std::size(buf), L"Windows %lu.%lu",
+                 info.dwMajorVersion, info.dwMinorVersion);
+        return buf;
+    }();
+    return osVersion;
 }
 
-#else  // ---- non-Windows ----------------------------------------------------
+#elif defined(__ANDROID__)
 
 std::wstring GetOSVersionString()
 {
-    utsname uts{};
-    if (uname(&uts) != 0)
-        return L"Unknown OS";
+    static const std::wstring osVersion = []() -> std::wstring
+    {
+        // ro.build.version.release is the user-facing release string, e.g. "14".
+        char release[PROP_VALUE_MAX] = {};
+        if (__system_property_get("ro.build.version.release", release) <= 0)
+            return L"Android";
 
-    // sysname is the kernel name ("Linux"); release is like "6.18.33-...". Show
-    // only the kernel major.minor to keep the overlay line short.
-    int major = 0;
-    int minor = 0;
-    wchar_t buf[64];
-    if (sscanf(uts.release, "%d.%d", &major, &minor) == 2)
-        swprintf(buf, std::size(buf), L"%hs %d.%d", uts.sysname, major, minor);
-    else
-        swprintf(buf, std::size(buf), L"%hs", uts.sysname);
-    return buf;
+        wchar_t buf[64];
+        swprintf(buf, std::size(buf), L"Android %s", release);
+        return buf;
+    }();
+    return osVersion;
+}
+
+#elif defined(__APPLE__)
+
+std::wstring GetOSVersionString()
+{
+    static const std::wstring osVersion = []() -> std::wstring
+    {
+#if TARGET_OS_IPHONE
+        const char* osName = "iOS";
+#else
+        const char* osName = "macOS";
+#endif
+        // kern.osproductversion is the marketing version (e.g. "14.5"),
+        // available since macOS 10.13.4 / iOS 11.
+        char version[64] = {};
+        size_t len = sizeof(version);
+        wchar_t buf[64];
+        if (sysctlbyname("kern.osproductversion", version, &len, nullptr, 0) == 0 &&
+            version[0] != '\0')
+            swprintf(buf, std::size(buf), L"%s %s", osName, version);
+        else
+            swprintf(buf, std::size(buf), L"%s", osName);
+        return buf;
+    }();
+    return osVersion;
+}
+
+#else  // ---- generic POSIX (Linux, BSD) ------------------------------------
+
+std::wstring GetOSVersionString()
+{
+    static const std::wstring osVersion = []() -> std::wstring
+    {
+        utsname uts{};
+        if (uname(&uts) != 0)
+            return L"Unknown OS";
+
+        // sysname is the kernel name ("Linux"); release is like "6.18.33-...".
+        // Show only the kernel major.minor to keep the overlay line short.
+        int major = 0;
+        int minor = 0;
+        wchar_t buf[64];
+        if (sscanf(uts.release, "%d.%d", &major, &minor) == 2)
+            swprintf(buf, std::size(buf), L"%s %d.%d", uts.sysname, major, minor);
+        else
+            swprintf(buf, std::size(buf), L"%s", uts.sysname);
+        return buf;
+    }();
+    return osVersion;
 }
 
 #endif // _WIN32

--- a/src/source/Core/Utilities/PlatformInfo.cpp
+++ b/src/source/Core/Utilities/PlatformInfo.cpp
@@ -1,7 +1,11 @@
 #include "stdafx.h"
 #include "PlatformInfo.h"
 
+#include <string>
+
 #ifdef _WIN32
+#include <cwchar>       // swprintf
+#include <iterator>     // std::size
 // Intentionally not including <winternl.h>: it redeclares types already in
 // <windows.h> and conflicts under MinGW. OSVERSIONINFOW (from windows.h) is
 // layout-identical to RTL_OSVERSIONINFOW, so RtlGetVersion can write into it.
@@ -15,12 +19,14 @@
 #include <cstdio>       // sscanf
 #endif
 
-#include <cwchar>       // swprintf
-#include <iterator>     // std::size
-
 // The OS name and version are fixed for the process lifetime, so each platform
 // computes the string once into a function-local static. GetOSVersionString is
 // called every frame from the debug overlay; caching keeps it off the hot path.
+//
+// The non-Windows branches build the result with std::wstring concatenation
+// rather than swprintf("%s", ...): a narrow-to-wide "%s" conversion in a wide
+// printf is non-portable. OS strings are ASCII, so the byte-wise widening via
+// the iterator-pair wstring constructor is safe here.
 
 namespace Core::Platform
 {
@@ -70,9 +76,8 @@ std::wstring GetOSVersionString()
         if (__system_property_get("ro.build.version.release", release) <= 0)
             return L"Android";
 
-        wchar_t buf[64];
-        swprintf(buf, std::size(buf), L"Android %s", release);
-        return buf;
+        const std::string releaseStr(release);
+        return L"Android " + std::wstring(releaseStr.begin(), releaseStr.end());
     }();
     return osVersion;
 }
@@ -84,21 +89,22 @@ std::wstring GetOSVersionString()
     static const std::wstring osVersion = []() -> std::wstring
     {
 #if TARGET_OS_IPHONE
-        const char* osName = "iOS";
+        const std::string name = "iOS";
 #else
-        const char* osName = "macOS";
+        const std::string name = "macOS";
 #endif
+        const std::wstring nameW(name.begin(), name.end());
+
         // kern.osproductversion is the marketing version (e.g. "14.5"),
         // available since macOS 10.13.4 / iOS 11.
         char version[64] = {};
         size_t len = sizeof(version);
-        wchar_t buf[64];
-        if (sysctlbyname("kern.osproductversion", version, &len, nullptr, 0) == 0 &&
-            version[0] != '\0')
-            swprintf(buf, std::size(buf), L"%s %s", osName, version);
-        else
-            swprintf(buf, std::size(buf), L"%s", osName);
-        return buf;
+        if (sysctlbyname("kern.osproductversion", version, &len, nullptr, 0) != 0 ||
+            version[0] == '\0')
+            return nameW;
+
+        const std::string versionStr(version);
+        return nameW + L" " + std::wstring(versionStr.begin(), versionStr.end());
     }();
     return osVersion;
 }
@@ -115,14 +121,15 @@ std::wstring GetOSVersionString()
 
         // sysname is the kernel name ("Linux"); release is like "6.18.33-...".
         // Show only the kernel major.minor to keep the overlay line short.
+        const std::string sysName(uts.sysname);
+        const std::wstring sysNameW(sysName.begin(), sysName.end());
+
         int major = 0;
         int minor = 0;
-        wchar_t buf[64];
-        if (sscanf(uts.release, "%d.%d", &major, &minor) == 2)
-            swprintf(buf, std::size(buf), L"%s %d.%d", uts.sysname, major, minor);
-        else
-            swprintf(buf, std::size(buf), L"%s", uts.sysname);
-        return buf;
+        if (sscanf(uts.release, "%d.%d", &major, &minor) != 2)
+            return sysNameW;
+
+        return sysNameW + L" " + std::to_wstring(major) + L"." + std::to_wstring(minor);
     }();
     return osVersion;
 }

--- a/src/source/Core/Utilities/PlatformInfo.cpp
+++ b/src/source/Core/Utilities/PlatformInfo.cpp
@@ -1,0 +1,69 @@
+#include "stdafx.h"
+#include "PlatformInfo.h"
+
+#ifdef _WIN32
+// Intentionally not including <winternl.h>: it redeclares types already in
+// <windows.h> and conflicts under MinGW. OSVERSIONINFOW (from windows.h) is
+// layout-identical to RTL_OSVERSIONINFOW, so RtlGetVersion can write into it.
+#else
+#include <sys/utsname.h>
+#include <cstdio>       // sscanf
+#endif
+
+#include <cwchar>       // swprintf
+
+namespace Core::Platform
+{
+
+#ifdef _WIN32
+
+std::wstring GetOSVersionString()
+{
+    // GetVersionEx is intercepted by the application-compatibility manifest and
+    // caps at 6.2 (Windows 8) for unmanifested apps. RtlGetVersion bypasses that
+    // shim and reports the true OS version, so resolve it dynamically from ntdll.
+    using RtlGetVersionPtr = LONG(WINAPI*)(OSVERSIONINFOW*);
+
+    HMODULE hNtdll = GetModuleHandleW(L"ntdll.dll");
+    if (hNtdll == nullptr)
+        return L"Windows (unknown)";
+
+    auto pRtlGetVersion =
+        reinterpret_cast<RtlGetVersionPtr>(GetProcAddress(hNtdll, "RtlGetVersion"));
+    if (pRtlGetVersion == nullptr)
+        return L"Windows (unknown)";
+
+    OSVERSIONINFOW info = {};
+    info.dwOSVersionInfoSize = sizeof(info);
+    if (pRtlGetVersion(&info) != 0)  // 0 == STATUS_SUCCESS
+        return L"Windows (unknown)";
+
+    wchar_t buf[64];
+    swprintf(buf, std::size(buf), L"Windows %lu.%lu",
+             info.dwMajorVersion, info.dwMinorVersion);
+    return buf;
+}
+
+#else  // ---- non-Windows ----------------------------------------------------
+
+std::wstring GetOSVersionString()
+{
+    utsname uts{};
+    if (uname(&uts) != 0)
+        return L"Unknown OS";
+
+    // sysname is the kernel name ("Linux"); release is like "6.18.33-...". Show
+    // only the kernel major.minor to keep the overlay line short.
+    int major = 0;
+    int minor = 0;
+    wchar_t buf[64];
+    if (sscanf(uts.release, "%d.%d", &major, &minor) == 2)
+        swprintf(buf, std::size(buf), L"%hs %d.%d", uts.sysname, major, minor);
+    else
+        swprintf(buf, std::size(buf), L"%hs", uts.sysname);
+    return buf;
+}
+
+#endif // _WIN32
+
+}

--- a/src/source/Core/Utilities/PlatformInfo.h
+++ b/src/source/Core/Utilities/PlatformInfo.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+namespace Core::Platform
+{
+    // Human-readable operating system name and version for diagnostic overlays
+    // and logs, e.g. "Windows 10.0" or "Linux 6.18". Resolved at runtime.
+    std::wstring GetOSVersionString();
+}

--- a/src/source/Core/Utilities/PlatformInfo.h
+++ b/src/source/Core/Utilities/PlatformInfo.h
@@ -5,6 +5,7 @@
 namespace Core::Platform
 {
     // Human-readable operating system name and version for diagnostic overlays
-    // and logs, e.g. "Windows 10.0" or "Linux 6.18". Resolved at runtime.
+    // and logs, e.g. "Windows 10.0", "Linux 6.18", "macOS 14.5", "iOS 17.5", or
+    // "Android 14". Resolved once at runtime per platform and cached.
     std::wstring GetOSVersionString();
 }

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 #include "SceneManager.h"
 #include "Core/Utilities/FrameProfiler.h"
+#include "Core/Utilities/PlatformInfo.h"
 
 //=============================================================================
 // Frame Timing State Implementation
@@ -559,6 +560,11 @@ static void RenderDebugInfo()
 #endif
     swprintf(szLine, L"Build: %hs %hs %hs %hs  %hs %hs",
              kBuildType, kEditor, kCompiler, kArch, __DATE__, __TIME__);
+    g_pRenderText->RenderText((int)DEBUG_TEXT_X, y, szLine); y += DEBUG_TEXT_LINE_HEIGHT;
+
+    // Runtime OS name and version (compile-time arch above doesn't capture which
+    // OS build the binary is actually running on).
+    swprintf(szLine, L"OS: %ls", Core::Platform::GetOSVersionString().c_str());
     g_pRenderText->RenderText((int)DEBUG_TEXT_X, y, szLine); y += DEBUG_TEXT_LINE_HEIGHT;
 
     // Active camera mode (cycled with F9).


### PR DESCRIPTION
## What

Adds an `OS:` line to the `\$details` debug overlay showing the operating system name and version detected at runtime, e.g. `OS: Windows 10.0` or `OS: Linux 6.18`. It sits below the existing compile-time `Build:` line, which reports arch/compiler but not which OS build the binary is actually running on.

## How

- New `Core::Platform::GetOSVersionString()` helper in `src/source/Core/Utilities/PlatformInfo.{h,cpp}`:
  - **Windows:** resolves `RtlGetVersion` from `ntdll` rather than `GetVersionEx`, which the application-compatibility manifest caps at 6.2 for unmanifested apps.
  - **POSIX:** uses `uname()`, reporting the kernel name and major.minor release.
- `RenderDebugInfo()` in `SceneManager.cpp` renders the new line.

The helper lives in its own file under a `Core::Platform` namespace, following the project's one-type-per-file and namespace conventions, and is picked up automatically by the recursive source glob.

## Testing

Built for Win32 (MinGW i686, Release, editor on) and verified it compiles and links. Toggle in-game with `\$details on`.