### PR TITLE
Treat binary game assets as binary to fix Windows clone corruption (#516)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,30 @@
 *.cs text
 *.csproj text
 *.sln text
+
+# Binary game assets: never apply text detection or EOL normalization.
+# Some encrypted .bmd / .oz* files contain no NUL bytes, so `text=auto`
+# misdetects them as text; on a Windows clone (core.autocrlf=true) their lone
+# LF is rewritten to CRLF, corrupting the file by one byte (see issue #516).
+# Case-insensitive classes cover mixed-case extensions in the asset tree.
+*.[Bb][Mm][Dd]   binary
+*.[Oo][Zz][Bb]   binary
+*.[Oo][Zz][Jj]   binary
+*.[Oo][Zz][Jj]2  binary
+*.[Oo][Zz][Tt]   binary
+*.[Oo][Zz][Gg]   binary
+*.[Oo][Zz][Pp]   binary
+*.[Oo][Zz][Dd]   binary
+*.[Aa][Tt][Tt]   binary
+*.[Mm][Aa][Pp]   binary
+*.[Oo][Bb][Jj]   binary
+*.[Cc][Ww][Ss]   binary
+*.[Cc][Ss][Rr]   binary
+*.[Tt][Gg][Aa]   binary
+*.[Bb][Mm][Pp]   binary
+*.[Jj][Pp][Gg]   binary
+*.[Jj][Pp][Ee][Gg] binary
+*.[Pp][Nn][Gg]   binary
+*.[Ww][Aa][Vv]   binary
+*.[Oo][Gg][Gg]   binary
+*.[Mm][Pp]3      binary


### PR DESCRIPTION
## Problem

`Minimap_World57_eng.bmd` fails on a fresh Windows clone with a "File corrupted" error (issue #516), while Linux clones, zip downloads and manual copies work.

## Root cause

The repo's `.gitattributes` uses `* text=auto`. Git's line-ending detection treats a file as text when it contains no NUL (`0x00`) bytes. This particular encrypted minimap has zero NUL bytes anywhere in the file, so Git classifies it as text. On a Windows clone (`core.autocrlf=true`), its single `0x0A` (LF) byte is rewritten to `0x0D 0x0A` (CRLF) on checkout, adding one byte and shifting the whole file. The client's checksum then rejects it.

Most `.bmd`/`.oz*` assets contain NUL bytes, so Git leaves them untouched; only NUL-free assets are affected. A repo scan found a handful of such files (e.g. the World57 minimaps, `Filter.bmd`, `Quest.bmd`, `ItemTooltip_*.bmd`, `ItemAddOption.bmd`, `MasterSkillTreeData.bmd`, some wing `.SMD` models, `EncTerrain6.map`), all of which would corrupt the same way.

The committed blobs are correct; the corruption only happens on Windows checkout.

## Fix

Declare binary game-asset extensions as `binary` in `.gitattributes` so Git never applies text detection or EOL conversion to them. Case-insensitive glob classes cover the mixed-case extensions in the asset tree.

## Note for existing corrupted clones

`.gitattributes` prevents future corruption. Anyone with an already-corrupted Windows working tree must renormalize once after pulling:

```
git rm --cached -r .
git reset --hard
```

Fixes #516.