### PR TITLE
Restrict advanced class creation

### DIFF
--- a/docs/character-creation.md
+++ b/docs/character-creation.md
@@ -1,0 +1,10 @@
+# Character creation
+
+The character creation screen allows new characters from the following classes:
+
+- Dark Knight
+- Dark Wizard
+- Fairy Elf
+- Magic Gladiator
+
+Dark Lord, Summoner, and Rage Fighter remain visible but disabled and cannot be submitted for creation from the client.

--- a/src/source/Character/CharMakeWin.cpp
+++ b/src/source/Character/CharMakeWin.cpp
@@ -68,6 +68,13 @@ namespace
     constexpr int kDescriptionTextOffsetY = 12;
     constexpr int kDescriptionLineSpacing = 19;
 
+    constexpr bool IsCharacterCreationAllowed(CLASS_TYPE classType)
+    {
+        return classType != CLASS_DARK_LORD
+            && classType != CLASS_SUMMONER
+            && classType != CLASS_RAGEFIGHTER;
+    }
+
     struct ClassStats
     {
         std::array<const wchar_t*, 4> values;
@@ -304,6 +311,10 @@ void CCharMakeWin::UpdateDisplay()
     m_abtnJob[CLASS_SUMMONER].SetEnable(true);
 #endif //PBG_ADD_CHARACTERCARD
 
+    m_abtnJob[CLASS_DARK_LORD].SetEnable(false);
+    m_abtnJob[CLASS_SUMMONER].SetEnable(false);
+    m_abtnJob[CLASS_RAGEFIGHTER].SetEnable(false);
+
     const bool isDarkLord = (m_nSelJob == CLASS_DARK_LORD);
     m_asprBack[CMW_SPR_STAT].SetSize(0, isDarkLord ? kDarkLordStatHeight : kDefaultStatHeight, Y);
 
@@ -366,6 +377,12 @@ void CCharMakeWin::RequestCreateCharacter()
         g_pSingleTextInputBox->GetText(InputText[0]);
 
     CUIMng& rUIMng = CUIMng::Instance();
+
+    if (!IsCharacterCreationAllowed(CharacterView.Class))
+    {
+        rUIMng.PopUpMsgWin(MESSAGE_BLOCKED_CHARACTER);
+        return;
+    }
 
     const std::wstring characterName = InputText[0];
 


### PR DESCRIPTION
## What changed

- Disabled Dark Lord, Summoner, and Rage Fighter on the character creation screen.
- Added a request-time guard so restricted classes cannot be submitted even if the UI state is bypassed.
- Documented the classes available for new character creation.

## Why

This client should allow creation of Dark Knight, Dark Wizard, Fairy Elf, and Magic Gladiator only.