### PR TITLE
fix(ingameshop): decode the catalog with MultiByteToWideChar, not a reinterpret cast

### DIFF
--- a/src/source/GameShop/ShopListManager/ShopList.cpp
+++ b/src/source/GameShop/ShopListManager/ShopList.cpp
@@ -54,12 +54,17 @@ WZResult CShopList::LoadCategroy(const wchar_t* szFilePath) // OK
     {
         this->GetCategoryListPtr()->Clear();
 
+        int linesRead = 0;
+        int rowsParsed = 0;
+
         while (true)
         {
             memset(buff, 0, sizeof(buff));
 
             if (!ifs.getline(buff, sizeof(buff)))
                 break;
+
+            ++linesRead;
 
             CShopCategory cat;
 
@@ -68,10 +73,19 @@ WZResult CShopList::LoadCategroy(const wchar_t* szFilePath) // OK
             if (cat.SetCategory(data))
             {
                 this->GetCategoryListPtr()->Append(cat);
+                ++rowsParsed;
             }
         }
 
         ifs.close();
+
+        // Make a zero-row decode impossible to mistake for success.
+        // If the decoder ever mangles the catalog again, rowsParsed=0 (with a
+        // non-zero linesRead) will be obvious in muConsoleDebug instead of
+        // silently producing an empty shop grid with no error dialog.
+        g_ConsoleDebug->Write(MCD_NORMAL,
+            L"[XShop] LoadCategroy: parsed %d category rows from %d lines (encode=%d) <%ls>",
+            rowsParsed, linesRead, (int)enc, szFilePath);
     }
     else
     {
@@ -238,34 +252,36 @@ std::wstring CShopList::GetDecodedString(const char* buffer, FILE_ENCODE encode)
 {
     std::wstring result;
 
-    if (encode == FE_UTF8)
+    if (encode == FE_UNICODE)
     {
-        int cchWideChar = MultiByteToWideChar(CP_UTF8, 0, buffer, -1, 0, 0);
-        auto lpWideCharStr = new WCHAR[cchWideChar + 1];
-        MultiByteToWideChar(CP_UTF8, 0, buffer, -1, lpWideCharStr, cchWideChar);
-
-        cchWideChar = WideCharToMultiByte(0, 0, lpWideCharStr, -1, 0, 0, 0, 0);
-        char* buff = new char[cchWideChar + 1];
-        WideCharToMultiByte(0, 0, lpWideCharStr, -1, buff, cchWideChar, 0, 0);
-
-        // todo: check if that's correct
-        result = (wchar_t*) buff;
-
-        delete[] lpWideCharStr;
-        delete[] buff;
+        // UTF-16LE input: std::ifstream::getline read the raw little-endian bytes
+        // into a narrow buffer, so they already are wide characters. Reinterpret
+        // is the correct decode here (catalog files are ANSI today, so this path
+        // is not normally exercised, but keep it lossless rather than empty).
+        result = reinterpret_cast<const wchar_t*>(buffer);
+        return result;
     }
-    else
+
+    // FE_ANSI -> CP_ACP, FE_UTF8 -> CP_UTF8. Convert the narrow bytes to UTF-16
+    // properly. The old decompiled code reinterpret-cast the narrow ASCII bytes
+    // as wchar_t* ("todo: check if that's correct"), which turned a row like
+    // "10@Item@200@..." into a single garbage token with no wide '@'
+    // delimiters. CStringToken then yielded 1 field instead of 7, so every row
+    // decoded to Root=0 -> zero category zones -> no tabs and an empty grid.
+    const UINT codePage = (encode == FE_UTF8) ? CP_UTF8 : CP_ACP;
+
+    int cchWideChar = MultiByteToWideChar(codePage, 0, buffer, -1, 0, 0);
+    if (cchWideChar <= 0)
     {
-        if (encode == FE_UNICODE)
-        {
-            result = L"\0";
-        }
-        else
-        {
-            // todo: check if that's correct
-            result = (wchar_t*)(buffer);
-        }
+        return result; // empty string on conversion failure
     }
+
+    auto lpWideCharStr = new WCHAR[cchWideChar];
+    MultiByteToWideChar(codePage, 0, buffer, -1, lpWideCharStr, cchWideChar);
+
+    result = lpWideCharStr;
+
+    delete[] lpWideCharStr;
 
     return result;
 }


### PR DESCRIPTION
### Problem
A correctly delivered ASCII (no-BOM) in-game shop catalog renders as an **empty shop grid** — no tabs, no items, and no error dialog.

### Root cause
`CShopList::GetDecodedString` reinterpret-cast the narrow catalog bytes straight to `wchar_t*` for the `FE_ANSI` path (two leftover "todo: check if that's correct" decompile markers), and returned `L"\0"` for `FE_UNICODE`. For a no-BOM ASCII catalog the cast turned a row like `10@Item@200@201@10@1@1` into a single garbage UTF-16 token with no wide `@` delimiters, so the tokenizer produced 1 field instead of 7. Every category then decoded to `Root=0` → zero category zones → no shop tabs and an empty grid.

### Fix
- `FE_ANSI` → `CP_ACP`, `FE_UTF8` → `CP_UTF8`: convert narrow bytes to UTF-16 properly via `MultiByteToWideChar`, with a guard on a `<= 0` length.
- `FE_UNICODE`: the `ifstream::getline` path already read raw UTF-16LE bytes into the narrow buffer, so a reinterpret is the correct (lossless) decode there — return it instead of `L"\0"`.
- `LoadCategroy` now logs parsed-rows / lines-read so a zero-row decode can no longer masquerade as a successful (but empty) load.

### Testing
Verified with a standalone `MultiByteToWideChar` harness: the real ASCII row now yields 7 tokens (first field `_wtoi == 10`) vs 1 token (`== 0`) before. In-game, the shop grid populates from a previously-empty ASCII catalog.
