### PR TITLE
bugfix: display wizards ring name when dropped in the ground

### DIFF
--- a/src/source/Engine/Object/ZzzInventory.cpp
+++ b/src/source/Engine/Object/ZzzInventory.cpp
@@ -6117,6 +6117,8 @@ std::unordered_set<int> yellowTextItems = {
     MODEL_BOX_OF_LUCK,
     MODEL_FRUITS,
     MODEL_SPIRIT,
+    MODEL_EVENT + 14,
+    MODEL_EVENT + 15,
     MODEL_EVENT + 16,
     MODEL_EVENT + 5,
     MODEL_OLD_SCROLL,
@@ -6519,7 +6521,7 @@ void BuildGroundItemLabelDescriptor(OBJECT* o, ITEM* ip, GroundItemLabelDescript
     {
         SetDescriptorOrangeTextColor(descriptor);
     }
-    else if (o->Type == MODEL_ORB_OF_SUMMONING)
+    if (o->Type == MODEL_ORB_OF_SUMMONING)
     {
         SetDescriptorGrayTextColor(descriptor);
         FormatGroundItemLabelText(descriptor.Name, L"%ls %ls", SkillAttribute[30 + ItemLevel].Name, I18N::Game::Jewel);
@@ -6701,7 +6703,6 @@ void BuildGroundItemLabelDescriptor(OBJECT* o, ITEM* ip, GroundItemLabelDescript
     }
     else if (o->Type == MODEL_EVENT + 14)
     {
-        SetDescriptorYellowTextColor(descriptor);
         switch (ItemLevel)
         {
         case 2:
@@ -6717,7 +6718,6 @@ void BuildGroundItemLabelDescriptor(OBJECT* o, ITEM* ip, GroundItemLabelDescript
     }
     else if (o->Type == MODEL_EVENT + 15)
     {
-        SetDescriptorYellowTextColor(descriptor);
         CopyGroundItemLabelText(descriptor.Name, I18N::Game::RingOfWizard);
     }
     else if (o->Type == MODEL_TRANSFORMATION_RING)

--- a/src/source/Engine/Object/ZzzInventory.cpp
+++ b/src/source/Engine/Object/ZzzInventory.cpp
@@ -6126,8 +6126,7 @@ std::unordered_set<int> yellowTextItems = {
     MODEL_EVENT + 11,
     MODEL_EVENT + 12,
     MODEL_EVENT + 13,
-    MODEL_EVENT + 14,
-    MODEL_EVENT + 15,
+
     MODEL_SUSPICIOUS_SCRAP_OF_PAPER,
     MODEL_GAIONS_ORDER,
     MODEL_FIRST_SECROMICON_FRAGMENT,
@@ -6485,18 +6484,22 @@ void BuildGroundItemLabelDescriptor(OBJECT* o, ITEM* ip, GroundItemLabelDescript
     descriptor.TextColor = MakeRgba(255, 255, 255, 255);
     descriptor.BgColor = MakeRgba(0, 0, 0, 255);
 
-    // Use the item name by default
-    if (o->Type == MODEL_ZEN) // Zen
+    // Use the item name by default, only when o->Type is in MODEL_ITEM range
+    // Items with special types (e.g. MODEL_EVENT + N) are handled by overrides below
+    if (o->Type >= MODEL_ITEM && o->Type < MODEL_ITEM + MAX_ITEM)
     {
-        FormatGroundItemLabelText(descriptor.Name, L"%ls %d", ItemAttribute[o->Type - MODEL_ITEM].Name, ItemLevel);
-    }
-    else if (ItemLevel == 0)
-    {
-        CopyGroundItemLabelText(descriptor.Name, ItemAttribute[o->Type - MODEL_ITEM].Name);
-    }
-    else
-    {
-        FormatGroundItemLabelText(descriptor.Name, L"%ls +%d", ItemAttribute[o->Type - MODEL_ITEM].Name, ItemLevel);
+        if (o->Type == MODEL_ZEN) // Zen
+        {
+            FormatGroundItemLabelText(descriptor.Name, L"%ls %d", ItemAttribute[o->Type - MODEL_ITEM].Name, ItemLevel);
+        }
+        else if (ItemLevel == 0)
+        {
+            CopyGroundItemLabelText(descriptor.Name, ItemAttribute[o->Type - MODEL_ITEM].Name);
+        }
+        else
+        {
+            FormatGroundItemLabelText(descriptor.Name, L"%ls +%d", ItemAttribute[o->Type - MODEL_ITEM].Name, ItemLevel);
+        }
     }
 
     if (boldTextItems.count(o->Type) > 0)
@@ -6698,6 +6701,7 @@ void BuildGroundItemLabelDescriptor(OBJECT* o, ITEM* ip, GroundItemLabelDescript
     }
     else if (o->Type == MODEL_EVENT + 14)
     {
+        SetDescriptorYellowTextColor(descriptor);
         switch (ItemLevel)
         {
         case 2:
@@ -6713,6 +6717,7 @@ void BuildGroundItemLabelDescriptor(OBJECT* o, ITEM* ip, GroundItemLabelDescript
     }
     else if (o->Type == MODEL_EVENT + 15)
     {
+        SetDescriptorYellowTextColor(descriptor);
         CopyGroundItemLabelText(descriptor.Name, I18N::Game::RingOfWizard);
     }
     else if (o->Type == MODEL_TRANSFORMATION_RING)

--- a/src/source/Engine/Object/ZzzInventory.cpp
+++ b/src/source/Engine/Object/ZzzInventory.cpp
@@ -6779,9 +6779,12 @@ void BuildGroundItemLabelDescriptor(OBJECT* o, ITEM* ip, GroundItemLabelDescript
     {
         SetDescriptorOrangeTextColor(descriptor);
     }
-    else if (o->Type >= MODEL_ITEM && o->Type < MODEL_ITEM + MAX_ITEM)
+    else if (o->Type >= MODEL_ITEM && o->Type < MODEL_ITEM + MAX_ITEM
+        && (whiteTextItems.count(o->Type) > 0
+            || yellowTextItems.count(o->Type) > 0
+            || orangeTextItems.count(o->Type) > 0))
     {
-        // Name was already set by the MODEL_ITEM block above, color by Block 1. No override needed.
+        // Color was already set by Block 1 (white/yellow/orange). No override needed.
     }
     else
     {

--- a/src/source/Engine/Object/ZzzInventory.cpp
+++ b/src/source/Engine/Object/ZzzInventory.cpp
@@ -6779,6 +6779,10 @@ void BuildGroundItemLabelDescriptor(OBJECT* o, ITEM* ip, GroundItemLabelDescript
     {
         SetDescriptorOrangeTextColor(descriptor);
     }
+    else if (o->Type >= MODEL_ITEM && o->Type < MODEL_ITEM + MAX_ITEM)
+    {
+        // Name was already set by the MODEL_ITEM block above, color by Block 1. No override needed.
+    }
     else
     {
         if (IsDivineArchangelWeaponModel(o->Type))

--- a/src/source/Engine/Object/ZzzInventory.cpp
+++ b/src/source/Engine/Object/ZzzInventory.cpp
@@ -6117,8 +6117,6 @@ std::unordered_set<int> yellowTextItems = {
     MODEL_BOX_OF_LUCK,
     MODEL_FRUITS,
     MODEL_SPIRIT,
-    MODEL_EVENT + 14,
-    MODEL_EVENT + 15,
     MODEL_EVENT + 16,
     MODEL_EVENT + 5,
     MODEL_OLD_SCROLL,
@@ -6128,7 +6126,8 @@ std::unordered_set<int> yellowTextItems = {
     MODEL_EVENT + 11,
     MODEL_EVENT + 12,
     MODEL_EVENT + 13,
-
+    MODEL_EVENT + 14,
+    MODEL_EVENT + 15,
     MODEL_SUSPICIOUS_SCRAP_OF_PAPER,
     MODEL_GAIONS_ORDER,
     MODEL_FIRST_SECROMICON_FRAGMENT,


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

This is just a quick fix, this logic needs to be refactored, it's a mess :neutral_face: 

### 1. Ground item label out-of-range

`BuildGroundItemLabelDescriptor` indexed `ItemAttribute[o->Type - MODEL_ITEM]` unconditionally, but event items (`MODEL_EVENT + N`) and other special types fall outside the `MODEL_ITEM` range, reading garbage/out-of-bounds. Guard the `ItemAttribute` lookup with a range check so only types within `[MODEL_ITEM, MODEL_ITEM + MAX_ITEM)` use the item name table. Special types rely on their override blocks below.

### 2. Missing yellow text for event items

`MODEL_EVENT + 14` (Wizard's Ring) and `MODEL_EVENT + 15` were missing from `yellowTextItems` so they rendered in default white. Also changed the `MODEL_ORB_OF_SUMMONING` branch from `else if` to `if` — it was gated on the item-name path, but event items skip that path, so the orb color was never applied. Removed the redundant `SetDescriptorYellowTextColor` calls from the `MODEL_EVENT + 14/15` override blocks since the yellow-text set handles them now

<img width="691" height="561" alt="image" src="https://github.com/user-attachments/assets/4331ba39-eae6-48ce-8d2a-b1b6ec5f5ea6" />
<img width="832" height="450" alt="image" src="https://github.com/user-attachments/assets/35569b93-5879-4131-a706-5d733b098dd5" />
<img width="501" height="377" alt="image" src="https://github.com/user-attachments/assets/5ed9c998-672b-49fe-a422-2eaf5f21b9a6" />


## Checklist

- [X] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [X] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)).
- [X] Changes are focused on one concern; the diff is as small as it reasonably can be.
