### PR TITLE
Fix wchar_t width handling in map-change auth and GameShop strings

### DIFF
--- a/src/source/GameShop/ShopListManager/BannerInfo.cpp
+++ b/src/source/GameShop/ShopListManager/BannerInfo.cpp
@@ -14,6 +14,8 @@
 #include "StringToken.h"
 #include "StringMethod.h"
 
+#include <iterator>
+
 #ifdef _WIN32
 #include <urlmon.h>
 
@@ -43,9 +45,9 @@ bool CBannerInfo::SetBanner(std::wstring strdata, std::wstring strDirPath, bool 
 
     this->BannerSeq = _wtoi(Token.nextToken().c_str());
 
-    StringCchCopy(this->BannerName, sizeof(this->BannerName), Token.nextToken().c_str());
+    StringCchCopy(this->BannerName, std::size(this->BannerName), Token.nextToken().c_str());
 
-    StringCchCopy(this->BannerImageURL, sizeof(this->BannerImageURL), Token.nextToken().c_str());
+    StringCchCopy(this->BannerImageURL, std::size(this->BannerImageURL), Token.nextToken().c_str());
 
     this->BannerOrder = _wtoi(Token.nextToken().c_str());
     this->BannerDirection = _wtoi(Token.nextToken().c_str());
@@ -53,7 +55,7 @@ bool CBannerInfo::SetBanner(std::wstring strdata, std::wstring strDirPath, bool 
     CStringMethod::ConvertStringToDateTime(this->BannerStartDate, Token.nextToken());
     CStringMethod::ConvertStringToDateTime(this->BannerEndDate, Token.nextToken());
 
-    StringCchCopy(this->BannerLinkURL, sizeof(this->BannerLinkURL), Token.nextToken().c_str());
+    StringCchCopy(this->BannerLinkURL, std::size(this->BannerLinkURL), Token.nextToken().c_str());
 
     std::wstring url = this->BannerImageURL;
     std::size_t pos = url.rfind(L"/", std::wstring::npos);
@@ -62,7 +64,7 @@ bool CBannerInfo::SetBanner(std::wstring strdata, std::wstring strDirPath, bool 
     {
         std::wstring sub = url.substr(pos + 1, url.length() - pos - 1);
 
-        StringCchPrintf(this->BannerImagePath, sizeof(this->BannerImagePath), L"%ls%ls", strDirPath.c_str(), sub.c_str());
+        StringCchPrintf(this->BannerImagePath, std::size(this->BannerImagePath), L"%ls%ls", strDirPath.c_str(), sub.c_str());
 
         if (bDonwLoad || GetFileAttributes(this->BannerImagePath) == INVALID_FILE_ATTRIBUTES)
         {

--- a/src/source/GameShop/ShopListManager/FTPFileDownLoader.cpp
+++ b/src/source/GameShop/ShopListManager/FTPFileDownLoader.cpp
@@ -11,6 +11,9 @@
 #include "stdafx.h"
 #ifdef KJH_ADD_INGAMESHOP_UI_SYSTEM
 #include "FTPFileDownLoader.h"
+
+#include <iterator>
+
 CFTPFileDownLoader::CFTPFileDownLoader() // OK
 {
     this->m_Break = 0;
@@ -59,7 +62,7 @@ WZResult CFTPFileDownLoader::DownLoadFiles(DownloaderType type,
 
     wchar_t Buffer[MAX_PATH] = { 0 };
 
-    StringCchPrintf(Buffer, sizeof(Buffer), L"%03d.%04d.%03d", Version.Zone, Version.year, Version.yearId);
+    StringCchPrintf(Buffer, std::size(Buffer), L"%03d.%04d.%03d", Version.Zone, Version.year, Version.yearId);
 
     strRemotepath += Buffer;
     strRemotepath += L"/";

--- a/src/source/GameShop/ShopListManager/ListManager.cpp
+++ b/src/source/GameShop/ShopListManager/ListManager.cpp
@@ -15,6 +15,8 @@
 #include <process.h>
 #endif
 
+#include <iterator>
+
 CListManager::CListManager() // OK
 {
     this->m_pFTPDownLoader = NULL;
@@ -140,7 +142,7 @@ std::wstring		CListManager::GetScriptPath() // OK
 {
     TCHAR buff[MAX_PATH] = { 0 };
 
-    StringCchPrintf(buff, sizeof(buff), L"%03d.%04d.%03d",
+    StringCchPrintf(buff, std::size(buff), L"%03d.%04d.%03d",
         m_ListManagerInfo.m_Version.Zone,
         m_ListManagerInfo.m_Version.year,
         m_ListManagerInfo.m_Version.yearId);

--- a/src/source/GameShop/ShopListManager/ShopCategory.cpp
+++ b/src/source/GameShop/ShopListManager/ShopCategory.cpp
@@ -13,6 +13,8 @@
 #include "ShopCategory.h"
 #include "StringToken.h"
 
+#include <iterator>
+
 CShopCategory::CShopCategory() // OK
 {
     this->CategoryList.clear();
@@ -34,7 +36,7 @@ bool CShopCategory::SetCategory(std::wstring strdata) // OK
         return 0;
 
     this->ProductDisplaySeq = _wtoi(token.nextToken().c_str());
-    StringCchCopy(this->CategroyName, sizeof(this->CategroyName), token.nextToken().c_str());
+    StringCchCopy(this->CategroyName, std::size(this->CategroyName), token.nextToken().c_str());
     this->EventFlag = _wtoi(token.nextToken().c_str());
     this->OpenFlag = _wtoi(token.nextToken().c_str());
     this->ParentProductDisplaySeq = _wtoi(token.nextToken().c_str());

--- a/src/source/GameShop/ShopListManager/ShopPackage.cpp
+++ b/src/source/GameShop/ShopListManager/ShopPackage.cpp
@@ -14,6 +14,8 @@
 #include "StringToken.h"
 #include "StringMethod.h"
 
+#include <iterator>
+
 CShopPackage::CShopPackage() // OK
 {
     this->LeftCount = -1;
@@ -37,24 +39,24 @@ bool	CShopPackage::SetPackage(std::wstring strdata) // OK
     this->ProductDisplaySeq = _wtoi(token.nextToken().c_str());
     this->ViewOrder = _wtoi(token.nextToken().c_str());
     this->PackageProductSeq = _wtoi(token.nextToken().c_str());
-    StringCchCopy(this->PackageProductName, sizeof(this->PackageProductName), token.nextToken().c_str());
+    StringCchCopy(this->PackageProductName, std::size(this->PackageProductName), token.nextToken().c_str());
     this->PackageProductType = _wtoi(token.nextToken().c_str());
     this->Price = _wtoi(token.nextToken().c_str());
-    StringCchCopy(this->Description, sizeof(this->Description), token.nextToken().c_str());
-    StringCchCopy(this->Caution, sizeof(this->Caution), token.nextToken().c_str());
+    StringCchCopy(this->Description, std::size(this->Description), token.nextToken().c_str());
+    StringCchCopy(this->Caution, std::size(this->Caution), token.nextToken().c_str());
     this->SalesFlag = _wtoi(token.nextToken().c_str());
     this->GiftFlag = _wtoi(token.nextToken().c_str());
     CStringMethod::ConvertStringToDateTime(this->StartDate, token.nextToken());
     CStringMethod::ConvertStringToDateTime(this->EndDate, token.nextToken());
     this->CapsuleFlag = _wtoi(token.nextToken().c_str());
     this->CapsuleCount = _wtoi(token.nextToken().c_str());
-    StringCchCopy(this->ProductCashName, sizeof(this->ProductCashName), token.nextToken().c_str());
-    StringCchCopy(this->PricUnitName, sizeof(this->PricUnitName), token.nextToken().c_str());
+    StringCchCopy(this->ProductCashName, std::size(this->ProductCashName), token.nextToken().c_str());
+    StringCchCopy(this->PricUnitName, std::size(this->PricUnitName), token.nextToken().c_str());
     this->DeleteFlag = _wtoi(token.nextToken().c_str());
     this->EventFlag = _wtoi(token.nextToken().c_str());
     this->ProductAmount = _wtoi(token.nextToken().c_str());
     this->SetProductSeqList(token.nextToken());
-    StringCchCopy(this->InGamePackageID, sizeof(this->InGamePackageID), token.nextToken().c_str());
+    StringCchCopy(this->InGamePackageID, std::size(this->InGamePackageID), token.nextToken().c_str());
     this->ProductCashSeq = _wtoi(token.nextToken().c_str());
     this->PriceCount = _wtoi(token.nextToken().c_str());
     this->SetPriceSeqList(token.nextToken());

--- a/src/source/GameShop/ShopListManager/ShopProduct.cpp
+++ b/src/source/GameShop/ShopListManager/ShopProduct.cpp
@@ -13,6 +13,8 @@
 #include "ShopProduct.h"
 #include "StringToken.h"
 
+#include <iterator>
+
 CShopProduct::CShopProduct() // OK
 {
 }
@@ -31,10 +33,10 @@ bool CShopProduct::SetProduct(std::wstring strdata) // OK
         return 0;
 
     this->ProductSeq = _wtoi(token.nextToken().c_str());
-    StringCchCopy(this->ProductName, sizeof(this->ProductName), token.nextToken().c_str());
-    StringCchCopy(this->PropertyName, sizeof(this->PropertyName), token.nextToken().c_str());
-    StringCchCopy(this->Value, sizeof(this->Value), token.nextToken().c_str());
-    StringCchCopy(this->UnitName, sizeof(this->UnitName), token.nextToken().c_str());
+    StringCchCopy(this->ProductName, std::size(this->ProductName), token.nextToken().c_str());
+    StringCchCopy(this->PropertyName, std::size(this->PropertyName), token.nextToken().c_str());
+    StringCchCopy(this->Value, std::size(this->Value), token.nextToken().c_str());
+    StringCchCopy(this->UnitName, std::size(this->UnitName), token.nextToken().c_str());
     this->Price = _wtoi(token.nextToken().c_str());
     this->PriceSeq = _wtoi(token.nextToken().c_str());
     this->PropertyType = _wtoi(token.nextToken().c_str());
@@ -43,7 +45,7 @@ bool CShopProduct::SetProduct(std::wstring strdata) // OK
     this->DeleteFlag = _wtoi(token.nextToken().c_str());
     this->StorageGroup = _wtoi(token.nextToken().c_str());
     this->ShareFlag = _wtoi(token.nextToken().c_str());
-    StringCchCopy(this->InGamePackageID, sizeof(this->InGamePackageID), token.nextToken().c_str());
+    StringCchCopy(this->InGamePackageID, std::size(this->InGamePackageID), token.nextToken().c_str());
     this->PropertySeq = _wtoi(token.nextToken().c_str());
     this->ProductType = _wtoi(token.nextToken().c_str());
     this->UnitType = _wtoi(token.nextToken().c_str());

--- a/src/source/GameShop/ShopListManager/interface/PathMethod/Path.cpp
+++ b/src/source/GameShop/ShopListManager/interface/PathMethod/Path.cpp
@@ -17,6 +17,8 @@
 #include "Core/Platform/CrtDbg.h"
 #include "Core/Platform/StrSafe.h"
 
+#include <iterator>
+
 TCHAR* Path::GetCurrentFullPath(TCHAR* szPath)
 {
     if (!szPath) return 0;
@@ -225,14 +227,14 @@ BOOL			Path::CreateDirectorys(TCHAR* szFilePath, BOOL bIsFile)
     wchar_t PathName[MAX_PATH] = { 0 };
     wchar_t buff2[MAX_PATH] = { 0 };
 
-    StringCchCopy(PathName, sizeof(PathName), szFilePath);
+    StringCchCopy(PathName, std::size(PathName), szFilePath);
 
     if (bIsFile)
         Path::GetDirectory(PathName);
 
     if (CreateDirectory(PathName, 0) == 0)
     {
-        StringCchCopy(buff2, sizeof(buff2), PathName);
+        StringCchCopy(buff2, std::size(buff2), PathName);
 
         wchar_t* chr1 = wcsrchr(buff2, L'\\');
         wchar_t* chr2 = wcschr(buff2, L'\\');

--- a/src/source/GameShop/ShopListManager/interface/WZResult/WZResult.cpp
+++ b/src/source/GameShop/ShopListManager/interface/WZResult/WZResult.cpp
@@ -14,6 +14,8 @@
 #include "Core/Platform/CrtDbg.h"
 #include "Core/Platform/StrSafe.h"
 
+#include <iterator>
+
 WZResult::WZResult() // OK
 {
     this->SetSuccessResult();
@@ -47,7 +49,7 @@ WZResult& WZResult::operator=(const WZResult& a2) // OK
 {
     this->m_dwErrorCode = a2.m_dwErrorCode;
     this->m_dwWindowErrorCode = a2.m_dwWindowErrorCode;
-    StringCchCopy(this->m_szErrorMessage, sizeof(this->m_szErrorMessage), a2.m_szErrorMessage);
+    StringCchCopy(this->m_szErrorMessage, std::size(this->m_szErrorMessage), a2.m_szErrorMessage);
     return *this;
 }
 
@@ -58,14 +60,14 @@ void WZResult::SetResult(DWORD dwErrorCode, DWORD dwWindowErrorCode, const TCHAR
     va_start(va, szFormat);
     this->m_dwErrorCode = dwErrorCode;
     this->m_dwWindowErrorCode = dwWindowErrorCode;
-    StringCchVPrintf(this->m_szErrorMessage, sizeof(this->m_szErrorMessage), szFormat, va);
+    StringCchVPrintf(this->m_szErrorMessage, std::size(this->m_szErrorMessage), szFormat, va);
 }
 
 void WZResult::SetSuccessResult() // OK
 {
     this->m_dwErrorCode = WZ_SUCCESS;
     this->m_dwWindowErrorCode = ERROR_SUCCESS;
-    StringCchCopy(this->m_szErrorMessage, sizeof(this->m_szErrorMessage), L"Success");
+    StringCchCopy(this->m_szErrorMessage, std::size(this->m_szErrorMessage), L"Success");
 }
 
 WZResult WZResult::BuildSuccessResult() // OK
@@ -86,7 +88,7 @@ WZResult WZResult::BuildResult(DWORD dwErrorCode, DWORD dwWindowErrorCode, const
     va_start(args, szFormat);
 
     memset(Buffer, 0, sizeof(Buffer));
-    StringCchVPrintf(Buffer, sizeof(Buffer), szFormat, args);
+    StringCchVPrintf(Buffer, std::size(Buffer), szFormat, args);
 
     result.SetResult(dwErrorCode, dwWindowErrorCode, Buffer);
 

--- a/src/source/Network/Server/CSMapServer.cpp
+++ b/src/source/Network/Server/CSMapServer.cpp
@@ -2,7 +2,6 @@
 
 #include "Network/Server/CSMapServer.h"
 
-#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstddef>
@@ -132,29 +131,33 @@ void CSMServer::SendChangeMapServer(void)
         return;
     }
 
-    constexpr std::size_t kCharacterIdLength = MAX_USERNAME_SIZE + 1;
-    constexpr std::size_t kPacketBufferLength = MAX_USERNAME_SIZE + 2;
+    // The wire fields for the login ID and character name are fixed-width narrow
+    // byte arrays (MAX_USERNAME_SIZE each). The extra byte gives the conversion
+    // room for a null terminator so a full MAX_USERNAME_SIZE-character name is
+    // not truncated; only the first MAX_USERNAME_SIZE bytes are encrypted and
+    // sent.
+    constexpr std::size_t kNameFieldLength = MAX_USERNAME_SIZE + 1;
 
-    std::array<wchar_t, kCharacterIdLength> characterIdBuffer {};
-
-    const std::size_t heroIdCopyLength = std::min<std::size_t>(m_heroId.size(), MAX_USERNAME_SIZE);
-    std::wmemcpy(characterIdBuffer.data(), m_heroId.c_str(), heroIdCopyLength);
-    characterIdBuffer[heroIdCopyLength] = L'\0';
+    // Convert the wide character name down to narrow wire bytes. Reinterpreting
+    // the wchar_t buffer as bytes would embed the platform-dependent wchar_t
+    // width (2 bytes on Windows, 4 on Linux) and interleave null bytes into the
+    // field, corrupting the name the server reads.
+    std::array<char, kNameFieldLength> characterName {};
+    CMultiLanguage::ConvertToUtf8(characterName.data(), m_heroId.c_str(), static_cast<int>(characterName.size()));
 
     ClearCharacters(-1);
     InitGame();
 
-    std::array<wchar_t, kPacketBufferLength> loginIdBuffer {};
-    std::array<wchar_t, kPacketBufferLength> characterPacketBuffer {};
+    // TODO: Populate loginId with LogInID if credentials are required again.
+    // The map change re-authenticates via the auth codes, so it is left empty.
+    std::array<char, kNameFieldLength> loginId {};
 
-    // TODO: Populate loginIdBuffer with LogInID if credentials are required again.
-    std::wmemcpy(characterPacketBuffer.data(), characterIdBuffer.data(), heroIdCopyLength + 1);
-
-    BuxConvert(reinterpret_cast<BYTE*>(loginIdBuffer.data()), kPacketBufferLength);
+    BuxConvert(reinterpret_cast<BYTE*>(loginId.data()), MAX_USERNAME_SIZE);
+    BuxConvert(reinterpret_cast<BYTE*>(characterName.data()), MAX_USERNAME_SIZE);
     SocketClient->ToGameServer()->SendServerChangeAuthentication(
-        reinterpret_cast<BYTE*>(loginIdBuffer.data()),
+        reinterpret_cast<BYTE*>(loginId.data()),
         MAX_USERNAME_SIZE,
-        reinterpret_cast<BYTE*>(characterPacketBuffer.data()),
+        reinterpret_cast<BYTE*>(characterName.data()),
         MAX_USERNAME_SIZE,
         m_serverInfo.m_iJoinAuthCode1,
         m_serverInfo.m_iJoinAuthCode2,


### PR DESCRIPTION
Two independent fixes surfaced by the #462 Phase 2 wide-character portability audit.

## #518 - server-change auth character name
`CSMServer::SendChangeMapServer` reinterpreted a `wchar_t` buffer as the `BYTE*` name field of the server-change auth packet. That embedded the platform-dependent `wchar_t` width (2 bytes on Windows, 4 on Linux) and interleaved null bytes into a field the server reads as fixed-width narrow bytes, so the character name arrived corrupted.

The name is now converted to narrow bytes with `ConvertToUtf8` before encryption and transmission, and the encryption runs over the correct byte length.

## #519 - GameShop StrSafe character counts
The `StringCch*` functions take a destination capacity in characters, but the `ShopListManager` callers passed `sizeof(dest)` on `wchar_t` buffers, i.e. twice (Windows) or four times (Linux) the real capacity. That lets a copy write past the array before it truncates.

The calls now pass `std::size(dest)`. Beyond the `StringCchCopy` calls named in the issue, the same defect existed via `StringCchPrintf` and `StringCchVPrintf` on wide buffers in the same directory (`BannerInfo`, `FTPFileDownLoader`, `WZResult`, `ListManager`); those are fixed too. `Path.cpp` line 183 `StringCchLengthA` is left as is, since it operates on a genuine `char[]` buffer where the byte count already equals the character count.

## Note, not addressed here
The server-change name field is documented as `CharacterNameXor3`, but this path encrypts with `BuxConvert` rather than Xor3. This change only corrects the width handling; whether the cipher is also wrong is a separate protocol question worth its own issue.

Fixes #518
Fixes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)