### PR TITLE
Fix IGS_StorageItem m_szType copy overrunning the struct

### DIFF
--- a/src/source/Core/Platform/WinCompat.h
+++ b/src/source/Core/Platform/WinCompat.h
@@ -42,7 +42,7 @@ typedef int       BOOL;
 typedef float     FLOAT;
 typedef char      CHAR;
 typedef unsigned char UCHAR;
-typedef wchar_t   WCHAR;  // NOTE: 32-bit here vs 16-bit on Windows; the wchar_t width migration is Phase 2.
+typedef wchar_t   WCHAR;  // 32-bit here vs 16-bit on Windows; width handled at the .NET interop boundary (#462).
 typedef void      VOID;
 typedef DWORD     COLORREF;
 

--- a/src/source/UI/Legacy/UIControls.cpp
+++ b/src/source/UI/Legacy/UIControls.cpp
@@ -6108,7 +6108,7 @@ void CUIInGameShopListBox::AddText(IGS_StorageItem& _StorageItem)
     wcsncpy(sItem.m_szName, _StorageItem.m_szName, MAX_TEXT_LENGTH);
     wcsncpy(sItem.m_szNum, _StorageItem.m_szNum, MAX_TEXT_LENGTH);
     wcsncpy(sItem.m_szPeriod, _StorageItem.m_szPeriod, MAX_TEXT_LENGTH);
-    wcsncpy(&(sItem.m_szType), &(_StorageItem.m_szType), sizeof(wchar_t));
+    sItem.m_szType = _StorageItem.m_szType;
     wcsncpy(sItem.m_szSendUserName, _StorageItem.m_szSendUserName, MAX_USERNAME_SIZE + 1);
     wcsncpy(sItem.m_szMessage, _StorageItem.m_szMessage, MAX_GIFT_MESSAGE_SIZE);
 


### PR DESCRIPTION
Part of the #462 Phase 2 (wide-char portability) verification pass.

## What this fixes

`IGS_StorageItem::m_szType` is a single `wchar_t` (the last field of the
struct), but `CUIInGameShopListBox::AddText` copied it with:

```cpp
wcsncpy(&(sItem.m_szType), &(_StorageItem.m_szType), sizeof(wchar_t));
```

`wcsncpy`'s count is in characters, not bytes, so this writes `sizeof(wchar_t)`
characters (2 on Windows, 4 on Linux) into a one-character field, running past
the end of the struct. It is wrong on both platforms and worse where `wchar_t`
is 32-bit. Replaced with a plain scalar assignment.

## Also

Clarifies the `WCHAR` typedef comment in `Core/Platform/WinCompat.h`: the
`wchar_t` width difference is handled at the .NET interop boundary
(`ClientLibrary/NativeInterop.cs` decodes per-platform width), not by a
codebase-wide fixed-width migration. No wire or on-disk format embeds `wchar_t`.

## Context

A full wchar_t width audit for #462 Phase 2 confirmed the interop boundary is
the only width-sensitive cross-platform surface and it is already handled. This
was the one live bug the audit turned up; remaining items are tracked separately.