### PR TITLE
fix: duplicate buff icon

### DIFF
--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -3858,7 +3858,6 @@ void ReceiveMagicFinish(const BYTE* ReceiveBuffer)
     case AT_SKILL_ICE_STORM:
         UnRegisterBuff(eDeBuff_Freeze, o);
         break;
-        //  몬스터.
     case AT_SKILL_MONSTER_MAGIC_DEF:
         SetActionDestroy_Def(o);
         UnRegisterBuff(eBuff_Defense, o);
@@ -3881,6 +3880,11 @@ void ReceiveMagicFinish(const BYTE* ReceiveBuffer)
         break;
     case AT_SKILL_ALICE_THORNS:
         UnRegisterBuff(eBuff_Thorns, o);
+        break;
+    case AT_SKILL_EXPANSION_OF_WIZARDRY:
+    case AT_SKILL_EXPANSION_OF_WIZARDRY_STR:
+    case AT_SKILL_EXPANSION_OF_WIZARDRY_MASTERY:
+        UnRegisterBuff(eBuff_SwellOfMagicPower, o);
         break;
     case AT_SKILL_ALICE_BERSERKER:
     case AT_SKILL_ALICE_BERSERKER_STR:
@@ -4864,6 +4868,8 @@ BOOL ReceiveMagic(const BYTE* ReceiveBuffer, int Size, BOOL bEncrypted)
     {
         SetAttackSpeed();
         SetAction(so, PLAYER_SKILL_SWELL_OF_MP);
+
+        g_CharacterRegisterBuff(to, eBuff_SwellOfMagicPower);
 
         vec3_t vLight;
         Vector(0.3f, 0.2f, 0.9f, vLight);
@@ -15520,10 +15526,6 @@ void ClearBuffPhysicalEffect(eBuffState buff, OBJECT* o)
 
 void RegisterBuff(eBuffState buff, OBJECT* o, const int bufftime)
 {
-    eBuffClass buffclasstype = g_IsBuffClass(buff);
-
-    if (buffclasstype == eBuffClass_Count) return;
-
     if (!o)
     {
         return;
@@ -15534,12 +15536,21 @@ void RegisterBuff(eBuffState buff, OBJECT* o, const int bufftime)
         return;
     }
 
-    InsertBuffPhysicalEffect(buff, o);
+    eBuffClass buffclasstype = g_IsBuffClass(buff);
+
+    if (buffclasstype != eBuffClass_Count)
+    {
+        InsertBuffPhysicalEffect(buff, o);
+    }
 
     if (CheckExceptionBuff(buff, o, false))
     {
         g_CharacterRegisterBuff(o, buff);
-        InsertBuffLogicalEffect(buff, o, bufftime);
+
+        if (buffclasstype != eBuffClass_Count)
+        {
+            InsertBuffLogicalEffect(buff, o, bufftime);
+        }
     }
 }
 
@@ -15547,13 +15558,18 @@ void UnRegisterBuff(eBuffState buff, OBJECT* o)
 {
     eBuffClass buffclasstype = g_IsBuffClass(buff);
 
-    if (buffclasstype == eBuffClass_Count) return;
-
-    ClearBuffPhysicalEffect(buff, o);
+    if (buffclasstype != eBuffClass_Count)
+    {
+        ClearBuffPhysicalEffect(buff, o);
+    }
 
     if (CheckExceptionBuff(buff, o, true))
     {
         g_CharacterUnRegisterBuff(o, buff);
-        ClearBuffLogicalEffect(buff, o);
+
+        if (buffclasstype != eBuffClass_Count)
+        {
+            ClearBuffLogicalEffect(buff, o);
+        }
     }
 }

--- a/src/source/UI/NewUI/HUD/NewUIBuffWindow.cpp
+++ b/src/source/UI/NewUI/HUD/NewUIBuffWindow.cpp
@@ -86,33 +86,32 @@ void SEASON3B::CNewUIBuffWindow::SetPos(int iScreenWidth)
     }
 }
 
-static eBuffState NormalizeBuffState(eBuffState raw)
+static int BuffTier(eBuffState buf)
 {
-    switch (raw)
+    switch (buf)
     {
-    case EFFECT_GREATER_LIFE_ENHANCED:
-    case EFFECT_GREATER_LIFE_MASTERED:
-        return eBuff_Life;
-    case EFFECT_MAGIC_CIRCLE_IMPROVED:
-    case EFFECT_MAGIC_CIRCLE_ENHANCED:
-        return eBuff_SwellOfMagicPower;
-    case EFFECT_GREATER_CRITICAL_DAMAGE_MASTERED:
-    case EFFECT_GREATER_CRITICAL_DAMAGE_EXTENDED:
-        return eBuff_AddCriticalDamage;
-    case EFFECT_INFINITY_ARROW_IMPROVED:
-        return eBuff_InfinityArrow;
-    case EFFECT_BLIND_IMPROVED:
-        return eDeBuff_Blind;
-    case EFFECT_POISON_ARROW_IMPROVED:
-        return EFFECT_POISON_ARROW;
-    case EFFECT_BLESS_IMPROVED:
-        return EFFECT_BLESS;
-    case EFFECT_IRON_DEFENSE_IMPROVED:
-        return EFFECT_IRON_DEFENSE;
-    case EFFECT_BLOOD_HOWLING_IMPROVED:
-        return EFFECT_BLOOD_HOWLING;
-    default:
-        return raw;
+    case eBuff_Life: return 0;
+    case EFFECT_GREATER_LIFE_ENHANCED: return 1;
+    case EFFECT_GREATER_LIFE_MASTERED: return 2;
+    case eBuff_SwellOfMagicPower: return 0;
+    case EFFECT_MAGIC_CIRCLE_IMPROVED: return 1;
+    case EFFECT_MAGIC_CIRCLE_ENHANCED: return 2;
+    case eBuff_AddCriticalDamage: return 0;
+    case EFFECT_GREATER_CRITICAL_DAMAGE_EXTENDED: return 1;
+    case EFFECT_GREATER_CRITICAL_DAMAGE_MASTERED: return 2;
+    case eBuff_InfinityArrow: return 0;
+    case EFFECT_INFINITY_ARROW_IMPROVED: return 1;
+    case eDeBuff_Blind: return 0;
+    case EFFECT_BLIND_IMPROVED: return 1;
+    case EFFECT_POISON_ARROW: return 0;
+    case EFFECT_POISON_ARROW_IMPROVED: return 1;
+    case EFFECT_BLESS: return 0;
+    case EFFECT_BLESS_IMPROVED: return 1;
+    case EFFECT_IRON_DEFENSE: return 0;
+    case EFFECT_IRON_DEFENSE_IMPROVED: return 1;
+    case EFFECT_BLOOD_HOWLING: return 0;
+    case EFFECT_BLOOD_HOWLING_IMPROVED: return 1;
+    default: return 0;
     }
 }
 
@@ -122,7 +121,6 @@ void SEASON3B::CNewUIBuffWindow::BuffSort(std::list<eBuffState>& buffstate)
     int iBuffSize = g_CharacterBuffSize(pHeroObject);
 
     eBuffState top[eBuff_Count] = {};
-    bool present[eBuff_Count] = {};
 
     for (int i = 0; i < iBuffSize; ++i)
     {
@@ -131,13 +129,16 @@ void SEASON3B::CNewUIBuffWindow::BuffSort(std::list<eBuffState>& buffstate)
         {
             continue;
         }
+        if (SetDisableRenderBuff(buf))
+        {
+            continue;
+        }
 
         eBuffState base = NormalizeBuffState(buf);
-        if (static_cast<int>(buf) > static_cast<int>(top[base]))
+        if (BuffTier(buf) > BuffTier(top[base]))
         {
             top[base] = buf;
         }
-        present[base] = true;
     }
 
     for (int i = 0; i < iBuffSize; ++i)
@@ -153,7 +154,7 @@ void SEASON3B::CNewUIBuffWindow::BuffSort(std::list<eBuffState>& buffstate)
         }
 
         eBuffState base = NormalizeBuffState(buf);
-        if (present[base] && buf != top[base])
+        if (buf != top[base])
         {
             continue;
         }
@@ -169,7 +170,7 @@ void SEASON3B::CNewUIBuffWindow::BuffSort(std::list<eBuffState>& buffstate)
         }
         else
         {
-            assert(!"SetDisableRenderBuff");
+            continue;
         }
     }
 }

--- a/src/source/UI/NewUI/HUD/NewUIBuffWindow.cpp
+++ b/src/source/UI/NewUI/HUD/NewUIBuffWindow.cpp
@@ -86,32 +86,56 @@ void SEASON3B::CNewUIBuffWindow::SetPos(int iScreenWidth)
     }
 }
 
+static eBuffState NormalizeBuffState(eBuffState raw)
+{
+    switch (raw)
+    {
+    case EFFECT_GREATER_LIFE_ENHANCED:
+    case EFFECT_GREATER_LIFE_MASTERED:
+        return eBuff_Life;
+    case EFFECT_MAGIC_CIRCLE_IMPROVED:
+    case EFFECT_MAGIC_CIRCLE_ENHANCED:
+        return eBuff_SwellOfMagicPower;
+    case EFFECT_GREATER_CRITICAL_DAMAGE_MASTERED:
+    case EFFECT_GREATER_CRITICAL_DAMAGE_EXTENDED:
+        return eBuff_AddCriticalDamage;
+    case EFFECT_INFINITY_ARROW_IMPROVED:
+        return eBuff_InfinityArrow;
+    case EFFECT_BLIND_IMPROVED:
+        return eDeBuff_Blind;
+    case EFFECT_POISON_ARROW_IMPROVED:
+        return EFFECT_POISON_ARROW;
+    case EFFECT_BLESS_IMPROVED:
+        return EFFECT_BLESS;
+    case EFFECT_IRON_DEFENSE_IMPROVED:
+        return EFFECT_IRON_DEFENSE;
+    case EFFECT_BLOOD_HOWLING_IMPROVED:
+        return EFFECT_BLOOD_HOWLING;
+    default:
+        return raw;
+    }
+}
+
 static int BuffTier(eBuffState buf)
 {
     switch (buf)
     {
-    case eBuff_Life: return 0;
-    case EFFECT_GREATER_LIFE_ENHANCED: return 1;
-    case EFFECT_GREATER_LIFE_MASTERED: return 2;
-    case eBuff_SwellOfMagicPower: return 0;
-    case EFFECT_MAGIC_CIRCLE_IMPROVED: return 1;
-    case EFFECT_MAGIC_CIRCLE_ENHANCED: return 2;
-    case eBuff_AddCriticalDamage: return 0;
-    case EFFECT_GREATER_CRITICAL_DAMAGE_EXTENDED: return 1;
-    case EFFECT_GREATER_CRITICAL_DAMAGE_MASTERED: return 2;
-    case eBuff_InfinityArrow: return 0;
-    case EFFECT_INFINITY_ARROW_IMPROVED: return 1;
-    case eDeBuff_Blind: return 0;
-    case EFFECT_BLIND_IMPROVED: return 1;
-    case EFFECT_POISON_ARROW: return 0;
-    case EFFECT_POISON_ARROW_IMPROVED: return 1;
-    case EFFECT_BLESS: return 0;
-    case EFFECT_BLESS_IMPROVED: return 1;
-    case EFFECT_IRON_DEFENSE: return 0;
-    case EFFECT_IRON_DEFENSE_IMPROVED: return 1;
-    case EFFECT_BLOOD_HOWLING: return 0;
-    case EFFECT_BLOOD_HOWLING_IMPROVED: return 1;
-    default: return 0;
+    case EFFECT_GREATER_LIFE_ENHANCED:
+    case EFFECT_MAGIC_CIRCLE_IMPROVED:
+    case EFFECT_GREATER_CRITICAL_DAMAGE_EXTENDED:
+    case EFFECT_INFINITY_ARROW_IMPROVED:
+    case EFFECT_BLIND_IMPROVED:
+    case EFFECT_POISON_ARROW_IMPROVED:
+    case EFFECT_BLESS_IMPROVED:
+    case EFFECT_IRON_DEFENSE_IMPROVED:
+    case EFFECT_BLOOD_HOWLING_IMPROVED:
+        return 1;
+    case EFFECT_GREATER_LIFE_MASTERED:
+    case EFFECT_MAGIC_CIRCLE_ENHANCED:
+    case EFFECT_GREATER_CRITICAL_DAMAGE_MASTERED:
+        return 2;
+    default:
+        return 0;
     }
 }
 
@@ -135,7 +159,7 @@ void SEASON3B::CNewUIBuffWindow::BuffSort(std::list<eBuffState>& buffstate)
         }
 
         eBuffState base = NormalizeBuffState(buf);
-        if (BuffTier(buf) > BuffTier(top[base]))
+        if (top[base] == eBuffNone || BuffTier(buf) > BuffTier(top[base]))
         {
             top[base] = buf;
         }

--- a/src/source/UI/NewUI/HUD/NewUIBuffWindow.cpp
+++ b/src/source/UI/NewUI/HUD/NewUIBuffWindow.cpp
@@ -86,30 +86,90 @@ void SEASON3B::CNewUIBuffWindow::SetPos(int iScreenWidth)
     }
 }
 
+static eBuffState NormalizeBuffState(eBuffState raw)
+{
+    switch (raw)
+    {
+    case EFFECT_GREATER_LIFE_ENHANCED:
+    case EFFECT_GREATER_LIFE_MASTERED:
+        return eBuff_Life;
+    case EFFECT_MAGIC_CIRCLE_IMPROVED:
+    case EFFECT_MAGIC_CIRCLE_ENHANCED:
+        return eBuff_SwellOfMagicPower;
+    case EFFECT_GREATER_CRITICAL_DAMAGE_MASTERED:
+    case EFFECT_GREATER_CRITICAL_DAMAGE_EXTENDED:
+        return eBuff_AddCriticalDamage;
+    case EFFECT_INFINITY_ARROW_IMPROVED:
+        return eBuff_InfinityArrow;
+    case EFFECT_BLIND_IMPROVED:
+        return eDeBuff_Blind;
+    case EFFECT_POISON_ARROW_IMPROVED:
+        return EFFECT_POISON_ARROW;
+    case EFFECT_BLESS_IMPROVED:
+        return EFFECT_BLESS;
+    case EFFECT_IRON_DEFENSE_IMPROVED:
+        return EFFECT_IRON_DEFENSE;
+    case EFFECT_BLOOD_HOWLING_IMPROVED:
+        return EFFECT_BLOOD_HOWLING;
+    default:
+        return raw;
+    }
+}
+
 void SEASON3B::CNewUIBuffWindow::BuffSort(std::list<eBuffState>& buffstate)
 {
     OBJECT* pHeroObject = &Hero->Object;
-
     int iBuffSize = g_CharacterBuffSize(pHeroObject);
+
+    eBuffState top[eBuff_Count] = {};
+    bool present[eBuff_Count] = {};
 
     for (int i = 0; i < iBuffSize; ++i)
     {
-        eBuffState eBuffType = g_CharacterBuff(pHeroObject, i);
+        eBuffState buf = g_CharacterBuff(pHeroObject, i);
+        if (buf == eBuffNone)
+        {
+            continue;
+        }
 
-        if (SetDisableRenderBuff(eBuffType))	continue;
+        eBuffState base = NormalizeBuffState(buf);
+        if (static_cast<int>(buf) > static_cast<int>(top[base]))
+        {
+            top[base] = buf;
+        }
+        present[base] = true;
+    }
 
-        if (eBuffType != eBuffNone) {
-            eBuffClass eBuffClassType = g_IsBuffClass(eBuffType);
+    for (int i = 0; i < iBuffSize; ++i)
+    {
+        eBuffState buf = g_CharacterBuff(pHeroObject, i);
+        if (buf == eBuffNone)
+        {
+            continue;
+        }
+        if (SetDisableRenderBuff(buf))
+        {
+            continue;
+        }
 
-            if (eBuffClassType == eBuffClass_Buff) {
-                buffstate.push_front(eBuffType);
-            }
-            else if (eBuffClassType == eBuffClass_DeBuff) {
-                buffstate.push_back(eBuffType);
-            }
-            else {
-                assert(!"SetDisableRenderBuff");
-            }
+        eBuffState base = NormalizeBuffState(buf);
+        if (present[base] && buf != top[base])
+        {
+            continue;
+        }
+
+        eBuffClass eBuffClassType = g_IsBuffClass(buf);
+        if (eBuffClassType == eBuffClass_Buff)
+        {
+            buffstate.push_front(buf);
+        }
+        else if (eBuffClassType == eBuffClass_DeBuff)
+        {
+            buffstate.push_back(buf);
+        }
+        else
+        {
+            assert(!"SetDisableRenderBuff");
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary
**WSclient.cpp — ReceiveMagic / ReceiveMagicFinish**
- Register `eBuff_SwellOfMagicPower` (82) on cast for `AT_SKILL_EXPANSION_OF_WIZARDRY` / `_STR` / `_MASTERY`
- Unregister on expiry in `ReceiveMagicFinish`
- Matches the pattern every other buff skill in the file already follows

**WSclient.cpp — RegisterBuff / UnRegisterBuff**
- Remove the early-`return` when `g_IsBuffClass` returns `eBuffClass_Count`
- Guard `InsertBuffPhysicalEffect` / `InsertBuffLogicalEffect` / `ClearBuffPhysicalEffect` / `ClearBuffLogicalEffect` behind the class check instead
- Unknown-class buffs still enter `m_BuffMap` but skip effect handlers

**NewUIBuffWindow.cpp — NormalizeBuffState + BuffSort dedup**
- `NormalizeBuffState` maps 12 variant IDs to their 9 canonical bases:

| Variant IDs | Base | Chain |
|---|---|---|
| 135, 136 | `eBuff_Life` (8) | Swell Life |
| 138, 139 | `eBuff_SwellOfMagicPower` (82) | Expansion of Wizardry |
| 148, 149 | `eBuff_AddCriticalDamage` (5) | Critical Damage Increase |
| 143 | `eBuff_InfinityArrow` (6) | Infinity Arrow |
| 144 | `eDeBuff_Blind` (73) | Blind |
| 160 | `EFFECT_POISON_ARROW` (159) | Poison Arrow |
| 161 | `EFFECT_BLESS` (142) | Bless |
| 165 | `EFFECT_IRON_DEFENSE` (134) | Iron Defense |
| 167 | `EFFECT_BLOOD_HOWLING` (166) | Blood Howling |

- `BuffSort` uses two passes: pass one finds the highest variant present per chain, pass two skips lower-tier members
- Only the highest-tier icon renders; base buffs stay in `m_BuffMap` for stat calculations

**Before this PR:**
- MuHelper/manual casts of Expansion of Wizardry didn't recognize the buff as active
- Upgraded skills (STR / MASTERY / PROFICIENCY) showed duplicate icons in the buff window

**After this PR:**
- Base skill → correct base icon
- Upgrade skill → correct upgrade icon (never both)
- MuHelper detects the buff regardless of upgrade tier

## Related issues

NA

## Checklist

- [X] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [X] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)).
- [X] Changes are focused on one concern; the diff is as small as it reasonably can be.
