### PR TITLE
fix(render): Incorrect tile resolution. Fixes #556

### DIFF
--- a/src/source/Render/Shaders/TerrainShader.cpp
+++ b/src/source/Render/Shaders/TerrainShader.cpp
@@ -28,6 +28,7 @@ typedef GLuint (APIENTRY* PFNGLGETUNIFORMBLOCKINDEXPROC)(GLuint, const GLchar*);
 typedef void   (APIENTRY* PFNGLUNIFORMBLOCKBINDINGPROC)(GLuint, GLuint, GLuint);
 typedef void   (APIENTRY* PFNGLUNIFORM1IPROC)(GLint, GLint);
 typedef void   (APIENTRY* PFNGLUNIFORM1FPROC)(GLint, GLfloat);
+typedef void   (APIENTRY* PFNGLUNIFORM2FPROC)(GLint, GLfloat, GLfloat);
 typedef void   (APIENTRY* PFNGLACTIVETEXTUREPROC)(GLenum);
 
 static PFNGLCREATESHADERPROC       fn_glCreateShader       = nullptr;
@@ -47,6 +48,7 @@ static PFNGLGETUNIFORMBLOCKINDEXPROC fn_glGetUniformBlockIndex = nullptr;
 static PFNGLUNIFORMBLOCKBINDINGPROC fn_glUniformBlockBinding = nullptr;
 static PFNGLUNIFORM1IPROC          fn_glUniform1i           = nullptr;
 static PFNGLUNIFORM1FPROC          fn_glUniform1f           = nullptr;
+static PFNGLUNIFORM2FPROC          fn_glUniform2f           = nullptr;
 static PFNGLACTIVETEXTUREPROC      fn_glActiveTexture       = nullptr;
 
 static bool LoadGLShaderFunctions()
@@ -71,6 +73,7 @@ static bool LoadGLShaderFunctions()
     fn_glUniformBlockBinding = (PFNGLUNIFORMBLOCKBINDINGPROC)SDL_GL_GetProcAddress("glUniformBlockBinding");
     fn_glUniform1i           = (PFNGLUNIFORM1IPROC)SDL_GL_GetProcAddress("glUniform1i");
     fn_glUniform1f           = (PFNGLUNIFORM1FPROC)SDL_GL_GetProcAddress("glUniform1f");
+    fn_glUniform2f           = (PFNGLUNIFORM2FPROC)SDL_GL_GetProcAddress("glUniform2f");
     fn_glActiveTexture       = (PFNGLACTIVETEXTUREPROC)SDL_GL_GetProcAddress("glActiveTexture");
 
     loaded = (fn_glCreateShader != nullptr &&
@@ -86,6 +89,7 @@ static bool LoadGLShaderFunctions()
               fn_glGetUniformLocation != nullptr &&
               fn_glUniform1i != nullptr &&
               fn_glUniform1f != nullptr &&
+              fn_glUniform2f != nullptr &&
               fn_glActiveTexture != nullptr);
     return loaded;
 }
@@ -112,15 +116,24 @@ uniform float u_WaterMove;
 uniform int   u_BaseIsWater;
 uniform int   u_OverlayIsWater;
 
+// Per-tile UV scale mirroring legacy FaceTexture()'s `Width = 64.f/b->Width` (pre-divided by
+// TERRAIN_SCALE on the CPU side, see TerrainShader::SetUVScale / RenderTerrainFace's caller) --
+// different terrain tile bitmaps are packed at different pixel resolutions (64/128/256px seen in
+// this tree's assets), so a single fixed constant here can only ever match one of them. Base and
+// overlay are independent because tex1/tex2 can be differently-sized bitmaps on the same tile.
+uniform vec2 u_BaseUVScale;
+uniform vec2 u_OverlayUVScale;
+
 out vec2 v_UVBase;
 out vec2 v_UVOverlay;
 out vec3 v_Light;
 out float v_Alpha;
 
 void main() {
-    vec2 baseUV = a_Pos.xy * 0.0025;
-    v_UVBase    = (u_BaseIsWater    == 1) ? baseUV + vec2(u_WaterMove, 0.0) : baseUV;
-    v_UVOverlay = (u_OverlayIsWater == 1) ? baseUV + vec2(u_WaterMove, 0.0) : baseUV;
+    vec2 uvBase    = a_Pos.xy * u_BaseUVScale;
+    vec2 uvOverlay = a_Pos.xy * u_OverlayUVScale;
+    v_UVBase    = (u_BaseIsWater    == 1) ? uvBase    + vec2(u_WaterMove, 0.0) : uvBase;
+    v_UVOverlay = (u_OverlayIsWater == 1) ? uvOverlay + vec2(u_WaterMove, 0.0) : uvOverlay;
     v_Light = a_Light;
     v_Alpha = a_Alpha;
     gl_Position = u_MVP * vec4(a_Pos, 1.0);
@@ -250,6 +263,8 @@ void TerrainShader::CreateGL()
     m_LocBaseIsWater    = fn_glGetUniformLocation(m_Program, "u_BaseIsWater");
     m_LocOverlayIsWater = fn_glGetUniformLocation(m_Program, "u_OverlayIsWater");
     m_LocAlphaRef       = fn_glGetUniformLocation(m_Program, "u_AlphaRef");
+    m_LocBaseUVScale    = fn_glGetUniformLocation(m_Program, "u_BaseUVScale");
+    m_LocOverlayUVScale = fn_glGetUniformLocation(m_Program, "u_OverlayUVScale");
 
     // Assign default texture unit slots (u_BaseTex = 0, u_OverlayTex = 1)
     BindProgram(m_Program);
@@ -260,6 +275,12 @@ void TerrainShader::CreateGL()
     if (m_LocOverlayIsWater != -1) fn_glUniform1i(m_LocOverlayIsWater, 0);
     if (m_LocAlphaRef != -1) fn_glUniform1f(m_LocAlphaRef, -1.0f);
     m_LastAlphaRef = -1.0f;
+    // Standard 64px-tile scale (64/64/TERRAIN_SCALE = 0.01) as a sane pre-first-draw default;
+    // every real tile draw overwrites this via SetUVScale() before use.
+    if (m_LocBaseUVScale != -1) fn_glUniform2f(m_LocBaseUVScale, 0.01f, 0.01f);
+    if (m_LocOverlayUVScale != -1) fn_glUniform2f(m_LocOverlayUVScale, 0.01f, 0.01f);
+    m_LastBaseUVScale[0] = m_LastBaseUVScale[1] = 0.01f;
+    m_LastOverlayUVScale[0] = m_LastOverlayUVScale[1] = 0.01f;
     BindProgram(0);
 
     g_ErrorReport.Write(L"[TerrainShader] Created program ID %d, u_BaseTex loc %d, u_OverlayTex loc %d\r\n", m_Program, m_LocBaseTex, m_LocOverlayTex);
@@ -297,6 +318,24 @@ void TerrainShader::SetOverlayTexture(GLuint texID)
 {
     BindTexture2D(1, texID);
     if (fn_glActiveTexture) fn_glActiveTexture(GL_TEXTURE0); // Restore default active texture
+}
+
+void TerrainShader::SetUVScale(float baseScaleX, float baseScaleY, float overlayScaleX, float overlayScaleY)
+{
+    // Dirty-checked like SyncAlphaRef -- adjacent tiles on the same map very often share both
+    // textures, so this is usually a no-op glUniform-wise.
+    if (m_LocBaseUVScale != -1 && fn_glUniform2f &&
+        (baseScaleX != m_LastBaseUVScale[0] || baseScaleY != m_LastBaseUVScale[1])) {
+        fn_glUniform2f(m_LocBaseUVScale, baseScaleX, baseScaleY);
+        m_LastBaseUVScale[0] = baseScaleX;
+        m_LastBaseUVScale[1] = baseScaleY;
+    }
+    if (m_LocOverlayUVScale != -1 && fn_glUniform2f &&
+        (overlayScaleX != m_LastOverlayUVScale[0] || overlayScaleY != m_LastOverlayUVScale[1])) {
+        fn_glUniform2f(m_LocOverlayUVScale, overlayScaleX, overlayScaleY);
+        m_LastOverlayUVScale[0] = overlayScaleX;
+        m_LastOverlayUVScale[1] = overlayScaleY;
+    }
 }
 
 void TerrainShader::SetWaterMove(float waterMove)

--- a/src/source/Render/Shaders/TerrainShader.h
+++ b/src/source/Render/Shaders/TerrainShader.h
@@ -16,6 +16,11 @@ public:
     void SetBaseTexture(GLuint texID);
     void SetOverlayTexture(GLuint texID);
 
+    // Per-tile UV scale, mirroring legacy FaceTexture()'s `Width = 64.f/b->Width` (already divided
+    // by TERRAIN_SCALE by the caller so it's ready to multiply world-space a_Pos.xy directly).
+    // Base and overlay get independent scales because tex1/tex2 can be differently-sized bitmaps.
+    void SetUVScale(float baseScaleX, float baseScaleY, float overlayScaleX, float overlayScaleY);
+
     // TASK-30 phase 2: water UV scroll. `waterMove` set once per frame (matches the CPU `WaterMove`
     // global, itself recomputed once per frame in RenderTerrain()); the base/overlay water flags are
     // set once per tile draw, alongside SetBaseTexture()/SetOverlayTexture().
@@ -51,8 +56,15 @@ private:
     GLint m_LocBaseIsWater = -1;
     GLint m_LocOverlayIsWater = -1;
     GLint m_LocAlphaRef = -1;
+    GLint m_LocBaseUVScale = -1;
+    GLint m_LocOverlayUVScale = -1;
 
     // Sentinel guaranteed to differ from any real g_AlphaRef value, forcing the first
     // SyncAlphaRef() call after Create() to upload u_AlphaRef.
     float m_LastAlphaRef = -12345.0f;
+
+    // Dirty-check cache for SetUVScale, same reasoning as m_LastAlphaRef -- avoid a redundant
+    // glUniform2f pair on the (common) case of consecutive tiles sharing both textures.
+    float m_LastBaseUVScale[2] = { -12345.0f, -12345.0f };
+    float m_LastOverlayUVScale[2] = { -12345.0f, -12345.0f };
 };

--- a/src/source/Render/Terrain/ZzzLodTerrain.cpp
+++ b/src/source/Render/Terrain/ZzzLodTerrain.cpp
@@ -1808,6 +1808,14 @@ void RenderTerrainFace(float xf, float yf, int xi, int yi, float lodf)
 
                 TerrainShader::Instance().SetBaseTexture(b1->TextureNumber);
                 TerrainShader::Instance().SetOverlayTexture(b2->TextureNumber);
+                // Matches legacy FaceTexture()'s `Width = 64.f/b->Width` exactly (see that function,
+                // ~10 lines below where the non-shader fallback still runs) -- terrain tile bitmaps in
+                // this tree are not all the same resolution (64/128/256px observed), so the UV scale
+                // must be derived per-texture, not a single shared constant. Pre-divided by
+                // TERRAIN_SCALE here since a_Pos in the vertex shader is world-space, not grid-index.
+                TerrainShader::Instance().SetUVScale(
+                    (64.f / b1->Width) / TERRAIN_SCALE, (64.f / b1->Height) / TERRAIN_SCALE,
+                    (64.f / b2->Width) / TERRAIN_SCALE, (64.f / b2->Height) / TERRAIN_SCALE);
                 TerrainShader::Instance().SetWaterFlags(baseIsWater, overlayIsWater);
                 // DXP-01: synced per-tile (not once per frustrum pass like SetWaterMove) because
                 // alpha-test state can change between tile draws via the wrapper family; dirty-checked


### PR DESCRIPTION
## Summary

Terrain tiles rendered visibly larger/blurrier than the pre-FFP baseline (screenshotted on
Noria). `TerrainShader`'s GPU fast path computed ground-tile UV with a single hardcoded
constant (`a_Pos.xy * 0.0025`), but terrain tile bitmaps in this tree are not uniformly sized
(64/128/256px all present — confirmed by decoding the actual `.OZJ` assets). A shared constant
can only ever be correct for one texture resolution; Noria's tiles are 256px and rendered
stretched under the old value.

Fixes it by deriving the UV scale **per tile, per texture** in the vertex shader, mirroring the
legacy fixed-function `FaceTexture()`'s own formula (`Width = 64.f/b->Width`) instead of a baked-in
constant:

- `TerrainShader.h`/`.cpp`: new `SetUVScale(baseX, baseY, overlayX, overlayY)`, two new
  `u_BaseUVScale`/`u_OverlayUVScale` uniforms (dirty-checked like the existing `SyncAlphaRef`).
- `ZzzLodTerrain.cpp`: `RenderTerrainFace()`'s shader branch now computes the scale from each
  tile's actual bound texture (`64.f/b->Width`, `64.f/b->Height`, divided by `TERRAIN_SCALE`)
  right where `b1`/`b2` are already resolved for `SetBaseTexture`/`SetOverlayTexture`.

Fixes #556 

## Test plan

- [x] Debug build, clean incremental compile + link
- [x] In-game: Noria ground tiles visually compared against `perf-baseline-pre-ffp` — confirmed
      matching size (owner-verified)
- [x] Spot-check a map using a different tile resolution than Noria's 256px (fix is now
      data-driven per texture, so it should generalize, but not yet directly observed elsewhere)


