### PR TITLE
bugfix: fallback attack not consuming arrows

### DIFF
--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -1059,6 +1059,11 @@ namespace MUHelper
             return 0;
         }
 
+        if (gCharacterManager.GetEquipedBowType() != BOWTYPE_NONE && !CheckArrow())
+        {
+            return 0;
+        }
+
         Hero->MovementType = MOVEMENT_ATTACK;
         ActionTarget = iCharIndex;
         Attacking = 1;


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

Skip fallback basic attack when Elf has no arrows/bolts

In SimulateBasicAttack, a bow/crossbow Elf with 0 ammo would still call Action() as a fallback, causing a melee punch instead of idle. Added an ammo check before the fallback — if a ranged weapon is equipped and CheckArrow() fails, the fallback attack is skipped entirely, leaving the character idle rather than punching.
MuHelper.cpp:1062 — guard: if (GetEquipedBowType() != BOWTYPE_NONE && !CheckArrow()) return;

## Checklist

- [X] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [X] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)).
- [X] Changes are focused on one concern; the diff is as small as it reasonably can be.
