### PR TITLE
Harden pet data loading against malformed pet.bmd entries

### DIFF
--- a/src/source/GameLogic/Pets/w_PetProcess.cpp
+++ b/src/source/GameLogic/Pets/w_PetProcess.cpp
@@ -42,17 +42,21 @@ void PetInfo::Destroy()
 
 void PetInfo::SetActions(int count, int* actions, float* speeds)
 {
-    if (NULL == actions || 0 >= count || NULL == speeds)
+    constexpr int MAX_PET_ACTIONS = 100;
+
+    if (NULL == actions || NULL == speeds || count <= 0 || count > MAX_PET_ACTIONS)
     {
         return;
     }
+
+    Destroy();
 
     m_count = count;
     m_actions = new int[count]();
     memcpy(m_actions, actions, sizeof(int) * m_count);
 
     m_speeds = new float[count];
-    memcpy(m_speeds, speeds, sizeof(int) * m_count);
+    memcpy(m_speeds, speeds, sizeof(float) * m_count);
 }
 
 PetProcessPtr g_petProcess;
@@ -198,7 +202,7 @@ bool PetProcess::LoadData()
     float _scale;
     int _count;
     int* _action = new int[_array];
-    auto* _speed = new float[_array];
+    float* _speed = new float[_array];
 
     int _listSize = 0;
     fread(&_listSize, sizeof(DWORD), 1, fp);
@@ -255,6 +259,12 @@ bool PetProcess::LoadData()
             // layout `Size` was computed with, overflowing the allocation.
             memcpy(_speed, pSeek, sizeof(float) * _array);
             pSeek += sizeof(float) * _array;
+
+            constexpr int MAX_PET_ACTIONS = 100;
+            if (_type < 0 || _type > 10000 || _count <= 0 || _count > _array || _count > MAX_PET_ACTIONS)
+            {
+                continue;
+            }
 
             PetInfoPtr petInfo = PetInfo::Make();
             petInfo->SetBlendMesh(_blendMesh);


### PR DESCRIPTION
Cherry-picks the residual hardening from #494 (by @NaraBalvan) onto current main.

## Why this is a subset of #494

#494 fixed three x64 login-scene crashes. Two of them (the camera waypoint count read and the pet speed `memcpy` size) already landed on main via the native-Linux port (#497), so those hunks are now redundant and conflict with main. This PR keeps only what main does **not** already have: the defensive hardening.

## Changes (`w_PetProcess.cpp`)

- **`PetInfo::SetActions`**: reject `count <= 0` or `count > 100`, and call `Destroy()` before reallocating so a repeat call does not leak the previous `m_actions`/`m_speeds`. Also `sizeof(int)` -> `sizeof(float)` on the speeds copy (no-op since both are 4 bytes, but correct).
- **`PetProcess::LoadData`**: skip entries whose `_type`/`_count` are out of range instead of allocating from corrupt values.

## Notes

- Authorship preserved: the commit is authored by @NaraBalvan (cherry-picked from #494); the redundant crash-fix hunks were dropped during conflict resolution.
- Supersedes the hardening portion of #494, which now needs a rebase onto post-#497 main.
- Builds clean on the native Linux x64 target.