### PR TITLE
fix(muhelper): exclude mount/stance animations from the auto-helper swing gate

### DIFF
--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -830,7 +830,31 @@ namespace MUHelper
     // same way the manual click path gates in MoveHero (ZzzInterface.cpp).
     static bool IsHeroSwingInProgress()
     {
-        return Engine::Object::IsAttackAction(Hero->Object.CurrentAction);
+        const int iAction = Hero->Object.CurrentAction;
+
+        // Outside the swing enum range entirely -> not a swing.
+        if (!Engine::Object::IsAttackAction(iAction))
+            return false;
+
+        // Several non-swing *stance* animations (mounted idle/walk/run, two-hand-
+        // sword stance, ride-horse, rage-fenrir) share the [PLAYER_ATTACK_FIST ..
+        // PLAYER_RIDE_SKILL] enum range that IsAttackAction() spans. MoveHero
+        // (ZzzInterface.cpp) OR-excludes exactly these four ranges when deciding
+        // whether the hero may move; mirror that here. Otherwise a Fenrir-mounted
+        // idle character (CurrentAction == PLAYER_FENRIR_STAND, inside the range)
+        // reads as a perpetual swing, IsHeroSwingInProgress() never clears, and
+        // SimulateSkill()/SimulateAttack() never fire -- the auto-helper is dead
+        // for the whole session while Horn of Fenrir (or any mount) is equipped.
+        if ((iAction >= PLAYER_STOP_TWO_HAND_SWORD_TWO && iAction <= PLAYER_RUN_TWO_HAND_SWORD_TWO)
+            || (iAction >= PLAYER_DARKLORD_STAND && iAction <= PLAYER_RUN_RIDE_HORSE)
+            || (iAction >= PLAYER_FENRIR_RUN && iAction <= PLAYER_FENRIR_WALK_ONE_LEFT)
+            || (iAction >= PLAYER_RAGE_FENRIR_WALK && iAction <= PLAYER_RAGE_FENRIR_STAND_ONE_LEFT))
+            return false;
+
+        // Genuine attack/skill swing -> Fenrir attack/skill actions sit below
+        // PLAYER_FENRIR_RUN, so they stay gated and cadence still tracks
+        // AttackSpeed when mounted.
+        return true;
     }
 
     int CMuHelper::SimulateAttack(ActionSkillType iSkill)


### PR DESCRIPTION
### Problem
With any mount equipped, the auto-helper (MUHelper) never attacks for the entire session. Standing idle while mounted leaves the helper permanently gated — `SimulateSkill()` / `SimulateAttack()` never fire.

### Root cause
`IsHeroSwingInProgress()` returns `IsAttackAction(CurrentAction)`, which is `true` for the whole `[PLAYER_ATTACK_FIST .. PLAYER_RIDE_SKILL]` enum range. That range also contains non-swing **stance** animations: mounted idle/walk/run (Fenrir), two-hand-sword stance, ride-horse, and rage-fenrir. While mounted and idle, `CurrentAction == PLAYER_FENRIR_STAND`, which is inside the range, so the swing gate never clears.

### Fix
`MoveHero` (`ZzzInterface.cpp`) already OR-excludes exactly these four stance ranges when deciding whether the hero may move. Mirror that exclusion in `IsHeroSwingInProgress()`. Real swings stay gated (Fenrir attack/skill actions sit below `PLAYER_FENRIR_RUN`), so helper cadence still tracks `AttackSpeed`, but the helper is no longer held hostage by a mounted idle pose.

### Testing
Repro: equip any mount, stand idle, enable the auto-helper → it never attacks. After the fix it fires on its normal timer while mounted, and unmounted behavior is unchanged.
