### PR TITLE
Download in-game shop files with libcurl on Linux

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential cmake ninja-build pkg-config \
-            clang zlib1g-dev \
+            clang zlib1g-dev libcurl4-openssl-dev \
             libgl1-mesa-dev libglu1-mesa-dev libglew-dev libegl1-mesa-dev \
             libturbojpeg0-dev \
             libx11-dev libxext-dev libxrandr-dev libxi-dev libxcursor-dev \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,13 +108,14 @@ file(GLOB_RECURSE MU_CLIENT_SOURCES
 list(FILTER MU_CLIENT_SOURCES EXCLUDE REGEX "[/\\]Platform[/\\][^/\\]+[/\\][Ww]in[Mm]ain\\.[Cc]pp$")
 list(FILTER MU_CLIENT_SOURCES EXCLUDE REGEX "[/\\]Platform[/\\][^/\\]+[/\\]main\\.(cpp|mm)$")
 
-# The in-game shop's catalog downloader is a WinINet/urlmon HTTP+FTP stack with
-# no portable equivalent yet (issue #462). Exclude just that layer on
-# non-Windows; the rest of the shop (UI, list managers) compiles portably and
-# its download entry points fail gracefully there. Replacing the downloader
-# with libcurl is a follow-up.
-if(NOT WIN32)
-  list(FILTER MU_CLIENT_SOURCES EXCLUDE REGEX "[/\\]GameShop[/\\]FileDownloader[/\\]")
+# The in-game shop's catalog downloader is a WinINet/urlmon HTTP+FTP stack on
+# Windows (FileDownloader/FTPConnecter/HTTPConnecter/DownloadInfo). Off Windows
+# it is replaced by a libcurl implementation (CurlFileDownloader, issue #462).
+# Keep only the transport that fits the platform in the build.
+if(WIN32)
+  list(FILTER MU_CLIENT_SOURCES EXCLUDE REGEX "[/\\]GameShop[/\\]FileDownloader[/\\]CurlFileDownloader\\.cpp$")
+else()
+  list(FILTER MU_CLIENT_SOURCES EXCLUDE REGEX "[/\\]GameShop[/\\]FileDownloader[/\\](FileDownloader|FTPConnecter|HTTPConnecter|DownloadInfo)\\.cpp$")
 endif()
 
 # Add MuEditor sources when editor is enabled
@@ -170,6 +171,13 @@ endif()
 # links MuClient inherit them automatically.
 add_library(MuClient STATIC ${MU_CLIENT_SOURCES})
 target_compile_features(MuClient PUBLIC cxx_std_20)
+
+# The in-game shop downloader uses libcurl off Windows (issue #462); on Windows
+# it uses the OS WinINet/urlmon stack and needs no extra dependency here.
+if(NOT WIN32)
+  find_package(CURL REQUIRED)
+  target_link_libraries(MuClient PUBLIC CURL::libcurl)
+endif()
 
 # The engine relies on self-registering globals whose constructors get
 # silently dropped if the linker only pulls archive members on demand, so

--- a/src/source/GameShop/FileDownloader/CurlFileDownloader.cpp
+++ b/src/source/GameShop/FileDownloader/CurlFileDownloader.cpp
@@ -1,0 +1,168 @@
+// libcurl implementation of the shop file downloader (issue #462). Compiled
+// only on non-Windows; on Windows the WinINet FileDownloader is used instead.
+
+#include "stdafx.h"
+
+#if !defined(_WIN32) && defined(KJH_ADD_INGAMESHOP_UI_SYSTEM)
+
+#include "CurlFileDownloader.h"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <curl/curl.h>
+
+#include "Data/Translation/MultiLanguage.h"
+#include "GameShop/ShopListManager/interface/WZResult/ErrorCodeDefine.h"
+
+namespace
+{
+// Mirrors the WinINet downloader's fixed 3s connect timeout.
+constexpr long kConnectTimeoutMs = 3000;
+// Abort a transfer that stalls below 1 byte/s for this long, so a dead server
+// cannot hang the shop indefinitely (the non-Windows path runs inline, without
+// the Windows watchdog thread).
+constexpr long kLowSpeedLimitBytesPerSec = 1;
+constexpr long kLowSpeedTimeoutSec = 30;
+
+// libcurl needs one process-wide init before any easy handle is created.
+// curl_easy_init would do it lazily, but not thread-safely; do it once here.
+void EnsureCurlGlobalInit()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] { curl_global_init(CURL_GLOBAL_DEFAULT); });
+}
+
+std::string WideToUtf8(const std::wstring& value)
+{
+    if (value.empty())
+    {
+        return std::string();
+    }
+
+    // ConvertToUtf8 treats its third argument as the destination capacity and
+    // clamps to it; size for the worst-case 4-byte UTF-8 expansion plus a null.
+    std::vector<char> buffer(value.size() * 4 + 1, '\0');
+    CMultiLanguage::ConvertToUtf8(buffer.data(), value.c_str(), static_cast<int>(buffer.size()));
+    return std::string(buffer.data());
+}
+
+std::wstring Utf8ToWide(const char* value)
+{
+    if (value == nullptr || *value == '\0')
+    {
+        return std::wstring();
+    }
+
+    std::vector<wchar_t> buffer(std::strlen(value) + 1, L'\0');
+    CMultiLanguage::ConvertFromUtf8(buffer.data(), value, static_cast<int>(buffer.size()));
+    return std::wstring(buffer.data());
+}
+
+// Progress callback: a non-zero return aborts the transfer. Used to honour the
+// caller's break flag.
+int XferInfoCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t, curl_off_t)
+{
+    const volatile int* pBreak = static_cast<const volatile int*>(clientp);
+    return (pBreak != nullptr && *pBreak != 0) ? 1 : 0;
+}
+
+size_t WriteToStream(char* ptr, size_t size, size_t nmemb, void* userdata)
+{
+    auto* out = static_cast<std::ofstream*>(userdata);
+    const size_t byteCount = size * nmemb;
+    out->write(ptr, static_cast<std::streamsize>(byteCount));
+    // A short return tells libcurl the write failed and aborts the transfer.
+    return out->good() ? byteCount : 0;
+}
+} // namespace
+
+WZResult CurlFileDownloader::DownloadFile(const std::wstring& url,
+    const std::wstring& localPath,
+    const std::wstring& username,
+    const std::wstring& password,
+    bool passiveFtp,
+    const volatile int* pBreak)
+{
+    WZResult result;
+
+    const std::filesystem::path targetPath(localPath);
+    std::error_code fsError;
+    if (targetPath.has_parent_path())
+    {
+        std::filesystem::create_directories(targetPath.parent_path(), fsError);
+    }
+
+    std::ofstream out(targetPath, std::ios::binary | std::ios::trunc);
+    if (!out.is_open())
+    {
+        result.SetResult(DL_CREATE_LOCALFILE, 0, L"[CurlFileDownloader] Fail : cannot open local file %ls", localPath.c_str());
+        return result;
+    }
+
+    EnsureCurlGlobalInit();
+    CURL* curl = curl_easy_init();
+    if (curl == nullptr)
+    {
+        result.SetResult(DL_CREATE_SESSION, 0, L"[CurlFileDownloader] Fail : curl_easy_init");
+        return result;
+    }
+
+    const std::string urlUtf8 = WideToUtf8(url);
+    const std::string userUtf8 = WideToUtf8(username);
+    const std::string passwordUtf8 = WideToUtf8(password);
+
+    curl_easy_setopt(curl, CURLOPT_URL, urlUtf8.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteToStream);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &out);
+    curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);      // HTTP >= 400 is a failure
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, kConnectTimeoutMs);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, kLowSpeedLimitBytesPerSec);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, kLowSpeedTimeoutSec);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, &XferInfoCallback);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, const_cast<int*>(pBreak));
+    curl_easy_setopt(curl, CURLOPT_FTP_USE_EPSV, passiveFtp ? 1L : 0L);
+    if (!passiveFtp)
+    {
+        curl_easy_setopt(curl, CURLOPT_FTPPORT, "-");     // active mode
+    }
+    if (!userUtf8.empty())
+    {
+        curl_easy_setopt(curl, CURLOPT_USERNAME, userUtf8.c_str());
+        curl_easy_setopt(curl, CURLOPT_PASSWORD, passwordUtf8.c_str());
+    }
+
+    const CURLcode code = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
+    out.close();
+
+    if (code == CURLE_OK)
+    {
+        result.SetSuccessResult();
+        return result;
+    }
+
+    // Remove the partial file so a failed download is not mistaken for a good one.
+    std::filesystem::remove(targetPath, fsError);
+
+    if (code == CURLE_ABORTED_BY_CALLBACK)
+    {
+        result.SetResult(WZ_USER_BREAK, code, L"[CurlFileDownloader] User Break : %ls", url.c_str());
+    }
+    else
+    {
+        const std::wstring reason = Utf8ToWide(curl_easy_strerror(code));
+        result.SetResult(DL_READ_REMOTEFILE, code, L"[CurlFileDownloader] Fail : %ls (%ls)", reason.c_str(), url.c_str());
+    }
+
+    return result;
+}
+
+#endif // !_WIN32 && KJH_ADD_INGAMESHOP_UI_SYSTEM

--- a/src/source/GameShop/FileDownloader/CurlFileDownloader.cpp
+++ b/src/source/GameShop/FileDownloader/CurlFileDownloader.cpp
@@ -104,6 +104,12 @@ WZResult CurlFileDownloader::DownloadFile(const std::wstring& url,
         return result;
     }
 
+    // Run the throwing UTF-8 conversions before curl_easy_init so no exception
+    // can leak the CURL handle between init and curl_easy_cleanup.
+    const std::string urlUtf8 = WideToUtf8(url);
+    const std::string userUtf8 = WideToUtf8(username);
+    const std::string passwordUtf8 = WideToUtf8(password);
+
     EnsureCurlGlobalInit();
     CURL* curl = curl_easy_init();
     if (curl == nullptr)
@@ -111,10 +117,6 @@ WZResult CurlFileDownloader::DownloadFile(const std::wstring& url,
         result.SetResult(DL_CREATE_SESSION, 0, L"[CurlFileDownloader] Fail : curl_easy_init");
         return result;
     }
-
-    const std::string urlUtf8 = WideToUtf8(url);
-    const std::string userUtf8 = WideToUtf8(username);
-    const std::string passwordUtf8 = WideToUtf8(password);
 
     curl_easy_setopt(curl, CURLOPT_URL, urlUtf8.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteToStream);

--- a/src/source/GameShop/FileDownloader/CurlFileDownloader.h
+++ b/src/source/GameShop/FileDownloader/CurlFileDownloader.h
@@ -1,0 +1,29 @@
+// libcurl-backed shop file downloader (issue #462).
+//
+// The in-game shop's catalog/script downloader is a WinINet + urlmon stack on
+// Windows (FileDownloader/FTPConnecter/HTTPConnecter). Those have no portable
+// equivalent, so off Windows this class downloads a single remote file (FTP or
+// HTTP) to a local path with libcurl instead. It is compiled only on
+// non-Windows; the WinINet path stays in use on Windows unchanged.
+#pragma once
+
+#include <string>
+
+#include "GameShop/ShopListManager/interface/WZResult/WZResult.h"
+
+class CurlFileDownloader
+{
+public:
+    // Downloads url to localPath, creating parent directories as needed.
+    // username/password are used for FTP authentication (ignored when empty).
+    // passiveFtp selects passive vs. active FTP transfer mode. pBreak, when not
+    // null, is polled during the transfer and aborts it once it becomes
+    // non-zero. Returns a WZResult using the same DL_/WZ_ codes as the WinINet
+    // downloader so callers handle both paths identically.
+    static WZResult DownloadFile(const std::wstring& url,
+        const std::wstring& localPath,
+        const std::wstring& username,
+        const std::wstring& password,
+        bool passiveFtp,
+        const volatile int* pBreak);
+};

--- a/src/source/GameShop/ShopListManager/FTPFileDownLoader.cpp
+++ b/src/source/GameShop/ShopListManager/FTPFileDownLoader.cpp
@@ -14,6 +14,37 @@
 
 #include <iterator>
 
+#ifndef _WIN32
+#include <string>
+
+#include "GameShop/FileDownloader/CurlFileDownloader.h"
+
+namespace
+{
+std::wstring BuildFtpUrl(const std::wstring& host, unsigned short port, const std::wstring& remotePath)
+{
+    // WinINet's FtpOpenFile treated the remote path as relative to the login
+    // directory; libcurl's ftp://host/path does the same with a single leading
+    // slash. Normalise separators and drop any leading slash so exactly one
+    // sits between the host and the path.
+    std::wstring path = remotePath;
+    for (wchar_t& ch : path)
+    {
+        if (ch == L'\\')
+        {
+            ch = L'/';
+        }
+    }
+    while (!path.empty() && path.front() == L'/')
+    {
+        path.erase(path.begin());
+    }
+
+    return L"ftp://" + host + L":" + std::to_wstring(port) + L"/" + path;
+}
+} // namespace
+#endif // _WIN32
+
 CFTPFileDownLoader::CFTPFileDownLoader() // OK
 {
     this->m_Break = 0;
@@ -44,9 +75,34 @@ WZResult CFTPFileDownLoader::DownLoadFiles(DownloaderType type,
     static WZResult result;
 
 #ifndef _WIN32
-    // The WinInet downloader is excluded off Windows (issue #462); report the
-    // download as failed so the shop falls back to its no-script state.
-    result.SetResult(1, 0, L"File download is not supported on this platform");
+    // Off Windows the WinINet FileDownloader is replaced by libcurl (issue #462).
+    result.BuildSuccessResult();
+
+    wchar_t versionDir[MAX_PATH] = { 0 };
+    StringCchPrintf(versionDir, std::size(versionDir), L"%03d.%04d.%03d", Version.Zone, Version.year, Version.yearId);
+
+    const std::wstring remoteBase = strRemotepath + versionDir + L"/";
+    const std::wstring localBase = strlocalpath + versionDir + L"/";
+
+    for (std::vector<std::wstring>::iterator it = vScriptFiles.begin(); it != vScriptFiles.end(); ++it)
+    {
+        const std::wstring localPath = localBase + (*it);
+        const std::wstring url = BuildFtpUrl(strServerIP, PortNum, remoteBase + (*it));
+
+        result = CurlFileDownloader::DownloadFile(url, localPath, strUserName, strPWD, bPassiveMode, &this->m_Break);
+
+        if (this->m_Break != 0)
+        {
+            result.SetResult(1, 0, L"Time Out Break");
+            break;
+        }
+
+        if (!result.IsSuccess())
+        {
+            break;
+        }
+    }
+
     return result;
 #else
     result.BuildSuccessResult();


### PR DESCRIPTION
## What
The in-game shop's catalog/script downloader is a WinINet + urlmon FTP/HTTP stack with no portable equivalent, so off Windows the shop could not fetch its update scripts - the download entry point failed immediately (issue #462).

This adds a libcurl-backed downloader for non-Windows and routes the shop's download path through it. The Windows WinINet path is unchanged.

## How
- **`CurlFileDownloader`** (new, `GameShop/FileDownloader/`) fetches a single remote file (FTP or HTTP) to a local path with libcurl. It mirrors the WinINet downloader: a 3s connect timeout, passive/active FTP selection, the caller's break flag via the progress callback, and the same `WZResult`/`DL_*` result codes so callers handle both paths identically. A low-speed abort keeps a dead server from hanging the shop, which runs the download inline off Windows (no watchdog thread there).
- **`CFTPFileDownLoader`** non-Windows branch builds the FTP URL and calls `CurlFileDownloader` instead of returning a failure.
- **CMake** compiles the WinINet stack (`FileDownloader`/`FTPConnecter`/`HTTPConnecter`/`DownloadInfo`) on Windows and `CurlFileDownloader` elsewhere, and links `CURL::libcurl` off Windows via `find_package(CURL REQUIRED)`.
- **Linux CI** installs `libcurl4-openssl-dev`.

## Scope
This completes the "disable-on-Linux -> real downloader" follow-up for the shop's FTP/HTTP transport. The banner-image download (`URLDownloadToFile`) remains `_WIN32`-guarded and is out of scope here.

## Testing
- The exact libcurl usage (all `CURLOPT_*`, both callback signatures, `curl_off_t`/`CURLcode`, `curl_easy_strerror`) compiles clean under `-Wall -Wextra -std=c++20` against libcurl 8.5.
- Full native compile/link is exercised by the Linux CI in this PR. A live FTP transfer against a real shop server was not tested.

Part of #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)