### PR TITLE
Use the SDL input path for IsKeyDown on Windows too

### DIFF
--- a/src/source/Core/Input/KeyState.cpp
+++ b/src/source/Core/Input/KeyState.cpp
@@ -1,13 +1,10 @@
 #include "stdafx.h"
 #include "Core/Input/KeyState.h"
 
-#ifndef _WIN32
 #include <SDL3/SDL.h>
-#endif
 
 namespace Core::Input
 {
-#ifndef _WIN32
     namespace
     {
         // Map a Win32 virtual-key code (or ASCII letter/digit) to an SDL
@@ -53,20 +50,15 @@ namespace Core::Input
             }
         }
     }
-#endif // !_WIN32
 
     bool IsKeyDown(int virtualKey)
     {
-#ifdef _WIN32
-        // On Windows the legacy UI polls global key/mouse-button state that must
-        // keep working while a Win32 child EDIT control holds keyboard focus.
-        // SDL_GetKeyboardState only reflects keys delivered to the SDL window, so
-        // it goes blind whenever an EDIT box is focused (e.g. the login screen).
-        // Keep the global async query here; switch to the SDL path below once the
-        // EDIT controls are replaced (issue #447). GetAsyncKeyState reports the
-        // mouse buttons (VK_LBUTTON/...) and modifiers too, matching the original.
-        return (GetAsyncKeyState(virtualKey) & 0x8000) != 0;
-#else
+        // Poll live input from SDL on every platform. The Win32 path used
+        // GetAsyncKeyState because the old child EDIT controls stole keyboard
+        // focus from the SDL window; they were replaced by the portable text
+        // field (#447), so SDL input state is authoritative here too. The main
+        // loop pumps SDL_PollEvent each frame, so this state stays current.
+
         // Mouse buttons and modifiers come from the SDL mouse / mod state.
         switch (virtualKey)
         {
@@ -84,6 +76,5 @@ namespace Core::Input
 
         const bool* state = SDL_GetKeyboardState(nullptr);
         return state != nullptr && state[sc];
-#endif // _WIN32
     }
 }


### PR DESCRIPTION
## Summary

`Core::Input::IsKeyDown` had a Windows-only branch that polled `GetAsyncKeyState`, while every other platform used SDL keyboard/mouse/mod state. The Win32 path existed for one reason: the legacy child `EDIT` controls stole keyboard focus from the SDL window, which would blind `SDL_GetKeyboardState`.

Those EDIT controls were replaced by the portable text field (#447), so SDL input state is now authoritative on Windows as well. This drops the platform split: `IsKeyDown` uses a single SDL-backed path everywhere, removing the last `GetAsyncKeyState` call.

Part of the Win32 removal tracked in #462.

## Why it's correct on Windows now

- #447 removed the focus-stealing child `EDIT` windows, so the SDL window holds keyboard focus during gameplay and `SDL_GetKeyboardState` reflects all keys.
- `MainLoop()` calls `SDL_PollEvent` every frame unconditionally (not `_WIN32`-guarded), so SDL's keyboard/mouse/mod state is pumped and stays current on Windows.

## Scope

- Single file: `src/source/Core/Input/KeyState.cpp`. Mouse buttons and modifiers come from `SDL_GetMouseState`/`SDL_GetModState`; keys map through the existing `VkToScancode` table.
- No change to the `WndProc` / `SDL_SetWindowsMessageHook` transitional path yet (that removal is a separate follow-up).

## Testing

- Builds and links clean for the Windows target (MinGW i686) and Linux (unchanged path).
- Windows manual test to exercise: login typing + Enter submit, chat open/type, movement keys, Ctrl/Shift/Alt combos, F10 zoom-lock, and left/right/middle mouse buttons.