### PR TITLE
feat (render) : Disable KHR_debug Callback for Performance

### DIFF
--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -1483,7 +1483,13 @@ void UpdateResolutionDependentSystems()
     CUIMng::Instance().RepositionSceneUI();
 }
 
-#if 0 // Disabled KHR_debug callback due to severe Debug mode performance degradation (GL_DEBUG_OUTPUT_SYNCHRONOUS stalling)
+#ifdef _DEBUG
+// Set to 1 to enable GL_KHR_debug callback logging (DXP-08 diagnostic soak mode).
+// Disabled (0) by default because GL_DEBUG_OUTPUT_SYNCHRONOUS and stack symbolization cause
+// severe CPU/GPU stalls during normal development iteration.
+#define ENABLE_GL_KHR_DEBUG_CALLBACK 0
+
+#if ENABLE_GL_KHR_DEBUG_CALLBACK
 // DXP-08 pre-flip diagnostic: logs every GL_KHR_debug message (Core-profile violations
 // included) to MuError.log instead of the driver silently no-oping or hard-failing.
 // Registered only when the debug context flag (set alongside SDL_GL_CreateContext, see
@@ -1557,8 +1563,8 @@ static void APIENTRY GLDebugCallback(GLenum source, GLenum type, GLuint id, GLen
         g_ErrorReport.Write(L"  ^ first occurrence of this message -- call stack:\r\n");
         LogSymbolizedStack();
     }
-}
-#endif // 0
+#endif // ENABLE_GL_KHR_DEBUG_CALLBACK
+#endif // _DEBUG
 
 #ifdef _WIN32
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nCmdShow)
@@ -1703,7 +1709,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
     }
-#ifdef _DEBUG
+#if defined(_DEBUG) && ENABLE_GL_KHR_DEBUG_CALLBACK
     // KHR_debug callback (registered below, after context creation) needs the context
     // created with the debug flag to get synchronous, precisely-attributed messages.
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
@@ -1742,7 +1748,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
     SDL_GL_MakeCurrent(g_sdlWindow, g_sdlGLContext);
     RHI::Init(nullptr, static_cast<int>(WindowWidth), static_cast<int>(WindowHeight));
 
-#if 0 // Disabled KHR_debug callback due to severe Debug mode performance degradation (GL_DEBUG_OUTPUT_SYNCHRONOUS stalling)
+#if defined(_DEBUG) && ENABLE_GL_KHR_DEBUG_CALLBACK
     // DXP-08: register the KHR_debug callback now that a current context exists.
     // glew.h (included via stdafx.h) supplies the PFNGLDEBUGMESSAGECALLBACKPROC
     // typedef and GL_DEBUG_* enums, but glewInit() is never called in this codebase
@@ -1775,7 +1781,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
             g_ErrorReport.Write(L"> GL_KHR_debug unavailable (glDebugMessageCallback not found).\r\n");
         }
     }
-#endif // 0
+#endif // defined(_DEBUG) && ENABLE_GL_KHR_DEBUG_CALLBACK
 
     // Initialize single-pass GLSL engines (Item Specular & Planar Ground Shadows)
     CItemSpecularShader::Instance().Init();

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -1483,7 +1483,7 @@ void UpdateResolutionDependentSystems()
     CUIMng::Instance().RepositionSceneUI();
 }
 
-#ifdef _DEBUG
+#if 0 // Disabled KHR_debug callback due to severe Debug mode performance degradation (GL_DEBUG_OUTPUT_SYNCHRONOUS stalling)
 // DXP-08 pre-flip diagnostic: logs every GL_KHR_debug message (Core-profile violations
 // included) to MuError.log instead of the driver silently no-oping or hard-failing.
 // Registered only when the debug context flag (set alongside SDL_GL_CreateContext, see
@@ -1558,7 +1558,7 @@ static void APIENTRY GLDebugCallback(GLenum source, GLenum type, GLuint id, GLen
         LogSymbolizedStack();
     }
 }
-#endif // _DEBUG
+#endif // 0
 
 #ifdef _WIN32
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nCmdShow)
@@ -1742,7 +1742,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
     SDL_GL_MakeCurrent(g_sdlWindow, g_sdlGLContext);
     RHI::Init(nullptr, static_cast<int>(WindowWidth), static_cast<int>(WindowHeight));
 
-#ifdef _DEBUG
+#if 0 // Disabled KHR_debug callback due to severe Debug mode performance degradation (GL_DEBUG_OUTPUT_SYNCHRONOUS stalling)
     // DXP-08: register the KHR_debug callback now that a current context exists.
     // glew.h (included via stdafx.h) supplies the PFNGLDEBUGMESSAGECALLBACKPROC
     // typedef and GL_DEBUG_* enums, but glewInit() is never called in this codebase
@@ -1775,7 +1775,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
             g_ErrorReport.Write(L"> GL_KHR_debug unavailable (glDebugMessageCallback not found).\r\n");
         }
     }
-#endif // _DEBUG
+#endif // 0
 
     // Initialize single-pass GLSL engines (Item Specular & Planar Ground Shadows)
     CItemSpecularShader::Instance().Init();


### PR DESCRIPTION
# Disable KHR_debug Callback for Performance

## Description
This PR gates the OpenGL `KHR_debug` callback setup behind a preprocessor macro (`ENABLE_GL_KHR_DEBUG_CALLBACK`), effectively disabling it by default in all build configurations, including `_DEBUG`.

## Motivation
The `KHR_debug` callback was initially introduced as a temporary diagnostic tool during the DXP-08 OpenGL Core Profile transition to help attribute errors synchronously. However, using `GL_DEBUG_OUTPUT_SYNCHRONOUS` alongside heavy `dbghelp.lib` stack walkbacks (`CaptureStackBackTrace`) caused massive stalls and severely degraded rendering performance during debug development iteration. 

Since the core profile port is now functionally verified and we no longer need constant synchronous error attribution, this diagnostic overhead has been disabled. The mechanism is preserved as a "nuclear option" (`#define ENABLE_GL_KHR_DEBUG_CALLBACK 1`) for future debugging if severe GL rendering issues arise.

## Changes Made
- Introduced the `ENABLE_GL_KHR_DEBUG_CALLBACK` macro in `Winmain.cpp`.
- Gated the `SDL_GL_CONTEXT_DEBUG_FLAG` attribute during SDL context creation to avoid unnecessary driver debug overhead.
- Guarded `GLDebugCallback` definitions, `LogSymbolizedStack`, and `SDL_GL_GetProcAddress` registration logic behind the macro.
- The `ENABLE_GL_KHR_DEBUG_CALLBACK` toggle is positioned near the diagnostic functions it controls for graceful toggling when needed.
