### PR TITLE
Fix Rage Fighter buff skills in MU Helper

### DIFF
--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -474,7 +474,6 @@ namespace MUHelper
 
     int CMuHelper::BuffTarget(CHARACTER* pTargetChar, ActionSkillType iBuffSkill)
     {
-        // TODO: List other buffs here
         OBJECT* obj = &pTargetChar->Object;
 
         auto CastIfMissing = [&](bool bBuffActive, bool bTimerRespected, bool bNeedsTarget) -> int
@@ -531,10 +530,24 @@ namespace MUHelper
         case AT_SKILL_ALICE_THORNS:
             return CastIfMissing(g_isCharacterBuff(obj, eBuff_Thorns), false, false);
 
+        // Rage Fighter party buffs — self/party AoE, no explicit target needed.
+        case AT_SKILL_ATT_UP_OURFORCES:
+            return CastIfMissing(g_isCharacterBuff(obj, eBuff_Att_up_Ourforces), true, false);
+
+        case AT_SKILL_HP_UP_OURFORCES:
+        case AT_SKILL_HP_UP_OURFORCES_STR:
+            return CastIfMissing(g_isCharacterBuff(obj, eBuff_Hp_up_Ourforces), true, false);
+
+        case AT_SKILL_DEF_UP_OURFORCES:
+        case AT_SKILL_DEF_UP_OURFORCES_STR:
+        case AT_SKILL_DEF_UP_OURFORCES_MASTERY:
+            return CastIfMissing(g_isCharacterBuff(obj, eBuff_Def_up_Ourforces), true, false);
+
         default:
             return 1;
         }
     }
+
 
     int CMuHelper::ConsumePotion()
     {


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->
## Summary
Adds the missing Rage Fighter buff skills and their master-tier variants to the `BuffTarget` method in `CMuHelper`. 
Previously, these skills were omitted from the switch statement, causing them to fall through to `default: return 1` (which signals that no buff is needed). As a result, the client-side MU Helper autopilot never cast Rage Fighter buffs automatically. 
The following skill cases were added:
- `AT_SKILL_ATT_UP_OURFORCES` (Ignore Defense)
- `AT_SKILL_HP_UP_OURFORCES` / `AT_SKILL_HP_UP_OURFORCES_STR` (Increase Health)
- `AT_SKILL_DEF_UP_OURFORCES` / `AT_SKILL_DEF_UP_OURFORCES_STR` / `AT_SKILL_DEF_UP_OURFORCES_MASTERY` (Increase Block)
## Related issues
<!-- e.g. Closes #123 -->
## Checklist
- [x] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [x] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)).
- [x] Changes are focused on one concern; the diff is as small as it reasonably can be.