### PR TITLE
bugfix: stuck npc dialog state

### DIFF
--- a/src/source/UI/NewUI/Events/NewUIDoppelGangerWindow.cpp
+++ b/src/source/UI/NewUI/Events/NewUIDoppelGangerWindow.cpp
@@ -210,7 +210,7 @@ void CNewUIDoppelGangerWindow::OpeningProcess()
 
 void CNewUIDoppelGangerWindow::ClosingProcess()
 {
-    // 	SocketClient->ToGameServer()->SendCloseNpcRequest();
+    SocketClient->ToGameServer()->SendCloseNpcRequest();
 }
 
 float CNewUIDoppelGangerWindow::GetLayerDepth()

--- a/src/source/UI/NewUI/Inventory/NewUIUnitedMarketPlaceWindow.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIUnitedMarketPlaceWindow.cpp
@@ -226,7 +226,7 @@ void CNewUIUnitedMarketPlaceWindow::OpeningProcess()
 
 void CNewUIUnitedMarketPlaceWindow::ClosingProcess()
 {
-    // 	SocketClient->ToGameServer()->SendCloseNpcRequest();
+    SocketClient->ToGameServer()->SendCloseNpcRequest();
 }
 
 float CNewUIUnitedMarketPlaceWindow::GetLayerDepth()


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

The Cancel/ESC/close-box on two NPC dialogs — Julia warp (INTERFACE_UNITEDMARKETPLACE_NPC_JULIA)
and Doppelganger entry — only hid the UI but never told the server the dialog was closed.
This left the player's server state stuck in NpcDialogOpened, blocking all subsequent
NPC interactions until the next teleport or warp.

Both ClosingProcess() methods were no-op stubs since their files were created.
Every other NPC dialog in the client (22 call sites) actively sends CloseNpcRequest
on close; these two were simply never wired up

<!-- What does this PR do, and why? -->

## Checklist

- [X] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [X] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)).
- [X] Changes are focused on one concern; the diff is as small as it reasonably can be.
