### PR TITLE
[Fix] Click-through on the window close “X” (yellow one) and de-duplicate the handler

### DIFF
--- a/src/source/Guild/NewUIGuildInfoWindow.cpp
+++ b/src/source/Guild/NewUIGuildInfoWindow.cpp
@@ -189,17 +189,15 @@ bool SEASON3B::CNewUIGuildInfoWindow::UpdateMouseEvent()
 
 bool SEASON3B::CNewUIGuildInfoWindow::Check_Btn()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
     if (m_BtnExit.UpdateMouseEvent() == true)
     {
         g_pNewUISystem->Hide(SEASON3B::INTERFACE_GUILDINFO);
         m_EventState = EVENT_NONE;
         return false;
     }
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_GUILDINFO))
     {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_GUILDINFO);
         m_EventState = EVENT_NONE;
         return false;
     }

--- a/src/source/Guild/NewUIGuildMakeWindow.cpp
+++ b/src/source/Guild/NewUIGuildMakeWindow.cpp
@@ -516,11 +516,9 @@ bool CNewUIGuildMakeWindow::UpdateMouseEvent()
         return true;
     }
 
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_NPCGUILDMASTER))
     {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_NPCGUILDMASTER);
         return false;
     }
 

--- a/src/source/UI/NewUI/Character/NewUICharacterInfoWindow.cpp
+++ b/src/source/UI/NewUI/Character/NewUICharacterInfoWindow.cpp
@@ -162,13 +162,9 @@ bool SEASON3B::CNewUICharacterInfoWindow::UpdateMouseEvent()
 
 bool SEASON3B::CNewUICharacterInfoWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_CHARACTER);
+    // Top-right corner close "X" (shared frame). Hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_CHARACTER))
         return true;
-    }
 
     if (CharacterAttribute->LevelUpPoint > 0)
     {

--- a/src/source/UI/NewUI/Character/NewUIPetInfoWindow.cpp
+++ b/src/source/UI/NewUI/Character/NewUIPetInfoWindow.cpp
@@ -309,13 +309,9 @@ float CNewUIPetInfoWindow::GetLayerDepth()
 
 bool CNewUIPetInfoWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_PET);
+    // Top-right corner close "X" (shared frame). Hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_PET))
         return true;
-    }
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Combat/NewUICastleWindow.cpp
+++ b/src/source/UI/NewUI/Combat/NewUICastleWindow.cpp
@@ -293,13 +293,8 @@ void CNewUICastleWindow::RenderFrame()
 
 bool CNewUICastleWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-    POINT ptExitBtn2 = { m_Pos.x + 13, m_Pos.y + 391 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_SENATUS);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_SENATUS);
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Combat/NewUIDuelWatchWindow.cpp
+++ b/src/source/UI/NewUI/Combat/NewUIDuelWatchWindow.cpp
@@ -250,12 +250,8 @@ void CNewUIDuelWatchWindow::RenderFrame()
 
 bool CNewUIDuelWatchWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_DUELWATCH);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_DUELWATCH);
 
     for (BYTE i = 0; i < 4; ++i)
     {

--- a/src/source/UI/NewUI/Combat/NewUIGuardWindow.cpp
+++ b/src/source/UI/NewUI/Combat/NewUIGuardWindow.cpp
@@ -316,12 +316,8 @@ void CNewUIGuardWindow::RenderFrame()
 
 bool CNewUIGuardWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_GUARDSMAN);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_GUARDSMAN);
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Events/NewUIBloodCastleEnter.cpp
+++ b/src/source/UI/NewUI/Events/NewUIBloodCastleEnter.cpp
@@ -228,13 +228,9 @@ bool CNewUIEnterBloodCastle::Render()
 
 bool CNewUIEnterBloodCastle::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_BLOODCASTLE);
+    // Top-right corner close "X" (shared frame). Hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_BLOODCASTLE))
         return true;
-    }
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Events/NewUICatapultWindow.cpp
+++ b/src/source/UI/NewUI/Events/NewUICatapultWindow.cpp
@@ -500,13 +500,9 @@ void SEASON3B::CNewUICatapultWindow::UnloadImages()
 
 bool SEASON3B::CNewUICatapultWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_CATAPULT);
+    // Top-right corner close "X" (shared frame). Hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_CATAPULT))
         return true;
-    }
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Events/NewUIDoppelGangerWindow.cpp
+++ b/src/source/UI/NewUI/Events/NewUIDoppelGangerWindow.cpp
@@ -262,12 +262,8 @@ void CNewUIDoppelGangerWindow::RenderFrame()
 
 bool CNewUIDoppelGangerWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_DOPPELGANGER_NPC);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_DOPPELGANGER_NPC);
 
     if (m_BtnEnter.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Events/NewUIEnterDevilSquare.cpp
+++ b/src/source/UI/NewUI/Events/NewUIEnterDevilSquare.cpp
@@ -184,13 +184,9 @@ bool CNewUIEnterDevilSquare::Render()
 // BtnProcess
 bool CNewUIEnterDevilSquare::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_DEVILSQUARE);
+    // Top-right corner close "X" (shared frame). Hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_DEVILSQUARE))
         return true;
-    }
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Events/NewUIExchangeLuckyCoin.cpp
+++ b/src/source/UI/NewUI/Events/NewUIExchangeLuckyCoin.cpp
@@ -185,13 +185,9 @@ void CNewUIExchangeLuckyCoin::RenderBtn()
 
 bool CNewUIExchangeLuckyCoin::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && SEASON3B::CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_EXCHANGE_LUCKYCOIN);
+    // Top-right corner close "X" (shared frame). Hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_EXCHANGE_LUCKYCOIN))
         return true;
-    }
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Events/NewUIGateSwitchWindow.cpp
+++ b/src/source/UI/NewUI/Events/NewUIGateSwitchWindow.cpp
@@ -218,12 +218,8 @@ void CNewUIGateSwitchWindow::RenderFrame()
 
 bool CNewUIGateSwitchWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_GATESWITCH);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_GATESWITCH);
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Events/NewUIGoldBowmanLena.cpp
+++ b/src/source/UI/NewUI/Events/NewUIGoldBowmanLena.cpp
@@ -125,10 +125,9 @@ bool CNewUIGoldBowmanLena::UpdateMouseEvent()
         }
     }
 
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12)) {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_GOLD_BOWMAN_LENA);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_GOLD_BOWMAN_LENA))
+    {
         return false;
     }
 

--- a/src/source/UI/NewUI/Events/NewUIGoldBowmanWindow.cpp
+++ b/src/source/UI/NewUI/Events/NewUIGoldBowmanWindow.cpp
@@ -124,11 +124,9 @@ bool CNewUIGoldBowmanWindow::UpdateMouseEvent()
         m_EditBox->DoAction();
     }
 
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_GOLD_BOWMAN))
     {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_GOLD_BOWMAN);
         return false;
     }
 

--- a/src/source/UI/NewUI/Events/NewUIRegistrationLuckyCoin.cpp
+++ b/src/source/UI/NewUI/Events/NewUIRegistrationLuckyCoin.cpp
@@ -147,13 +147,9 @@ namespace SEASON3B
 
     bool CNewUIRegistrationLuckyCoin::BtnProcess()
     {
-        POINT pClose = { GetPos().x + 169, GetPos().y + 7 };
-
-        if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(pClose.x, pClose.y, 13, 12))
-        {
-            g_pNewUISystem->Hide(SEASON3B::INTERFACE_LUCKYCOIN_REGISTRATION);
+        // Top-right corner close "X" (shared frame): hides + swallows the click.
+        if (g_pNewUISystem->HandleFrameCornerClose(GetPos(), SEASON3B::INTERFACE_LUCKYCOIN_REGISTRATION))
             return false;
-        }
 
         if (m_CloseButton.UpdateMouseEvent() == true)
         {

--- a/src/source/UI/NewUI/HUD/NewUICommandWindow.cpp
+++ b/src/source/UI/NewUI/HUD/NewUICommandWindow.cpp
@@ -112,11 +112,9 @@ void SEASON3B::CNewUICommandWindow::ClosingProcess()
 
 bool SEASON3B::CNewUICommandWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_COMMAND))
     {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_COMMAND);
         PlayBuffer(SOUND_CLICK01);
         return true;
     }

--- a/src/source/UI/NewUI/HUD/NewUIGensRanking.cpp
+++ b/src/source/UI/NewUI/HUD/NewUIGensRanking.cpp
@@ -313,13 +313,9 @@ bool CNewUIGensRanking::UpdateKeyEvent()
 
 bool CNewUIGensRanking::BtnProcess()
 {
-    POINT pClose = { GetPos().x + 169, GetPos().y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(pClose.x, pClose.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(INTERFACE_GENSRANKING);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(GetPos(), INTERFACE_GENSRANKING))
         return false;
-    }
 
     if (m_BtnExit.UpdateMouseEvent())
     {

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryExtension.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryExtension.cpp
@@ -89,6 +89,10 @@ void CNewUIInventoryExtension::SetPos(int x, int y)
 
 bool CNewUIInventoryExtension::UpdateMouseEvent()
 {
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, INTERFACE_INVENTORY_EXT))
+        return false;
+
     for (int i = 0; i < CharacterAttribute->InventoryExtensions; i++)
     {
         if (const auto m_extension = m_extensions[i])

--- a/src/source/UI/NewUI/Inventory/NewUILuckyItemWnd.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUILuckyItemWnd.cpp
@@ -541,12 +541,8 @@ bool CNewUILuckyItemWnd::UpdateMouseEvent(void)
         return false;
     Process_InventoryCtrl();
 
-    POINT ptExitBtn1 = { m_ptPos.x + 169, m_ptPos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_LUCKYITEMWND);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_ptPos, SEASON3B::INTERFACE_LUCKYITEMWND);
 
     Process_BTN_Action();
 

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
@@ -646,12 +646,8 @@ void CNewUIMixInventory::RenderFrame()
 
 bool CNewUIMixInventory::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_MIXINVENTORY);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_MIXINVENTORY);
 
     if (GetMixState() == MIX_FINISHED)
     {

--- a/src/source/UI/NewUI/Inventory/NewUIMyInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMyInventory.cpp
@@ -1580,13 +1580,9 @@ bool CNewUIMyInventory::InventoryProcess() const
 
 bool CNewUIMyInventory::BtnProcess()
 {
-    const POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(INTERFACE_INVENTORY);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, INTERFACE_INVENTORY))
         return true;
-    }
     if (m_BtnExit.UpdateMouseEvent())
     {
         if (g_pNewUISystem->IsVisible(INTERFACE_MYSHOP_INVENTORY))

--- a/src/source/UI/NewUI/Inventory/NewUIMyShopInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMyShopInventory.cpp
@@ -392,11 +392,9 @@ bool SEASON3B::CNewUIMyShopInventory::UpdateMouseEvent()
             return false;
         }
 
-        POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-        if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
+        // Top-right corner close "X" (shared frame): hides + swallows the click.
+        if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_MYSHOP_INVENTORY))
         {
-            g_pNewUISystem->Hide(SEASON3B::INTERFACE_MYSHOP_INVENTORY);
             return false;
         }
 

--- a/src/source/UI/NewUI/Inventory/NewUIPurchaseShopInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIPurchaseShopInventory.cpp
@@ -153,10 +153,9 @@ void SEASON3B::CNewUIPurchaseShopInventory::UnloadImages()
 
 bool SEASON3B::CNewUIPurchaseShopInventory::UpdateMouseEvent()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-    if (SEASON3B::IsRelease(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_PURCHASESHOP_INVENTORY))
     {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_PURCHASESHOP_INVENTORY);
         return false;
     }
     if (m_Button->UpdateMouseEvent())

--- a/src/source/UI/NewUI/Inventory/NewUIStorageInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIStorageInventory.cpp
@@ -514,11 +514,9 @@ bool CNewUIStorageInventory::ProcessBtns()
         return true;
     }
 
-    if (IsPress(VK_LBUTTON) && CheckMouseIn(m_Pos.x + 169, m_Pos.y + 7, 13, 12))
-    {
-        g_pNewUISystem->Hide(INTERFACE_STORAGE);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, INTERFACE_STORAGE))
         return true;
-    }
 
     return false;
 }

--- a/src/source/UI/NewUI/Inventory/NewUIStorageInventoryExt.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIStorageInventoryExt.cpp
@@ -348,11 +348,9 @@ bool CNewUIStorageInventoryExt::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* 
 
 bool CNewUIStorageInventoryExt::ProcessBtns() const
 {
-    if (IsPress(VK_LBUTTON) && CheckMouseIn(m_Pos.x + 169, m_Pos.y + 7, 13, 12))
-    {
-        g_pNewUISystem->Hide(INTERFACE_STORAGE);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, INTERFACE_STORAGE))
         return true;
-    }
 
     return false;
 }

--- a/src/source/UI/NewUI/Inventory/NewUIUnitedMarketPlaceWindow.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIUnitedMarketPlaceWindow.cpp
@@ -279,12 +279,8 @@ void CNewUIUnitedMarketPlaceWindow::RenderFrame()
 
 bool CNewUIUnitedMarketPlaceWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_UNITEDMARKETPLACE_NPC_JULIA);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_UNITEDMARKETPLACE_NPC_JULIA);
 
     if (m_BtnEnter.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/NPCs/NewUIEmpireGuardianNPC.cpp
+++ b/src/source/UI/NewUI/NPCs/NewUIEmpireGuardianNPC.cpp
@@ -158,12 +158,8 @@ bool CNewUIEmpireGuardianNPC::Render()
 
 bool CNewUIEmpireGuardianNPC::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_EMPIREGUARDIAN_NPC);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_EMPIREGUARDIAN_NPC);
 
     if (m_btNegative.UpdateMouseEvent())
     {

--- a/src/source/UI/NewUI/NPCs/NewUIGatemanWindow.cpp
+++ b/src/source/UI/NewUI/NPCs/NewUIGatemanWindow.cpp
@@ -222,12 +222,8 @@ void CNewUIGatemanWindow::RenderFrame()
 
 bool CNewUIGatemanWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_GATEKEEPER);
-    }
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_GATEKEEPER);
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/NPCs/NewUINPCDialogue.cpp
+++ b/src/source/UI/NewUI/NPCs/NewUINPCDialogue.cpp
@@ -105,11 +105,9 @@ bool CNewUINPCDialogue::ProcessBtns()
         g_pNewUISystem->Hide(SEASON3B::INTERFACE_NPC_DIALOGUE);
         return true;
     }
-    else if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(m_Pos.x + 169, m_Pos.y + 7, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_NPC_DIALOGUE);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    else if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_NPC_DIALOGUE))
         return true;
-    }
     else if (m_btnProgressR.UpdateMouseEvent())
     {
         m_nSelNPCPage = MIN(++m_nSelNPCPage, m_nMaxNPCPage);

--- a/src/source/UI/NewUI/NPCs/NewUINPCShop.cpp
+++ b/src/source/UI/NewUI/NPCs/NewUINPCShop.cpp
@@ -376,12 +376,9 @@ bool SEASON3B::CNewUINPCShop::InventoryProcess()
 
 bool SEASON3B::CNewUINPCShop::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12) && m_bSellingItem == false)
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    if (m_bSellingItem == false && g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_NPCSHOP))
     {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_NPCSHOP);
-
         return true;
     }
 

--- a/src/source/UI/NewUI/NewUISystem.cpp
+++ b/src/source/UI/NewUI/NewUISystem.cpp
@@ -1807,6 +1807,28 @@ bool CNewUISystem::CheckKeyUse()
     return false;
 }
 
+bool CNewUISystem::HandleFrameCornerClose(const POINT& winPos, DWORD dwKey)
+{
+    // Box of the corner glyph in the shared 190-wide frame, enlarged a little
+    // past the original 13x12 so the whole visible "X" is clickable. One place
+    // to tune for every window that uses this frame.
+    constexpr int X_OFFSET = 167, Y_OFFSET = 5, WIDTH = 18, HEIGHT = 18;
+
+    if (IsPress(VK_LBUTTON)
+        && CheckMouseIn(winPos.x + X_OFFSET, winPos.y + Y_OFFSET, WIDTH, HEIGHT))
+    {
+        Hide(dwKey);
+        // Clear the raw button state: world movement reads MouseLButtonPush
+        // directly (not the UI consume result), so without this the click falls
+        // through and walks the character.
+        MouseLButton = false;
+        MouseLButtonPop = false;
+        MouseLButtonPush = false;
+        return true;
+    }
+    return false;
+}
+
 bool CNewUISystem::Update()
 {
     if (m_pNewItemMng)

--- a/src/source/UI/NewUI/NewUISystem.cpp
+++ b/src/source/UI/NewUI/NewUISystem.cpp
@@ -1809,10 +1809,11 @@ bool CNewUISystem::CheckKeyUse()
 
 bool CNewUISystem::HandleFrameCornerClose(const POINT& winPos, DWORD dwKey)
 {
-    // Box of the corner glyph in the shared 190-wide frame, enlarged a little
-    // past the original 13x12 so the whole visible "X" is clickable. One place
-    // to tune for every window that uses this frame.
-    constexpr int X_OFFSET = 167, Y_OFFSET = 5, WIDTH = 18, HEIGHT = 18;
+    // Box of the corner glyph in the shared 190-wide frame. Matches the MU Helper
+    // close "X" exactly (13x12 anchored at +169,+7) — the same hit-box the
+    // per-window copies used originally, so the click feel is identical across
+    // every window. One place to tune for every window that uses this frame.
+    constexpr int X_OFFSET = 169, Y_OFFSET = 7, WIDTH = 13, HEIGHT = 12;
 
     if (IsPress(VK_LBUTTON)
         && CheckMouseIn(winPos.x + X_OFFSET, winPos.y + Y_OFFSET, WIDTH, HEIGHT))

--- a/src/source/UI/NewUI/NewUISystem.h
+++ b/src/source/UI/NewUI/NewUISystem.h
@@ -106,6 +106,13 @@ namespace SEASON3B
         void Toggle(DWORD dwKey);	//. Show <-> Hide
         void HideAll();
 
+        // Shared handler for the top-right "X" close glyph baked into the common
+        // item-frame (newui_item_back04.tga). Hides `dwKey` when the corner is
+        // left-clicked and swallows the mouse so the click can't fall through to
+        // the world (which would walk the character). Returns true if handled.
+        // Replaces the ptExitBtn1 block that was copy-pasted across the windows.
+        bool HandleFrameCornerClose(const POINT& winPos, DWORD dwKey);
+
         void Enable(DWORD dwKey);
         void Disable(DWORD dwKey);
 

--- a/src/source/UI/NewUI/Party/NewUIPartyInfoWindow.cpp
+++ b/src/source/UI/NewUI/Party/NewUIPartyInfoWindow.cpp
@@ -80,13 +80,9 @@ void CNewUIPartyInfoWindow::ClosingProcess()
 
 bool CNewUIPartyInfoWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_PARTY);
+    // Top-right corner close "X" (shared frame). Hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_PARTY))
         return true;
-    }
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Quests/NewUIMyQuestInfoWindow.cpp
+++ b/src/source/UI/NewUI/Quests/NewUIMyQuestInfoWindow.cpp
@@ -91,13 +91,9 @@ bool SEASON3B::CNewUIMyQuestInfoWindow::UpdateMouseEvent()
 
 bool SEASON3B::CNewUIMyQuestInfoWindow::BtnProcess()
 {
-    POINT ptExitBtn1 = { m_Pos.x + 169, m_Pos.y + 7 };
-
-    if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(ptExitBtn1.x, ptExitBtn1.y, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_MYQUEST);
+    // Top-right corner close "X" (shared frame). Hides + swallows the click.
+    if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_MYQUEST))
         return true;
-    }
 
     if (m_BtnExit.UpdateMouseEvent() == true)
     {

--- a/src/source/UI/NewUI/Quests/NewUINPCQuest.cpp
+++ b/src/source/UI/NewUI/Quests/NewUINPCQuest.cpp
@@ -477,11 +477,9 @@ bool CNewUINPCQuest::ProcessBtns()
         g_pNewUISystem->Hide(SEASON3B::INTERFACE_NPCQUEST);
         return true;
     }
-    else if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(m_Pos.x + 169, m_Pos.y + 7, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_NPCQUEST);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    else if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_NPCQUEST))
         return true;
-    }
     else if (g_csQuest.BeQuestItem())
     {
         if (m_btnComplete.UpdateMouseEvent())

--- a/src/source/UI/NewUI/Quests/NewUIQuestProgress.cpp
+++ b/src/source/UI/NewUI/Quests/NewUIQuestProgress.cpp
@@ -104,11 +104,9 @@ bool CNewUIQuestProgress::ProcessBtns()
         g_pNewUISystem->Hide(SEASON3B::INTERFACE_QUEST_PROGRESS);
         return true;
     }
-    else if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(m_Pos.x + 169, m_Pos.y + 7, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_QUEST_PROGRESS);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    else if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_QUEST_PROGRESS))
         return true;
-    }
     else if (m_btnProgressR.UpdateMouseEvent())
     {
         if (m_nSelNPCPage == m_nMaxNPCPage)

--- a/src/source/UI/NewUI/Quests/NewUIQuestProgressByEtc.cpp
+++ b/src/source/UI/NewUI/Quests/NewUIQuestProgressByEtc.cpp
@@ -109,11 +109,9 @@ bool CNewUIQuestProgressByEtc::ProcessBtns()
         g_pNewUISystem->Hide(SEASON3B::INTERFACE_QUEST_PROGRESS_ETC);
         return true;
     }
-    else if (SEASON3B::IsPress(VK_LBUTTON) && CheckMouseIn(m_Pos.x + 169, m_Pos.y + 7, 13, 12))
-    {
-        g_pNewUISystem->Hide(SEASON3B::INTERFACE_QUEST_PROGRESS_ETC);
+    // Top-right corner close "X" (shared frame): hides + swallows the click.
+    else if (g_pNewUISystem->HandleFrameCornerClose(m_Pos, SEASON3B::INTERFACE_QUEST_PROGRESS_ETC))
         return true;
-    }
     else if (m_btnProgressR.UpdateMouseEvent())
     {
         if (m_nSelNPCPage == m_nMaxNPCPage)


### PR DESCRIPTION
# Fix click-through on the window close “X” (yellow one) and de-duplicate the handler

## Summary

The top-right “X” close glyph that sits on the shared item-frame
(`newui_item_back04.tga`) — used by the inventory, character, pet, NPC shops,
quests, storage, trade-style and several event windows — did not swallow the
click. Clicking the “X” fell through to the world, so the character **walked
toward the spot you clicked** instead of just closing the window. The clickable
area was also smaller than the visible glyph, so the close often “missed”.

On top of that, the exact same corner hit-test was **copy-pasted across ~36
window classes** (mostly as a `ptExitBtn1` block, sometimes `pClose` or an inline
`CheckMouseIn`), each with the same latent bug.

This PR introduces one shared handler, routes every window through it, and fixes
the click-through in a single place.

## Root cause of the click-through

World movement is gated in `ZzzInterface.cpp` by
`if (!MouseOnWindow && !g_pNewUISystem->CheckMouseUse())` and acts on the **raw**
`MouseLButtonPush` flag. The duplicated corner blocks called `Hide(...)` and
returned a consumed result, but never cleared `MouseLButtonPush`, so the press
still reached the movement code and the character walked. Returning “handled”
from the UI was not enough.

## What it does

- **New shared helper** `CNewUISystem::HandleFrameCornerClose(const POINT& winPos, DWORD dwKey)`:
  - hit-tests the corner glyph (box enlarged a little past the old `13×12` so the
    whole visible “X” is clickable — one place to tune for every window),
  - hides `dwKey`,
  - clears `MouseLButton` / `MouseLButtonPop` / `MouseLButtonPush` so the click
    can’t fall through to the world,
  - returns `true` when it handled the click.
- **Replaced the duplicated corner-close block in 36 windows** with a call to the
  helper, preserving each window’s own behavior (its `return true`/`return false`
  or no-return, side effects like `PlayBuffer`, the `m_bSellingItem` guard in the
  NPC shop, `else if` chains, and `m_Pos` / `m_ptPos` / `GetPos()`).
- **Added the missing handler** to two windows that rendered the frame (so they
  show the glyph) but had no corner close at all: the inventory extension (`K`)
  and the lucky-coin registration window.
- Removed a pre-existing dead variable (`ptExitBtn2`) left in the castle-siege
  window.

Net change: **−77 lines** across 38 files.

## Notes / intentional changes

- **Purchase-shop window** was normalized from `IsRelease` to `IsPress` so it
  matches every other window (and the helper). The original used release, which
  was an inconsistency rather than an intended difference.
- **Two windows are intentionally left as-is** because they already behave
  correctly and do not fit the `Hide(iface)` shape:
  - the trade-style window closes through its own `ProcessCloseBtn()`,
  - MU Helper reacts on hover and uses a different base frame.

## Testing

Built and run on the native Linux client. Verified live that the corner “X” now
closes the window **and the character no longer walks** for the inventory,
character, pet and chaos-machine windows (representative of the bare-call,
`return true` and `return false` groups). The remaining windows go through the
same helper, so they behave identically.