### PR TITLE
fix: health threshold being ovewritten with 0 or 10, and system message target

### DIFF
--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -4043,7 +4043,10 @@ BOOL ReceiveMagic(const BYTE* ReceiveBuffer, int Size, BOOL bEncrypted)
     {
         if (Success == false)
         {
-            g_pSystemLogBox->AddText(I18N::Game::StongerEffectHasTakenPlace, SEASON3B::TYPE_SYSTEM_MESSAGE);
+            if (SourceKey == HeroKey)
+            {
+                g_pSystemLogBox->AddText(I18N::Game::StongerEffectHasTakenPlace, SEASON3B::TYPE_SYSTEM_MESSAGE);
+            }
             return FALSE;
         }
     }

--- a/src/source/UI/NewUI/NewUIMuHelper.cpp
+++ b/src/source/UI/NewUI/NewUIMuHelper.cpp
@@ -2367,6 +2367,8 @@ bool CNewUIMuHelperExt::Create(CNewUIManager* pNewUIMng, int x, int y)
 
     InitText();
 
+    ApplySavedConfig();
+
     Show(false);
 
     return true;
@@ -2741,7 +2743,6 @@ bool CNewUIMuHelperExt::UpdateMouseEvent()
 
     if (CheckMouseIn(m_Pos.x + 33 - 8, m_Pos.y + 80, 124 + 8, 16))
     {
-        int iOldValue = m_iCurrentPotionThreshold;
         if (MouseWheel > 0)
         {
             MouseWheel = 0;
@@ -2779,7 +2780,6 @@ bool CNewUIMuHelperExt::UpdateMouseEvent()
     {
         if (CheckMouseIn(m_Pos.x + 33 - 8, m_Pos.y + 145, 124 + 8, 16))
         {
-            int iOldValue = m_iCurrentHealThreshold;
             if (MouseWheel > 0)
             {
                 MouseWheel = 0;
@@ -2817,7 +2817,6 @@ bool CNewUIMuHelperExt::UpdateMouseEvent()
     {
         if (CheckMouseIn(m_Pos.x + 32 - 8, m_Pos.y + 100, 124 + 8, 16))
         {
-            int iOldValue = m_iCurrentPartyHealThreshold;
             if (MouseWheel > 0)
             {
                 MouseWheel = 0;

--- a/src/source/UI/NewUI/NewUIMuHelper.cpp
+++ b/src/source/UI/NewUI/NewUIMuHelper.cpp
@@ -1047,6 +1047,11 @@ void CNewUIMuHelper::ApplyConfig()
 {
     g_MuHelper.Load(_TempConfig);
 
+    if (g_pNewUIMuHelperExt)
+    {
+        g_pNewUIMuHelperExt->ApplySavedConfig();
+    }
+
     m_aiSelectedSkills[0] = _TempConfig.aiSkill[0] ? _TempConfig.aiSkill[0] : -1;
     m_aiSelectedSkills[1] = _TempConfig.aiSkill[1] ? _TempConfig.aiSkill[1] : -1;
     m_aiSelectedSkills[2] = _TempConfig.aiSkill[2] ? _TempConfig.aiSkill[2] : -1;


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

Guard the "Stronger effect has taken place" system message so it only shows for the local player, not for other party members' buffs. Initialize MUHelper ext threshold members on create to prevent stale reads.

## Related issues

NA

## Checklist

- [X] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [X] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)).
- [X] Changes are focused on one concern; the diff is as small as it reasonably can be.
