### PR TITLE
docs(render): document CoreProfile and AnimationTaskPool config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# MU Online Client Sources
+# MU Online Client Sources
 
 [![MinGW Build](https://github.com/sven-n/MuMain/actions/workflows/mingw-build.yml/badge.svg?branch=main)](https://github.com/sven-n/MuMain/actions/workflows/mingw-build.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sven-n/MuMain)
@@ -263,8 +263,24 @@ The [OpenMU launcher](https://github.com/MUnique/OpenMU/releases/download/v0.8.1
 will work as well. By default, it connects to localhost and port `44406`.
 The client identifies itself with Version `2.04d` and serial `k1Pk2jcET48mxL3b`.
 
+#### Client Configuration (`config.ini`)
+The client reads options from `config.ini` in the executable directory:
+
+| Section | Key | Default Value | Description |
+| :--- | :--- | :--- | :--- |
+| **`[Render]`** | `CoreProfile` | `1` | **Graphics Pipeline Engine**<br>`1` = Enforces **OpenGL 3.3 Core Profile** (UBO matrices, GLSL 3.3 shaders, hardware skeletal skinning, no FFP calls).<br>`0` = Fallback rollback path to OpenGL Compatibility Profile. |
+| **`[UI]`** | `EnableAnimationTaskPool` | `0` | **Parallel Animation Processing**<br>`1` = Enables multi-threaded character animation tick pool (`AnimationTaskPool`) for crowded scenes ($\ge 20$ active characters).<br>`0` = Sequential single-threaded animation calculation. |
+| **`[UI]`** | `Locale` | `"en"` | **UI Language Locale** (`en`, `es`, `pt`, `ru`, `ko`). |
+| **`[Camera]`** | `Zoom` | `1735` | **3D Camera Default Distance**. |
+
+#### Command Line Flags & Options
+- **Connection string**: `main.exe connect /u<IP> /p<PORT>`
+- **`--enable-taskpool`**: Forces `AnimationTaskPool` multi-threaded character animation updates on at launch.
+- **`--editor`**: Enables the ImGui in-game editor (toggle with **F12** on `*_mueditor` builds).
+
 ## Documentation
 
+- [GPU Skinning & Core Profile](docs/GPU%20Skinning/README.md) - architecture, UBO layouts, ImmediateRenderer (`IR::`), and milestone catalog (`DXP-01` to `DXP-27`).
 - [Camera system](docs/camera-system.md) - modes, switching (F9), config,
   frustum culling, `$details` overlay, and the gameplay behaviour changes
   from the 3D camera rework.

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ The client reads options from `config.ini` in the executable directory:
 
 | Section | Key | Default Value | Description |
 | :--- | :--- | :--- | :--- |
-| **`[Render]`** | `CoreProfile` | `1` | **Graphics Pipeline Engine**<br>`1` = Enforces **OpenGL 3.3 Core Profile** (UBO matrices, GLSL 3.3 shaders, hardware skeletal skinning, no FFP calls).<br>`0` = Fallback rollback path to OpenGL Compatibility Profile. |
+| **`[Render]`** | `CoreProfile` | `1` | **OpenGL Context Profile Switch**<br>`1` = Enforces **OpenGL 3.3 Core Profile** (Default). All rendering runs via UBO matrices, GLSL 3.3 shaders, GPU skeletal skinning, and `ImmediateRenderer` (`IR::`).<br>`0` = Requests **OpenGL Compatibility Profile** context (Re-enables legacy FFP driver state toggles like `glAlphaTest`/`glEnable(GL_TEXTURE_2D)` for legacy driver hooks; shader & UBO pipelines remain active). |
 | **`[UI]`** | `EnableAnimationTaskPool` | `0` | **Parallel Animation Processing**<br>`1` = Enables multi-threaded character animation tick pool (`AnimationTaskPool`) for crowded scenes ($\ge 20$ active characters).<br>`0` = Sequential single-threaded animation calculation. |
 | **`[UI]`** | `Locale` | `"en"` | **UI Language Locale** (`en`, `es`, `pt`, `ru`, `ko`). |
 | **`[Camera]`** | `Zoom` | `1735` | **3D Camera Default Distance**. |

--- a/docs/GPU Skinning/README.md
+++ b/docs/GPU Skinning/README.md
@@ -44,3 +44,21 @@ This documentation details the architecture, design decisions, milestone catalog
 | **Uniform Buffers** | [`Render/Core/GlobalUBO.h`](../../src/source/Render/Core/GlobalUBO.h)<br>[`Render/Core/BoneUBO.h`](../../src/source/Render/Core/BoneUBO.h) | Uniform Buffer Objects for Camera/Model matrices (`Slot 0`) and Skeletal Bones (`Slot 1`). |
 | **Immediate Renderer** | [`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp) | Dynamic quad/fan topology decomposition and 2D/3D immediate-mode submission. |
 | **Item Specular Shader** | [`Render/Shaders/ItemSpecularShader.cpp`](../../src/source/Render/Shaders/ItemSpecularShader.cpp) | Modern single-pass GPU shader for +7 through +15 equipment shine & chrome effects. |
+
+---
+
+## Graphics & Performance Configuration Switches
+
+The graphics and performance engine exposes runtime switches via `config.ini` and command-line flags:
+
+### 1. `config.ini` Switches
+- **`[Render] CoreProfile`** (Default: `1`):
+  - `1`: Enforces **OpenGL 3.3 Core Profile** (`SDL_GL_CONTEXT_PROFILE_CORE`). All rendering runs via UBOs, GLSL 3.3 shaders, and hardware vertex skinning, completely bypassing legacy FFP state.
+  - `0`: Fallback rollback path to **OpenGL Compatibility Profile** (`SDL_GL_CONTEXT_PROFILE_COMPATIBILITY`).
+- **`[UI] EnableAnimationTaskPool`** (Default: `0`):
+  - `1`: Enables the multi-threaded character animation task pool (`AnimationTaskPool`) when $\ge 20$ active characters are present.
+  - `0`: Runs character skeletal animation updates sequentially on the main thread.
+
+### 2. Command Line Flags
+- **`--enable-taskpool`**: Forces `AnimationTaskPool` on at launch regardless of `config.ini`.
+- **`--editor`**: Enables the in-game ImGui editor overlay (**F12**) on `*_mueditor` builds.

--- a/docs/GPU Skinning/README.md
+++ b/docs/GPU Skinning/README.md
@@ -53,8 +53,8 @@ The graphics and performance engine exposes runtime switches via `config.ini` an
 
 ### 1. `config.ini` Switches
 - **`[Render] CoreProfile`** (Default: `1`):
-  - `1`: Enforces **OpenGL 3.3 Core Profile** (`SDL_GL_CONTEXT_PROFILE_CORE`). All rendering runs via UBOs, GLSL 3.3 shaders, and hardware vertex skinning, completely bypassing legacy FFP state.
-  - `0`: Fallback rollback path to **OpenGL Compatibility Profile** (`SDL_GL_CONTEXT_PROFILE_COMPATIBILITY`).
+  - `1`: Enforces **OpenGL 3.3 Core Profile** (`SDL_GL_CONTEXT_PROFILE_CORE`). All rendering runs via UBOs, GLSL 3.3 shaders, GPU skeletal skinning, and `ImmediateRenderer` (`IR::`).
+  - `0`: Requests **OpenGL Compatibility Profile** (`SDL_GL_CONTEXT_PROFILE_COMPATIBILITY`). Re-enables legacy FFP driver state toggles (e.g. `glAlphaTest`, `glEnable(GL_TEXTURE_2D)`) for legacy driver hook compatibility; all primary rendering remains shader and UBO driven.
 - **`[UI] EnableAnimationTaskPool`** (Default: `0`):
   - `1`: Enables the multi-threaded character animation task pool (`AnimationTaskPool`) when $\ge 20$ active characters are present.
   - `0`: Runs character skeletal animation updates sequentially on the main thread.

--- a/docs/GPU Skinning/core-profile-migration.md
+++ b/docs/GPU Skinning/core-profile-migration.md
@@ -95,7 +95,7 @@ graph TD
 
 1. **Sequential Append**: New draw calls append vertices sequentially into the buffer using `RHI::AppendBuffer`.
 2. **Orphan-on-Wrap**: When the ring-buffer reaches capacity, it re-allocates or orphans the buffer, starting fresh at offset 0 without stalling the GPU pipeline.
-3. **Persistent Program Binding**: Modern `IR::End()` retains shader program bindings across consecutive draw calls, enabling program-bind cache hits when drawing sequences of UI elements or particles.
+3. **Persistent Program Binding**: Modern `IR::Begin()` binds the `PassthroughShader` through `BindState`'s dirty-check cache. If the same program is already bound from a prior draw, the `glUseProgram` call is skipped. `IR::End()` does not participate in bind caching.
 
 ---
 
@@ -107,7 +107,7 @@ To prevent technical debt and ensure cross-platform driver compatibility, the cl
 
 ### Automated Build-Time Verification Guard
 
-The build system executes [`CLIENT/tools/check_gl_wrapper_monopoly.py`](../../tools/check_gl_wrapper_monopoly.py) as an automatic custom target before compiling `MuClient`.
+The build system executes [`CLIENT/Tools/check_gl_wrapper_monopoly.py`](../../Tools/check_gl_wrapper_monopoly.py) as an automatic custom target before compiling `MuClient`.
 
 ```mermaid
 flowchart TD
@@ -124,6 +124,8 @@ If developer code outside `Render/` attempts to invoke raw driver functions, the
 
 All texture operations are encapsulated behind the RHI layer:
 
-- **Creation & Upload**: [`GlobalBitmap.cpp`](../../src/source/Render/Textures/GlobalBitmap.cpp) creates textures via `RHI::CreateTexture` with explicit mipmap generation and format specifications (`RHI_FORMAT_R8G8B8A8_UNORM`).
+- **Creation & Upload**: [`GlobalBitmap.cpp`](../../src/source/Render/Sprites/GlobalBitmap.cpp) creates textures via `RHI::CreateTexture`. The format is RGBA8 (hardcoded — no named RHI format constant exists; `DXGI_FORMAT_R8G8B8A8_UNORM`-style named constants are D3D11-side only; the GL backend hardwires `GL_RGBA8`). No automatic mipmap generation occurs — textures are single-level unless explicitly updated.
 - **Dynamic Streaming**: UI fonts, dynamic minimaps, and reconnect dialogs update sub-regions of textures using `RHI::UpdateTexture`.
-- **Pixel Readback**: Screen capture, screenshot export, and UI background blur effects use `RHI::ReadPixels` to extract frame buffer pixels safely into host memory.
+- **Pixel Readback**: Two separate readback functions exist behind the RHI:
+  - `RHI::ReadColorFramebuffer` — used by screenshot export and the reconnect-dialog background blur. Returns top-down row order regardless of backend.
+  - `RHI::ReadDepthPixel` — used by `CameraProjection::TestDepthBuffer` for depth-buffer sampling. Note: `RHI::ReadPixels` does **not** exist as a function.

--- a/docs/GPU Skinning/dxp-milestones.md
+++ b/docs/GPU Skinning/dxp-milestones.md
@@ -10,6 +10,9 @@ The milestones below are organized **chronologically in the exact order of imple
 
 ### Phase A: FFP Retirement & Core Profile Baseline (August 1–2, 2026)
 
+> [!NOTE]
+> Phase A milestones (DXP-01 through DXP-11) were implemented on the `feature-ffp-shader-port` branch and squash-merged into the `gl-only-port` baseline commit (`0702144`). Their `DXP-xx` tag strings are preserved in the archived DXP task memory files and commit history but were **not carried forward as inline code comments** into the squashed source tree.
+
 | Milestone | Subsystem | Focus / Objective | Status |
 |---|---|---|---|
 | **[DXP-01](#dxp-01--alpha-test-shader-port)** | Shaders | Shader-level alpha testing (`u_AlphaRef` / `discard`). | Completed |
@@ -21,6 +24,7 @@ The milestones below are organized **chronologically in the exact order of imple
 | **[DXP-07a](#dxp-07a--cpu-ortho-matrix-calculation)** | UI / 2D | `BeginBitmap()` ortho matrix calculation moved to CPU. | Completed |
 | **[DXP-07b](#dxp-07b--cpu-camera-matrix-calculation)** | Render Core | `BeginOpengl()` camera view/proj matrices moved to CPU. | Completed |
 | **[DXP-07c](#dxp-07c--decoupled-picking--mouse-matrix-chain)** | UI / Mouse | Mouse picking & camera projection decoupled from GL matrix stack. | Completed |
+| **[DXP-07d](#dxp-07d--item-preview-panel-cpu-camera-validation)** | UI / 3D Panels | Shadow-compare validation series for all 6 item-preview panel cameras. | Completed |
 | **[DXP-09](#dxp-09--pipeline-hygiene--ir-topology-decomposition)** | Renderer Core | Code hygiene, dead code removal, IR quad/fan decomposition. | Completed |
 | **[DXP-08a](#dxp-08a--core-profile-soak--illegal-ffp-sweep)** | Core Engine | Core Profile soak testing & illegal FFP state call sweep. | Completed |
 | **[DXP-08](#dxp-08--opengl-33-core-profile-migration)** | Core Engine | Core Profile flip & legacy fixed-function branch retirement. | Completed |
@@ -50,8 +54,8 @@ The milestones below are organized **chronologically in the exact order of imple
 | **[DXP-14](#dxp-14--rhi-shader-pipeline--ubo-layout-parity)** | RHI Shaders | Core shader pipeline port and UBO/constant buffer matching. | Completed |
 | **[DXP-15](#dxp-15--rhi-immediate-renderer--2d-pipeline)** | RHI 2D Pipeline | `ImmediateRenderer` integration into RHI abstraction. | Completed |
 | **[DXP-16](#dxp-16--rhi-world-pipelines--blend-encapsulation)** | RHI 3D World | Terrain, BMD mesh, and Planar Shadow RHI pipeline port. | Completed |
-| **[DXP-17](#dxp-17--depth--projection-matrix-clip-space-alignment)** | Projection | Clip-space perspective projection helper unification. | Completed |
-| **[DXP-21](#dxp-21--cloth-mesh-compute-decoupling)** | Cloth Physics | Seam for dynamic cloth mesh compute optimization. | Completed |
+| **[DXP-17](#dxp-17--depth--projection-matrix-clip-space-alignment)** | Projection | Clip-space perspective projection helper unification. | Partially Completed |
+| **[DXP-21](#dxp-21--cloth-mesh-compute-decoupling)** | Cloth Physics | Seam for dynamic cloth mesh compute optimization. | Deferred |
 
 ---
 
@@ -95,6 +99,10 @@ The milestones below are organized **chronologically in the exact order of imple
 - **Scope**: `CameraProjection.cpp` & `ZzzOpenglUtil.cpp`.
 - **Purpose**: Removed `glGetFloatv(GL_MODELVIEW_MATRIX)` and `glGetFloatv(GL_PROJECTION_MATRIX)` from 3D ray picking (`UpdateMousePosition`) and replaced them with CPU matrix cache reads.
 
+#### DXP-07d — Item-Preview Panel CPU Camera Validation
+- **Scope**: `UI/NewUI/NewUI3DRenderMng.cpp`, `UI/NewUI/Events/NewUIRegistrationLuckyCoin.cpp`, `UI/NewUI/Events/NewUIGoldBowmanLena.cpp`, `UI/Legacy/UIWindows.cpp`, `Scenes/SceneCommon.cpp`, `GameShop/NewUIInGameShop.cpp`, `Render/Shaders/BMDMeshShader.cpp`.
+- **Purpose**: Six-increment shadow-compare diagnostic series that validated each 3D item-preview panel's CPU-computed projection and view matrices against the legacy GL matrix stack, confirming bit-for-bit accuracy before the FFP matrix-stack calls were deleted in DXP-08a. Tag string present in source code comments (17 occurrences across 9 files); Phase A squash did not strip these.
+
 #### DXP-09 — Pipeline Hygiene & IR Topology Decomposition
 - **Scope**: `Render/Core/ImmediateRenderer.cpp` & `ZzzOpenglUtil.cpp`.
 - **Purpose**: Decomposed immediate-mode `GL_QUADS` and `GL_TRIANGLE_FAN` primitives into indexing-compatible triangle lists (`GL_TRIANGLES`) for hardware abstraction compatibility.
@@ -108,7 +116,7 @@ The milestones below are organized **chronologically in the exact order of imple
 - **Purpose**: Flipped default context creation to OpenGL 3.3 Core Profile (`g_CoreProfile = true`). Retired legacy fixed-function fallback branches across core render loops.
 
 #### DXP-10 — State Wrapper Monopoly & Guard Script
-- **Scope**: [`CLIENT/tools/check_gl_wrapper_monopoly.py`](../../tools/check_gl_wrapper_monopoly.py).
+- **Scope**: [`Tools/check_gl_wrapper_monopoly.py`](../../Tools/check_gl_wrapper_monopoly.py).
 - **Purpose**: Established the state-wrapper monopoly invariant: no raw graphics API calls permitted outside `Render/`. Added an automated build-time Python verification guard.
 
 ---
@@ -132,12 +140,12 @@ The milestones below are organized **chronologically in the exact order of imple
 - **Purpose**: Resolved enum aliasing where CHROME2/3/5/6/7 and METAL shared `RENDER_CHROME` flag checks, ensuring accurate GPU shader variant dispatch for specialized reflection effects.
 
 #### DXP-22 — Bind State Monopoly & Cache Invalidation
-- **Scope**: [`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp) & [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp).
+- **Scope**: [`Render/Core/BindState.h`](../../src/source/Render/Core/BindState.h), [`Render/Core/BindState.cpp`](../../src/source/Render/Core/BindState.cpp), [`Render/Core/ImmediateRenderer.cpp`](../../src/source/Render/Core/ImmediateRenderer.cpp), [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp), `Render/Terrain/ZzzLodTerrain.cpp`.
 - **Purpose**: Implemented robust bind cache invalidation upon resource deletion (`glDeleteVertexArrays`, `glDeleteTextures`) to prevent false hit state corruption.
 
 #### DXP-23 — Uniform Upload Profiling & GPU Diagnostics
-- **Scope**: `Render/Core/FrameProfiler.cpp`.
-- **Purpose**: Profiled per-draw uniform upload costs and established diagnostic criteria to distinguish CPU-bound driver stalls from GPU queue-wait latency in the `FrameProfiler` HUD.
+- **Scope**: `Core/Utilities/FrameProfiler.h`, `Scenes/MainScene.cpp`, `Scenes/MainScene.h`, `Scenes/SceneManager.cpp`, `Core/Utilities/Log/muConsoleDebug.cpp`, `Render/Effects/ZzzEffectParticle.cpp`, `Render/Effects/ZzzEffectJoint.cpp`.
+- **Purpose**: Profiled per-draw uniform upload costs and established diagnostic criteria to distinguish CPU-bound driver stalls from GPU queue-wait latency in the `FrameProfiler` HUD. Added console debug toggles to isolate effect rendering subsystems (`$effects off`, wing/joint/boid diagnostics).
 
 #### DXP-24 — Shadow Bone Matrix Corruption & Dummy Bones
 - **Scope**: [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp) & `Render/Shaders/PlanarShadowShader.cpp`.
@@ -160,7 +168,7 @@ The milestones below are organized **chronologically in the exact order of imple
 ### Phase C: Full Hardware Abstraction Layer & Subsystem Port
 
 #### DXP-12 — RHI Texture Management & Readback
-- **Scope**: [`GlobalBitmap.cpp`](../../src/source/Render/Textures/GlobalBitmap.cpp), `ZzzInventory.cpp`, `UIControls.cpp`.
+- **Scope**: [`GlobalBitmap.cpp`](../../src/source/Render/Sprites/GlobalBitmap.cpp), `ZzzInventory.cpp`, `UIControls.cpp`.
 - **Purpose**: Moved texture creation, dynamic sub-image streaming, and screen readbacks (screenshots, disconnect blur) behind the abstract `RHI` interface.
 
 #### DXP-13 — RHI Device & Windowing Handoff
@@ -168,7 +176,7 @@ The milestones below are organized **chronologically in the exact order of imple
 - **Purpose**: Encapsulated device creation, swapchain management, context lifecycle, and window resize events into the RHI subsystem layer.
 
 #### DXP-14 — RHI Shader Pipeline & Constant Buffer Layout Matching
-- **Scope**: `Render/RHI/`, `Render/Shaders/`.
+- **Scope**: `Render/Core/GlobalUBO.h`, `Render/Core/SceneUBO.h`, `Render/Core/BoneUBO.h`.
 - **Purpose**: Enforced byte-exact layout alignment between shader uniform blocks (`GlobalUBO`, `BoneUBO`, `SceneUBO`) and hardware constant buffer slots across graphic backends.
 
 #### DXP-15 — RHI Immediate Renderer & 2D Pipeline
@@ -176,13 +184,13 @@ The milestones below are organized **chronologically in the exact order of imple
 - **Purpose**: Integrated 2D sprite, UI box, and font rendering through the abstract RHI pipeline state objects and dynamic vertex stream buffers.
 
 #### DXP-16 — RHI World Pipelines & Blend Encapsulation
-- **Scope**: `ZzzLodTerrain.cpp`, [`Render/Models/ZzzBMD.cpp`](../../src/source/Render/Models/ZzzBMD.cpp), `PlanarShadowShader.cpp`.
+- **Scope**: `Scenes/CharacterScene.cpp`, `Scenes/SceneManager.cpp`, `UI/Legacy/UIControls.cpp`.
 - **Purpose**: Fully converted terrain rendering, BMD mesh skinning, planar shadow projection, and RHI blend mode state objects to unified backend execution.
 
 #### DXP-17 — Depth & Projection Matrix Clip Space Alignment
-- **Scope**: `Render/Core/RenderConfig.cpp` & `NewUI3DRenderMng.cpp`.
-- **Purpose**: Unified 3D perspective projection construction (`BuildPerspectiveProjection`) across world and 3D UI item preview cameras to handle backend clip-space depth conventions cleanly.
+- **Scope**: `Render/Core/RenderConfig.h/.cpp` & `UI/NewUI/NewUI3DRenderMng.cpp`.
+- **Purpose**: Unified 3D perspective projection construction (`BuildPerspectiveProjection`) across world and 3D UI item preview cameras to handle backend clip-space depth conventions cleanly. Item 1 (projection builders) is complete and user-confirmed. Items 2/3/5/6 (fog formulas, depth readback, gamma, viewport depth range) were explicitly closed as accepted low-priority risk without full verification.
 
 #### DXP-21 — Cloth Mesh Compute Decoupling
 - **Scope**: `Engine/Physics/PhysicsManager.cpp`.
-- **Purpose**: Decoupled dynamic CPU cloth simulation state from static GPU mesh skinning pathways, establishing an isolated seam for future dynamic compute extensions.
+- **Purpose**: Planned decoupling of dynamic CPU cloth simulation from static GPU mesh skinning pathways. **Status: Deferred by owner decision (2026-08-02)** — waiting for D3D11 compute backend before implementing. No code change landed.

--- a/docs/GPU Skinning/dxp-milestones.md
+++ b/docs/GPU Skinning/dxp-milestones.md
@@ -189,7 +189,8 @@ The milestones below are organized **chronologically in the exact order of imple
 
 #### DXP-17 — Depth & Projection Matrix Clip Space Alignment
 - **Scope**: `Render/Core/RenderConfig.h/.cpp` & `UI/NewUI/NewUI3DRenderMng.cpp`.
-- **Purpose**: Unified 3D perspective projection construction (`BuildPerspectiveProjection`) across world and 3D UI item preview cameras to handle backend clip-space depth conventions cleanly. Item 1 (projection builders) is complete and user-confirmed. Items 2/3/5/6 (fog formulas, depth readback, gamma, viewport depth range) were explicitly closed as accepted low-priority risk without full verification.
+- **Purpose**: Unified 3D perspective projection construction (`BuildPerspectiveProjection`) across world and 3D UI item preview cameras to handle backend clip-space depth conventions cleanly. 
+- **Status Note (Partially Completed)**: Item 1 (projection builders) is complete and fixed the underwater geometry bleed bug. Items 2/3/5/6 (fog formulas, depth readback, gamma, viewport depth range) were explicitly closed by owner decision as accepted low-priority risk. These remain unaudited because they are harmless under OpenGL's `[-1, 1]` matrix. They will be reopened as micro-tasks during Phase C only if a concrete visual symptom (like fog-distance mismatch) appears when the D3D11 `[0, 1]` matrix is active.
 
 #### DXP-21 — Cloth Mesh Compute Decoupling
 - **Scope**: `Engine/Physics/PhysicsManager.cpp`.

--- a/docs/GPU Skinning/gpu-skinning-architecture.md
+++ b/docs/GPU Skinning/gpu-skinning-architecture.md
@@ -14,7 +14,7 @@ The **GPU Skeletal Skinning Engine** (introduced in `DXP-20`) offloads vertex tr
 graph TD
     A["Character Animation Tick"] --> B["Calculate Matrix Palette<br>BoneTransform[200]"]
     B --> C["BoneUBO::UploadBones()"]
-    C --> D["Uniform Buffer<br>(Slot 1: u_Bones[200])"]
+    C --> D["Uniform Buffer<br>(Slot 2: u_Bones[200])"]
     D --> E["GPU Hardware Vertex Shader<br>(bmd_mesh.vert)"]
     E --> F["GPU Skinning:<br>u_Bones[a_BoneIndex] * a_Pos"]
     E --> G["World Placement:<br>u_BodyOrigin + u_BodyScale * localPos"]
@@ -30,20 +30,23 @@ The client allocates three primary Uniform Buffer Object slots reserved for rend
 graph TD
     subgraph UBO["Uniform Buffer Memory Slots"]
         UBO0["Slot 0: GlobalMatrices UBO<br>(u_View, u_Proj, u_MVP, u_Time)"]
-        UBO1["Slot 1: BoneMatrices UBO<br>(u_Bones[200])"]
-        UBO2["Slot 2: SceneData UBO<br>(u_Fog, u_Light, u_Time)"]
+        UBO1["Slot 1: SceneData UBO<br>(u_Fog, u_Light, u_Time)"]
+        UBO2["Slot 2: BoneMatrices UBO<br>(u_Bones[200])"]
     end
 ```
 
-### Bone UBO Layout (`Slot 1`)
+### Bone UBO Layout (`Slot 2`)
 
 The bone UBO stores an array of 200 4x4 bone matrices in `std140` layout:
 
 ```glsl
-layout(std140, binding = 1) uniform BoneMatrices {
+layout(std140, binding = 1) uniform BoneMatrices {  // shader-side comment; runtime binding is slot 2
     mat4 u_Bones[200];
 };
 ```
+
+> [!NOTE]
+> **Pre-existing binding inconsistency**: The GLSL source comment says `binding = 1`, but at runtime `BoneUBO::Create()` binds to **slot 2**. This mismatch exists in the codebase itself (not introduced by documentation). The runtime binding (slot 2) is authoritative — it is what the GPU actually uses.
 
 #### The `MAX_BONES = 200` Invariant
 
@@ -78,17 +81,16 @@ To avoid redundant GPU buffer uploads (`glBufferSubData`) when consecutive meshe
 
 ```cpp
 void SetActiveBoneTransform(vec34_t* pTransform) {
-    if (g_pActiveBoneTransform != pTransform) {
-        g_pActiveBoneTransform = pTransform;
-        g_BoneTransformVersion++; // Bumps global version stamp
-    }
+    g_pActiveBoneTransform = pTransform;
+    g_BoneTransformVersion++; // Unconditionally bumps global version stamp every call
 }
 ```
 
-`BoneUBO::UploadBones(ptr, count, version)` skips uploading to the GPU **only if both** the pointer `ptr` AND the `version` stamp match the previous upload.
+> [!NOTE]
+> `SetActiveBoneTransform()` **does not** guard on pointer comparison. It unconditionally sets the pointer and bumps the version stamp every call. The deduplication logic lives entirely in `BoneUBO::UploadBones(ptr, count, version)`, which skips a GPU buffer upload **only if both** the pointer `ptr` AND the `version` stamp match the values from the previous upload.
 
 > [!CAUTION]
-> **Pointer-Only Caching Hazard**: Pointer-only caching is unsafe because sub-item rendering (e.g., wings) uses **stack-local** matrix arrays allocated at the same stack depth across calls. Two distinct calls receive the *same memory address* with *different matrix content*. Version stamping prevents stale matrix uploads.
+> **Pointer-Only Caching Hazard**: Pointer-only caching in `UploadBones` would be unsafe because sub-item rendering (e.g., wings) uses **stack-local** matrix arrays allocated at the same stack depth across calls. Two distinct calls could receive the *same memory address* with *different matrix content*. The `version` stamp prevents stale matrix uploads by ensuring identity requires both address AND generation match.
 
 ---
 
@@ -119,11 +121,13 @@ For lit or reflective meshes:
 
 $$\text{skinnedNormal} = \text{normalize}(\text{mat3}(\text{u\_Bones}[\text{a\_BoneIndex}]) \cdot \text{a\_Normal})$$
 
-For chrome reflection shader modes (`u_RenderMode == 3` or `4`), animated chrome UV coordinates are calculated directly on the GPU from the skinned normal:
+For chrome reflection (`u_RenderMode == 3`), animated chrome UV coordinates are calculated on the GPU from the skinned normal. RenderMode 3 covers both plain `RENDER_CHROME` and the CHROME2/3/5/6/7/METAL variants — the variant is selected via the `u_ChromeVariant` uniform (introduced in DXP-20-inc5). The base formula (plain chrome fallback):
 
 $$\text{v\_ChromeUV.x} = \text{skinnedNormal.z} \cdot 0.5 + \text{u\_ChromeWave}$$
 
 $$\text{v\_ChromeUV.y} = \text{skinnedNormal.y} \cdot 0.5 + \text{u\_ChromeWave} \cdot 2.0$$
+
+CHROME2/3/5/6/7/METAL variants use separate per-variant UV formulas dispatched via `u_ChromeVariant`; CHROME4/OIL take a CPU dynamic-VBO path and are never GPU-eligible.
 
 ### Matrix Translate Flag (`m_LastTranslate`)
 
@@ -139,10 +143,10 @@ High-level equipment (+7 through +15 armor and weapons) displays dynamic animate
 
 ```mermaid
 graph LR
-    RM4["Render Mode 4"] --> V1["SHADER_VARIANT_CHROME_1<br>(Base + Animated Chrome 1)"]
-    RM5["Render Mode 5"] --> V2["SHADER_VARIANT_CHROME_2<br>(Base + Animated Chrome 2)"]
-    RM6["Render Mode 6"] --> VM["SHADER_VARIANT_CHROME_METAL<br>(Base + Static Metal Specular)"]
-    RM7["Render Mode 7"] --> VF["SHADER_VARIANT_FULL_SPECULAR<br>(Base + Chrome1 + Metal Specular)"]
+    RM4["Render Mode 4"] --> V1["CHROME_1<br>(Base + Animated Chrome 1)"]
+    RM5["Render Mode 5"] --> VM["CHROME_METAL<br>(Base + Static Metal Specular)"]
+    RM6["Render Mode 6"] --> VF1["FULL_SPECULAR_V1<br>(Base + Chrome + Specular Tier 1)"]
+    RM7["Render Mode 7"] --> VF2["FULL_SPECULAR_V2<br>(Base + Chrome + Specular Tier 2)"]
 ```
 
 ### Two-Tier Tint Modulation

--- a/docs/GPU Skinning/immediate-renderer-architecture.md
+++ b/docs/GPU Skinning/immediate-renderer-architecture.md
@@ -16,7 +16,7 @@ The **ImmediateRenderer (`IR::`)** acts as a high-performance CPU-to-GPU dynamic
 graph TD
     A["Immediate-Style Calls<br>IR::Begin(GL_QUADS)<br>IR::TexCoord2f(), IR::Vertex3f()"] --> B["Vertex Assembly<br>[Pos(3f) | UV(2f) | Color(4ub)]"]
     B --> C["IR::End() Topology Decomposition<br>QUADS -> Triangles [v0,v1,v2], [v0,v2,v3]<br>FAN -> Triangles [v0,vi,vi+1]"]
-    C --> D["Streaming Ring-Buffer Upload<br>RHI::AppendBuffer(VertexStream)"]
+    C --> D["Streaming Ring-Buffer Upload<br>RHI::AppendBuffer(IRVertex)"]
     D --> E["Draw Call Dispatch<br>RHI::DrawIndexed(GL_TRIANGLES)"]
 ```
 
@@ -80,22 +80,22 @@ $$\text{Triangle } i: [v_0, v_{i}, v_{i+1}] \quad \text{for } 1 \le i \le N-2$$
 
 Dynamic 2D rendering submits thousands of temporary vertices per frame. To eliminate heap allocations and GPU stalls, `IR::` uses a streaming ring-buffer architecture (`DXP-26`):
 
-### 4.1 Memory Interleaving (`VertexStream`)
-Vertices are stored in a contiguous 32-byte interleaved structure optimized for cache locality and vertex attribute fetch performance:
+### 4.1 Memory Interleaving (`IRVertex`)
+Vertices are stored in a contiguous 36-byte interleaved structure optimized for cache locality and vertex attribute fetch performance:
 
 | Offset | Attribute | Type | Size |
 |---|---|---|---|
 | `0` | Position (`a_Pos`) | `float[3]` | 12 bytes |
 | `12` | TexCoord (`a_UV`) | `float[2]` | 8 bytes |
-| `20` | Color (`a_Color`) | `uint8_t[4]` | 4 bytes |
-| `24` | Padding / Alignment | `uint8_t[8]` | 8 bytes |
+| `20` | Color (`a_Color`) | `float[4]` (r, g, b, a) | 16 bytes |
+| | **Total stride** | | **36 bytes** |
 
 ### 4.2 Orphan-on-Wrap Semantics
 - Vertices append sequentially into a pre-allocated dynamic VBO.
 - When remaining buffer capacity is insufficient for a draw call, `IR::` issues an **orphan-on-wrap** call (`glBufferData(..., NULL, GL_STREAM_DRAW)`), returning a fresh memory region from the driver without stalling currently executing GPU pipelines.
 
 ### 4.3 Program Bind Caching
-`IR::End()` checks the currently bound shader program ID. If consecutive draw calls share the same active shader program (e.g., batch rendering UI buttons or health bars), program re-binding is skipped, maximizing driver throughput.
+`IR::Begin()` calls `PassthroughShader::Bind()`, which routes through `BindState::BindProgram()` — a dirty-check cache that skips `glUseProgram` if the same program is already active. If consecutive draw calls share the same shader program (e.g., batch rendering UI buttons or health bars), the bind is a no-op. `IR::End()` does **not** contain a bind cache — it calls `PassthroughShader::Unbind()` which unconditionally issues `BindProgram(0)`, resetting the bound program after every draw.
 
 ---
 


### PR DESCRIPTION
## 📝 Summary
This PR updates `README.md` and `docs/GPU Skinning/README.md` to document the runtime configuration switches and command-line launch options introduced during fixed-function pipeline (FFP) retirement and GPU skeletal skinning integration.
---
## 📄 Changes Included
### 1. **`README.md`**
- Added **Client Configuration (`config.ini`)** reference table:
  - `[Render] CoreProfile` (Default: `1`): Toggles between OpenGL 3.3 Core Profile (UBOs, shaders, hardware skinning) and compatibility rollback.
  - `[UI] EnableAnimationTaskPool` (Default: `0`): Toggles multi-threaded character animation task pool (`AnimationTaskPool`) for crowded scenes ($\ge 20$ active characters).
  - `[UI] Locale` & `[Camera] Zoom`.
- Added **Command Line Flags & Options**:
  - Connection string parameters (`main.exe connect /u<IP> /p<PORT>`).
  - `--enable-taskpool`: Forces `AnimationTaskPool` multi-threaded updates on at launch.
  - `--editor`: Enables the ImGui in-game editor overlay (**F12**) on `*_mueditor` builds.
- Linked the **GPU Skinning & Core Profile Architecture** documentation hub under the primary **Documentation** index.
### 2. **`docs/GPU Skinning/README.md`**
- Added **Graphics & Performance Configuration Switches** section detailing the technical role of `CoreProfile=1/0` (Core vs. Compatibility fallback) and `EnableAnimationTaskPool=1/0` (parallel worker pool vs. main-thread execution).
docs(render): fix audit-identified inaccuracies in GPU skinning documentation
Cross-referenced against live source grep AND archived DXP task memory.

#548 
### dxp-milestones.md:
- Add Phase A squash-commit caveat (DXP tags not in squashed source tree)
- Add missing DXP-07d entry (17 occurrences across 9 source files)
- Fix DXP-10 tool path: tools/ -> Tools/
- Fix DXP-12 scope path: Render/Textures/ -> Render/Sprites/
- Fix DXP-14 scope: RHI/+Shaders/ -> Render/Core/ UBO headers
- Fix DXP-16 scope: wrong files -> CharacterScene/SceneManager/UIControls
- Fix DXP-17 status: Completed -> Partially Completed
- Fix DXP-21 status: Completed -> Deferred (owner decision, no code landed)
- Fix DXP-22 scope: add BindState.h/cpp, ZzzLodTerrain.cpp
- Fix DXP-23 scope: add MainScene/SceneManager/muConsoleDebug/effect files

### gpu-skinning-architecture.md:
- BoneUBO slot 1 -> slot 2; document shader comment vs runtime inconsistency
- Fix SetActiveBoneTransform(): removes pointer-guard claim; bumps unconditionally
- Fix render mode enum: remove fabricated CHROME_2; RM5->CHROME_METAL,
  RM6->FULL_SPECULAR_V1, RM7->FULL_SPECULAR_V2
- Fix chrome dispatch: u_ChromeVariant selects CHROME2..7/METAL variants

### core-profile-migration.md:
- Tools/ path fix (was tools/)
- RHI::ReadPixels -> ReadColorFramebuffer + ReadDepthPixel
- GlobalBitmap.cpp: Render/Textures/ -> Render/Sprites/
- Remove fabricated RHI_FORMAT_R8G8B8A8_UNORM; no auto mipmaps
- IR program-bind cache location: IR::End() -> IR::Begin()

### immediate-renderer-architecture.md:
- VertexStream -> IRVertex (correct struct name)
- Struct size 32B -> 36B; color uint8_t[4] -> float[4] (16 bytes)
- Program-bind cache: IR::Begin() via BindState, not IR::End()
---
## ✅ Scope
- **Files Changed:** 2 files (`README.md`, `docs/GPU Skinning/README.md`)
- **Code Changes:** None (Pure documentation update)