### PR TITLE
fix: MuHelper party buff rotation skipping members

### DIFF
--- a/src/source/GameLogic/Social/PartyManager.cpp
+++ b/src/source/GameLogic/Social/PartyManager.cpp
@@ -90,24 +90,7 @@ void CPartyManager::SearchPartyMember()
 
 bool CPartyManager::IsPartyActive()
 {
-    int iMemberCount = 0;
-
-    for (int i = 0; i < ((sizeof(Party) / sizeof(Party[0])) - 1); i++)
-    {
-        PARTY_t* pMember = &Party[i];
-        if (pMember->Name[0] == L'\0')
-        {
-            continue;
-        }
-
-        CHARACTER* pChar = FindCharacterByID(pMember->Name);
-        if (pChar != NULL)
-        {
-            iMemberCount++;
-        }
-    }
-
-    return iMemberCount > 1;
+    return PartyNumber > 1;
 }
 
 bool CPartyManager::IsPartyMember(int index)

--- a/src/source/MUHelper/MuHelper.cpp
+++ b/src/source/MUHelper/MuHelper.cpp
@@ -420,11 +420,13 @@ namespace MUHelper
 
         if (m_config.bSupportParty && g_pPartyManager->IsPartyActive())
         {
+            m_iCurrentBuffPartyIndex %= PartyNumber;
+
             PARTY_t* pMember = &Party[m_iCurrentBuffPartyIndex];
             CHARACTER* pChar = g_pPartyManager->GetPartyMemberChar(pMember);
+            int iBuffResult = 1;
 
             if (pChar != NULL
-                && pMember->Map == gMapManager.WorldActive
                 && ComputeDistanceFromTarget(pChar) <= MAX_ACTIONABLE_DISTANCE)
             {
                 if (!m_config.bBuffDurationParty
@@ -434,16 +436,29 @@ namespace MUHelper
                     m_bTimerActivatedBuffOngoing = true;
                 }
 
-                if (!BuffTarget(pChar, (ActionSkillType)m_config.aiBuff[m_iCurrentBuffIndex]))
+                iBuffResult = BuffTarget(pChar, (ActionSkillType)m_config.aiBuff[m_iCurrentBuffIndex]);
+            }
+
+            m_iCurrentBuffPartyIndex = (m_iCurrentBuffPartyIndex + 1) % PartyNumber;
+
+            if (m_iCurrentBuffPartyIndex == 0)
+            {
+                m_iCurrentBuffIndex = (m_iCurrentBuffIndex + 1) % m_config.aiBuff.size();
+
+                // Reaching this branch means everyone's been buffed, 
+                // so we're resetting the timer activated buff flag
+                if (m_iCurrentBuffIndex == 0)
                 {
-                    return 0;
+                    m_bTimerActivatedBuffOngoing = false;
                 }
             }
 
-            m_iCurrentBuffPartyIndex = (m_iCurrentBuffPartyIndex + 1) % (sizeof(Party) / sizeof(Party[0]));
+            return iBuffResult;
         }
         else
         {
+            m_iCurrentBuffPartyIndex = 0;
+
             if (!m_config.bBuffDuration
                 && m_config.iBuffCastInterval != 0
                 && m_iSecondsElapsed % m_config.iBuffCastInterval == 0)
@@ -605,6 +620,8 @@ namespace MUHelper
 
         if (m_config.bAutoHealParty && g_pPartyManager->IsPartyActive())
         {
+            m_iCurrentHealPartyIndex %= PartyNumber;
+
             PARTY_t* pMember = &Party[m_iCurrentHealPartyIndex];
             CHARACTER* pChar = g_pPartyManager->GetPartyMemberChar(pMember);
             int iHealResult = 1;
@@ -615,20 +632,20 @@ namespace MUHelper
                 {
                     iHealResult = HealSelf(iHealingSkill);
                 }
-                else if (pMember->Map == gMapManager.WorldActive
-                    && pMember->stepHP * 10 <= m_config.iHealPartyThreshold
+                else if (pMember->stepHP * 10 <= m_config.iHealPartyThreshold
                     && ComputeDistanceFromTarget(pChar) <= MAX_ACTIONABLE_DISTANCE)
                 {
                     iHealResult = SimulateSkill(iHealingSkill, true, pChar->Key);
                 }
             }
 
-            m_iCurrentHealPartyIndex = (m_iCurrentHealPartyIndex + 1) % (sizeof(Party) / sizeof(Party[0]));
+            m_iCurrentHealPartyIndex = (m_iCurrentHealPartyIndex + 1) % PartyNumber;
 
             return iHealResult;
         }
         else
         {
+            m_iCurrentHealPartyIndex = 0;
             return HealSelf(iHealingSkill);
         }
 

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -7242,6 +7242,10 @@ void ReceivePartyResult(const BYTE* ReceiveBuffer)
 void ReceivePartyList(const BYTE* ReceiveBuffer)
 {
     auto Data = (LPPRECEIVE_PARTY_LISTS)ReceiveBuffer;
+    if (Data->Count > MAX_PARTYS)
+    {
+        Data->Count = MAX_PARTYS;
+    }
     int Offset = sizeof(PRECEIVE_PARTY_LISTS);
     PartyNumber = Data->Count;
     for (int i = 0; i < Data->Count; i++)

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -7259,6 +7259,12 @@ void ReceivePartyList(const BYTE* ReceiveBuffer)
         Offset += sizeof(PRECEIVE_PARTY_LIST);
     }
 
+    for (int i = Data->Count; i < MAX_PARTYS; i++)
+    {
+        memset(&Party[i], 0, sizeof(PARTY_t));
+        Party[i].index = -1;
+    }
+
     g_ConsoleDebug->Write(MCD_RECEIVE, L"0x42 [ReceivePartyList(partynum : %d)]", Data->Count);
 }
 
@@ -7282,6 +7288,11 @@ void ReceivePartyInfo(const BYTE* ReceiveBuffer)
 void ReceivePartyLeave(const BYTE* ReceiveBuffer)
 {
     PartyNumber = 0;
+    memset(Party, 0, sizeof(Party));
+    for (int i = 0; i < MAX_PARTYS; i++)
+    {
+        Party[i].index = -1;
+    }
     g_pSystemLogBox->AddText(I18N::Game::YouHaveJustLeftTheParty, SEASON3B::TYPE_ERROR_MESSAGE);
 
     if (g_iFollowCharacter >= 0)


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

## Fix: MuHelper party buff rotation skipping members and stale state bugs

### Root Cause

The party buff system had multiple defects that caused the helper to silently skip party members or lock up permanently, leaving party members unbuffed.

### Changes

#### `PartyManager.cpp` — `IsPartyActive()` loop bound
- Fixed loop limit from `(sizeof(Party) / sizeof(Party[0])) - 1` (4 iterations) to `MAX_PARTYS` (5 iterations), so the 5th party member is correctly counted.
- Simplified to `return PartyNumber > 1` — O(1), no iteration over all slots.

#### `WSclient.cpp` — Stale party data cleanup
- **`ReceivePartyList`**: Explicitly zeroes unused slots and resets `index = -1` after processing the new party list, preventing stale names from previous parties from being picked up.
- **`ReceivePartyLeave`**: Same cleanup on party leave, preventing stale indices from corrupting future party state.

#### `MuHelper.cpp` — Buff and Heal rotation fixes

- **Index modulo by `PartyNumber`**: Buff and heal indexes now wrap by the actual party member count instead of the hardcoded array size (5), preventing the rotation from landing on stale slots.
- **Always increment on failure**: The party index advances unconditionally each tick, even if the buff/heal fails, preventing permanent locks on a single unreachable member.
- **Reset indexes on solo**: Both `m_iCurrentBuffPartyIndex` and `m_iCurrentHealPartyIndex` are reset to 0 when returning to solo mode, preventing a stale offset on re-entry.
- **Remove stale map check**: `pMember->Map == gMapManager.WorldActive` was removed from both `Buff()` and `Heal()`. The `Map` field is only set on party list receipt and is never updated after map transitions, causing all members to be silently skipped until the next party list packet. `GetPartyMemberChar()` already returns `NULL` for off-map characters, making the check redundant.
- **Remove redundant `PartyNumber > 0` guards**: Since `IsPartyActive()` guarantees `PartyNumber > 1` before entering the party branch, the guards are dead code.

## Related issues

NA

## Checklist

- [X] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [X] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)).
- [X] Changes are focused on one concern; the diff is as small as it reasonably can be.
