### PR TITLE
docs(render): Add comprehensive GPU skinning and Core Profile architecture docs

### DIFF
--- a/docs/GPU Skinning/README.md
+++ b/docs/GPU Skinning/README.md
@@ -17,7 +17,10 @@ This documentation details the architecture, design decisions, milestone catalog
 3. **[Core Profile & Pipeline Migration](core-profile-migration.md)**  
    *Guide to modern shader pipeline migration and legacy FFP retirement.* Covers the removal of the fixed-function matrix stack, `ImmediateRenderer` (`IR::`) topology decomposition, RHI state encapsulation, and automated build-time wrapper enforcement.
 
-4. **[Gotchas & Invariants Catalog](gotchas-and-patterns.md)**  
+4. **[ImmediateRenderer (IR::) Architecture](immediate-renderer-architecture.md)**  
+   *Detailed technical specification of the ImmediateRenderer subsystem.* Covers Quad and Triangle Fan primitive decomposition math, interleaved dynamic vertex stream layouts, streaming ring-buffer orphan-on-wrap mechanics, RHI integration, and complete IR milestone task history.
+
+5. **[Gotchas & Invariants Catalog](gotchas-and-patterns.md)**  
    *Comprehensive catalog of known gotchas, threading synchronization rules, cache invalidation pitfalls, and performance invariants.*
 
 ---

--- a/docs/GPU Skinning/README.md
+++ b/docs/GPU Skinning/README.md
@@ -1,0 +1,43 @@
+# GPU Skinning & Modern Graphics Subsystem Documentation
+
+Welcome to the documentation for the MU Online Client **GPU Skinning & Modern Graphics Subsystem**.
+
+This documentation details the architecture, design decisions, milestone catalog, and technical invariants behind the migration of the client rendering engine from the legacy fixed-function pipeline (FFP) to modern GPU skeletal skinning, Uniform Buffer Objects (UBOs), Core Profile shaders, and the Render Hardware Interface (RHI) abstraction layer.
+
+---
+
+## Document Index
+
+1. **[DXP Milestone Catalog](dxp-milestones.md)**  
+   *The complete reference catalog for all `DXP-xx` milestone tags referenced in source code inline comments.* Contains background, scope, and resolution details for DXP-01 through DXP-27.
+
+2. **[GPU Skinning Architecture](gpu-skinning-architecture.md)**  
+   *Deep technical specification of GPU-based skeletal animation.* Details matrix palette management, UBO layouts (`GlobalUBO`, `BoneUBO`), vertex shader transformation equations, item specular / chrome GPU shaders, and skeleton invariants (`MAX_BONES=200`).
+
+3. **[Core Profile & Pipeline Migration](core-profile-migration.md)**  
+   *Guide to modern shader pipeline migration and legacy FFP retirement.* Covers the removal of the fixed-function matrix stack, `ImmediateRenderer` (`IR::`) topology decomposition, RHI state encapsulation, and automated build-time wrapper enforcement.
+
+4. **[Gotchas & Invariants Catalog](gotchas-and-patterns.md)**  
+   *Comprehensive catalog of known gotchas, threading synchronization rules, cache invalidation pitfalls, and performance invariants.*
+
+---
+
+## Architectural Highlights
+
+- **Zero-CPU Skeletal Skinning**: Character, monster, equipment, weapon, wing, and mount meshes perform skeletal bone transformation directly in the vertex shader (`bmd_mesh.vert`), freeing significant CPU resources.
+- **Render Hardware Interface (RHI)**: Modernized graphics abstraction layer (`RHI.h`) decoupling low-level driver state, shaders, textures, and vertex buffers from client application code.
+- **Core Profile Conformance**: Retirement of legacy immediate mode (`glBegin`/`glEnd`), `glPushMatrix`/`glPopMatrix`, and FFP matrix stack operations in favor of UBO-driven GLSL 3.3 Core Profile pipelines.
+- **Interleaved Streaming VBOs**: High-efficiency dynamic vertex buffer streaming (`[Pos | UV | Color]` interleaving) eliminating runtime heap allocations during draw passes.
+- **Decoupled Animation & Render Cadence**: Thread-safe parallel character animation calculation (`AnimationTaskPool`) decoupled from rendering FPS.
+
+---
+
+## Primary Subsystems & Source Map
+
+| Subsystem | Key Files | Description |
+|---|---|---|
+| **RHI Core** | [`Render/RHI/RHI.h`](../../src/source/Render/RHI/RHI.h) | Abstract rendering hardware interface definitions. |
+| **Model & Mesh Shader** | [`Render/Shaders/BMDMeshShader.cpp`](../../src/source/Render/Shaders/BMDMeshShader.cpp)<br>[`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp) | BMD mesh skinning shader, static/dynamic VBO management, matrix caching. |
+| **Uniform Buffers** | [`Render/Core/GlobalUBO.h`](../../src/source/Render/Core/GlobalUBO.h)<br>[`Render/Core/BoneUBO.h`](../../src/source/Render/Core/BoneUBO.h) | Uniform Buffer Objects for Camera/Model matrices (`Slot 0`) and Skeletal Bones (`Slot 1`). |
+| **Immediate Renderer** | [`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp) | Dynamic quad/fan topology decomposition and 2D/3D immediate-mode submission. |
+| **Item Specular Shader** | [`Render/Shaders/ItemSpecularShader.cpp`](../../src/source/Render/Shaders/ItemSpecularShader.cpp) | Modern single-pass GPU shader for +7 through +15 equipment shine & chrome effects. |

--- a/docs/GPU Skinning/core-profile-migration.md
+++ b/docs/GPU Skinning/core-profile-migration.md
@@ -1,0 +1,129 @@
+# Core Profile & Pipeline Migration Guide
+
+This document details the modernization of the client rendering engine from fixed-function pipeline (FFP) legacy patterns to OpenGL 3.3 Core Profile compliance, Uniform Buffer Object matrix management, Immediate Renderer (`IR::`) primitive decomposition, and strict graphics wrapper isolation.
+
+---
+
+## 1. Core Profile Migration Strategy
+
+The migration from legacy OpenGL compatibility profile to **OpenGL 3.3 Core Profile** (executed in `DXP-08`) enforced the complete elimination of fixed-function state machine features:
+
+```mermaid
+graph LR
+    subgraph Legacy["Legacy Fixed-Function Pattern"]
+        L1["glBegin(GL_QUADS) ... glEnd()"]
+        L2["glMatrixMode(GL_PROJECTION)"]
+        L3["glPushMatrix() / glPopMatrix()"]
+        L4["glAlphaFunc(GL_GREATER, ref)"]
+        L5["glEnable(GL_LIGHTING)"]
+        L6["glGetFloatv(GL_MODELVIEW_MATRIX)"]
+    end
+    subgraph Modern["Modern Core Profile Pattern"]
+        M1["ImmediateRenderer (IR::) / VBOs"]
+        M2["CPU Matrix Math -> GlobalUBO (Slot 0)"]
+        M3["GlobalUBO::PushModel / PopModel"]
+        M4["Shader u_AlphaRef + Fragment Discard"]
+        M5["GLSL Shaders (BMDMeshShader)"]
+        M6["CPU View Matrix Cache"]
+    end
+    L1 --> M1
+    L2 --> M2
+    L3 --> M3
+    L4 --> M4
+    L5 --> M5
+    L6 --> M6
+```
+
+---
+
+## 2. Matrix Stack & FFP Bridge Retirement
+
+In legacy client code, camera, world, and projection matrices were maintained on driver-side fixed-function matrix stacks (`GL_MODELVIEW` and `GL_PROJECTION`). Modern shaders read view and projection matrices directly from `GlobalUBO` (Slot 0).
+
+### CPU-Side Orthographic & Perspective Matrix Builders
+
+- **`BeginBitmap()` (2D UI Ortho)**: Replaced `glOrtho()` with CPU-side orthographic projection matrix calculation uploaded directly to `GlobalUBO`.
+- **`BeginOpengl()` (3D World View/Proj)**: Replaced `gluLookAt()` and `glFrustum()` with CPU-side view and perspective matrix math (`BuildPerspectiveProjection`).
+- **`UpdateMousePosition()` (3D Ray Picking)**: Decoupled mouse-click ground picking from `glGetFloatv` driver readbacks by reading cached CPU camera matrices.
+
+### Unified Projection Matrix Construction
+
+> [!NOTE]
+> All 3D cameras (world view, 3D UI item preview panels, photo viewers) construct perspective matrices via `BuildPerspectiveProjection()` (`Render/Core/RenderConfig.cpp`), ensuring consistent clip-space depth calculations across all rendering passes.
+
+---
+
+## 3. Immediate Renderer (`IR::`) & Primitive Decomposition
+
+For UI controls, health bars, 2D sprites, particles, and dynamic lines, the engine provides the `ImmediateRenderer` (`IR::`) subsystem ([`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp)).
+
+### Primitive Topology Decomposition
+
+Hardware shader pipelines do not natively support legacy quad (`GL_QUADS`) or triangle fan (`GL_TRIANGLE_FAN`) primitives. `IR::` decomposes these primitives CPU-side into indexed triangle lists (`GL_TRIANGLES`) before issuing draw calls:
+
+#### 1. Quads Decomposition (`GL_QUADS`)
+For every 4 vertices submitted (`v0, v1, v2, v3`), `IR::End()` appends two triangles:
+$$\text{Triangle 1}: [v_0, v_1, v_2], \quad \text{Triangle 2}: [v_0, v_2, v_3]$$
+
+#### 2. Triangle Fan Decomposition (`GL_TRIANGLE_FAN`)
+For $N$ vertices submitted ($v_0, v_1, \dots, v_{N-1}$), `IR::End()` generates $N-2$ triangles using the fan anchor $v_0$:
+$$\text{Triangle } i: [v_0, v_{i}, v_{i+1}] \quad \text{for } 1 \le i \le N-2$$
+
+```mermaid
+graph TD
+    subgraph Quad["Quad Decomposition (2 Triangles)"]
+        v0["v0"] --- v1["v1"]
+        v1 --- v2["v2"]
+        v2 --- v3["v3"]
+        v3 --- v0
+        v0 -. Split Diagonal .-> v2
+    end
+    subgraph Fan["Fan Decomposition (N-2 Triangles)"]
+        f0["v0 (Anchor)"] --- f1["v1"]
+        f0 --- f2["v2"]
+        f0 --- f3["v3"]
+        f0 --- f4["v4"]
+        f1 --- f2
+        f2 --- f3
+        f3 --- f4
+    end
+```
+
+### Streaming VBO Ring-Buffer Architecture
+
+`ImmediateRenderer` streams dynamic vertex data through a pre-allocated dynamic vertex buffer using ring-buffer upload semantics (`DXP-26`):
+
+1. **Sequential Append**: New draw calls append vertices sequentially into the buffer using `RHI::AppendBuffer`.
+2. **Orphan-on-Wrap**: When the ring-buffer reaches capacity, it re-allocates or orphans the buffer, starting fresh at offset 0 without stalling the GPU pipeline.
+3. **Persistent Program Binding**: Modern `IR::End()` retains shader program bindings across consecutive draw calls, enabling program-bind cache hits when drawing sequences of UI elements or particles.
+
+---
+
+## 4. Graphics Wrapper Monopoly & Enforcement
+
+To prevent technical debt and ensure cross-platform driver compatibility, the client enforces a strict **State-Wrapper Monopoly** (`DXP-10`):
+
+> **Invariant**: No raw graphics API calls (e.g., `glDrawArrays`, `glBindTexture`, `glUseProgram`) are permitted outside the `Render/` directory tree.
+
+### Automated Build-Time Verification Guard
+
+The build system executes [`CLIENT/tools/check_gl_wrapper_monopoly.py`](../../tools/check_gl_wrapper_monopoly.py) as an automatic custom target before compiling `MuClient`.
+
+```mermaid
+flowchart TD
+    A["check_gl_wrapper_monopoly.py Guard"] --> B{"Scan Source Files Outside Render/"}
+    B -- "No Raw Graphics Calls" --> C["Pass: Build Proceeds Cleanly"]
+    B -- "Raw Graphics Call Detected" --> D["Fail: Compilation Halts with Error & Line"]
+```
+
+If developer code outside `Render/` attempts to invoke raw driver functions, the Python guard halts the build with a descriptive error pointing to the violating file and line number.
+
+---
+
+## 5. RHI Texture Management & Memory Operations
+
+All texture operations are encapsulated behind the RHI layer:
+
+- **Creation & Upload**: [`GlobalBitmap.cpp`](../../src/source/Render/Textures/GlobalBitmap.cpp) creates textures via `RHI::CreateTexture` with explicit mipmap generation and format specifications (`RHI_FORMAT_R8G8B8A8_UNORM`).
+- **Dynamic Streaming**: UI fonts, dynamic minimaps, and reconnect dialogs update sub-regions of textures using `RHI::UpdateTexture`.
+- **Pixel Readback**: Screen capture, screenshot export, and UI background blur effects use `RHI::ReadPixels` to extract frame buffer pixels safely into host memory.

--- a/docs/GPU Skinning/dxp-milestones.md
+++ b/docs/GPU Skinning/dxp-milestones.md
@@ -1,0 +1,188 @@
+# DXP Milestone Implementation Chronology
+
+This document serves as the authoritative technical reference catalog for all **`DXP-xx`** milestone tags used in source code comments, commit logs, and architectural document cross-references across the client codebase.
+
+The milestones below are organized **chronologically in the exact order of implementation**, grouped by development phase.
+
+---
+
+## Milestone Execution Chronology Table
+
+### Phase A: FFP Retirement & Core Profile Baseline (August 1–2, 2026)
+
+| Milestone | Subsystem | Focus / Objective | Status |
+|---|---|---|---|
+| **[DXP-01](#dxp-01--alpha-test-shader-port)** | Shaders | Shader-level alpha testing (`u_AlphaRef` / `discard`). | Completed |
+| **[DXP-02](#dxp-02--gpu-acceleration-for-item-specular-tiers)** | Item Specular | GPU acceleration for all 4 item specular tiers (+7..+15 gear). | Completed |
+| **[DXP-03](#dxp-03--cloth--cape-immediaterenderer-port)** | Physics & Cloth | `CPhysicsCloth::RenderFace` port to `ImmediateRenderer`. | Completed |
+| **[DXP-04](#dxp-04--event-fog-sceneubo-integration)** | Map Environment | `GMBattleCastle` event fog integration into `SceneUBO`. | Completed |
+| **[DXP-05](#dxp-05--kanturu-terrain-pass-vbo-migration)** | Terrain | Kanturu-3rd terrain "after" pass ported off FFP `glBegin`. | Completed |
+| **[DXP-06](#dxp-06--planar-shadow-shader-core-profile-rewrite)** | Shadows | `CPlanarShadowShader` GLSL 330 core single-pass rewrite. | Completed |
+| **[DXP-07a](#dxp-07a--cpu-ortho-matrix-calculation)** | UI / 2D | `BeginBitmap()` ortho matrix calculation moved to CPU. | Completed |
+| **[DXP-07b](#dxp-07b--cpu-camera-matrix-calculation)** | Render Core | `BeginOpengl()` camera view/proj matrices moved to CPU. | Completed |
+| **[DXP-07c](#dxp-07c--decoupled-picking--mouse-matrix-chain)** | UI / Mouse | Mouse picking & camera projection decoupled from GL matrix stack. | Completed |
+| **[DXP-09](#dxp-09--pipeline-hygiene--ir-topology-decomposition)** | Renderer Core | Code hygiene, dead code removal, IR quad/fan decomposition. | Completed |
+| **[DXP-08a](#dxp-08a--core-profile-soak--illegal-ffp-sweep)** | Core Engine | Core Profile soak testing & illegal FFP state call sweep. | Completed |
+| **[DXP-08](#dxp-08--opengl-33-core-profile-migration)** | Core Engine | Core Profile flip & legacy fixed-function branch retirement. | Completed |
+| **[DXP-10](#dxp-10--state-wrapper-monopoly--guard-script)** | Build / Guard | Graphics wrapper monopoly enforcement script (`check_gl_wrapper_monopoly.py`). | Completed |
+
+### Phase B: GPU Skeletal Skinning & Performance Engine (August 2, 2026)
+
+| Milestone | Subsystem | Focus / Objective | Status |
+|---|---|---|---|
+| **[DXP-11](#dxp-11--rhi-interface-extraction)** | RHI Architecture | Design and extraction of Render Hardware Interface (`RHI.h`). | Completed |
+| **[DXP-20](#dxp-20--zero-cpu-gpu-skeletal-skinning)** | GPU Skinning | Zero-CPU GPU Skeletal Skinning (`BoneUBO`, `MAX_BONES=200`). | Completed |
+| **[DXP-20-inc4](#dxp-20-inc4--lazy-materialization-pattern)** | Optimization | `TransformCheap()` lazy materialization for CPU render caches. | Completed |
+| **[DXP-20-inc5](#dxp-20-inc5--chrome-render-mode-aliasing-fix)** | Chrome Shaders | Fix for collapsed/aliased chrome render mode GPU skinning checks. | Completed |
+| **[DXP-22](#dxp-22--bind-state-monopoly--cache-invalidation)** | State Cache | VAO/VBO/Program/Texture bind cache invalidation rules. | Completed |
+| **[DXP-23](#dxp-23--uniform-upload-profiling--gpu-diagnostics)** | Profiling | FrameProfiler GPU-bound vs CPU-bound bottleneck diagnostics. | Completed |
+| **[DXP-24](#dxp-24--shadow-bone-matrix-corruption--dummy-bones)** | Shadow / Bones | Fix for Planar Shadow division explosion via Dummy bone clearing. | Completed |
+| **[DXP-25](#dxp-25--logic-render-decoupling-for-ui-flags)** | UI State | Decoupling one-shot UI render flags from logic tick rates. | Completed |
+| **[DXP-26](#dxp-26--immediaterenderer-ring-buffer--bind-cache-fix)** | ImmediateRenderer | Streaming VBO ring-buffer & removal of per-draw unbind. | Completed |
+| **[DXP-27](#dxp-27--animation-rate-decoupling-from-render-fps)** | Animation Sync | Real-time throttling of render-frequency animation calls. | Completed |
+
+### Phase C: Full Hardware Abstraction Layer & Subsystem Port (August 3–4, 2026)
+
+| Milestone | Subsystem | Focus / Objective | Status |
+|---|---|---|---|
+| **[DXP-12](#dxp-12--rhi-texture-management--readback)** | RHI Textures | RHI texture creation, streaming upload, and pixel readback. | Completed |
+| **[DXP-13](#dxp-13--rhi-device--windowing-handoff)** | RHI Pipeline | Modern rendering engine init & RHI device creation. | Completed |
+| **[DXP-14](#dxp-14--rhi-shader-pipeline--ubo-layout-parity)** | RHI Shaders | Core shader pipeline port and UBO/constant buffer matching. | Completed |
+| **[DXP-15](#dxp-15--rhi-immediate-renderer--2d-pipeline)** | RHI 2D Pipeline | `ImmediateRenderer` integration into RHI abstraction. | Completed |
+| **[DXP-16](#dxp-16--rhi-world-pipelines--blend-encapsulation)** | RHI 3D World | Terrain, BMD mesh, and Planar Shadow RHI pipeline port. | Completed |
+| **[DXP-17](#dxp-17--depth--projection-matrix-clip-space-alignment)** | Projection | Clip-space perspective projection helper unification. | Completed |
+| **[DXP-21](#dxp-21--cloth-mesh-compute-decoupling)** | Cloth Physics | Seam for dynamic cloth mesh compute optimization. | Completed |
+
+---
+
+## Detailed Milestone Chronology
+
+### Phase A: FFP Retirement & Core Profile Baseline
+
+#### DXP-01 — Alpha Test Shader Port
+- **Scope**: `Render/Shaders/` & `ZzzOpenglUtil.cpp`.
+- **Purpose**: Eliminated fixed-function `glAlphaFunc` calls across all 2D and 3D pipelines by passing `u_AlphaRef` uniform to shaders and executing explicit `if (texColor.a < u_AlphaRef) discard;` in fragment shaders.
+
+#### DXP-02 — GPU Acceleration for Item Specular Tiers
+- **Scope**: `Render/Shaders/ItemSpecularShader.cpp` & `ZzzBMD.cpp`.
+- **Purpose**: Accelerated all 4 item-specular shine tiers (+7 through +15 equipment) directly on the GPU via `BMDMeshShader` render modes 4–7 (`itemSpecularGpuEligible`). Retired legacy fixed-function shader shims.
+
+#### DXP-03 — Cloth & Cape ImmediateRenderer Port
+- **Scope**: `Engine/Physics/PhysicsManager.cpp`.
+- **Purpose**: Converted `CPhysicsCloth::RenderFace` from legacy `glBegin(GL_QUADS)` to `ImmediateRenderer` (`IR::`), enabling cape and cloth rendering under modern shader pipelines.
+
+#### DXP-04 — Event Fog SceneUBO Integration
+- **Scope**: `World/GameMaps/GMBattleCastle.cpp`.
+- **Purpose**: Integrated map event fog parameters (Battle Castle 2000–2700 range) into `SceneUBO`, restoring event fog visibility for modern shader-rendered geometry.
+
+#### DXP-05 — Kanturu Terrain Pass VBO Migration
+- **Scope**: `World/GameMaps/GM_Kanturu_3rd.cpp` & `ZzzLodTerrain.cpp`.
+- **Purpose**: Ported Kanturu-3rd map multi-pass terrain overlay rendering off legacy immediate mode onto modern terrain VBO shader paths.
+
+#### DXP-06 — Planar Shadow Shader Core Profile Rewrite
+- **Scope**: `Render/Shaders/PlanarShadowShader.cpp`.
+- **Purpose**: Rewrote `CPlanarShadowShader` to GLSL 330 core. Replaced fixed-function vertex attributes (`gl_Vertex`, `gl_ModelViewProjectionMatrix`) with modern vertex layout attributes and UBO matrices.
+
+#### DXP-07a — CPU Ortho Matrix Calculation
+- **Scope**: `Render/Textures/ZzzOpenglUtil.cpp`.
+- **Purpose**: Replaced `glMatrixMode(GL_PROJECTION)` / `glLoadIdentity()` / `glOrtho()` in `BeginBitmap()` with CPU-side orthographic matrix construction uploaded directly to `GlobalUBO`.
+
+#### DXP-07b — CPU Camera Matrix Calculation
+- **Scope**: `Render/Textures/ZzzOpenglUtil.cpp`.
+- **Purpose**: Replaced `glMatrixMode(GL_MODELVIEW)` / `gluLookAt()` in `BeginOpengl()` with CPU-side view and projection matrix math uploaded directly to `GlobalUBO`.
+
+#### DXP-07c — Decoupled Picking & Mouse Matrix Chain
+- **Scope**: `CameraProjection.cpp` & `ZzzOpenglUtil.cpp`.
+- **Purpose**: Removed `glGetFloatv(GL_MODELVIEW_MATRIX)` and `glGetFloatv(GL_PROJECTION_MATRIX)` from 3D ray picking (`UpdateMousePosition`) and replaced them with CPU matrix cache reads.
+
+#### DXP-09 — Pipeline Hygiene & IR Topology Decomposition
+- **Scope**: `Render/Core/ImmediateRenderer.cpp` & `ZzzOpenglUtil.cpp`.
+- **Purpose**: Decomposed immediate-mode `GL_QUADS` and `GL_TRIANGLE_FAN` primitives into indexing-compatible triangle lists (`GL_TRIANGLES`) for hardware abstraction compatibility.
+
+#### DXP-08a — Core Profile Soak & Illegal FFP Sweep
+- **Scope**: Codebase-wide sweep in `Render/`, `Scenes/`, `World/`.
+- **Purpose**: Swept and removed legacy `glEnable(GL_ALPHA_TEST)`, `glMatrixMode`, `glPushMatrix`, and `glColor3f` calls that caused implicit Core Profile state corruption.
+
+#### DXP-08 — OpenGL 3.3 Core Profile Migration
+- **Scope**: `Render/Core/`, `Winmain.cpp`, CMake build manifests.
+- **Purpose**: Flipped default context creation to OpenGL 3.3 Core Profile (`g_CoreProfile = true`). Retired legacy fixed-function fallback branches across core render loops.
+
+#### DXP-10 — State Wrapper Monopoly & Guard Script
+- **Scope**: [`CLIENT/tools/check_gl_wrapper_monopoly.py`](../../tools/check_gl_wrapper_monopoly.py).
+- **Purpose**: Established the state-wrapper monopoly invariant: no raw graphics API calls permitted outside `Render/`. Added an automated build-time Python verification guard.
+
+---
+
+### Phase B: GPU Skeletal Skinning & Performance Engine
+
+#### DXP-11 — RHI Interface Extraction
+- **Scope**: [`Render/RHI/RHI.h`](../../src/source/Render/RHI/RHI.h) & [`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp).
+- **Purpose**: Designed and extracted the `RHI` (Render Hardware Interface) abstract base, converting `ImmediateRenderer` to use abstract buffer uploads and pipeline state binds.
+
+#### DXP-20 — Zero-CPU GPU Skeletal Skinning
+- **Scope**: [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp), [`Render/Core/BoneUBO.h`](../../src/source/Render/Core/BoneUBO.h), `bmd_mesh.vert`.
+- **Purpose**: Offloaded character, armor, weapon, wing, and mount skeletal transformations to GPU vertex shaders. Introduced `BoneUBO` (Slot 1) uploading up to `MAX_BONES=200` matrices per batch.
+
+#### DXP-20-inc4 — Lazy Materialization Pattern
+- **Scope**: [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp).
+- **Purpose**: Replaced eager per-frame CPU vertex matrix transformations with `BMD::TransformCheap()` lazy materialization, eliminating unnecessary CPU calculations when only GPU skinning is required.
+
+#### DXP-20-inc5 — Chrome Render Mode Aliasing Fix
+- **Scope**: [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp).
+- **Purpose**: Resolved enum aliasing where CHROME2/3/5/6/7 and METAL shared `RENDER_CHROME` flag checks, ensuring accurate GPU shader variant dispatch for specialized reflection effects.
+
+#### DXP-22 — Bind State Monopoly & Cache Invalidation
+- **Scope**: [`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp) & [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp).
+- **Purpose**: Implemented robust bind cache invalidation upon resource deletion (`glDeleteVertexArrays`, `glDeleteTextures`) to prevent false hit state corruption.
+
+#### DXP-23 — Uniform Upload Profiling & GPU Diagnostics
+- **Scope**: `Render/Core/FrameProfiler.cpp`.
+- **Purpose**: Profiled per-draw uniform upload costs and established diagnostic criteria to distinguish CPU-bound driver stalls from GPU queue-wait latency in the `FrameProfiler` HUD.
+
+#### DXP-24 — Shadow Bone Matrix Corruption & Dummy Bones
+- **Scope**: [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp) & `Render/Shaders/PlanarShadowShader.cpp`.
+- **Purpose**: Fixed shadow division explosions caused by uninitialized Dummy bone matrices by ensuring complete palette zeroing and bounds validation before shadow projection.
+
+#### DXP-25 — Logic-Render Decoupling for UI Flags
+- **Scope**: `Scenes/MainScene.cpp` & UI Window controls.
+- **Purpose**: Decoupled one-shot UI interaction flags (`m_bRenderSkillInfo`) from rendering execution to prevent visual flickering when rendering uncapped above logic tick rates.
+
+#### DXP-26 — ImmediateRenderer Ring-Buffer & Bind Cache Fix
+- **Scope**: [`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp).
+- **Purpose**: Implemented a streaming vertex ring-buffer with orphan-on-wrap semantics and removed redundant per-draw shader program unbinding, boosting immediate rendering performance.
+
+#### DXP-27 — Animation Rate Decoupling from Render FPS
+- **Scope**: `ZzzCharacter.cpp`, `PhysicsManager.cpp`, `Scenes/MainScene.cpp`.
+- **Purpose**: Added high-resolution timer throttling (`std::chrono::steady_clock`) to render-frequency animation calls to prevent cloth oscillation, wing-flaps, and camera tours from speeding up at high FPS.
+
+---
+
+### Phase C: Full Hardware Abstraction Layer & Subsystem Port
+
+#### DXP-12 — RHI Texture Management & Readback
+- **Scope**: [`GlobalBitmap.cpp`](../../src/source/Render/Textures/GlobalBitmap.cpp), `ZzzInventory.cpp`, `UIControls.cpp`.
+- **Purpose**: Moved texture creation, dynamic sub-image streaming, and screen readbacks (screenshots, disconnect blur) behind the abstract `RHI` interface.
+
+#### DXP-13 — RHI Device & Windowing Handoff
+- **Scope**: `Render/RHI/`, `Winmain.cpp`.
+- **Purpose**: Encapsulated device creation, swapchain management, context lifecycle, and window resize events into the RHI subsystem layer.
+
+#### DXP-14 — RHI Shader Pipeline & Constant Buffer Layout Matching
+- **Scope**: `Render/RHI/`, `Render/Shaders/`.
+- **Purpose**: Enforced byte-exact layout alignment between shader uniform blocks (`GlobalUBO`, `BoneUBO`, `SceneUBO`) and hardware constant buffer slots across graphic backends.
+
+#### DXP-15 — RHI Immediate Renderer & 2D Pipeline
+- **Scope**: [`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp).
+- **Purpose**: Integrated 2D sprite, UI box, and font rendering through the abstract RHI pipeline state objects and dynamic vertex stream buffers.
+
+#### DXP-16 — RHI World Pipelines & Blend Encapsulation
+- **Scope**: `ZzzLodTerrain.cpp`, [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp), `PlanarShadowShader.cpp`.
+- **Purpose**: Fully converted terrain rendering, BMD mesh skinning, planar shadow projection, and RHI blend mode state objects to unified backend execution.
+
+#### DXP-17 — Depth & Projection Matrix Clip Space Alignment
+- **Scope**: `Render/Core/RenderConfig.cpp` & `NewUI3DRenderMng.cpp`.
+- **Purpose**: Unified 3D perspective projection construction (`BuildPerspectiveProjection`) across world and 3D UI item preview cameras to handle backend clip-space depth conventions cleanly.
+
+#### DXP-21 — Cloth Mesh Compute Decoupling
+- **Scope**: `Engine/Physics/PhysicsManager.cpp`.
+- **Purpose**: Decoupled dynamic CPU cloth simulation state from static GPU mesh skinning pathways, establishing an isolated seam for future dynamic compute extensions.

--- a/docs/GPU Skinning/gotchas-and-patterns.md
+++ b/docs/GPU Skinning/gotchas-and-patterns.md
@@ -1,0 +1,56 @@
+# Gotchas, Technical Invariants & Architectural Patterns
+
+This document catalogues critical technical gotchas, thread safety rules, cache invalidation pitfalls, and performance invariants established during the implementation of the GPU skinning engine and modern graphics subsystem.
+
+---
+
+## 1. Skeletal Skinning & Memory Invariants
+
+### 1.1 `MAX_BONES = 200` Allocation & Upload Rule
+- **Gotcha**: Equipped armor models (`bmdArmor`) store small internal `NumBones` counts (e.g. 12 to 15), but armor vertices reference bone indices across the entire character skeleton (0 to 199).
+- **Rule**: `BoneUBO::UploadBones()` must upload all `MAX_BONES` (200) matrices. Heap allocations for `BoneTransform` across all character, pet, and object structures must allocate `new vec34_t[MAX_BONES]` to prevent out-of-bounds heap reads during upload.
+
+### 1.2 Version-Stamped Palette Deduplication vs. Stack-Local Pointer Hazard
+- **Gotcha**: Sub-item rendering (e.g., wings, attached effect meshes) allocates `BoneTransform` arrays on the CPU execution stack. Consecutive rendering calls frequently receive the *exact same stack memory address* populated with *different matrix data*.
+- **Rule**: Never use pointer-only comparison (`pTransform == g_pLastTransform`) to skip uploading bone matrix uniform buffers. Updates MUST bump a version stamp (`g_BoneTransformVersion++`), and cache checks must validate both `(ptr, version)` pairs.
+
+### 1.3 `TransformCheap` Lazy Materialization & Ambient Global State Snapshotting
+- **Pattern**: `BMD::TransformCheap()` defers CPU vertex skinning calculations until a consumer explicitly requests CPU vertex/normal positions via `EnsureCpuVertices()`.
+- **Gotcha**: Ambient global state (such as `BoneScale`) set prior to `Transform()` and reset immediately after will be lost if read later during deferred materialization.
+- **Rule**: Deferred computations depending on ambient global state **MUST** snapshot that state into instance variables (e.g., `m_LastBoneScale`) at the moment the request is made.
+
+### 1.4 Planar Shadow Division Explosion & Dummy Bones
+- **Gotcha**: Planar shadow projection applies a GPU skew matrix involving division: $\text{skewX} = \frac{z_{\text{rel}} \cdot (x_{\text{rel}} + s_x)}{z_{\text{rel}} - s_y}$. Models with uninitialized or Dummy bone slots carry stale memory into `u_Bones`, causing division near zero and stretching shadows across billions of world units ("infinity shadow").
+- **Rule**: `BoneTransform` arrays must be fully initialized/zeroed, including Dummy bone slots that do not contain mesh vertex weights.
+
+---
+
+## 2. Rendering, Shaders & Color Pipeline Gotchas
+
+### 2.1 Vertex Color Clamping in GLSL Shaders
+- **Gotcha**: Fixed-function OpenGL clamped vertex colors `glColor3fv()` to `[0, 1]` automatically before texture modulation. In GLSL shaders, unclamped vertex color values $> 1.0$ (from intense point lights) multiply texture colors to pure blown-out white.
+- **Rule**: All fragment shaders modulating vertex colors must explicitly clamp input colors: `clamp(v_Color, 0.0, 1.0)`.
+
+### 2.2 Collapsed/Aliased Render-Mode Enum Dispatch
+- **Gotcha**: `BMD::RenderMesh()` evaluates GPU skinning eligibility against `finalRenderFlags`. Multiple distinct visual flags (CHROME2, CHROME3, CHROME5, CHROME6, CHROME7, METAL) collapse into the single enum value `RENDER_CHROME`.
+- **Rule**: When adding GPU shader eligibility checks keyed on an enum, verify every flag that maps to that bucket shares identical downstream shader mathematics.
+
+### 2.3 Bind Cache Invalidation on Resource Deletion (`glDelete*`)
+- **Gotcha**: Driver resource deletion functions (`glDeleteVertexArrays`, `glDeleteTextures`) silently reset active driver bindings to 0 when deleting the currently bound resource. A driver bind cache unaware of deletion retains stale resource IDs, causing subsequent `Bind*(id)` calls to falsely hit the cache and skip real binding.
+- **Rule**: Every deletion call site must explicitly invalidate binding caches via `InvalidateVAOCache()`, `InvalidateTextureCache()`, etc.
+
+---
+
+## 3. Concurrency, Animation & Frame Decoupled Sync
+
+### 3.1 `AnimationTaskPool` Thread Safety & Read Barriers
+- **Gotcha**: `AnimationTaskPool` computes character skeletal animations asynchronously across background worker threads. `WaitCharactersAnimation()` provides the mandatory synchronization barrier.
+- **Rule**: Code executing outside the main render pass (e.g., logic ticks or mouse updates) **MUST NEVER** read `o->BoneTransform` matrices directly while worker threads are actively mutating them.
+
+### 3.2 Decoupled Render FPS & Fixed-Timestep Animation Acceleration
+- **Gotcha**: Functions advancing state by a fixed per-call increment scaled by `FPS_ANIMATION_FACTOR` (cloth physics `Move2()`, wing flap animation, tour cameras) will speed up proportionally when render FPS increases from 60 FPS to 250+ FPS if invoked from a render-frequency call site.
+- **Rule**: All render-frequency animation/physics updates must be throttled using real-time timers (`std::chrono::steady_clock`) to maintain a constant ~60 Hz simulation rate independent of rendering frame rate.
+
+### 3.3 One-Shot UI Render Flags
+- **Gotcha**: UI flags that are set by logic ticks and immediately cleared on the first render frame (e.g., `m_bRenderSkillInfo`) cause visual flickering/strobing when rendering uncapped above the 50 Hz/60 Hz logic tick rate.
+- **Rule**: Render pass code must only **read** UI state flags; logic tick handlers remain the sole authority responsible for clearing interaction flags.

--- a/docs/GPU Skinning/gpu-skinning-architecture.md
+++ b/docs/GPU Skinning/gpu-skinning-architecture.md
@@ -1,0 +1,171 @@
+# GPU Skeletal Skinning Architecture
+
+This document provides a comprehensive technical specification of the **GPU Skeletal Skinning Engine** implemented in the MU Online client (`Render/Models/ZzzBMD.cpp`, `Render/Core/BoneUBO.h`, and `Render/Shaders/BMDMeshShader.cpp`).
+
+---
+
+## 1. Overview & High-Level Pipeline
+
+Historically, skeletal transformation in MU Online was executed entirely on the CPU: every frame, every visible character, armor mesh, weapon, and monster calculated 3×4 matrix multiplications per vertex into CPU scratch arrays (`VertexTransform`), streaming transformed vertices to the GPU via legacy vertex arrays or immediate mode.
+
+The **GPU Skeletal Skinning Engine** (introduced in `DXP-20`) offloads vertex transformation entirely to the GPU hardware:
+
+```mermaid
+graph TD
+    A["Character Animation Tick"] --> B["Calculate Matrix Palette<br>BoneTransform[200]"]
+    B --> C["BoneUBO::UploadBones()"]
+    C --> D["Uniform Buffer<br>(Slot 1: u_Bones[200])"]
+    D --> E["GPU Hardware Vertex Shader<br>(bmd_mesh.vert)"]
+    E --> F["GPU Skinning:<br>u_Bones[a_BoneIndex] * a_Pos"]
+    E --> G["World Placement:<br>u_BodyOrigin + u_BodyScale * localPos"]
+```
+
+---
+
+## 2. Uniform Buffer Object (UBO) Architecture
+
+The client allocates three primary Uniform Buffer Object slots reserved for rendering models and world geometry:
+
+```mermaid
+graph TD
+    subgraph UBO["Uniform Buffer Memory Slots"]
+        UBO0["Slot 0: GlobalMatrices UBO<br>(u_View, u_Proj, u_MVP, u_Time)"]
+        UBO1["Slot 1: BoneMatrices UBO<br>(u_Bones[200])"]
+        UBO2["Slot 2: SceneData UBO<br>(u_Fog, u_Light, u_Time)"]
+    end
+```
+
+### Bone UBO Layout (`Slot 1`)
+
+The bone UBO stores an array of 200 4x4 bone matrices in `std140` layout:
+
+```glsl
+layout(std140, binding = 1) uniform BoneMatrices {
+    mat4 u_Bones[200];
+};
+```
+
+#### The `MAX_BONES = 200` Invariant
+
+> [!IMPORTANT]
+> **Critical Invariant**: Every `UploadBones()` invocation **MUST** upload all `MAX_BONES` (200) matrices regardless of the individual mesh's `bmd->NumBones` count.
+
+- **Root Cause**: Equipped armor items (`bmdArmor` — helm, chest, pants, gloves, boots) contain small internal `NumBones` metadata (e.g. 12 to 15 bones), but armor mesh vertices reference character skeleton bone indices spanning the full `0..199` range (e.g., knee = bone 35, foot = bone 42).
+- **The "Hollowman" Defect**: If `UploadBones()` only uploads `bmdArmor->NumBones` (15 matrices), bone indices > 15 read uninitialized garbage or zero matrices in the vertex shader, collapsing torso, arm, and leg vertices to the origin (rendering the character as a hollow/invisible float).
+- **Allocation Rule**: All `BoneTransform` buffers allocated in client code (e.g., `OBJECT::BoneTransform`) must allocate space for at least 200 `vec34_t` elements (`new vec34_t[MAX_BONES]`).
+
+---
+
+## 3. Skeleton Sharing & Active Palette Pointer
+
+In the engine's animation data model, equipped armor items do not run independent skeletal animation. Instead, armor meshes share the base character's skeletal transform palette.
+
+### `g_pActiveBoneTransform` Pointer Mechanics
+
+```cpp
+// In ZzzBMD.cpp / ZzzCharacter.cpp:
+vec34_t* activeBones = g_pActiveBoneTransform ? g_pActiveBoneTransform : pObject->BoneTransform;
+BoneUBO::Instance().UploadBones(activeBones, MAX_BONES, g_BoneTransformVersion);
+```
+
+1. Before rendering an equipped armor mesh (`bmdArmor`), the character pipeline sets `g_pActiveBoneTransform = characterObject->BoneTransform`.
+2. When `bmdArmor->RenderMesh()` executes, it detects `g_pActiveBoneTransform != nullptr` and uploads the character's active bone matrix palette to `u_Bones`.
+3. Equipped weapons, wings, and mounts (Fenrir, Dark Horse) similarly bind into the active skeleton palette pointer.
+
+### Version-Stamped Deduplication
+
+To avoid redundant GPU buffer uploads (`glBufferSubData`) when consecutive meshes share the identical skeleton:
+
+```cpp
+void SetActiveBoneTransform(vec34_t* pTransform) {
+    if (g_pActiveBoneTransform != pTransform) {
+        g_pActiveBoneTransform = pTransform;
+        g_BoneTransformVersion++; // Bumps global version stamp
+    }
+}
+```
+
+`BoneUBO::UploadBones(ptr, count, version)` skips uploading to the GPU **only if both** the pointer `ptr` AND the `version` stamp match the previous upload.
+
+> [!CAUTION]
+> **Pointer-Only Caching Hazard**: Pointer-only caching is unsafe because sub-item rendering (e.g., wings) uses **stack-local** matrix arrays allocated at the same stack depth across calls. Two distinct calls receive the *same memory address* with *different matrix content*. Version stamping prevents stale matrix uploads.
+
+---
+
+## 4. Vertex Shader Transformation Mathematics (`bmd_mesh.vert`)
+
+The GPU vertex shader converts rest-pose model vertices `a_Pos` into final screen-space clip coordinates.
+
+### Shader Inputs & Uniforms
+
+- `a_Pos`: Local rest-pose vertex position (`vec3`).
+- `a_Normal`: Local rest-pose vertex normal (`vec3`).
+- `a_BoneIndex`: Vertex bone attachment index (`int` or `float`).
+- `u_BodyOrigin`: Character/Object world position (`vec3`).
+- `u_BodyScale`: Object scale factor (`float`).
+- `u_MVPDraw`: Combined View-Projection matrix for the current pass (`mat4`).
+
+### World Placement Equations
+
+$$\text{localPos} = \text{u\_Bones}[\text{a\_BoneIndex}] \cdot \text{vec4}(\text{a\_Pos}, 1.0)$$
+
+$$\text{worldPos} = \text{u\_BodyOrigin} + \text{u\_BodyScale} \cdot \text{localPos.xyz}$$
+
+$$\text{gl\_Position} = \text{u\_MVPDraw} \cdot \text{vec4}(\text{worldPos}, 1.0)$$
+
+### Normal Skinning & Chrome Generation
+
+For lit or reflective meshes:
+
+$$\text{skinnedNormal} = \text{normalize}(\text{mat3}(\text{u\_Bones}[\text{a\_BoneIndex}]) \cdot \text{a\_Normal})$$
+
+For chrome reflection shader modes (`u_RenderMode == 3` or `4`), animated chrome UV coordinates are calculated directly on the GPU from the skinned normal:
+
+$$\text{v\_ChromeUV.x} = \text{skinnedNormal.z} \cdot 0.5 + \text{u\_ChromeWave}$$
+
+$$\text{v\_ChromeUV.y} = \text{skinnedNormal.y} \cdot 0.5 + \text{u\_ChromeWave} \cdot 2.0$$
+
+### Matrix Translate Flag (`m_LastTranslate`)
+
+World map decorations and static environment objects execute `Transform()` with `Translate = false`. For these objects, world translation is pre-encoded inside their bone matrices.
+
+When `m_LastTranslate == false`, the shader dispatcher passes `u_BodyOrigin = vec3(0.0)` and `u_BodyScale = 1.0f` to prevent applying world translation twice.
+
+---
+
+## 5. Item Specular & Equipment Glow Engine (`CItemSpecularShader`)
+
+High-level equipment (+7 through +15 armor and weapons) displays dynamic animated shine, specular highlights, and characteristic color tints.
+
+```mermaid
+graph LR
+    RM4["Render Mode 4"] --> V1["SHADER_VARIANT_CHROME_1<br>(Base + Animated Chrome 1)"]
+    RM5["Render Mode 5"] --> V2["SHADER_VARIANT_CHROME_2<br>(Base + Animated Chrome 2)"]
+    RM6["Render Mode 6"] --> VM["SHADER_VARIANT_CHROME_METAL<br>(Base + Static Metal Specular)"]
+    RM7["Render Mode 7"] --> VF["SHADER_VARIANT_FULL_SPECULAR<br>(Base + Chrome1 + Metal Specular)"]
+```
+
+### Two-Tier Tint Modulation
+
+1. **`u_BodyLight`**: Dynamic scene lighting (`Light * bodyLightScale`) modulating base textures and animated light sweeps.
+2. **`u_SpecularTint`**: Static item characteristic color (`PartObjectColor`) modulating metallic layers so armor identity is preserved (e.g., Dragon armor retains blue metallic shine).
+
+---
+
+## 6. Dynamic VBO Interleaving Architecture
+
+For dynamic meshes that update per frame (e.g., custom particle meshes or UI preview quads), the renderer uses interleaved vertex buffer layouts:
+
+```mermaid
+classDiagram
+    class InterleavedVertex {
+        +Position: vec3 (12 Bytes)
+        +UVCoord: vec2 (8 Bytes)
+        +VertexColor: vec4 (16 Bytes)
+        -- Total Stride: 36 Bytes (9 floats) --
+    }
+```
+
+### Performance Advantages
+- **Single GPU Upload**: Interleaving position, UV, and color into one contiguous memory block reduces GPU buffer sub-data calls from 3 to 1 per mesh pass.
+- **Pre-Allocated Staging Pools**: `BMD` instances hold pre-allocated `m_Staging` vectors, completely eliminating per-frame heap allocations during render passes.

--- a/docs/GPU Skinning/immediate-renderer-architecture.md
+++ b/docs/GPU Skinning/immediate-renderer-architecture.md
@@ -1,0 +1,126 @@
+# ImmediateRenderer (IR::) Architecture & Task Documentation
+
+This document provides a technical specification of the **ImmediateRenderer (`IR::`) Subsystem** (`Render/Core/ImmediateRenderer.h` and `Render/Core/ImmediateRenderer.cpp`), detailing its primitive decomposition math, dynamic vertex ring-buffer architecture, RHI integration, and complete task milestone history.
+
+---
+
+## 1. Overview & Subsystem Purpose
+
+Historically, 2D UI elements (windows, buttons, icons), health bars, dynamic particle effects, joint blurs, text rendering, and cloth physics meshes relied on fixed-function immediate mode calls (`glBegin`, `glEnd`, `glVertex3f`, `glTexCoord2f`, `glColor4f`).
+
+In GLSL 3.3 Core Profile, immediate mode functions and primitive topologies like `GL_QUADS` and `GL_TRIANGLE_FAN` are completely deprecated and removed.
+
+The **ImmediateRenderer (`IR::`)** acts as a high-performance CPU-to-GPU dynamic batcher that emulates an immediate-style API while building indexed triangle streaming buffers compatible with hardware shader pipelines.
+
+```mermaid
+graph TD
+    A["Immediate-Style Calls<br>IR::Begin(GL_QUADS)<br>IR::TexCoord2f(), IR::Vertex3f()"] --> B["Vertex Assembly<br>[Pos(3f) | UV(2f) | Color(4ub)]"]
+    B --> C["IR::End() Topology Decomposition<br>QUADS -> Triangles [v0,v1,v2], [v0,v2,v3]<br>FAN -> Triangles [v0,vi,vi+1]"]
+    C --> D["Streaming Ring-Buffer Upload<br>RHI::AppendBuffer(VertexStream)"]
+    D --> E["Draw Call Dispatch<br>RHI::DrawIndexed(GL_TRIANGLES)"]
+```
+
+---
+
+## 2. API Surface & Call Lifecycle
+
+The `IR::` pipeline exposes a stateful submission API mimicking legacy OpenGL semantics, ensuring minimal code refactoring when porting legacy call sites:
+
+```cpp
+IR::Begin(GL_QUADS);
+    IR::TexCoord2f(u0, v0);
+    IR::Color4f(r, g, b, a);
+    IR::Vertex3f(x0, y0, z0);
+
+    IR::TexCoord2f(u1, v1);
+    IR::Color4f(r, g, b, a);
+    IR::Vertex3f(x1, y1, z0);
+
+    IR::TexCoord2f(u2, v2);
+    IR::Color4f(r, g, b, a);
+    IR::Vertex3f(x1, y2, z0);
+
+    IR::TexCoord2f(u3, v3);
+    IR::Color4f(r, g, b, a);
+    IR::Vertex3f(x0, y2, z0);
+IR::End();
+```
+
+### State Accumulation Sequence
+1. **`IR::Begin(primitiveType)`**: Resets internal vertex scratch counters and sets current primitive mode (`GL_TRIANGLES`, `GL_QUADS`, `GL_TRIANGLE_FAN`, `GL_LINES`).
+2. **Attribute Mutators**: `IR::TexCoord2f()`, `IR::Color4f()`, `IR::Color4ub()` update active transient attributes.
+3. **`IR::Vertex3f()` / `IR::Vertex2f()`**: Pushes a new vertex combining `(Position, Current_UV, Current_Color)` into the scratch buffer array.
+4. **`IR::End()`**: Triggers primitive decomposition, streams vertex/index data to the ring-buffer, and dispatches the indexed draw call.
+
+---
+
+## 3. Primitive Topology Decomposition
+
+Hardware shader pipelines execute indexed triangle lists (`GL_TRIANGLES`). `IR::End()` decomposes non-standard topologies CPU-side before index stream generation:
+
+### 3.1 Quad Decomposition (`GL_QUADS`)
+Every block of 4 vertices $(v_0, v_1, v_2, v_3)$ is decomposed into two triangles:
+$$\text{Triangle 1}: [v_0, v_1, v_2], \quad \text{Triangle 2}: [v_0, v_2, v_3]$$
+
+```
+  v0 +----------+ v1
+     | \        |
+     |   \ T1   |   T1: [v0, v1, v2]
+     | T2  \    |   T2: [v0, v2, v3]
+  v3 +----------+ v2
+```
+
+### 3.2 Triangle Fan Decomposition (`GL_TRIANGLE_FAN`)
+For $N$ vertices submitted ($v_0, v_1, \dots, v_{N-1}$), $N-2$ triangles are generated anchored at root vertex $v_0$:
+$$\text{Triangle } i: [v_0, v_{i}, v_{i+1}] \quad \text{for } 1 \le i \le N-2$$
+
+---
+
+## 4. Streaming Vertex Ring-Buffer & Performance Optimizations
+
+Dynamic 2D rendering submits thousands of temporary vertices per frame. To eliminate heap allocations and GPU stalls, `IR::` uses a streaming ring-buffer architecture (`DXP-26`):
+
+### 4.1 Memory Interleaving (`VertexStream`)
+Vertices are stored in a contiguous 32-byte interleaved structure optimized for cache locality and vertex attribute fetch performance:
+
+| Offset | Attribute | Type | Size |
+|---|---|---|---|
+| `0` | Position (`a_Pos`) | `float[3]` | 12 bytes |
+| `12` | TexCoord (`a_UV`) | `float[2]` | 8 bytes |
+| `20` | Color (`a_Color`) | `uint8_t[4]` | 4 bytes |
+| `24` | Padding / Alignment | `uint8_t[8]` | 8 bytes |
+
+### 4.2 Orphan-on-Wrap Semantics
+- Vertices append sequentially into a pre-allocated dynamic VBO.
+- When remaining buffer capacity is insufficient for a draw call, `IR::` issues an **orphan-on-wrap** call (`glBufferData(..., NULL, GL_STREAM_DRAW)`), returning a fresh memory region from the driver without stalling currently executing GPU pipelines.
+
+### 4.3 Program Bind Caching
+`IR::End()` checks the currently bound shader program ID. If consecutive draw calls share the same active shader program (e.g., batch rendering UI buttons or health bars), program re-binding is skipped, maximizing driver throughput.
+
+---
+
+## 5. Task & Milestone History Catalog (`IR::`)
+
+The following milestone tasks directly involved or impacted the `ImmediateRenderer` subsystem:
+
+| Milestone | Subsystem | Description & Task Scope |
+|---|---|---|
+| **`DXP-03`** | Physics | **Cloth & Cape ImmediateRenderer Port**: Replaced legacy `glBegin(GL_QUADS)` in `CPhysicsCloth::RenderFace` with `IR::` primitive calls, restoring cape rendering in Core Profile. |
+| **`DXP-09`** | Core Render | **IR Primitive Topology Decomposition**: Implemented Quad and Triangle Fan index decomposition logic inside `IR::End()`. |
+| **`DXP-11`** | RHI Core | **RHI Interface Extraction**: Refactored `IR::` to execute buffer uploads and state bindings through abstract `RHI` methods (`RHI::AppendBuffer`, `RHI::DrawIndexed`). |
+| **`DXP-15`** | RHI 2D | **RHI Immediate Renderer & 2D Pipeline**: Integrated 2D sprites, UI boxes, text rendering, and health bars into abstract RHI Pipeline State Objects (PSOs). |
+| **`DXP-22`** | Core Render | **Bind State Monopoly & Cache Invalidation**: Added VAO and VBO bind cache clearing on resource deletion to prevent state corruption when `IR::` binds dynamic buffers. |
+| **`DXP-26`** | Core Render | **IR Ring-Buffer & Program Bind Cache Fix**: Introduced dynamic streaming ring-buffer with orphan-on-wrap upload semantics and persistent shader program binding cache. |
+
+---
+
+## 6. Primary Call Sites & Subsystems Map
+
+The `ImmediateRenderer` handles all dynamic 2D and un-instanced 3D dynamic geometry across the client codebase:
+
+| Category | Primary Source Files | Usage |
+|---|---|---|
+| **2D UI & Textures** | `Render/Textures/ZzzOpenglUtil.cpp`<br>`Sprites/Sprite.cpp` | `RenderBitmap`, `RenderColor`, `RenderQuad`, button states, window frames. |
+| **Physics & Cloth** | `Engine/Physics/PhysicsManager.cpp` | `CPhysicsCloth::RenderFace` (character capes, flags, banners). |
+| **Particles & Effects** | `Effects/ZzzEffectJoint.cpp`<br>`Effects/ZzzEffectBlurSpark.cpp` | Weapon trail blurs, magic skill sparks, aura rings. |
+| **Shadows & Terrain** | `Models/ShadowVolume.cpp`<br>`Terrain/CSWaterTerrain.cpp` | Planar shadow polygons and water surface quad meshes. |


### PR DESCRIPTION
## 📝 Summary
This is a follow-up documentation PR that adds comprehensive technical documentation for the GPU Skeletal Skinning Engine (`DXP-20`) and GL Core Profile rendering subsystem under `docs/GPU Skinning/`.
These docs serve as the primary architectural reference for developer onboarding, design invariants, matrix palette UBO structures, and the milestone reference catalog (`DXP-01` through `DXP-27`).
---
## 📄 Added Documentation (`docs/GPU Skinning/`)
| File | Purpose |
| :--- | :--- |
| **`README.md`** | Index document, subsystem map, primary source file cross-references, and high-level architectural overview. |
| **`gpu-skinning-architecture.md`** | Deep technical spec covering `Slot 1` `BoneUBO` layouts, `MAX_BONES=200` invariants, `bmd_mesh.vert` GLSL skinning equations, and character animation pipeline ticks. |
| **`core-profile-migration.md`** | Migration guide detailing legacy Fixed-Function Pipeline (FFP) retirement, `ImmediateRenderer` (`IR::`) dynamic topology decomposition, and RHI state encapsulation. |
| **`dxp-milestones.md`** | Reference catalog explaining the context, scope, and implementation details for all `DXP-01` through `DXP-27` milestone tags present in codebase inline comments. |
| **`gotchas-and-patterns.md`** | Pitfalls catalog covering threading synchronization (`AnimationTaskPool`), cache invalidation rules, matrix alignment, and performance invariants. |
---
## ✅ Changes Included
- **Files Changed:** 5 files (`+587` lines of documentation)
- **Code Changes:** None (Pure documentation update)