### PR TITLE
Make saving the login password opt-in with a confirmation

### DIFF
--- a/docs/options-window.md
+++ b/docs/options-window.md
@@ -32,7 +32,9 @@ window writes to these sections:
 - `[Window]` - width, height, windowed flag.
 - `[Graphics]` - render levels, vsync, fps limit.
 - `[Audio]` - volumes.
-- `[Login]`
+- `[Login]` - language, and the remembered-credential keys (`RememberMe`,
+  `SavePassword`, `EncryptedUsername`, `EncryptedPassword`); see
+  "Remembering login credentials" below.
 - `[ConnectionSettings]`
 - `[Camera]` - orbital wheel-zoom radius (`Zoom`). **New in this PR**, the
   only key the camera rework added.
@@ -40,3 +42,22 @@ window writes to these sections:
 Missing keys fall back to compile-time defaults from
 `src/source/Data/GameConfig/GameConfigConstants.h`. If `config.ini` doesn't exist,
 it's created the first time anything calls `Save()`.
+
+## Remembering login credentials
+
+The login screen has two separate checkboxes:
+
+- **Remember Username** - fills in your account name next time. Safe to leave
+  on; only the username is stored.
+- **Remember Password** - also stores the password. Because a saved password
+  lets anyone using the same computer log into your account, ticking it opens a
+  confirmation dialog first; the box only stays ticked if you accept it. Leave
+  this off on shared machines (e.g. an internet cafe).
+
+Editing the account or password field clears any stored credentials and turns
+Remember Password back off, so an out-of-date password is never left behind.
+
+Stored credentials are obfuscated (not plaintext) and tied to the current
+machine and user account, so copying `config.ini` to another machine does not
+reveal them. This is protection against a casual reader of the file, not a
+determined attacker - which is why saving the password is opt-in.

--- a/src/Localization/Game.en.resx
+++ b/src/Localization/Game.en.resx
@@ -1681,6 +1681,26 @@
     <value>Password</value>
     <comment>legacy_id=451</comment>
   </data>
+  <data name="LoginRememberUsername" xml:space="preserve">
+    <value>Remember Username</value>
+    <comment>Login screen: remember-username checkbox label.</comment>
+  </data>
+  <data name="LoginRememberPassword" xml:space="preserve">
+    <value>Remember Password</value>
+    <comment>Login screen: remember-password checkbox label.</comment>
+  </data>
+  <data name="LoginTrustWarning" xml:space="preserve">
+    <value>Only save the password on a PC you trust.</value>
+    <comment>Login screen: warning under the remember-password checkbox.</comment>
+  </data>
+  <data name="LoginSavePasswordWarningTitle" xml:space="preserve">
+    <value>WARNING!!!</value>
+    <comment>Remember-password confirmation dialog: header.</comment>
+  </data>
+  <data name="LoginSavePasswordWarningBody" xml:space="preserve">
+    <value>Saving the password lets anyone using this computer log into your account. Only do this on a PC you trust. Save the password?</value>
+    <comment>Remember-password confirmation dialog: body.</comment>
+  </data>
   <data name="Connect" xml:space="preserve">
     <value>Connect</value>
     <comment>legacy_id=452,562</comment>

--- a/src/source/Data/GameConfig/GameConfig.cpp
+++ b/src/source/Data/GameConfig/GameConfig.cpp
@@ -62,6 +62,7 @@ void GameConfig::Load()
     m_musicVolume  = ReadInt(CfgSectionAudio, CfgKeyMusicVolume, CfgDefaultMusicVolume);
 
     m_rememberMe        = ReadBool(CfgSectionLogin, CfgKeyRememberMe, CfgDefaultRememberMe);
+    m_savePassword      = ReadBool(CfgSectionLogin, CfgKeySavePassword, CfgDefaultSavePassword);
     m_languageSelection = ReadString(CfgSectionLogin, CfgKeyLanguage, CfgDefaultLanguage);
     m_encryptedUsername = ReadString(CfgSectionLogin, CfgKeyEncryptedUsername, CfgDefaultEncryptedUsername);
     m_encryptedPassword = ReadString(CfgSectionLogin, CfgKeyEncryptedPassword, CfgDefaultEncryptedPassword);
@@ -101,6 +102,7 @@ void GameConfig::Save()
     WriteInt(CfgSectionAudio, CfgKeyMusicVolume, m_musicVolume);
 
     WriteBool(CfgSectionLogin, CfgKeyRememberMe, m_rememberMe);
+    WriteBool(CfgSectionLogin, CfgKeySavePassword, m_savePassword);
     WriteString(CfgSectionLogin, CfgKeyLanguage, m_languageSelection);
     WriteString(CfgSectionLogin, CfgKeyEncryptedUsername, m_encryptedUsername);
     WriteString(CfgSectionLogin, CfgKeyEncryptedPassword, m_encryptedPassword);
@@ -138,6 +140,19 @@ void GameConfig::SetMusicVolume(int level)
 void GameConfig::SetRememberMe(bool remember)
 {
     m_rememberMe = remember;
+}
+
+void GameConfig::SetSavePassword(bool save)
+{
+    m_savePassword = save;
+}
+
+void GameConfig::ClearCredentials()
+{
+    m_encryptedUsername.clear();
+    m_encryptedPassword.clear();
+    m_savePassword = false;
+    Save();
 }
 
 void GameConfig::SetLanguageSelection(const std::wstring& lang)
@@ -231,16 +246,23 @@ std::vector<BYTE> GameConfig::HexToBinary(const std::wstring& hex)
 
 void GameConfig::DecryptCredentials(wchar_t* outUser, wchar_t* outPass, size_t userBufSize, size_t passBufSize)
 {
+    // Start empty so a missing username/password never leaves stale text behind.
+    if (outUser && userBufSize) outUser[0] = L'\0';
+    if (outPass && passBufSize) outPass[0] = L'\0';
+
     // Decrypt Username
     std::wstring user = DecryptSetting(GetEncryptedUsername());
     if (!user.empty()) {
         wcsncpy_s(outUser, userBufSize, user.c_str(), _TRUNCATE);
     }
 
-    // Decrypt Password
-    std::wstring pass = DecryptSetting(GetEncryptedPassword());
-    if (!pass.empty()) {
-        wcsncpy_s(outPass, passBufSize, pass.c_str(), _TRUNCATE);
+    // Decrypt Password only when the player consented to storing it; otherwise
+    // only the username is remembered.
+    if (m_savePassword) {
+        std::wstring pass = DecryptSetting(GetEncryptedPassword());
+        if (!pass.empty()) {
+            wcsncpy_s(outPass, passBufSize, pass.c_str(), _TRUNCATE);
+        }
     }
 }
 
@@ -346,12 +368,24 @@ std::wstring GameConfig::EncryptSetting(const wchar_t* input)
 void GameConfig::EncryptAndSaveCredentials(const wchar_t* user, const wchar_t* pass)
 {
     std::wstring encUser = EncryptSetting(user);
-    std::wstring encPass = EncryptSetting(pass);
-
-    if (!encUser.empty() && !encPass.empty())
+    if (encUser.empty())
     {
-        SetEncryptedUsername(encUser);
-        SetEncryptedPassword(encPass);
-        Save(); // Actually write to the .ini file
+        // No username to remember; leave any prior credentials untouched.
+        return;
     }
+
+    SetEncryptedUsername(encUser);
+
+    // The password is persisted only with explicit consent. Without it, clear
+    // any previously stored password so it never lingers in config.ini.
+    if (m_savePassword)
+    {
+        SetEncryptedPassword(EncryptSetting(pass));
+    }
+    else
+    {
+        SetEncryptedPassword(L"");
+    }
+
+    Save(); // Actually write to the .ini file
 }

--- a/src/source/Data/GameConfig/GameConfig.cpp
+++ b/src/source/Data/GameConfig/GameConfig.cpp
@@ -252,7 +252,7 @@ void GameConfig::DecryptCredentials(wchar_t* outUser, wchar_t* outPass, size_t u
 
     // Decrypt Username
     std::wstring user = DecryptSetting(GetEncryptedUsername());
-    if (!user.empty()) {
+    if (!user.empty() && outUser && userBufSize) {
         wcsncpy_s(outUser, userBufSize, user.c_str(), _TRUNCATE);
     }
 
@@ -260,7 +260,7 @@ void GameConfig::DecryptCredentials(wchar_t* outUser, wchar_t* outPass, size_t u
     // only the username is remembered.
     if (m_savePassword) {
         std::wstring pass = DecryptSetting(GetEncryptedPassword());
-        if (!pass.empty()) {
+        if (!pass.empty() && outPass && passBufSize) {
             wcsncpy_s(outPass, passBufSize, pass.c_str(), _TRUNCATE);
         }
     }

--- a/src/source/Data/GameConfig/GameConfig.h
+++ b/src/source/Data/GameConfig/GameConfig.h
@@ -32,6 +32,16 @@ public:
     bool GetRememberMe() const { return m_rememberMe; }
     void SetRememberMe(bool remember);
 
+    // Whether the password (not just the username) may be persisted. Off by
+    // default: "remember me" saves only the username unless the player opts in
+    // on a machine they trust.
+    bool GetSavePassword() const { return m_savePassword; }
+    void SetSavePassword(bool save);
+
+    // Drops the saved username and password from config.ini and revokes the
+    // save-password consent. Used when the player edits the credentials.
+    void ClearCredentials();
+
     std::wstring GetLanguageSelection() const { return m_languageSelection; }
     void SetLanguageSelection(const std::wstring& lang);
 
@@ -84,6 +94,7 @@ private:
     int  m_musicVolume;
 
     bool m_rememberMe;
+    bool m_savePassword;
     std::wstring m_languageSelection;
     std::wstring m_encryptedUsername;
     std::wstring m_encryptedPassword;

--- a/src/source/Data/GameConfig/GameConfigConstants.h
+++ b/src/source/Data/GameConfig/GameConfigConstants.h
@@ -24,6 +24,7 @@ namespace CfgKeys
 
     // Login
     inline constexpr wchar_t CfgKeyRememberMe[]        = L"RememberMe";
+    inline constexpr wchar_t CfgKeySavePassword[]      = L"SavePassword";
     inline constexpr wchar_t CfgKeyLanguage[]          = L"Language";
     inline constexpr wchar_t CfgKeyEncryptedUsername[] = L"EncryptedUsername";
     inline constexpr wchar_t CfgKeyEncryptedPassword[] = L"EncryptedPassword";
@@ -50,6 +51,7 @@ namespace CfgDefaults
     inline constexpr int  CfgDefaultMusicVolume = 5;
 
     inline constexpr bool CfgDefaultRememberMe = false;
+    inline constexpr bool CfgDefaultSavePassword = false;
     inline constexpr wchar_t CfgDefaultLanguage[] = L"Eng";
     inline constexpr wchar_t CfgDefaultEncryptedUsername[] = L"";
     inline constexpr wchar_t CfgDefaultEncryptedPassword[] = L"";

--- a/src/source/Scenes/LoginScene.cpp
+++ b/src/source/Scenes/LoginScene.cpp
@@ -27,6 +27,7 @@
 #include "SceneCommon.h"
 #include "Engine/Object/ZzzOpenData.h"
 #include "UI/NewUI/NewUISystem.h"
+#include "UI/NewUI/Dialogs/NewUICommonMessageBox.h"
 
 // External declarations
 extern int DeleteGuildIndex;
@@ -475,6 +476,17 @@ bool NewRenderLogInScene(HDC hDC)
         g_pOption->UpdateMouseEvent();
         g_pOption->UpdateKeyEvent();
         g_pOption->Render();
+    }
+
+    // Drive the NewUI message box here too (same reason as the option window):
+    // the login scene skips the full NewUI update, so a confirmation dialog such
+    // as the "Remember Password" prompt would otherwise never update or draw.
+    if (!g_MessageBox->IsEmpty())
+    {
+        g_MessageBox->UpdateMouseEvent();
+        g_MessageBox->UpdateKeyEvent();
+        g_MessageBox->Update();
+        g_MessageBox->Render();
     }
 
     EndBitmap();

--- a/src/source/UI/NewUI/Dialogs/NewUICommonMessageBox.cpp
+++ b/src/source/UI/NewUI/Dialogs/NewUICommonMessageBox.cpp
@@ -520,17 +520,22 @@ int SEASON3B::CNewUICommonMessageBox::SeparateText(const type_string& strMsg, DW
             if (TextExtentWidth > (DWORD)_TextSize && cur_offset != 0)
             {
                 // Break at the last space before the overflow so a word is not
-                // split across lines. When the line has no space (a single word
-                // wider than the box), fall back to the exact character cut.
-                int cutSize = prev_offset;
-                int nextStart = prev_offset;
-                size_t spacePos = (prev_offset > 0)
-                    ? strRemainText.rfind(L' ', (size_t)(prev_offset - 1))
-                    : type_string::npos;
-                if (spacePos != type_string::npos && spacePos > 0)
+                // split across lines. If the first character alone is wider than
+                // the box (prev_offset == 0), cut that character so the loop
+                // still makes progress instead of hanging; and when the line has
+                // no space, fall back to the exact character cut.
+                int cutSize = cur_offset;
+                int nextStart = cur_offset;
+                if (prev_offset > 0)
                 {
-                    cutSize = (int)spacePos;        // line ends before the space
-                    nextStart = (int)spacePos + 1;  // next line starts after it
+                    cutSize = prev_offset;
+                    nextStart = prev_offset;
+                    size_t spacePos = strRemainText.rfind(L' ', (size_t)prev_offset);
+                    if (spacePos != type_string::npos && spacePos > 0)
+                    {
+                        cutSize = (int)spacePos;        // line ends before the space
+                        nextStart = (int)spacePos + 1;  // next line starts after it
+                    }
                 }
 
                 strCutText = type_string(strRemainText, 0, cutSize);

--- a/src/source/UI/NewUI/Dialogs/NewUICommonMessageBox.cpp
+++ b/src/source/UI/NewUI/Dialogs/NewUICommonMessageBox.cpp
@@ -519,8 +519,22 @@ int SEASON3B::CNewUICommonMessageBox::SeparateText(const type_string& strMsg, DW
 
             if (TextExtentWidth > (DWORD)_TextSize && cur_offset != 0)
             {
-                strCutText = type_string(strRemainText, 0, prev_offset/* size */);
-                strRemainText = type_string(strRemainText, prev_offset, strRemainText.size() - prev_offset/* size */);
+                // Break at the last space before the overflow so a word is not
+                // split across lines. When the line has no space (a single word
+                // wider than the box), fall back to the exact character cut.
+                int cutSize = prev_offset;
+                int nextStart = prev_offset;
+                size_t spacePos = (prev_offset > 0)
+                    ? strRemainText.rfind(L' ', (size_t)(prev_offset - 1))
+                    : type_string::npos;
+                if (spacePos != type_string::npos && spacePos > 0)
+                {
+                    cutSize = (int)spacePos;        // line ends before the space
+                    nextStart = (int)spacePos + 1;  // next line starts after it
+                }
+
+                strCutText = type_string(strRemainText, 0, cutSize);
+                strRemainText = type_string(strRemainText, nextStart, strRemainText.size() - nextStart);
 
                 auto* pMsg = new MSGBOX_TEXTDATA;
                 pMsg->strMsg = strCutText;

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -18,6 +18,7 @@
 
 #include "Audio/DSPlaySound.h"
 #include "UI/NewUI/NewUISystem.h"
+#include "UI/NewUI/Dialogs/NewUICommonMessageBox.h"
 
 
 #include "Network/Server/ServerListManager.h"
@@ -41,6 +42,58 @@ extern int  LogIn;
 extern wchar_t LogInID[MAX_USERNAME_SIZE + 1];
 extern BYTE Version[SIZE_PROTOCOLVERSION];
 extern BYTE Serial[SIZE_PROTOCOLSERIAL + 1];
+
+namespace
+{
+// Result of the "Remember Password" confirmation dialog, polled by the login
+// window. The message-box callbacks are static, so they hand the outcome back
+// through this file-scoped state.
+enum class RememberPwConfirm { None, Pending, Ok, Cancel };
+RememberPwConfirm g_RememberPwConfirm = RememberPwConfirm::None;
+
+// OK/Cancel confirmation shown before the password is allowed to be stored.
+// Same shape as the game's other two-button dialogs (e.g. the guild request box).
+class CRememberPasswordMsgBoxLayout : public SEASON3B::TMsgBoxLayout<SEASON3B::CNewUICommonMessageBox>
+{
+public:
+    bool SetLayout() override;
+    static SEASON3B::CALLBACK_RESULT OnOk(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam);
+    static SEASON3B::CALLBACK_RESULT OnCancel(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam);
+};
+
+bool CRememberPasswordMsgBoxLayout::SetLayout()
+{
+    SEASON3B::CNewUICommonMessageBox* pMsgBox = GetMsgBox();
+    if (pMsgBox == nullptr)
+        return false;
+
+    if (!pMsgBox->Create(SEASON3B::MSGBOX_COMMON_TYPE_OKCANCEL,
+        L"Saving the password lets anyone using this computer log into your account.\nOnly do this on a PC you trust. Save the password?"))
+        return false;
+
+    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_USER_COMMON_OK);
+    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_USER_COMMON_CANCEL);
+    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_PRESSKEY_RETURN);
+    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_PRESSKEY_ESC);
+    return true;
+}
+
+SEASON3B::CALLBACK_RESULT CRememberPasswordMsgBoxLayout::OnOk(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf&)
+{
+    g_RememberPwConfirm = RememberPwConfirm::Ok;
+    PlayBuffer(SOUND_CLICK01);
+    g_MessageBox->SendEvent(pOwner, SEASON3B::MSGBOX_EVENT_DESTROY);
+    return SEASON3B::CALLBACK_BREAK;
+}
+
+SEASON3B::CALLBACK_RESULT CRememberPasswordMsgBoxLayout::OnCancel(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf&)
+{
+    g_RememberPwConfirm = RememberPwConfirm::Cancel;
+    PlayBuffer(SOUND_CLICK01);
+    g_MessageBox->SendEvent(pOwner, SEASON3B::MSGBOX_EVENT_DESTROY);
+    return SEASON3B::CALLBACK_BREAK;
+}
+} // namespace
 
 CLoginWin::CLoginWin()
 {
@@ -149,12 +202,13 @@ void CLoginWin::SetPosition(int x, int y)
 		m_pPasswordInputBox->SetPosition(boxX, int((y + 137) / g_fScreenRate_y));
 	}
 
-	m_aBtn[LIW_OK].SetPosition(x + 150, y + 178);
-	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 178);
+	// "Remember Username" (row 1) and "Remember Password" (row 2) stack
+	// vertically; the OK/Cancel buttons move down to make room. These pixel
+	// offsets are eyeballed against the login background and may need tuning.
 	m_aBtnRememberMe.SetPosition(x + 109, y + 156);
-	// Sits to the right of "Remember me?" on the same row. These pixel offsets
-	// are tuned by eye against the login background and may need adjustment.
-	m_aBtnSavePassword.SetPosition(x + 215, y + 156);
+	m_aBtnSavePassword.SetPosition(x + 109, y + 174);
+	m_aBtn[LIW_OK].SetPosition(x + 150, y + 210);
+	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 210);
 }
 
 void CLoginWin::Show(bool bShow)
@@ -192,6 +246,12 @@ bool CLoginWin::CursorInWin(int nArea)
 
 void CLoginWin::UpdateWhileActive(double)
 {
+	// While the "Remember Password" confirmation dialog is open, let it own the
+	// input so Enter/Esc/clicks don't also drive the login screen behind it. The
+	// dialog's outcome is applied on the next frame, once it has closed.
+	if (!g_MessageBox->IsEmpty())
+		return;
+
 	if (m_aBtn[LIW_OK].IsClick() || CInput::Instance().IsKeyDown(VK_RETURN))
 	{
 		PlayBuffer(SOUND_CLICK01);
@@ -223,18 +283,38 @@ void CLoginWin::UpdateWhileActive(double)
 
 	if (m_aBtnSavePassword.IsClick())
 	{
-		const bool bWantSave = m_aBtnSavePassword.IsCheck();
-
-		// Storing the password implies remembering the account; turning it on
-		// also turns "remember me" on.
-		if (bWantSave && !m_RememberMe)
+		if (m_aBtnSavePassword.IsCheck())
 		{
-			m_RememberMe = 1;
-			m_aBtnRememberMe.SetCheck(true);
-			GameConfig::GetInstance().SetRememberMe(true);
-		}
+			// Storing the password implies remembering the account.
+			if (!m_RememberMe)
+			{
+				m_RememberMe = 1;
+				m_aBtnRememberMe.SetCheck(true);
+				GameConfig::GetInstance().SetRememberMe(true);
+			}
 
-		GameConfig::GetInstance().SetSavePassword(bWantSave);
+			// Require an explicit confirmation before consenting. The checkbox
+			// stays ticked while the dialog is open and is reverted on cancel.
+			g_RememberPwConfirm = RememberPwConfirm::Pending;
+			SEASON3B::CreateMessageBox(MSGBOX_LAYOUT_CLASS(CRememberPasswordMsgBoxLayout));
+		}
+		else
+		{
+			GameConfig::GetInstance().SetSavePassword(false);
+		}
+	}
+
+	// Apply the confirmation dialog's outcome once the player answers it.
+	if (g_RememberPwConfirm == RememberPwConfirm::Ok)
+	{
+		g_RememberPwConfirm = RememberPwConfirm::None;
+		GameConfig::GetInstance().SetSavePassword(true);
+	}
+	else if (g_RememberPwConfirm == RememberPwConfirm::Cancel)
+	{
+		g_RememberPwConfirm = RememberPwConfirm::None;
+		m_aBtnSavePassword.SetCheck(false);
+		GameConfig::GetInstance().SetSavePassword(false);
 	}
 }
 
@@ -297,17 +377,14 @@ void CLoginWin::RenderControls()
     mu_swprintf(szServerName, pServerStatus, g_ServerListManager->GetSelectServerName(), g_ServerListManager->GetSelectServerIndex());
     g_pRenderText->RenderText(int((baseX + 111) / g_fScreenRate_x), int((baseY + 80) / g_fScreenRate_y), szServerName);
 
-    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), L"Remember me?");
-    g_pRenderText->RenderText(int((baseX + 235) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), L"Save password");
+    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), L"Remember Username");
+    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 177) / g_fScreenRate_y), L"Remember Password");
 
-    // Warn while the password is set to be stored. Positions here are eyeballed
-    // against the login background and may need tuning.
-    if (m_aBtnSavePassword.IsCheck())
-    {
-        g_pRenderText->SetTextColor(255, 210, 60, 255);
-        g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 212) / g_fScreenRate_y), L"Save the password only on a computer you trust.");
-        g_pRenderText->SetTextColor(CLRDW_WHITE);
-    }
+    // Warning directly under the "Remember Password" checkbox. Positions here
+    // are eyeballed against the login background and may need tuning.
+    g_pRenderText->SetTextColor(255, 210, 60, 255);
+    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 192) / g_fScreenRate_y), L"Only save the password on a PC you trust.");
+    g_pRenderText->SetTextColor(CLRDW_WHITE);
 }
 
 void CLoginWin::RequestLogin()

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -219,46 +219,50 @@ void CLoginWin::UpdateWhileActive(double)
 		return;
 	}
 
+	UpdateRememberCheckboxes();
+}
+
+void CLoginWin::UpdateRememberCheckboxes()
+{
+	GameConfig& config = GameConfig::GetInstance();
+
 	if (m_aBtnRememberMe.IsClick())
 	{
 		m_RememberMe = m_aBtnRememberMe.IsCheck();
-		GameConfig::GetInstance().SetRememberMe(m_RememberMe != 0);
+		config.SetRememberMe(m_RememberMe != 0);
 
 		// Saving the password requires remembering the account, so drop the
 		// password consent when "remember me" is switched off.
 		if (!m_RememberMe && m_aBtnSavePassword.IsCheck())
 		{
 			m_aBtnSavePassword.SetCheck(false);
-			GameConfig::GetInstance().SetSavePassword(false);
-		}
-	}
-
-	if (m_aBtnSavePassword.IsClick())
-	{
-		GameConfig& config = GameConfig::GetInstance();
-
-		if (m_aBtnSavePassword.IsCheck())
-		{
-			// Enabling requires confirmation. Revert the tick immediately; it is
-			// re-applied only if the dialog is accepted, so a cancel (however the
-			// dialog closes) always leaves the box unchecked.
-			m_aBtnSavePassword.SetCheck(false);
-
-			// Storing the password implies remembering the account.
-			if (!m_RememberMe)
-			{
-				m_RememberMe = 1;
-				m_aBtnRememberMe.SetCheck(true);
-				config.SetRememberMe(true);
-			}
-			UI::Login::OpenRememberPasswordPrompt();
-		}
-		else
-		{
-			// Player unticked it: revoke the stored password immediately.
 			config.SetSavePassword(false);
 		}
 	}
+
+	if (!m_aBtnSavePassword.IsClick())
+		return;
+
+	if (!m_aBtnSavePassword.IsCheck())
+	{
+		// Player unticked it: revoke the stored password immediately.
+		config.SetSavePassword(false);
+		return;
+	}
+
+	// Enabling requires confirmation. Revert the tick immediately; it is
+	// re-applied only if the dialog is accepted, so a cancel (however the dialog
+	// closes) always leaves the box unchecked.
+	m_aBtnSavePassword.SetCheck(false);
+
+	// Storing the password implies remembering the account.
+	if (!m_RememberMe)
+	{
+		m_RememberMe = 1;
+		m_aBtnRememberMe.SetCheck(true);
+		config.SetRememberMe(true);
+	}
+	UI::Login::OpenRememberPasswordPrompt();
 }
 
 void CLoginWin::UpdateWhileShow(double dDeltaTick)
@@ -266,23 +270,29 @@ void CLoginWin::UpdateWhileShow(double dDeltaTick)
     m_pUsernameInputBox->DoAction();
     m_pPasswordInputBox->DoAction();
 
-    // Apply the confirmation dialog's outcome here rather than in
-    // UpdateWhileActive: the modal message box leaves the login window inactive,
-    // so UpdateWhileActive stops being called, but UpdateWhileShow keeps running.
-    const UI::Login::RememberPasswordChoice choice = UI::Login::RememberPasswordChoiceState();
-    if (choice == UI::Login::RememberPasswordChoice::Ok)
-    {
-        UI::Login::ClearRememberPasswordChoice();
-        GameConfig::GetInstance().SetSavePassword(true);
-        m_aBtnSavePassword.SetCheck(true);
-    }
-    else if (choice == UI::Login::RememberPasswordChoice::Cancel)
-    {
-        UI::Login::ClearRememberPasswordChoice();
-        GameConfig::GetInstance().SetSavePassword(false);
-        m_aBtnSavePassword.SetCheck(false);
-    }
+    ApplyRememberPasswordChoice();
+    RevokeSavedCredentialsIfEdited();
+}
 
+void CLoginWin::ApplyRememberPasswordChoice()
+{
+    // Applied here rather than in UpdateWhileActive because the modal message box
+    // leaves the login window inactive (so UpdateWhileActive stops running),
+    // while UpdateWhileShow keeps being called.
+    const UI::Login::RememberPasswordChoice choice = UI::Login::RememberPasswordChoiceState();
+    if (choice != UI::Login::RememberPasswordChoice::Ok
+        && choice != UI::Login::RememberPasswordChoice::Cancel)
+        return;
+
+    UI::Login::ClearRememberPasswordChoice();
+
+    const bool bAccepted = (choice == UI::Login::RememberPasswordChoice::Ok);
+    GameConfig::GetInstance().SetSavePassword(bAccepted);
+    m_aBtnSavePassword.SetCheck(bAccepted);
+}
+
+void CLoginWin::RevokeSavedCredentialsIfEdited()
+{
     // Editing the account or password drops any stored credentials and revokes
     // the save-password consent, so an out-of-date password never lingers in
     // config.ini for the next person on this machine.
@@ -291,21 +301,21 @@ void CLoginWin::UpdateWhileShow(double dDeltaTick)
     m_pUsernameInputBox->GetText(curUser, _countof(curUser));
     m_pPasswordInputBox->GetText(curPass, _countof(curPass));
 
-    if (wcscmp(curUser, m_prevUsername) != 0 || wcscmp(curPass, m_prevPassword) != 0)
-    {
-        GameConfig& config = GameConfig::GetInstance();
-        const bool bHadStored = m_aBtnSavePassword.IsCheck()
-            || !config.GetEncryptedUsername().empty()
-            || !config.GetEncryptedPassword().empty();
-        if (bHadStored)
-        {
-            m_aBtnSavePassword.SetCheck(false);
-            config.ClearCredentials();
-        }
+    if (wcscmp(curUser, m_prevUsername) == 0 && wcscmp(curPass, m_prevPassword) == 0)
+        return;
 
-        wcscpy_s(m_prevUsername, _countof(m_prevUsername), curUser);
-        wcscpy_s(m_prevPassword, _countof(m_prevPassword), curPass);
+    GameConfig& config = GameConfig::GetInstance();
+    const bool bHadStored = m_aBtnSavePassword.IsCheck()
+        || !config.GetEncryptedUsername().empty()
+        || !config.GetEncryptedPassword().empty();
+    if (bHadStored)
+    {
+        m_aBtnSavePassword.SetCheck(false);
+        config.ClearCredentials();
     }
+
+    wcscpy_s(m_prevUsername, _countof(m_prevUsername), curUser);
+    wcscpy_s(m_prevPassword, _countof(m_prevPassword), curPass);
 }
 
 void CLoginWin::RenderControls()

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -71,9 +71,10 @@ void CLoginWin::Create()
         m_Password[0] = L'\0';
     }
 
-    // 75px taller than the original 245 so the second checkbox row, its trust
-    // warning, and the buttons fit on the panel (issue #462 credential consent).
-    CWin::Create(329, 320, BITMAP_LOG_IN + 7);
+    // The login background is fixed artwork and does not scale with the window
+    // size, so keep the original height. The credential-consent controls fit on
+    // the panel and the trust warning is drawn just below it (issue #462).
+    CWin::Create(329, 245, BITMAP_LOG_IN + 7);
 
     m_asprInputBox[LIW_ACCOUNT].Create(156, 23, BITMAP_LOG_IN + 8);
     m_asprInputBox[LIW_PASSWORD].Create(156, 23, BITMAP_LOG_IN + 8);
@@ -158,8 +159,8 @@ void CLoginWin::SetPosition(int x, int y)
 	// offsets are eyeballed against the login background and may need tuning.
 	m_aBtnRememberMe.SetPosition(x + 109, y + 156);
 	m_aBtnSavePassword.SetPosition(x + 109, y + 176);
-	m_aBtn[LIW_OK].SetPosition(x + 150, y + 276);
-	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 276);
+	m_aBtn[LIW_OK].SetPosition(x + 150, y + 200);
+	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 200);
 }
 
 void CLoginWin::Show(bool bShow)
@@ -337,11 +338,11 @@ void CLoginWin::RenderControls()
     g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), L"Remember Username");
     g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 179) / g_fScreenRate_y), L"Remember Password");
 
-    // Warning directly under the "Remember Password" checkbox, in the extra
-    // space added at the bottom of the window. Positions are eyeballed against
-    // the login background and may need tuning.
+    // Trust warning rendered just below the login panel (the panel artwork is a
+    // fixed size, so there is no room for this long line inside it). Position is
+    // eyeballed against the background and may need tuning.
     g_pRenderText->SetTextColor(255, 210, 60, 255);
-    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 200) / g_fScreenRate_y), L"Only save the password on a PC you trust.");
+    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 252) / g_fScreenRate_y), L"Only save the password on a PC you trust.");
     g_pRenderText->SetTextColor(CLRDW_WHITE);
 }
 

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -71,9 +71,9 @@ void CLoginWin::Create()
         m_Password[0] = L'\0';
     }
 
-    // 25px taller than the original 245 so the second checkbox row and its
-    // trust warning fit on the panel (issue #462 credential consent).
-    CWin::Create(329, 270, BITMAP_LOG_IN + 7);
+    // 75px taller than the original 245 so the second checkbox row, its trust
+    // warning, and the buttons fit on the panel (issue #462 credential consent).
+    CWin::Create(329, 320, BITMAP_LOG_IN + 7);
 
     m_asprInputBox[LIW_ACCOUNT].Create(156, 23, BITMAP_LOG_IN + 8);
     m_asprInputBox[LIW_PASSWORD].Create(156, 23, BITMAP_LOG_IN + 8);
@@ -158,8 +158,8 @@ void CLoginWin::SetPosition(int x, int y)
 	// offsets are eyeballed against the login background and may need tuning.
 	m_aBtnRememberMe.SetPosition(x + 109, y + 156);
 	m_aBtnSavePassword.SetPosition(x + 109, y + 176);
-	m_aBtn[LIW_OK].SetPosition(x + 150, y + 226);
-	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 226);
+	m_aBtn[LIW_OK].SetPosition(x + 150, y + 276);
+	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 276);
 }
 
 void CLoginWin::Show(bool bShow)

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -83,6 +83,9 @@ void CLoginWin::Create()
     m_aBtnRememberMe.Create(16, 16, BITMAP_CHECK_BTN, 2, 0, 0, -1, 1, 1, 1);
     CWin::RegisterButton(&m_aBtnRememberMe);
 
+    m_aBtnSavePassword.Create(16, 16, BITMAP_CHECK_BTN, 2, 0, 0, -1, 1, 1, 1);
+    CWin::RegisterButton(&m_aBtnSavePassword);
+
     SAFE_DELETE(m_pUsernameInputBox);
 
     m_pUsernameInputBox = new CUITextInputBox;
@@ -113,6 +116,15 @@ void CLoginWin::Create()
         m_aBtnRememberMe.SetCheck(true);
     }
 
+    // The password is only pre-filled and re-saved when the player previously
+    // opted in on a trusted machine.
+    m_aBtnSavePassword.SetCheck(m_RememberMe && GameConfig::GetInstance().GetSavePassword());
+
+    // Seed the edit-detection snapshot with what we just loaded so filling the
+    // boxes here is not mistaken for the player editing them.
+    m_pUsernameInputBox->GetText(m_prevUsername, _countof(m_prevUsername));
+    m_pPasswordInputBox->GetText(m_prevPassword, _countof(m_prevPassword));
+
     this->FirstLoad = 1;
 }
 
@@ -140,6 +152,9 @@ void CLoginWin::SetPosition(int x, int y)
 	m_aBtn[LIW_OK].SetPosition(x + 150, y + 178);
 	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 178);
 	m_aBtnRememberMe.SetPosition(x + 109, y + 156);
+	// Sits to the right of "Remember me?" on the same row. These pixel offsets
+	// are tuned by eye against the login background and may need adjustment.
+	m_aBtnSavePassword.SetPosition(x + 215, y + 156);
 }
 
 void CLoginWin::Show(bool bShow)
@@ -152,6 +167,7 @@ void CLoginWin::Show(bool bShow)
         m_aBtn[i].Show(bShow);
     }
     m_aBtnRememberMe.Show(bShow);
+    m_aBtnSavePassword.Show(bShow);
 
     // Drive the text fields' state so a hidden login screen releases keyboard
     // focus (portable fields stop SDL text input when hidden, #447).
@@ -195,6 +211,30 @@ void CLoginWin::UpdateWhileActive(double)
 	{
 		m_RememberMe = m_aBtnRememberMe.IsCheck();
 		GameConfig::GetInstance().SetRememberMe(m_RememberMe != 0);
+
+		// Saving the password requires remembering the account, so drop the
+		// password consent when "remember me" is switched off.
+		if (!m_RememberMe && m_aBtnSavePassword.IsCheck())
+		{
+			m_aBtnSavePassword.SetCheck(false);
+			GameConfig::GetInstance().SetSavePassword(false);
+		}
+	}
+
+	if (m_aBtnSavePassword.IsClick())
+	{
+		const bool bWantSave = m_aBtnSavePassword.IsCheck();
+
+		// Storing the password implies remembering the account; turning it on
+		// also turns "remember me" on.
+		if (bWantSave && !m_RememberMe)
+		{
+			m_RememberMe = 1;
+			m_aBtnRememberMe.SetCheck(true);
+			GameConfig::GetInstance().SetRememberMe(true);
+		}
+
+		GameConfig::GetInstance().SetSavePassword(bWantSave);
 	}
 }
 
@@ -202,6 +242,30 @@ void CLoginWin::UpdateWhileShow(double dDeltaTick)
 {
     m_pUsernameInputBox->DoAction();
     m_pPasswordInputBox->DoAction();
+
+    // Editing the account or password drops any stored credentials and revokes
+    // the save-password consent, so an out-of-date password never lingers in
+    // config.ini for the next person on this machine.
+    wchar_t curUser[MAX_USERNAME_SIZE + 1] = {};
+    wchar_t curPass[MAX_PASSWORD_SIZE + 1] = {};
+    m_pUsernameInputBox->GetText(curUser, _countof(curUser));
+    m_pPasswordInputBox->GetText(curPass, _countof(curPass));
+
+    if (wcscmp(curUser, m_prevUsername) != 0 || wcscmp(curPass, m_prevPassword) != 0)
+    {
+        GameConfig& config = GameConfig::GetInstance();
+        const bool bHadStored = m_aBtnSavePassword.IsCheck()
+            || !config.GetEncryptedUsername().empty()
+            || !config.GetEncryptedPassword().empty();
+        if (bHadStored)
+        {
+            m_aBtnSavePassword.SetCheck(false);
+            config.ClearCredentials();
+        }
+
+        wcscpy_s(m_prevUsername, _countof(m_prevUsername), curUser);
+        wcscpy_s(m_prevPassword, _countof(m_prevPassword), curPass);
+    }
 }
 
 void CLoginWin::RenderControls()
@@ -234,6 +298,16 @@ void CLoginWin::RenderControls()
     g_pRenderText->RenderText(int((baseX + 111) / g_fScreenRate_x), int((baseY + 80) / g_fScreenRate_y), szServerName);
 
     g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), L"Remember me?");
+    g_pRenderText->RenderText(int((baseX + 235) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), L"Save password");
+
+    // Warn while the password is set to be stored. Positions here are eyeballed
+    // against the login background and may need tuning.
+    if (m_aBtnSavePassword.IsCheck())
+    {
+        g_pRenderText->SetTextColor(255, 210, 60, 255);
+        g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 212) / g_fScreenRate_y), L"Save the password only on a computer you trust.");
+        g_pRenderText->SetTextColor(CLRDW_WHITE);
+    }
 }
 
 void CLoginWin::RequestLogin()
@@ -246,17 +320,17 @@ void CLoginWin::RequestLogin()
     m_pUsernameInputBox->GetText(m_Username, _countof(m_Username));
     m_pPasswordInputBox->GetText(m_Password, _countof(m_Password));
 
-    // Handle credentials saving
+    // Handle credentials saving. The username is remembered when "remember me"
+    // is set; the password is only stored on top of that with explicit consent.
     if (m_aBtnRememberMe.IsCheck())
     {
+        GameConfig::GetInstance().SetSavePassword(m_aBtnSavePassword.IsCheck());
         GameConfig::GetInstance().EncryptAndSaveCredentials(m_Username, m_Password);
     }
     else
     {
         // Clear saved credentials if user unchecked "Remember Me"
-        GameConfig::GetInstance().SetEncryptedUsername(L"");
-        GameConfig::GetInstance().SetEncryptedPassword(L"");
-        GameConfig::GetInstance().Save();
+        GameConfig::GetInstance().ClearCredentials();
     }
 
     if (wcslen(m_Username) <= 0)

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -204,25 +204,6 @@ void CLoginWin::UpdateWhileActive(double)
 	if (!g_MessageBox->IsEmpty())
 		return;
 
-	// Apply the confirmation dialog's outcome first, then swallow this frame's
-	// input so the key or click that dismissed the dialog does not also drive the
-	// login form (e.g. Enter both accepting the dialog and submitting the login).
-	const UI::Login::RememberPasswordChoice choice = UI::Login::RememberPasswordChoiceState();
-	if (choice == UI::Login::RememberPasswordChoice::Ok)
-	{
-		UI::Login::ClearRememberPasswordChoice();
-		GameConfig::GetInstance().SetSavePassword(true);
-		m_aBtnSavePassword.SetCheck(true);
-		return;
-	}
-	if (choice == UI::Login::RememberPasswordChoice::Cancel)
-	{
-		UI::Login::ClearRememberPasswordChoice();
-		GameConfig::GetInstance().SetSavePassword(false);
-		m_aBtnSavePassword.SetCheck(false);
-		return;
-	}
-
 	if (m_aBtn[LIW_OK].IsClick() || CInput::Instance().IsKeyDown(VK_RETURN))
 	{
 		PlayBuffer(SOUND_CLICK01);
@@ -284,6 +265,23 @@ void CLoginWin::UpdateWhileShow(double dDeltaTick)
 {
     m_pUsernameInputBox->DoAction();
     m_pPasswordInputBox->DoAction();
+
+    // Apply the confirmation dialog's outcome here rather than in
+    // UpdateWhileActive: the modal message box leaves the login window inactive,
+    // so UpdateWhileActive stops being called, but UpdateWhileShow keeps running.
+    const UI::Login::RememberPasswordChoice choice = UI::Login::RememberPasswordChoiceState();
+    if (choice == UI::Login::RememberPasswordChoice::Ok)
+    {
+        UI::Login::ClearRememberPasswordChoice();
+        GameConfig::GetInstance().SetSavePassword(true);
+        m_aBtnSavePassword.SetCheck(true);
+    }
+    else if (choice == UI::Login::RememberPasswordChoice::Cancel)
+    {
+        UI::Login::ClearRememberPasswordChoice();
+        GameConfig::GetInstance().SetSavePassword(false);
+        m_aBtnSavePassword.SetCheck(false);
+    }
 
     // Editing the account or password drops any stored credentials and revokes
     // the save-password consent, so an out-of-date password never lingers in

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -204,6 +204,25 @@ void CLoginWin::UpdateWhileActive(double)
 	if (!g_MessageBox->IsEmpty())
 		return;
 
+	// Apply the confirmation dialog's outcome first, then swallow this frame's
+	// input so the key or click that dismissed the dialog does not also drive the
+	// login form (e.g. Enter both accepting the dialog and submitting the login).
+	const UI::Login::RememberPasswordChoice choice = UI::Login::RememberPasswordChoiceState();
+	if (choice == UI::Login::RememberPasswordChoice::Ok)
+	{
+		UI::Login::ClearRememberPasswordChoice();
+		GameConfig::GetInstance().SetSavePassword(true);
+		m_aBtnSavePassword.SetCheck(true);
+		return;
+	}
+	if (choice == UI::Login::RememberPasswordChoice::Cancel)
+	{
+		UI::Login::ClearRememberPasswordChoice();
+		GameConfig::GetInstance().SetSavePassword(false);
+		m_aBtnSavePassword.SetCheck(false);
+		return;
+	}
+
 	if (m_aBtn[LIW_OK].IsClick() || CInput::Instance().IsKeyDown(VK_RETURN))
 	{
 		PlayBuffer(SOUND_CLICK01);
@@ -258,21 +277,6 @@ void CLoginWin::UpdateWhileActive(double)
 			// Player unticked it: revoke the stored password immediately.
 			config.SetSavePassword(false);
 		}
-	}
-
-	// Apply the confirmation dialog's outcome once the player answers it.
-	const UI::Login::RememberPasswordChoice choice = UI::Login::RememberPasswordChoiceState();
-	if (choice == UI::Login::RememberPasswordChoice::Ok)
-	{
-		UI::Login::ClearRememberPasswordChoice();
-		GameConfig::GetInstance().SetSavePassword(true);
-		m_aBtnSavePassword.SetCheck(true);
-	}
-	else if (choice == UI::Login::RememberPasswordChoice::Cancel)
-	{
-		UI::Login::ClearRememberPasswordChoice();
-		GameConfig::GetInstance().SetSavePassword(false);
-		m_aBtnSavePassword.SetCheck(false);
 	}
 }
 

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -231,12 +231,13 @@ void CLoginWin::UpdateRememberCheckboxes()
 		m_RememberMe = m_aBtnRememberMe.IsCheck();
 		config.SetRememberMe(m_RememberMe != 0);
 
-		// Saving the password requires remembering the account, so drop the
-		// password consent when "remember me" is switched off.
-		if (!m_RememberMe && m_aBtnSavePassword.IsCheck())
+		// Switching off "remember me" revokes everything: drop the stored
+		// credentials from config.ini now so they can't linger if the game is
+		// closed before the next login.
+		if (!m_RememberMe)
 		{
 			m_aBtnSavePassword.SetCheck(false);
-			config.SetSavePassword(false);
+			config.ClearCredentials();
 		}
 	}
 
@@ -245,8 +246,10 @@ void CLoginWin::UpdateRememberCheckboxes()
 
 	if (!m_aBtnSavePassword.IsCheck())
 	{
-		// Player unticked it: revoke the stored password immediately.
+		// Player unticked it: drop the stored password from config.ini now.
 		config.SetSavePassword(false);
+		config.SetEncryptedPassword(L"");
+		config.Save();
 		return;
 	}
 
@@ -347,14 +350,14 @@ void CLoginWin::RenderControls()
     mu_swprintf(szServerName, pServerStatus, g_ServerListManager->GetSelectServerName(), g_ServerListManager->GetSelectServerIndex());
     g_pRenderText->RenderText(int((baseX + 111) / g_fScreenRate_x), int((baseY + 80) / g_fScreenRate_y), szServerName);
 
-    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), L"Remember Username");
-    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 179) / g_fScreenRate_y), L"Remember Password");
+    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), I18N::Game::LoginRememberUsername);
+    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 179) / g_fScreenRate_y), I18N::Game::LoginRememberPassword);
 
     // Trust warning rendered just below the login panel (the panel artwork is a
     // fixed size, so there is no room for this long line inside it). Position is
     // eyeballed against the background and may need tuning.
     g_pRenderText->SetTextColor(255, 210, 60, 255);
-    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 252) / g_fScreenRate_y), L"Only save the password on a PC you trust.");
+    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 252) / g_fScreenRate_y), I18N::Game::LoginTrustWarning);
     g_pRenderText->SetTextColor(CLRDW_WHITE);
 }
 

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -18,7 +18,8 @@
 
 #include "Audio/DSPlaySound.h"
 #include "UI/NewUI/NewUISystem.h"
-#include "UI/NewUI/Dialogs/NewUICommonMessageBox.h"
+#include "UI/NewUI/Dialogs/NewUIMessageBox.h"
+#include "UI/Windows/RememberPasswordPrompt.h"
 
 
 #include "Network/Server/ServerListManager.h"
@@ -42,58 +43,6 @@ extern int  LogIn;
 extern wchar_t LogInID[MAX_USERNAME_SIZE + 1];
 extern BYTE Version[SIZE_PROTOCOLVERSION];
 extern BYTE Serial[SIZE_PROTOCOLSERIAL + 1];
-
-namespace
-{
-// Result of the "Remember Password" confirmation dialog, polled by the login
-// window. The message-box callbacks are static, so they hand the outcome back
-// through this file-scoped state.
-enum class RememberPwConfirm { None, Pending, Ok, Cancel };
-RememberPwConfirm g_RememberPwConfirm = RememberPwConfirm::None;
-
-// OK/Cancel confirmation shown before the password is allowed to be stored.
-// Same shape as the game's other two-button dialogs (e.g. the guild request box).
-class CRememberPasswordMsgBoxLayout : public SEASON3B::TMsgBoxLayout<SEASON3B::CNewUICommonMessageBox>
-{
-public:
-    bool SetLayout() override;
-    static SEASON3B::CALLBACK_RESULT OnOk(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam);
-    static SEASON3B::CALLBACK_RESULT OnCancel(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam);
-};
-
-bool CRememberPasswordMsgBoxLayout::SetLayout()
-{
-    SEASON3B::CNewUICommonMessageBox* pMsgBox = GetMsgBox();
-    if (pMsgBox == nullptr)
-        return false;
-
-    if (!pMsgBox->Create(SEASON3B::MSGBOX_COMMON_TYPE_OKCANCEL,
-        L"Saving the password lets anyone using this computer log into your account.\nOnly do this on a PC you trust. Save the password?"))
-        return false;
-
-    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_USER_COMMON_OK);
-    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_USER_COMMON_CANCEL);
-    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_PRESSKEY_RETURN);
-    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_PRESSKEY_ESC);
-    return true;
-}
-
-SEASON3B::CALLBACK_RESULT CRememberPasswordMsgBoxLayout::OnOk(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf&)
-{
-    g_RememberPwConfirm = RememberPwConfirm::Ok;
-    PlayBuffer(SOUND_CLICK01);
-    g_MessageBox->SendEvent(pOwner, SEASON3B::MSGBOX_EVENT_DESTROY);
-    return SEASON3B::CALLBACK_BREAK;
-}
-
-SEASON3B::CALLBACK_RESULT CRememberPasswordMsgBoxLayout::OnCancel(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf&)
-{
-    g_RememberPwConfirm = RememberPwConfirm::Cancel;
-    PlayBuffer(SOUND_CLICK01);
-    g_MessageBox->SendEvent(pOwner, SEASON3B::MSGBOX_EVENT_DESTROY);
-    return SEASON3B::CALLBACK_BREAK;
-}
-} // namespace
 
 CLoginWin::CLoginWin()
 {
@@ -122,7 +71,9 @@ void CLoginWin::Create()
         m_Password[0] = L'\0';
     }
 
-    CWin::Create(329, 245, BITMAP_LOG_IN + 7);
+    // 25px taller than the original 245 so the second checkbox row and its
+    // trust warning fit on the panel (issue #462 credential consent).
+    CWin::Create(329, 270, BITMAP_LOG_IN + 7);
 
     m_asprInputBox[LIW_ACCOUNT].Create(156, 23, BITMAP_LOG_IN + 8);
     m_asprInputBox[LIW_PASSWORD].Create(156, 23, BITMAP_LOG_IN + 8);
@@ -206,9 +157,9 @@ void CLoginWin::SetPosition(int x, int y)
 	// vertically; the OK/Cancel buttons move down to make room. These pixel
 	// offsets are eyeballed against the login background and may need tuning.
 	m_aBtnRememberMe.SetPosition(x + 109, y + 156);
-	m_aBtnSavePassword.SetPosition(x + 109, y + 174);
-	m_aBtn[LIW_OK].SetPosition(x + 150, y + 210);
-	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 210);
+	m_aBtnSavePassword.SetPosition(x + 109, y + 176);
+	m_aBtn[LIW_OK].SetPosition(x + 150, y + 226);
+	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 226);
 }
 
 void CLoginWin::Show(bool bShow)
@@ -283,38 +234,44 @@ void CLoginWin::UpdateWhileActive(double)
 
 	if (m_aBtnSavePassword.IsClick())
 	{
+		GameConfig& config = GameConfig::GetInstance();
+
 		if (m_aBtnSavePassword.IsCheck())
 		{
+			// Enabling requires confirmation. Revert the tick immediately; it is
+			// re-applied only if the dialog is accepted, so a cancel (however the
+			// dialog closes) always leaves the box unchecked.
+			m_aBtnSavePassword.SetCheck(false);
+
 			// Storing the password implies remembering the account.
 			if (!m_RememberMe)
 			{
 				m_RememberMe = 1;
 				m_aBtnRememberMe.SetCheck(true);
-				GameConfig::GetInstance().SetRememberMe(true);
+				config.SetRememberMe(true);
 			}
-
-			// Require an explicit confirmation before consenting. The checkbox
-			// stays ticked while the dialog is open and is reverted on cancel.
-			g_RememberPwConfirm = RememberPwConfirm::Pending;
-			SEASON3B::CreateMessageBox(MSGBOX_LAYOUT_CLASS(CRememberPasswordMsgBoxLayout));
+			UI::Login::OpenRememberPasswordPrompt();
 		}
 		else
 		{
-			GameConfig::GetInstance().SetSavePassword(false);
+			// Player unticked it: revoke the stored password immediately.
+			config.SetSavePassword(false);
 		}
 	}
 
 	// Apply the confirmation dialog's outcome once the player answers it.
-	if (g_RememberPwConfirm == RememberPwConfirm::Ok)
+	const UI::Login::RememberPasswordChoice choice = UI::Login::RememberPasswordChoiceState();
+	if (choice == UI::Login::RememberPasswordChoice::Ok)
 	{
-		g_RememberPwConfirm = RememberPwConfirm::None;
+		UI::Login::ClearRememberPasswordChoice();
 		GameConfig::GetInstance().SetSavePassword(true);
+		m_aBtnSavePassword.SetCheck(true);
 	}
-	else if (g_RememberPwConfirm == RememberPwConfirm::Cancel)
+	else if (choice == UI::Login::RememberPasswordChoice::Cancel)
 	{
-		g_RememberPwConfirm = RememberPwConfirm::None;
-		m_aBtnSavePassword.SetCheck(false);
+		UI::Login::ClearRememberPasswordChoice();
 		GameConfig::GetInstance().SetSavePassword(false);
+		m_aBtnSavePassword.SetCheck(false);
 	}
 }
 
@@ -378,12 +335,13 @@ void CLoginWin::RenderControls()
     g_pRenderText->RenderText(int((baseX + 111) / g_fScreenRate_x), int((baseY + 80) / g_fScreenRate_y), szServerName);
 
     g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), L"Remember Username");
-    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 177) / g_fScreenRate_y), L"Remember Password");
+    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 179) / g_fScreenRate_y), L"Remember Password");
 
-    // Warning directly under the "Remember Password" checkbox. Positions here
-    // are eyeballed against the login background and may need tuning.
+    // Warning directly under the "Remember Password" checkbox, in the extra
+    // space added at the bottom of the window. Positions are eyeballed against
+    // the login background and may need tuning.
     g_pRenderText->SetTextColor(255, 210, 60, 255);
-    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 192) / g_fScreenRate_y), L"Only save the password on a PC you trust.");
+    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 200) / g_fScreenRate_y), L"Only save the password on a PC you trust.");
     g_pRenderText->SetTextColor(CLRDW_WHITE);
 }
 

--- a/src/source/UI/Windows/LoginWin.h
+++ b/src/source/UI/Windows/LoginWin.h
@@ -15,7 +15,13 @@ protected:
     CSprite		m_asprInputBox[2];
     CButton		m_aBtn[2];
     CButton     m_aBtnRememberMe;
+    CButton     m_aBtnSavePassword;
     CUITextInputBox* m_pUsernameInputBox, * m_pPasswordInputBox;
+
+    // Snapshot of the field contents, used to detect that the player edited the
+    // username or password so the stored credentials can be dropped.
+    wchar_t     m_prevUsername[MAX_USERNAME_SIZE + 1] = {};
+    wchar_t     m_prevPassword[MAX_PASSWORD_SIZE + 1] = {};
 
 public:
     CLoginWin();

--- a/src/source/UI/Windows/LoginWin.h
+++ b/src/source/UI/Windows/LoginWin.h
@@ -46,4 +46,9 @@ protected:
     void RenderControls();
     void RequestLogin();
     void CancelLogin();
+
+    // "Remember me" credential handling, split out of the update loop.
+    void UpdateRememberCheckboxes();
+    void ApplyRememberPasswordChoice();
+    void RevokeSavedCredentialsIfEdited();
 };

--- a/src/source/UI/Windows/RememberPasswordPrompt.cpp
+++ b/src/source/UI/Windows/RememberPasswordPrompt.cpp
@@ -1,0 +1,75 @@
+#include "stdafx.h"
+#include "UI/Windows/RememberPasswordPrompt.h"
+
+#include "Audio/DSPlaySound.h"
+#include "UI/NewUI/Dialogs/NewUICommonMessageBox.h"
+
+namespace
+{
+UI::Login::RememberPasswordChoice g_Choice = UI::Login::RememberPasswordChoice::None;
+
+// Two-button confirmation, modelled on the game's other OK/Cancel dialogs (e.g.
+// the guild-request box). A bold yellow "WARNING!!!" header sits above the
+// orange message body.
+class CRememberPasswordMsgBoxLayout : public SEASON3B::TMsgBoxLayout<SEASON3B::CNewUICommonMessageBox>
+{
+public:
+    bool SetLayout() override;
+    static SEASON3B::CALLBACK_RESULT OnOk(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam);
+    static SEASON3B::CALLBACK_RESULT OnCancel(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam);
+};
+
+bool CRememberPasswordMsgBoxLayout::SetLayout()
+{
+    SEASON3B::CNewUICommonMessageBox* pMsgBox = GetMsgBox();
+    if (pMsgBox == nullptr)
+        return false;
+
+    if (!pMsgBox->Create(SEASON3B::MSGBOX_COMMON_TYPE_OKCANCEL))
+        return false;
+
+    pMsgBox->AddMsg(L"WARNING!!!", CLRDW_YELLOW, SEASON3B::MSGBOX_FONT_BOLD);
+    pMsgBox->AddMsg(L"Saving the password lets anyone using this computer log into your account. Only do this on a PC you trust. Save the password?", CLRDW_ORANGE);
+
+    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_USER_COMMON_OK);
+    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_USER_COMMON_CANCEL);
+    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_PRESSKEY_RETURN);
+    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_PRESSKEY_ESC);
+    return true;
+}
+
+SEASON3B::CALLBACK_RESULT CRememberPasswordMsgBoxLayout::OnOk(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf&)
+{
+    g_Choice = UI::Login::RememberPasswordChoice::Ok;
+    PlayBuffer(SOUND_CLICK01);
+    g_MessageBox->SendEvent(pOwner, SEASON3B::MSGBOX_EVENT_DESTROY);
+    return SEASON3B::CALLBACK_BREAK;
+}
+
+SEASON3B::CALLBACK_RESULT CRememberPasswordMsgBoxLayout::OnCancel(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf&)
+{
+    g_Choice = UI::Login::RememberPasswordChoice::Cancel;
+    PlayBuffer(SOUND_CLICK01);
+    g_MessageBox->SendEvent(pOwner, SEASON3B::MSGBOX_EVENT_DESTROY);
+    return SEASON3B::CALLBACK_BREAK;
+}
+} // namespace
+
+namespace UI::Login
+{
+void OpenRememberPasswordPrompt()
+{
+    g_Choice = RememberPasswordChoice::Pending;
+    SEASON3B::CreateMessageBox(MSGBOX_LAYOUT_CLASS(CRememberPasswordMsgBoxLayout));
+}
+
+RememberPasswordChoice RememberPasswordChoiceState()
+{
+    return g_Choice;
+}
+
+void ClearRememberPasswordChoice()
+{
+    g_Choice = RememberPasswordChoice::None;
+}
+} // namespace UI::Login

--- a/src/source/UI/Windows/RememberPasswordPrompt.cpp
+++ b/src/source/UI/Windows/RememberPasswordPrompt.cpp
@@ -2,6 +2,7 @@
 #include "UI/Windows/RememberPasswordPrompt.h"
 
 #include "Audio/DSPlaySound.h"
+#include "I18N/All.h"
 #include "UI/NewUI/Dialogs/NewUICommonMessageBox.h"
 
 namespace
@@ -28,8 +29,8 @@ bool CRememberPasswordMsgBoxLayout::SetLayout()
     if (!pMsgBox->Create(SEASON3B::MSGBOX_COMMON_TYPE_OKCANCEL))
         return false;
 
-    pMsgBox->AddMsg(L"WARNING!!!", CLRDW_YELLOW, SEASON3B::MSGBOX_FONT_BOLD);
-    pMsgBox->AddMsg(L"Saving the password lets anyone using this computer log into your account. Only do this on a PC you trust. Save the password?", CLRDW_ORANGE);
+    pMsgBox->AddMsg(I18N::Game::LoginSavePasswordWarningTitle, CLRDW_YELLOW, SEASON3B::MSGBOX_FONT_BOLD);
+    pMsgBox->AddMsg(I18N::Game::LoginSavePasswordWarningBody, CLRDW_ORANGE);
 
     pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_USER_COMMON_OK);
     pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_USER_COMMON_CANCEL);

--- a/src/source/UI/Windows/RememberPasswordPrompt.h
+++ b/src/source/UI/Windows/RememberPasswordPrompt.h
@@ -1,0 +1,24 @@
+// In-game OK/Cancel confirmation shown before the login password is stored.
+// Kept separate from the login window so the message-box layout class lives in
+// its own translation unit.
+#pragma once
+
+namespace UI::Login
+{
+    // The player's answer to the "Remember Password" confirmation dialog.
+    enum class RememberPasswordChoice
+    {
+        None,     // nothing to apply
+        Pending,  // dialog is open, awaiting an answer
+        Ok,       // player confirmed
+        Cancel,   // player declined
+    };
+
+    // Opens the confirmation dialog (which warns about storing the password on a
+    // shared machine) and marks the choice Pending.
+    void OpenRememberPasswordPrompt();
+
+    // The current answer. The caller applies it and then clears it.
+    RememberPasswordChoice RememberPasswordChoiceState();
+    void ClearRememberPasswordChoice();
+}


### PR DESCRIPTION
## What
Reworks the login screen's "remember me" so the password is only stored with explicit, informed consent. This addresses the shared-machine case (e.g. an internet cafe on one OS account) where stronger crypto does not help - everyone shares the same key - so the real control is not storing the secret unless the player opts in. This is the credential half of issue #462's remaining work; the WinInet/DPAPI portability shim itself is left as-is.

## How
- **GameConfig:** new `SavePassword` flag. The username is remembered on its own; the password is stored only with consent (`DecryptCredentials` / `EncryptAndSaveCredentials` honour the flag), and `ClearCredentials()` drops both.
- **Login screen:** separate **Remember Username** and **Remember Password** checkboxes. Ticking Remember Password opens an in-game OK/Cancel confirmation (bold yellow `WARNING!!!` over an orange body) restating the shared-machine risk; the box only stays ticked if accepted, and cancelling leaves it unchecked. Editing the account or password field clears stored credentials and revokes consent.
- **Crypto unchanged:** the existing portable shim stays machine/user-scoped obfuscation - the right level for a "casual reader of `config.ini`" threat. Against a shared OS account no cipher helps, which is why the consent gate is the fix.
- **Supporting changes:** the login scene pumps the NewUI message box (it does not run the full NewUI update), and the common message box now wraps text at whole words instead of mid-word.

## Docs
`docs/options-window.md` documents the Remember Username / Remember Password behaviour and the `config.ini` keys.

## Testing
Iterated and verified in-game on Windows by the author (checkbox confirm/cancel, edit-clears-credentials, layout). CI covers the MinGW (x86/x64) and native Linux builds.

Part of #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)