### PR TITLE
fix: apply in-game resolution changes through SDL

### DIFF
--- a/docs/options-window.md
+++ b/docs/options-window.md
@@ -23,6 +23,12 @@ What was added on top of that:
   configured maximum.
 - **Resolution combo-box clicks no longer leak through** to the checkboxes
   behind the dropdown.
+- **Resolution changes go through SDL** (PR
+  [#530](https://github.com/sven-n/MuMain/pull/530)), which makes the live
+  apply actually work in windowed mode on Windows. Windowed resizes re-center
+  the window on the display. Fullscreen picks the closest real display mode
+  (or borderless desktop when nothing matches), and the combo and
+  `config.ini` record the mode that actually resulted, not the one requested.
 
 ## What it stores in `config.ini`
 

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -1033,12 +1033,15 @@ namespace
     }
 }
 
-#ifndef _WIN32
-// Portable resolution change (issue #462). The Win32 path in ApplyResolution()
-// is entirely g_hWnd-gated and drives a synchronous WM_SIZE, neither of which
-// exists here, so the option window calls this instead. SDL owns the window;
-// resize it and apply the new dimensions immediately (SDL also posts a resize
-// event, but callers Save() config right after and must see the new size).
+// Resolution change through SDL (issue #462). SDL owns the window on every
+// platform, so resize it via SDL rather than the OS. The old Windows path in
+// ApplyResolution() drove Win32 SetWindowPos/ChangeDisplaySettings on g_hWnd,
+// which fought SDL: it pins the min/max tracking size of a non-resizable
+// window, so a raw SetWindowPos was clamped back and the resolution never
+// changed unless a windowed/fullscreen toggle reset the style first.
+// SDL_SetWindowSize resizes regardless of the resizable flag and drives the
+// same HandleWindowResize update synchronously, so callers can Save() config
+// right after and see the new size.
 void MuApplyWindowResolution(unsigned int width, unsigned int height, bool windowed)
 {
     if (!g_sdlWindow || width == 0 || height == 0) return;
@@ -1067,7 +1070,6 @@ void MuApplyWindowResolution(unsigned int width, unsigned int height, bool windo
 
     HandleWindowResize(w, h);
 }
-#endif // !_WIN32
 
 MSG MainLoop()
 {

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -1041,7 +1041,7 @@ namespace
 // changed unless a windowed/fullscreen toggle reset the style first.
 // SDL_SetWindowSize resizes regardless of the resizable flag and drives the
 // same HandleWindowResize update synchronously, so callers can Save() config
-// right after and see the new size.
+// right after and see the size the window actually ended up with.
 void MuApplyWindowResolution(unsigned int width, unsigned int height, bool windowed)
 {
     if (!g_sdlWindow || width == 0 || height == 0) return;
@@ -1068,7 +1068,16 @@ void MuApplyWindowResolution(unsigned int width, unsigned int height, bool windo
         SDL_SetWindowFullscreen(g_sdlWindow, true);
     }
 
-    HandleWindowResize(w, h);
+    // The request is not a guarantee: the closest fullscreen mode can differ
+    // from what was asked, the borderless fallback is desktop-sized, and mode
+    // switches are asynchronous on some window managers. Settle the request,
+    // then resize the game to the size the window really got - callers persist
+    // WindowWidth/Height, and config must record what happened, not what was
+    // asked for. Logical size, matching what SDL_EVENT_WINDOW_RESIZED carries.
+    SDL_SyncWindow(g_sdlWindow);
+    int actualW = w, actualH = h;
+    SDL_GetWindowSize(g_sdlWindow, &actualW, &actualH);
+    HandleWindowResize(actualW, actualH);
 }
 
 MSG MainLoop()

--- a/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
+++ b/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
@@ -17,7 +17,6 @@ extern int m_MusicOnOff;
 extern int m_SoundOnOff;
 extern unsigned int WindowWidth, WindowHeight;
 extern BOOL g_bUseWindowMode;
-extern HWND g_hWnd;
 void ReinitializeFonts();
 void MuApplyWindowResolution(unsigned int width, unsigned int height, bool windowed);
 float ConvertX(float x);

--- a/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
+++ b/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
@@ -352,164 +352,24 @@ bool SEASON3B::CNewUIOptionWindow::UpdateMouseEvent()
     bool oldWindowedMode = m_bWindowedMode;
     HandleCheckboxInputs();
 
-    // Apply windowed/fullscreen toggle. Saving to config alone isn't enough —
-    // we also have to swap the window style and display mode live so the user
-    // sees the switch without restarting.
+    // Apply windowed/fullscreen toggle. SDL owns the window, so switch modes
+    // through it (MuApplyWindowResolution -> SDL_SetWindowFullscreen /
+    // SDL_SetWindowSize) rather than driving the OS directly: the old Win32
+    // ChangeDisplaySettings / SetWindowLongPtr path fought SDL and left its
+    // state inconsistent with a later resolution change. Keep the current
+    // size, apply the new mode, and let MuApplyWindowResolution drive
+    // HandleWindowResize.
     if (m_bWindowedMode != oldWindowedMode)
     {
-        // Capture the size we INTEND to end up at. WM_SIZE fires multiple times
-        // during the style/display transition and can stomp WindowWidth/Height
-        // with stale outer-chrome values; we force-correct back to these at the
-        // end of the transition.
-        const unsigned int desiredW = WindowWidth;
-        const unsigned int desiredH = WindowHeight;
-
         g_bUseWindowMode = m_bWindowedMode ? TRUE : FALSE;
         GameConfig::GetInstance().SetWindowMode(m_bWindowedMode);
         GameConfig::GetInstance().Save();
 
-        if (g_hWnd)
-        {
-            bool switched = false;
-            if (m_bWindowedMode)
-            {
-                // Fullscreen → windowed: restore default display mode + OS-framed style.
-                // Use the same restrictive style as the initial CreateWindow path
-                // (Winmain.cpp) and ApplyResolution() so window behaviour is identical
-                // regardless of which UI route the user took to enter windowed mode.
-                ChangeDisplaySettings(nullptr, 0);
+        MuApplyWindowResolution(WindowWidth, WindowHeight, m_bWindowedMode);
 
-                DWORD style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU
-                            | WS_MINIMIZEBOX | WS_BORDER | WS_CLIPCHILDREN
-                            | WS_VISIBLE;
-                SetWindowLongPtr(g_hWnd, GWL_STYLE, style);
-
-                RECT windowRect = { 0, 0, (LONG)WindowWidth, (LONG)WindowHeight };
-                AdjustWindowRect(&windowRect, style, FALSE);
-                SetWindowPos(g_hWnd, HWND_NOTOPMOST, 100, 100,
-                             windowRect.right - windowRect.left,
-                             windowRect.bottom - windowRect.top,
-                             SWP_SHOWWINDOW | SWP_FRAMECHANGED);
-                switched = true;
-            }
-            else
-            {
-                // Windowed → fullscreen: try to change display mode to current
-                // (WindowWidth × WindowHeight, desktop bpp). Windows can reject
-                // this when a previous display change is still settling, so use
-                // a drain-pump + retry loop, and first force-reset the display
-                // so we always start from a known clean desktop mode.
-                DEVMODE dmScreenSettings = {};
-                dmScreenSettings.dmSize        = sizeof(dmScreenSettings);
-                dmScreenSettings.dmPelsWidth   = WindowWidth;
-                dmScreenSettings.dmPelsHeight  = WindowHeight;
-                dmScreenSettings.dmBitsPerPel  = GetDesktopBitsPerPel();
-                dmScreenSettings.dmFields      = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT;
-
-                auto pumpMessages = []()
-                {
-                    MSG msg;
-                    while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
-                    {
-                        TranslateMessage(&msg);
-                        DispatchMessage(&msg);
-                    }
-                };
-
-                // Clean slate: reset to desktop default, drain messages, then
-                // try the real change. This avoids "DISP_CHANGE_FAILED because
-                // a change is already in progress" after rapid toggles.
-                ChangeDisplaySettings(nullptr, 0);
-                pumpMessages();
-
-                LONG result = DISP_CHANGE_FAILED;
-                for (int attempt = 0; attempt < 3; attempt++)
-                {
-                    result = ChangeDisplaySettings(&dmScreenSettings, CDS_FULLSCREEN);
-                    if (result == DISP_CHANGE_SUCCESSFUL) break;
-                    pumpMessages();
-                }
-
-                if (result == DISP_CHANGE_SUCCESSFUL)
-                {
-                    // Trust the requested mode. Mid-transition SM_CXSCREEN returns
-                    // stale desktop/chrome dimensions, and EnumDisplaySettings
-                    // CURRENT reads the persistent registry mode (CDS_FULLSCREEN
-                    // is temporary and doesn't update the registry) — both lied
-                    // to us in practice. If the monitor actually substitutes a
-                    // different mode, the user can pick a supported resolution
-                    // explicitly from the dropdown.
-                    DWORD style = WS_POPUP | WS_VISIBLE;
-                    SetWindowLongPtr(g_hWnd, GWL_STYLE, style);
-                    SetWindowPos(g_hWnd, HWND_TOPMOST, 0, 0, (int)WindowWidth, (int)WindowHeight,
-                                 SWP_SHOWWINDOW | SWP_FRAMECHANGED);
-                    switched = true;
-                }
-                else
-                {
-                    m_bWindowedMode   = true;
-                    g_bUseWindowMode  = TRUE;
-                    GameConfig::GetInstance().SetWindowMode(true);
-                    GameConfig::GetInstance().Save();
-                }
-            }
-
-            // Whether the switch succeeded or got rolled back, both branches went
-            // through ChangeDisplaySettings (and sometimes SetWindowPos), which
-            // queue WM_ACTIVATE / WM_DISPLAYCHANGE. If a stray WM_ACTIVATE(INACTIVE)
-            // lands and we don't re-activate, g_bWndActive stays false — IsPress()
-            // short-circuits on it, silently dropping every click on the checkbox
-            // until *any* other window op (e.g. a resolution resize) reactivates
-            // the window. So always drain + re-activate after an attempt, even
-            // when the mode switch itself didn't succeed.
-            MSG msg;
-            while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
-            {
-                TranslateMessage(&msg);
-                DispatchMessage(&msg);
-            }
-            SetForegroundWindow(g_hWnd);
-            SetFocus(g_hWnd);
-            g_bWndActive = true;
-
-            // WM_SIZE fired during the transition can leave WindowWidth/Height
-            // at a stale outer-chrome value (seen as 1296×1063 when we asked
-            // for 1280×1024). Force them back to the requested size, resync
-            // scale factors, and re-issue SetWindowPos so the actual client
-            // rect matches. Only relevant when the mode switch succeeded and
-            // the final window should be at `desired*`.
-            if (switched && (WindowWidth != desiredW || WindowHeight != desiredH))
-            {
-                WindowWidth        = desiredW;
-                WindowHeight       = desiredH;
-                g_fScreenRate_x    = (float)WindowWidth  / (float)REFERENCE_WIDTH;
-                g_fScreenRate_y    = (float)WindowHeight / (float)REFERENCE_HEIGHT;
-                OpenglWindowWidth  = (int)WindowWidth;
-                OpenglWindowHeight = (int)WindowHeight;
-                if (m_bWindowedMode)
-                {
-                    RECT windowRect = { 0, 0, (LONG)desiredW, (LONG)desiredH };
-                    AdjustWindowRect(&windowRect, WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_BORDER | WS_CLIPCHILDREN, FALSE);
-                    SetWindowPos(g_hWnd, HWND_TOP, 0, 0,
-                                 windowRect.right - windowRect.left,
-                                 windowRect.bottom - windowRect.top,
-                                 SWP_NOMOVE | SWP_NOZORDER);
-                }
-                else
-                {
-                    SetWindowPos(g_hWnd, HWND_TOPMOST, 0, 0, (int)desiredW, (int)desiredH,
-                                 SWP_SHOWWINDOW | SWP_FRAMECHANGED);
-                }
-                ReinitializeFonts();
-                UpdateResolutionDependentSystems();
-            }
-
-            UpdateCursorClip();  // clip in fullscreen, release in windowed
-
-            // Clear the in-flight VK_LBUTTON press so the same click doesn't
-            // toggle again next frame. User must release and click again.
-            g_pNewKeyInput->SetKeyState(VK_LBUTTON, SEASON3B::CNewKeyInput::KEY_NONE);
-        }
+        // Consume the in-flight VK_LBUTTON press so the same click doesn't
+        // toggle again next frame; the user must release and click again.
+        g_pNewKeyInput->SetKeyState(VK_LBUTTON, SEASON3B::CNewKeyInput::KEY_NONE);
     }
 
     if (HandleVolumeSlider(m_iVolumeLevel, 104))

--- a/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
+++ b/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
@@ -25,9 +25,7 @@ void ReinitializeFonts();
 void UpdateResolutionDependentSystems();
 void UpdateCursorClip();
 DWORD GetDesktopBitsPerPel();
-#ifndef _WIN32
 void MuApplyWindowResolution(unsigned int width, unsigned int height, bool windowed);
-#endif
 float ConvertX(float x);
 float ConvertY(float y);
 
@@ -1029,72 +1027,16 @@ void SEASON3B::CNewUIOptionWindow::ApplyResolution()
     const unsigned int newWidth  = s_Resolutions[m_iResolutionIndex].width;
     const unsigned int newHeight = s_Resolutions[m_iResolutionIndex].height;
 
-#ifndef _WIN32
-    // SDL owns the window off Windows; the Win32 SetWindowPos/ChangeDisplaySettings
-    // path below is all g_hWnd-gated and never runs here. Resize through SDL,
-    // which updates WindowWidth/Height before we persist them. #462.
+    // SDL owns the window on every platform, so resize through SDL. The old
+    // Windows path drove Win32 SetWindowPos/ChangeDisplaySettings on g_hWnd,
+    // which SDL clamped straight back to the current size for a non-resizable
+    // window — the resolution only "took" when a windowed/fullscreen toggle
+    // reset the window style first (issue #462). MuApplyWindowResolution
+    // resizes via SDL regardless of the resizable flag and updates
+    // WindowWidth/Height synchronously through HandleWindowResize, so the
+    // Save() below records the size the user actually got.
     MuApplyWindowResolution(newWidth, newHeight, g_bUseWindowMode != FALSE);
+
     GameConfig::GetInstance().SetWindowSize(WindowWidth, WindowHeight);
     GameConfig::GetInstance().Save();
-    return;
-#endif
-
-    // Change display mode FIRST (for fullscreen) before recreating fonts and
-    // the GL text buffer. ReinitializeTextRenderer allocates a DIB sized off
-    // g_hDC/WindowWidth/g_fScreenRate, so it must run after the window and
-    // display already sit at the new dimensions — otherwise the text-buffer
-    // bitmap ends up at a stale size and rendered text vanishes until you
-    // bump the resolution again.
-    if (g_hWnd && !g_bUseWindowMode)
-    {
-        DEVMODE dmScreenSettings = {};
-        dmScreenSettings.dmSize       = sizeof(dmScreenSettings);
-        dmScreenSettings.dmPelsWidth  = newWidth;
-        dmScreenSettings.dmPelsHeight = newHeight;
-        dmScreenSettings.dmBitsPerPel = GetDesktopBitsPerPel();
-        dmScreenSettings.dmFields     = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT;
-
-        if (ChangeDisplaySettings(&dmScreenSettings, CDS_FULLSCREEN) != DISP_CHANGE_SUCCESSFUL)
-        {
-            // Monitor rejected this mode at 32bpp fullscreen — keep the old
-            // resolution and snap the combo selection back so the UI doesn't lie.
-            m_iResolutionIndex = FindCurrentResolutionIndex();
-            m_ResolutionCombo.SetSelectedIndex(m_iResolutionIndex);
-            return;
-        }
-    }
-
-    // Resize the window to the new dimensions.
-    if (g_hWnd && g_bUseWindowMode)
-    {
-        RECT windowRect = { 0, 0, (LONG)newWidth, (LONG)newHeight };
-        AdjustWindowRect(&windowRect, WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_BORDER | WS_CLIPCHILDREN, FALSE);
-        SetWindowPos(g_hWnd, HWND_TOP, 0, 0,
-                     windowRect.right - windowRect.left,
-                     windowRect.bottom - windowRect.top,
-                     SWP_NOMOVE | SWP_NOZORDER);
-    }
-    else if (g_hWnd)
-    {
-        SetWindowPos(g_hWnd, HWND_TOPMOST, 0, 0,
-                     (int)newWidth, (int)newHeight,
-                     SWP_SHOWWINDOW | SWP_FRAMECHANGED);
-    }
-
-    // SetWindowPos above triggered WM_SIZE synchronously, which already set
-    // WindowWidth/Height/screen rates and called ReinitializeFonts() and
-    // UpdateResolutionDependentSystems(). Don't repeat that work here — just
-    // persist the new size in config.
-    GameConfig::GetInstance().SetWindowSize(WindowWidth, WindowHeight);
-    GameConfig::GetInstance().Save();
-
-    // Fullscreen SetWindowPos with SWP_FRAMECHANGED deactivated the window;
-    // re-assert focus and activation so subsequent clicks aren't dropped.
-    if (g_hWnd && !g_bUseWindowMode)
-    {
-        SetForegroundWindow(g_hWnd);
-        SetFocus(g_hWnd);
-        g_bWndActive = true;
-    }
-    UpdateCursorClip();  // rebind cursor to new client rect (or release in windowed)
 }

--- a/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
+++ b/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
@@ -16,15 +16,9 @@
 extern int m_MusicOnOff;
 extern int m_SoundOnOff;
 extern unsigned int WindowWidth, WindowHeight;
-extern float g_fScreenRate_x, g_fScreenRate_y;
-extern int OpenglWindowWidth, OpenglWindowHeight;
 extern BOOL g_bUseWindowMode;
 extern HWND g_hWnd;
-extern bool g_bWndActive;
 void ReinitializeFonts();
-void UpdateResolutionDependentSystems();
-void UpdateCursorClip();
-DWORD GetDesktopBitsPerPel();
 void MuApplyWindowResolution(unsigned int width, unsigned int height, bool windowed);
 float ConvertX(float x);
 float ConvertY(float y);

--- a/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
+++ b/src/source/UI/NewUI/Options/NewUIOptionWindow.cpp
@@ -38,6 +38,19 @@ static const struct { int width; int height; const wchar_t* label; } s_Resolutio
     { 2560, 1440, L"2560 x 1440" },
 };
 static const int s_NumResolutions = sizeof(s_Resolutions) / sizeof(s_Resolutions[0]);
+static const int s_DefaultResolutionIndex = 8;  // the 1920 x 1080 entry above
+
+// Index into s_Resolutions of an exact size match, or -1 when the size is not
+// a listed mode (e.g. borderless desktop on an unlisted display size).
+static int FindListedResolutionIndex(int width, int height)
+{
+    for (int i = 0; i < s_NumResolutions; ++i)
+    {
+        if (s_Resolutions[i].width == width && s_Resolutions[i].height == height)
+            return i;
+    }
+    return -1;
+}
 
 // I18N locale codes (ASCII) paired with the language's display name in that
 // language. The set mirrors what ResxGen emits and what I18N::GetAvailableLocales()
@@ -346,25 +359,8 @@ bool SEASON3B::CNewUIOptionWindow::UpdateMouseEvent()
     bool oldWindowedMode = m_bWindowedMode;
     HandleCheckboxInputs();
 
-    // Apply windowed/fullscreen toggle. SDL owns the window, so switch modes
-    // through it (MuApplyWindowResolution -> SDL_SetWindowFullscreen /
-    // SDL_SetWindowSize) rather than driving the OS directly: the old Win32
-    // ChangeDisplaySettings / SetWindowLongPtr path fought SDL and left its
-    // state inconsistent with a later resolution change. Keep the current
-    // size, apply the new mode, and let MuApplyWindowResolution drive
-    // HandleWindowResize.
     if (m_bWindowedMode != oldWindowedMode)
-    {
-        g_bUseWindowMode = m_bWindowedMode ? TRUE : FALSE;
-        GameConfig::GetInstance().SetWindowMode(m_bWindowedMode);
-        GameConfig::GetInstance().Save();
-
-        MuApplyWindowResolution(WindowWidth, WindowHeight, m_bWindowedMode);
-
-        // Consume the in-flight VK_LBUTTON press so the same click doesn't
-        // toggle again next frame; the user must release and click again.
-        g_pNewKeyInput->SetKeyState(VK_LBUTTON, SEASON3B::CNewKeyInput::KEY_NONE);
-    }
+        ApplyWindowModeToggle();
 
     if (HandleVolumeSlider(m_iVolumeLevel, 104))
         OnSoundVolumeChanged();
@@ -816,12 +812,8 @@ bool SEASON3B::CNewUIOptionWindow::GetRenderAllEffects()
 
 int SEASON3B::CNewUIOptionWindow::FindCurrentResolutionIndex()
 {
-    for (int i = 0; i < s_NumResolutions; ++i)
-    {
-        if (s_Resolutions[i].width == (int)WindowWidth && s_Resolutions[i].height == (int)WindowHeight)
-            return i;
-    }
-    return 8; // default to 1920x1080
+    const int listed = FindListedResolutionIndex((int)WindowWidth, (int)WindowHeight);
+    return listed >= 0 ? listed : s_DefaultResolutionIndex;
 }
 
 int SEASON3B::CNewUIOptionWindow::FindCurrentLanguageIndex()
@@ -891,6 +883,47 @@ void SEASON3B::CNewUIOptionWindow::ApplyResolution()
     // Save() below records the size the user actually got.
     MuApplyWindowResolution(newWidth, newHeight, g_bUseWindowMode != FALSE);
 
+    // SDL may have coerced the request (closest fullscreen mode, borderless
+    // desktop fallback): WindowWidth/Height now hold the size that actually
+    // resulted. Persist that, and snap the combo to it so the UI never claims
+    // a resolution the display did not adopt.
+    SyncResolutionComboToWindow();
     GameConfig::GetInstance().SetWindowSize(WindowWidth, WindowHeight);
     GameConfig::GetInstance().Save();
+}
+
+// Point the resolution combo at the mode the window really has. If the actual
+// size is not a listed mode, keep the current selection - config still
+// records the real size.
+void SEASON3B::CNewUIOptionWindow::SyncResolutionComboToWindow()
+{
+    const int listed = FindListedResolutionIndex((int)WindowWidth, (int)WindowHeight);
+    if (listed < 0)
+        return;
+    m_iResolutionIndex = listed;
+    m_ResolutionCombo.SetSelectedIndex(listed);
+}
+
+// Windowed/fullscreen toggle. SDL owns the window, so switch modes through it
+// (MuApplyWindowResolution -> SDL_SetWindowFullscreen / SDL_SetWindowSize)
+// rather than driving the OS directly: the old Win32 ChangeDisplaySettings /
+// SetWindowLongPtr path fought SDL and left its state inconsistent with a
+// later resolution change. Keeps the current size and applies the new mode.
+void SEASON3B::CNewUIOptionWindow::ApplyWindowModeToggle()
+{
+    g_bUseWindowMode = m_bWindowedMode ? TRUE : FALSE;
+    GameConfig::GetInstance().SetWindowMode(m_bWindowedMode);
+
+    MuApplyWindowResolution(WindowWidth, WindowHeight, m_bWindowedMode);
+
+    // The mode switch may have coerced the size (closest fullscreen mode,
+    // borderless desktop fallback), so save AFTER the apply and persist the
+    // size that actually resulted along with the new mode.
+    SyncResolutionComboToWindow();
+    GameConfig::GetInstance().SetWindowSize(WindowWidth, WindowHeight);
+    GameConfig::GetInstance().Save();
+
+    // Consume the in-flight VK_LBUTTON press so the same click doesn't
+    // toggle again next frame; the user must release and click again.
+    g_pNewKeyInput->SetKeyState(VK_LBUTTON, SEASON3B::CNewKeyInput::KEY_NONE);
 }

--- a/src/source/UI/NewUI/Options/NewUIOptionWindow.h
+++ b/src/source/UI/NewUI/Options/NewUIOptionWindow.h
@@ -115,6 +115,8 @@ namespace SEASON3B
         void ApplyResolution();
         int FindCurrentResolutionIndex();
         void InitResolutionCombo();
+        void SyncResolutionComboToWindow();
+        void ApplyWindowModeToggle();
 
         void ApplyLanguage();
         int FindCurrentLanguageIndex();


### PR DESCRIPTION
## Problem

The options-window **Resolution** combo did not apply in windowed mode. The window is SDL-owned, but `ApplyResolution` drove the Win32 `SetWindowPos` / `ChangeDisplaySettings` path on `g_hWnd`. SDL pins the min/max tracking size of a non-resizable window, so the raw `SetWindowPos` was clamped straight back to the current size — changing the resolution did nothing. It only "took" when a windowed/fullscreen toggle happened to reset the window style first, which is why it seemed to work intermittently.

## Fix

Route `ApplyResolution` through `MuApplyWindowResolution` (`SDL_SetWindowSize` / `SDL_SetWindowFullscreen`) on **every** platform, and compile `MuApplyWindowResolution` on Windows too (it was `#ifndef _WIN32`). It resizes regardless of the resizable flag and drives `HandleWindowResize` synchronously, so the config is saved with the size the user actually got. This also drops ~70 lines of Win32-specific window juggling from `ApplyResolution`.

Follow-ups from review:

- The windowed/fullscreen checkbox toggle also routes through SDL now instead of raw Win32 (`ChangeDisplaySettings` / `SetWindowLongPtr`), so SDL's window state never diverges from the OS state.
- `MuApplyWindowResolution` settles the request with `SDL_SyncWindow` and reads back the size the window actually got, so a coerced fullscreen request (closest-mode pick or borderless fallback) is what gets persisted and shown in the combo — `config.ini` records what happened, not what was asked for. The toggle path persists mode + resulting size together, after the apply.

Note: in windowed mode the window is now **re-centered** on the display after a resolution change (`SDL_WINDOWPOS_CENTERED`), replacing the old fixed position.

## Testing

Windows x64, windowed mode: changing the Resolution combo 1024×768 → 1280×720 → 800×600 resizes the window live each time (verified by measuring the client rect), re-centers the window, and persists to `config.ini`. Relaunch opens at the saved size.

Fullscreen pass (Windows x64): toggling windowed ↔ fullscreen in both directions switches the display mode and keeps the combo and `config.ini` in agreement; changing resolution while fullscreen works for modes the display supports (1280×720, 1280×1024). Coercion case: requesting 1600×1200 on a panel without that mode — SDL fell back to 1920×1080, the combo snapped to 1920×1080, and `config.ini` recorded 1920×1080. Relaunch honors the saved state.

Refs #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
