### PR TITLE
[Feature] Right-click moves items between inventory and the crafting box

### DIFF
--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.cpp
@@ -151,6 +151,11 @@ bool CNewUIInventoryActionController::HandleRightClick(CNewUIInventoryCtrl* targ
         return HandleSellToNPC(targetControl);
     }
 
+    if (g_pNewUISystem->IsVisible(INTERFACE_MIXINVENTORY) && g_pNewUISystem->IsVisible(INTERFACE_INVENTORY))
+    {
+        return HandleMixAutoMove(targetControl);
+    }
+
     if (g_pNewUISystem->IsVisible(INTERFACE_INVENTORY)
         && !g_pNewUISystem->IsVisible(INTERFACE_NPCSHOP)
         && !g_pNewUISystem->IsVisible(INTERFACE_TRADE)
@@ -179,6 +184,13 @@ bool CNewUIInventoryActionController::HandleStorageAutoMove(CNewUIInventoryCtrl*
     }
 
     return false;
+}
+
+bool CNewUIInventoryActionController::HandleMixAutoMove(CNewUIInventoryCtrl* targetControl) const
+{
+    // All crafting NPC dialogs (Chaos Machine, Seed Master, Elphis, Osbourne, ...) share the
+    // single mix window, so routing the right-click here covers every crafting NPC at once.
+    return g_pMixInventory->ProcessMyInvenItemAutoMove(targetControl);
 }
 
 bool CNewUIInventoryActionController::HandleSellToNPC(CNewUIInventoryCtrl* targetControl) const

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.h
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryActionController.h
@@ -31,6 +31,7 @@ private:
 
     bool HandleRightClick(CNewUIInventoryCtrl* targetControl) const;
     bool HandleStorageAutoMove(CNewUIInventoryCtrl* targetControl) const;
+    bool HandleMixAutoMove(CNewUIInventoryCtrl* targetControl) const;
     bool HandleSellToNPC(CNewUIInventoryCtrl* targetControl) const;
     bool HandleInventoryRightClickActions(CNewUIInventoryCtrl* targetControl) const;
     bool TryEquipItem(CNewUIInventoryCtrl* targetControl, ITEM* pItem, int iSrcIndex) const;

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
@@ -969,6 +969,51 @@ bool CNewUIMixInventory::InventoryProcess()
     return false;
 }
 
+bool CNewUIMixInventory::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl)
+{
+    if (CNewUIInventoryCtrl::GetPickedItem())
+        return false;
+
+    if (m_pNewInventoryCtrl == nullptr || GetMixState() != MIX_READY)
+        return false;
+
+    if (sourceCtrl == nullptr)
+        sourceCtrl = g_pMyInventory->GetInventoryCtrl();
+
+    if (sourceCtrl == nullptr || sourceCtrl->GetStorageType() != STORAGE_TYPE::INVENTORY)
+        return false;
+
+    ITEM* pItemObj = sourceCtrl->FindItemAtPt(MouseX, MouseY);
+    if (pItemObj == nullptr || !g_MixRecipeMgr.IsMixSource(pItemObj))
+        return false;
+
+    const ITEM_ATTRIBUTE* pItemAttr = &ItemAttribute[pItemObj->Type];
+    const int iTargetIndex = m_pNewInventoryCtrl->FindEmptySlot(pItemAttr->Width, pItemAttr->Height);
+    if (iTargetIndex < 0 || !m_pNewInventoryCtrl->CanMove(iTargetIndex, pItemObj))
+        return false;
+
+    if (!CNewUIInventoryCtrl::CreatePickedItem(sourceCtrl, pItemObj))
+        return false;
+
+    CNewUIPickedItem* pPickedItem = CNewUIInventoryCtrl::GetPickedItem();
+    if (pPickedItem == nullptr)
+        return false;
+
+    sourceCtrl->RemoveItem(pItemObj);
+    pPickedItem->HidePickedItem();
+
+    const int iSourceIndex = pPickedItem->GetSourceLinealPos();
+    const STORAGE_TYPE iCurInventory = g_MixRecipeMgr.GetMixInventoryEquipmentIndex();
+    if (!SendRequestEquipmentItem(STORAGE_TYPE::INVENTORY, iSourceIndex, pItemObj, iCurInventory, iTargetIndex))
+    {
+        CNewUIInventoryCtrl::BackupPickedItem();
+        return false;
+    }
+
+    PlayBuffer(SOUND_GET_ITEM01);
+    return true;
+}
+
 void CNewUIMixInventory::CheckMixInventory()
 {
     g_MixRecipeMgr.ResetMixItemInventory();

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
@@ -981,7 +981,12 @@ bool CNewUIMixInventory::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceC
         return false;
 
     if (sourceCtrl == nullptr)
+    {
+        if (g_pMyInventory == nullptr)
+            return false;
+
         sourceCtrl = g_pMyInventory->GetInventoryCtrl();
+    }
 
     if (sourceCtrl == nullptr || sourceCtrl->GetStorageType() != STORAGE_TYPE::INVENTORY)
         return false;
@@ -1022,11 +1027,14 @@ bool CNewUIMixInventory::ProcessMixItemAutoMoveToInventory()
     if (CNewUIInventoryCtrl::GetPickedItem())
         return false;
 
-    if (m_pNewInventoryCtrl == nullptr)
+    if (m_pNewInventoryCtrl == nullptr || GetMixState() != MIX_READY)
         return false;
 
     ITEM* pItemObj = m_pNewInventoryCtrl->FindItemAtPt(MouseX, MouseY);
     if (pItemObj == nullptr)
+        return false;
+
+    if (g_pMyInventory == nullptr)
         return false;
 
     CNewUIInventoryCtrl* pInventoryCtrl = g_pMyInventory->GetInventoryCtrl();
@@ -1035,7 +1043,7 @@ bool CNewUIMixInventory::ProcessMixItemAutoMoveToInventory()
 
     const ITEM_ATTRIBUTE* pItemAttr = &ItemAttribute[pItemObj->Type];
     const int iTargetIndex = pInventoryCtrl->FindEmptySlot(pItemAttr->Width, pItemAttr->Height);
-    if (iTargetIndex < 0)
+    if (iTargetIndex < 0 || !pInventoryCtrl->CanMove(iTargetIndex, pItemObj))
         return false;
 
     if (!CNewUIInventoryCtrl::CreatePickedItem(m_pNewInventoryCtrl, pItemObj))

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
@@ -972,47 +972,41 @@ bool CNewUIMixInventory::InventoryProcess()
     return false;
 }
 
-bool CNewUIMixInventory::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl)
+// Direction-agnostic core of the right-click moves: pick the item under the
+// cursor in srcCtrl, reserve a slot in dstCtrl, and send the same move that
+// drag & drop sends.
+bool CNewUIMixInventory::AutoMoveItem(CNewUIInventoryCtrl* srcCtrl, STORAGE_TYPE srcType,
+    CNewUIInventoryCtrl* dstCtrl, STORAGE_TYPE dstType, bool requireMixSource)
 {
     if (CNewUIInventoryCtrl::GetPickedItem())
         return false;
 
-    if (m_pNewInventoryCtrl == nullptr || GetMixState() != MIX_READY)
+    if (srcCtrl == nullptr || dstCtrl == nullptr || GetMixState() != MIX_READY)
         return false;
 
-    if (sourceCtrl == nullptr)
-    {
-        if (g_pMyInventory == nullptr)
-            return false;
-
-        sourceCtrl = g_pMyInventory->GetInventoryCtrl();
-    }
-
-    if (sourceCtrl == nullptr || sourceCtrl->GetStorageType() != STORAGE_TYPE::INVENTORY)
+    ITEM* pItemObj = srcCtrl->FindItemAtPt(MouseX, MouseY);
+    if (pItemObj == nullptr)
         return false;
 
-    ITEM* pItemObj = sourceCtrl->FindItemAtPt(MouseX, MouseY);
-    if (pItemObj == nullptr || !g_MixRecipeMgr.IsMixSource(pItemObj))
+    if (requireMixSource && !g_MixRecipeMgr.IsMixSource(pItemObj))
         return false;
 
     const ITEM_ATTRIBUTE* pItemAttr = &ItemAttribute[pItemObj->Type];
-    const int iTargetIndex = m_pNewInventoryCtrl->FindEmptySlot(pItemAttr->Width, pItemAttr->Height);
-    if (iTargetIndex < 0 || !m_pNewInventoryCtrl->CanMove(iTargetIndex, pItemObj))
+    const int iTargetIndex = dstCtrl->FindEmptySlot(pItemAttr->Width, pItemAttr->Height);
+    if (iTargetIndex < 0 || !dstCtrl->CanMove(iTargetIndex, pItemObj))
         return false;
 
-    if (!CNewUIInventoryCtrl::CreatePickedItem(sourceCtrl, pItemObj))
+    if (!CNewUIInventoryCtrl::CreatePickedItem(srcCtrl, pItemObj))
         return false;
 
     CNewUIPickedItem* pPickedItem = CNewUIInventoryCtrl::GetPickedItem();
     if (pPickedItem == nullptr)
         return false;
 
-    sourceCtrl->RemoveItem(pItemObj);
+    srcCtrl->RemoveItem(pItemObj);
     pPickedItem->HidePickedItem();
 
-    const int iSourceIndex = pPickedItem->GetSourceLinealPos();
-    const STORAGE_TYPE iCurInventory = g_MixRecipeMgr.GetMixInventoryEquipmentIndex();
-    if (!SendRequestEquipmentItem(STORAGE_TYPE::INVENTORY, iSourceIndex, pItemObj, iCurInventory, iTargetIndex))
+    if (!SendRequestEquipmentItem(srcType, pPickedItem->GetSourceLinealPos(), pItemObj, dstType, iTargetIndex))
     {
         CNewUIInventoryCtrl::BackupPickedItem();
         return false;
@@ -1022,50 +1016,25 @@ bool CNewUIMixInventory::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceC
     return true;
 }
 
+bool CNewUIMixInventory::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl)
+{
+    if (sourceCtrl == nullptr)
+        sourceCtrl = g_pMyInventory ? g_pMyInventory->GetInventoryCtrl() : nullptr;
+
+    if (sourceCtrl == nullptr || sourceCtrl->GetStorageType() != STORAGE_TYPE::INVENTORY)
+        return false;
+
+    return AutoMoveItem(sourceCtrl, STORAGE_TYPE::INVENTORY,
+        m_pNewInventoryCtrl, g_MixRecipeMgr.GetMixInventoryEquipmentIndex(),
+        /*requireMixSource*/ true);
+}
+
 bool CNewUIMixInventory::ProcessMixItemAutoMoveToInventory()
 {
-    if (CNewUIInventoryCtrl::GetPickedItem())
-        return false;
-
-    if (m_pNewInventoryCtrl == nullptr || GetMixState() != MIX_READY)
-        return false;
-
-    ITEM* pItemObj = m_pNewInventoryCtrl->FindItemAtPt(MouseX, MouseY);
-    if (pItemObj == nullptr)
-        return false;
-
-    if (g_pMyInventory == nullptr)
-        return false;
-
-    CNewUIInventoryCtrl* pInventoryCtrl = g_pMyInventory->GetInventoryCtrl();
-    if (pInventoryCtrl == nullptr)
-        return false;
-
-    const ITEM_ATTRIBUTE* pItemAttr = &ItemAttribute[pItemObj->Type];
-    const int iTargetIndex = pInventoryCtrl->FindEmptySlot(pItemAttr->Width, pItemAttr->Height);
-    if (iTargetIndex < 0 || !pInventoryCtrl->CanMove(iTargetIndex, pItemObj))
-        return false;
-
-    if (!CNewUIInventoryCtrl::CreatePickedItem(m_pNewInventoryCtrl, pItemObj))
-        return false;
-
-    CNewUIPickedItem* pPickedItem = CNewUIInventoryCtrl::GetPickedItem();
-    if (pPickedItem == nullptr)
-        return false;
-
-    m_pNewInventoryCtrl->RemoveItem(pItemObj);
-    pPickedItem->HidePickedItem();
-
-    const int iSourceIndex = pPickedItem->GetSourceLinealPos();
-    const STORAGE_TYPE iCurInventory = g_MixRecipeMgr.GetMixInventoryEquipmentIndex();
-    if (!SendRequestEquipmentItem(iCurInventory, iSourceIndex, pItemObj, STORAGE_TYPE::INVENTORY, iTargetIndex))
-    {
-        CNewUIInventoryCtrl::BackupPickedItem();
-        return false;
-    }
-
-    PlayBuffer(SOUND_GET_ITEM01);
-    return true;
+    CNewUIInventoryCtrl* dstCtrl = g_pMyInventory ? g_pMyInventory->GetInventoryCtrl() : nullptr;
+    return AutoMoveItem(m_pNewInventoryCtrl, g_MixRecipeMgr.GetMixInventoryEquipmentIndex(),
+        dstCtrl, STORAGE_TYPE::INVENTORY,
+        /*requireMixSource*/ false);
 }
 
 void CNewUIMixInventory::CheckMixInventory()

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
@@ -195,6 +195,9 @@ bool CNewUIMixInventory::UpdateMouseEvent()
     {
         if (SEASON3B::IsPress(VK_RBUTTON))
         {
+            // Right-click on a craft-box item sends it back to the inventory (mirror of the
+            // inventory -> craft-box right-click move).
+            ProcessMixItemAutoMoveToInventory();
             MouseRButton = false;
             MouseRButtonPop = false;
             MouseRButtonPush = false;
@@ -1005,6 +1008,49 @@ bool CNewUIMixInventory::ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceC
     const int iSourceIndex = pPickedItem->GetSourceLinealPos();
     const STORAGE_TYPE iCurInventory = g_MixRecipeMgr.GetMixInventoryEquipmentIndex();
     if (!SendRequestEquipmentItem(STORAGE_TYPE::INVENTORY, iSourceIndex, pItemObj, iCurInventory, iTargetIndex))
+    {
+        CNewUIInventoryCtrl::BackupPickedItem();
+        return false;
+    }
+
+    PlayBuffer(SOUND_GET_ITEM01);
+    return true;
+}
+
+bool CNewUIMixInventory::ProcessMixItemAutoMoveToInventory()
+{
+    if (CNewUIInventoryCtrl::GetPickedItem())
+        return false;
+
+    if (m_pNewInventoryCtrl == nullptr)
+        return false;
+
+    ITEM* pItemObj = m_pNewInventoryCtrl->FindItemAtPt(MouseX, MouseY);
+    if (pItemObj == nullptr)
+        return false;
+
+    CNewUIInventoryCtrl* pInventoryCtrl = g_pMyInventory->GetInventoryCtrl();
+    if (pInventoryCtrl == nullptr)
+        return false;
+
+    const ITEM_ATTRIBUTE* pItemAttr = &ItemAttribute[pItemObj->Type];
+    const int iTargetIndex = pInventoryCtrl->FindEmptySlot(pItemAttr->Width, pItemAttr->Height);
+    if (iTargetIndex < 0)
+        return false;
+
+    if (!CNewUIInventoryCtrl::CreatePickedItem(m_pNewInventoryCtrl, pItemObj))
+        return false;
+
+    CNewUIPickedItem* pPickedItem = CNewUIInventoryCtrl::GetPickedItem();
+    if (pPickedItem == nullptr)
+        return false;
+
+    m_pNewInventoryCtrl->RemoveItem(pItemObj);
+    pPickedItem->HidePickedItem();
+
+    const int iSourceIndex = pPickedItem->GetSourceLinealPos();
+    const STORAGE_TYPE iCurInventory = g_MixRecipeMgr.GetMixInventoryEquipmentIndex();
+    if (!SendRequestEquipmentItem(iCurInventory, iSourceIndex, pItemObj, STORAGE_TYPE::INVENTORY, iTargetIndex))
     {
         CNewUIInventoryCtrl::BackupPickedItem();
         return false;

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.h
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.h
@@ -55,6 +55,7 @@ namespace SEASON3B
         void Release();
 
         bool InsertItem(int iIndex, std::span<const BYTE> pbyItemPacket);
+        bool ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl = nullptr);
         void DeleteItem(int iIndex);
         void DeleteAllItems();
 

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.h
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.h
@@ -56,6 +56,7 @@ namespace SEASON3B
 
         bool InsertItem(int iIndex, std::span<const BYTE> pbyItemPacket);
         bool ProcessMyInvenItemAutoMove(CNewUIInventoryCtrl* sourceCtrl = nullptr);
+        bool ProcessMixItemAutoMoveToInventory();
         void DeleteItem(int iIndex);
         void DeleteAllItems();
 

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.h
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.h
@@ -89,6 +89,9 @@ namespace SEASON3B
         bool InventoryProcess();
         bool BtnProcess();
 
+        bool AutoMoveItem(CNewUIInventoryCtrl* srcCtrl, STORAGE_TYPE srcType,
+            CNewUIInventoryCtrl* dstCtrl, STORAGE_TYPE dstType, bool requireMixSource);
+
         void RenderMixDescriptions(float fPos_x, float fPos_y);
 
         void CheckMixInventory();


### PR DESCRIPTION
## Summary

Right-clicking an inventory item already "auto-moves" it to the open container — into
the vault, or sold to the NPC shop. But this did nothing in **crafting** windows: at the
Goblin Chaos Machine, the Seed Master, and every other crafting NPC, right-click was
ignored and you had to drag each ingredient in (and back out) by hand.

This makes right-click move items **both ways**: from the inventory into the open crafting
box, and from the crafting box back into the inventory — mirroring the drag-drop behaviour.

## Why one change covers every crafting NPC

All crafting dialogs — Chaos Machine, Pet Trainer, Elphis refinery, Osbourne smelting,
Jerridon item restore, Chaos Card master, Cherry Blossom spirit, Seed Master (extract /
seed sphere) and the seed socket mount/unmount — share the **single** mix window
(`INTERFACE_MIXINVENTORY`). The destination storage kind is taken from the active mix type
via `g_MixRecipeMgr.GetMixInventoryEquipmentIndex()` (CHAOS_MIX, ELPIS_MIX, EXTRACT_SEED_MIX,
…). So handling that one window handles all of them.

## What changed (client only)

- `CNewUIInventoryActionController::HandleRightClick` now routes a right-click to
  `HandleMixAutoMove` when the mix window is open, just like it routes to the vault and the
  NPC shop.
- New `CNewUIMixInventory::ProcessMyInvenItemAutoMove` (inventory → craft box): validates the
  item is a mix ingredient (`IsMixSource`), finds a free slot in the craft grid
  (`FindEmptySlot` + `CanMove`), picks the item up and sends the same
  `SendRequestEquipmentItem(INVENTORY → current craft storage, slot)` that drag-drop sends.
- New `CNewUIMixInventory::ProcessMixItemAutoMoveToInventory` (craft box → inventory): the
  reverse direction, wired into the mix window's own right-button handling (which previously
  just swallowed the click). Finds a free inventory slot and sends the matching move back.

The moves use the existing picked-item flow and the existing 0x24 move-response handler
(which already inserts into the mix box / inventory on success and restores the item on
failure), so **no server change is needed** — the server already accepts these moves
(drag-drop uses the exact same packet and storage kinds).

## Testing

Built with the cross-compile toolchain (mingw); verified in a live client against a local
OpenMU server: right-clicking an inventory item at a crafting NPC moves it into the craft
box, and right-clicking a craft-box item sends it back to the inventory.

## Scope

- Both directions of the inventory <-> crafting box move.
- No protocol or server changes; the storage-context validation on the server still applies
  (the move only succeeds while the matching crafting NPC dialog is open).