### PR TITLE
feat: rmlui migration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,10 @@
 *.csproj text
 *.sln text
 
+# Shell scripts must keep LF endings unconditionally -- a CRLF-corrupted
+# shebang line (e.g. "#!/usr/bin/env bash\r") fails to execute on Linux.
+*.sh text eol=lf
+
 # Binary game assets: never apply text detection or EOL normalization.
 # Some encrypted .bmd / .oz* files contain no NUL bytes, so `text=auto`
 # misdetects them as text; on a Windows clone (core.autocrlf=true) their lone

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ build-linux/
 # Bundled UI fonts (curated, shipped with the client) are source-controlled.
 !**/bin/fonts/
 !**/bin/fonts/**
+# RmlUi RML/RCSS documents (hand-authored UI markup, not generated/proprietary game assets like
+# the rest of bin/Data/) are source-controlled, same rationale as bin/fonts/ above.
+!**/bin/Data/
+!**/bin/Data/Interface/
+!**/bin/Data/Interface/RmlUi/
+!**/bin/Data/Interface/RmlUi/**
 **/obj/
 *.user
 *.suo

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "src/ThirdParty/RmlUi"]
 	path = src/ThirdParty/RmlUi
 	url = https://github.com/mikke89/RmlUi.git
+[submodule "src/ThirdParty/freetype"]
+	path = src/ThirdParty/freetype
+	url = https://github.com/freetype/freetype.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "src/ThirdParty/SDL_mixer"]
 	path = src/ThirdParty/SDL_mixer
 	url = https://github.com/libsdl-org/SDL_mixer.git
+[submodule "src/ThirdParty/RmlUi"]
+	path = src/ThirdParty/RmlUi
+	url = https://github.com/mikke89/RmlUi.git

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The client reads options from `config.ini` in the executable directory:
 ## Documentation
 
 - [GPU Skinning & Core Profile](docs/GPU%20Skinning/README.md) - architecture, UBO layouts, ImmediateRenderer (`IR::`), the FFP-retirement milestone catalog (`DXP-01` to `DXP-27`), and the Core Profile GL performance regression series (`GLP-xx`, `$glstats`).
+- [RmlUi UI System](docs/rmlui-ui-system/README.md) - the ongoing migration from the client's three legacy UI frameworks to RmlUi: render/input architecture, the frame render-order contract, the pluggable theming/modding system, and a catalog of real bugs found (and fixed) during the pilot migration.
 - [Camera system](docs/camera-system.md) - modes, switching (F9), config,
   frustum culling, `$details` overlay, and the gameplay behaviour changes
   from the 3D camera rework.

--- a/docs/rmlui-ui-system/README.md
+++ b/docs/rmlui-ui-system/README.md
@@ -62,6 +62,12 @@ system — end to end.
   allowlist — see [Theming & Modding](theming-and-modding.md).
 - **Event-driven input arbitration** at the SDL-event level (`Winmain.cpp`), using RmlUi's own
   official SDL backend for keycode/modifier mapping rather than a hand-rolled bridge.
+- **Reusable interaction helpers, not per-window reimplementation.** Draggability
+  (`UI::RmlBridge::MakeDraggable`) is one function call built on RmlUi's own native drag events —
+  the standing design principle is that any interaction pattern more than one migrated window
+  will want (dragging, and whatever comes after it) belongs in `UI::RmlBridge` as a shared
+  primitive, not copy-pasted or reinvented per window. See
+  [Architecture §7](architecture.md#7-reusable-interaction-helpers-uirmlbridge).
 
 ## Primary Subsystems & Source Map
 
@@ -72,6 +78,7 @@ system — end to end.
 | **System interface** | [`Render/RmlUi/RmlUiSystemInterface.h/.cpp`](../../src/source/Render/RmlUi/RmlUiSystemInterface.h) | `Rml::SystemInterface` implementation — clock, logging, clipboard. |
 | **Model/binder layer** | [`UI/RmlBridge/RmlModelBinder.h`](../../src/source/UI/RmlBridge/RmlModelBinder.h) | Generic per-window `Rml::DataModel` wrapper — owns the model instance and `DataModelHandle`, exposes `MarkDirty()`. |
 | **Theme framework** | [`UI/RmlBridge/RmlTheme.h/.cpp`](../../src/source/UI/RmlBridge/RmlTheme.h) | Active-theme resolution, per-theme `theme.ini` manifest reading, `LoadThemedDocument()`. |
+| **Draggable panels** | [`UI/RmlBridge/RmlDraggable.h/.cpp`](../../src/source/UI/RmlBridge/RmlDraggable.h) | `MakeDraggable(handle, panel, onMove)` — generic drag-to-move on RmlUi's native drag events. |
 | **Pilot window** | [`UI/Windows/LoginWin.h/.cpp`](../../src/source/UI/Windows/LoginWin.h) | The Phase 1 pilot — hybrid `CWin` + RmlUi overlay, the reference implementation every pattern in this doc set is drawn from. |
 | **Frame hook** | [`Scenes/SceneManager.cpp`](../../src/source/Scenes/SceneManager.cpp), [`Scenes/LoadingScene.cpp`](../../src/source/Scenes/LoadingScene.cpp) | Where `RmlUiRuntime::Update()/Render()` (and the post-render cursor/text draws) are called per scene. |
 | **RML/RCSS assets** | [`bin/Data/Interface/RmlUi/`](../../src/bin/Data/Interface/RmlUi/) | `login.rml` (shared, theme-agnostic) + `themes/<name>/` (per-theme RCSS + optional manifest). |

--- a/docs/rmlui-ui-system/README.md
+++ b/docs/rmlui-ui-system/README.md
@@ -21,9 +21,12 @@ layer. RmlUi is being adopted as the long-term replacement, migrated incremental
 new systems coexisting — not a big-bang rewrite.
 
 The login/character-select dialog (`CLoginWin`) is the **Phase 1 pilot**: the first real
-migrated window, and the one this documentation set is written against. It exercises the full
-pipeline — render interface, input arbitration, data binding, and (added later) the theming
-system — end to end.
+migrated window, and the one most of this documentation set is written against. It exercises the
+full pipeline — render interface, input arbitration, data binding, and (added later) the theming
+system — end to end. A second pass ("Batch 2") extended the rest of the login scene the same
+way — `CLoginMainWin`, `CSysMenuWin`, `COptionWin`, and `RememberPasswordPrompt` — validating the
+pattern against a window with no dynamic state at all, a full-screen dim-modal backdrop, a
+draggable control, and a window that was never `CWin`-based to begin with.
 
 ## Document Index
 
@@ -47,9 +50,24 @@ system — end to end.
 
 ## Architectural Highlights
 
-- **Coexistence, not replacement-in-place.** RmlUi renders as an overlay on top of (or instead
-  of) legacy sprite chrome, driven by the same underlying game state via a small model/binder
-  layer (`UI::RmlBridge`). Legacy call sites keep working unchanged.
+- **Coexistence at the codebase level, not a per-window overlay.** A migrated window's `CWin`
+  never draws its own background/frame chrome once migrated, in any theme — RmlUi owns 100% of a
+  migrated window's rendering, always *instead of* the legacy sprite chrome, never layered on top
+  of it (an earlier per-theme opt-back-in flag briefly allowed the "on top of" case; removed, see
+  [Gotchas](gotchas-and-patterns.md#a-per-theme-flag-to-opt-back-into-cwin-sprite-rendering-was-the-wrong-shape)).
+  What coexists is *old and new systems side by side across the codebase*, migrated window by
+  window, not old-and-new rendering layered within one window. Two structural shapes exist for a
+  migrated window, not one: a **hybrid** `CWin` + RmlUi overlay that keeps the legacy window's
+  position/hit-testing bookkeeping (`CLoginWin`, `CLoginMainWin`, `CSysMenuWin`, `COptionWin` — see
+  [Architecture §6](architecture.md#6-coexistence-bridging-cloginwins-specific-pattern)), and a
+  **pure RmlUi** window with no `CWin` involvement at all
+  (`RememberPasswordPrompt` — see [Architecture §6a](architecture.md#6a-a-pure-rmlui-window-with-no-cwin-at-all)).
+  A model/binder layer (`UI::RmlBridge::RmlModelBinder`) is the common case for a window with
+  dynamic state, not a hard requirement — `CLoginMainWin` has none and needs no binder at all (see
+  [Architecture §5](architecture.md#5-data-binding-modelbinder-pattern)). External legacy call
+  sites keep working unchanged either way (e.g. `CUIMng::m_SysMenuWin`, or
+  `RememberPasswordPrompt.h`'s free-function API), even where the internals they call into were
+  fully rewritten.
 - **Custom `RHI::`-backed render interface**, not RmlUi's bundled OpenGL/D3D backends — RmlUi's
   `RenderGeometry` draws through this engine's own `RHI::DrawIndexed` / `PassthroughShader`,
   sharing the same `GlobalUBO` every other 2D/3D draw call uses, rather than maintaining a second,
@@ -79,9 +97,10 @@ system — end to end.
 | **Model/binder layer** | [`UI/RmlBridge/RmlModelBinder.h`](../../src/source/UI/RmlBridge/RmlModelBinder.h) | Generic per-window `Rml::DataModel` wrapper — owns the model instance and `DataModelHandle`, exposes `MarkDirty()`. |
 | **Theme framework** | [`UI/RmlBridge/RmlTheme.h/.cpp`](../../src/source/UI/RmlBridge/RmlTheme.h) | Active-theme resolution, `LoadThemedDocument()`. |
 | **Draggable panels** | [`UI/RmlBridge/RmlDraggable.h/.cpp`](../../src/source/UI/RmlBridge/RmlDraggable.h) | `MakeDraggable(handle, panel, onMove)` — generic drag-to-move on RmlUi's native drag events. |
-| **Pilot window** | [`UI/Windows/LoginWin.h/.cpp`](../../src/source/UI/Windows/LoginWin.h) | The Phase 1 pilot — hybrid `CWin` + RmlUi overlay, the reference implementation every pattern in this doc set is drawn from. |
+| **Pilot window** | [`UI/Windows/LoginWin.h/.cpp`](../../src/source/UI/Windows/LoginWin.h) | The Phase 1 pilot — hybrid `CWin` + RmlUi overlay, the reference implementation most patterns in this doc set are drawn from. |
+| **Batch 2 windows** | [`UI/Windows/LoginMainWin`](../../src/source/UI/Windows/LoginMainWin.h), [`SysMenuWin`](../../src/source/UI/Windows/SysMenuWin.h), [`OptionWin`](../../src/source/UI/Windows/OptionWin.h), [`RememberPasswordPrompt`](../../src/source/UI/Windows/RememberPasswordPrompt.h) | Same login-scene extended in one pass. `RememberPasswordPrompt` is the one **pure-RmlUi** window (no `CWin` at all) — see [Architecture §6a](architecture.md#6a-a-pure-rmlui-window-with-no-cwin-at-all). `OptionWin` is `UI::RmlBridge::MakeDraggable`'s first production use. |
 | **Frame hook** | [`Scenes/SceneManager.cpp`](../../src/source/Scenes/SceneManager.cpp), [`Scenes/LoadingScene.cpp`](../../src/source/Scenes/LoadingScene.cpp) | Where `RmlUiRuntime::Update()/Render()` (and the post-render cursor/text draws) are called per scene. |
-| **RML/RCSS assets** | [`bin/Data/Interface/RmlUi/`](../../src/bin/Data/Interface/RmlUi/) | `login.rml` (shared, theme-agnostic) + `themes/<name>/` (per-theme RCSS, no manifest file needed). |
+| **RML/RCSS assets** | [`bin/Data/Interface/RmlUi/`](../../src/bin/Data/Interface/RmlUi/) | One `.rml` per window (shared, theme-agnostic) + `themes/<name>/` (per-theme RCSS, no manifest file needed) + `themes/<name>/base.rcss` (shared cross-window rules — `.btn`, `.checkbox-*`, `#backdrop` — linked by every window's `.rml` except `login.rml`, which predates it and stays self-contained; see [Theming & Modding](theming-and-modding.md#shared-cross-window-rcss-basercss)). |
 
 ---
 

--- a/docs/rmlui-ui-system/README.md
+++ b/docs/rmlui-ui-system/README.md
@@ -46,6 +46,12 @@ draggable control, and a window that was never `CWin`-based to begin with.
    migrating the next window — several of these are non-obvious traps that cost real debugging
    time once and don't need to cost it again.
 
+4. **[Roadmap](roadmap.md)**
+   *What's done, what's next, and the decisions still open.* Covers Phases 2-5 (message-box
+   engine, HUD, 3D-in-UI bridge, inventory), retirement criteria, and — critically — that the
+   adapter/facade pattern every later phase depends on has never actually been proven in real
+   code. Read this before starting any window beyond the login scene.
+
 ---
 
 ## Architectural Highlights

--- a/docs/rmlui-ui-system/README.md
+++ b/docs/rmlui-ui-system/README.md
@@ -36,7 +36,7 @@ system — end to end.
 2. **[Theming & Modding](theming-and-modding.md)**
    *How the swappable-theme system works, and how to add a new theme without touching engine
    code.* Covers the theme-folder convention, `LoadThemedDocument()`'s RML/RCSS resolution
-   mechanism, the `theme.ini` manifest format, and a step-by-step guide for modders.
+   mechanism, and a step-by-step guide for modders.
 
 3. **[Gotchas & Bug Catalog](gotchas-and-patterns.md)**
    *Real bugs found during the pilot migration, with root cause and fix.* Read this before
@@ -77,11 +77,11 @@ system — end to end.
 | **Render interface** | [`Render/RmlUi/RmlUiRenderInterface.h/.cpp`](../../src/source/Render/RmlUi/RmlUiRenderInterface.h) | `Rml::RenderInterface` implementation targeting `RHI::` directly — vertex conversion, texture loading, scissor. |
 | **System interface** | [`Render/RmlUi/RmlUiSystemInterface.h/.cpp`](../../src/source/Render/RmlUi/RmlUiSystemInterface.h) | `Rml::SystemInterface` implementation — clock, logging, clipboard. |
 | **Model/binder layer** | [`UI/RmlBridge/RmlModelBinder.h`](../../src/source/UI/RmlBridge/RmlModelBinder.h) | Generic per-window `Rml::DataModel` wrapper — owns the model instance and `DataModelHandle`, exposes `MarkDirty()`. |
-| **Theme framework** | [`UI/RmlBridge/RmlTheme.h/.cpp`](../../src/source/UI/RmlBridge/RmlTheme.h) | Active-theme resolution, per-theme `theme.ini` manifest reading, `LoadThemedDocument()`. |
+| **Theme framework** | [`UI/RmlBridge/RmlTheme.h/.cpp`](../../src/source/UI/RmlBridge/RmlTheme.h) | Active-theme resolution, `LoadThemedDocument()`. |
 | **Draggable panels** | [`UI/RmlBridge/RmlDraggable.h/.cpp`](../../src/source/UI/RmlBridge/RmlDraggable.h) | `MakeDraggable(handle, panel, onMove)` — generic drag-to-move on RmlUi's native drag events. |
 | **Pilot window** | [`UI/Windows/LoginWin.h/.cpp`](../../src/source/UI/Windows/LoginWin.h) | The Phase 1 pilot — hybrid `CWin` + RmlUi overlay, the reference implementation every pattern in this doc set is drawn from. |
 | **Frame hook** | [`Scenes/SceneManager.cpp`](../../src/source/Scenes/SceneManager.cpp), [`Scenes/LoadingScene.cpp`](../../src/source/Scenes/LoadingScene.cpp) | Where `RmlUiRuntime::Update()/Render()` (and the post-render cursor/text draws) are called per scene. |
-| **RML/RCSS assets** | [`bin/Data/Interface/RmlUi/`](../../src/bin/Data/Interface/RmlUi/) | `login.rml` (shared, theme-agnostic) + `themes/<name>/` (per-theme RCSS + optional manifest). |
+| **RML/RCSS assets** | [`bin/Data/Interface/RmlUi/`](../../src/bin/Data/Interface/RmlUi/) | `login.rml` (shared, theme-agnostic) + `themes/<name>/` (per-theme RCSS, no manifest file needed). |
 
 ---
 
@@ -93,17 +93,11 @@ system — end to end.
 |---|---|---|
 | `RmlTheme` | `legacy` | Active RmlUi theme name — any folder under `Data/Interface/RmlUi/themes/`. Read once at startup by `GameConfig::GetRmlTheme()`; **not yet a live in-game hot-swap** — change it and relaunch. See [Theming & Modding](theming-and-modding.md). |
 
-### Per-theme `theme.ini` (optional)
-
-Lives at `Data/Interface/RmlUi/themes/<name>/theme.ini`, read directly via `GetPrivateProfileIntW`
-(not through `GameConfig`):
-
-| Key | Default | Meaning |
-|---|---|---|
-| `[Theme] UsesLegacySpriteChrome` | `0` | `1` keeps the legacy `CWin` background sprite and `CUITextInputBox` frame sprites drawn underneath the RmlUi overlay (the `legacy` theme's shape). `0` (or no `theme.ini` at all) means the theme is fully programmatic — RCSS draws everything itself, no sprite dependency. |
-
-See [Theming & Modding](theming-and-modding.md) for the full mechanism and a step-by-step guide to
-adding a new theme.
+Every theme — including `legacy` — renders 100% of its window's chrome through RmlUi; `CWin` never
+draws a background or frame sprite for a migrated window, in any theme. `legacy` reproduces the
+original look by pointing its RCSS decorators at the same art files the old sprites used; `modern`
+uses flat colors/vector shapes instead. See [Theming & Modding](theming-and-modding.md) for the
+full mechanism and a step-by-step guide to adding a new theme.
 
 ## Vendored Dependency
 

--- a/docs/rmlui-ui-system/README.md
+++ b/docs/rmlui-ui-system/README.md
@@ -1,0 +1,107 @@
+# RmlUi UI System Documentation
+
+Welcome to the documentation for the MU Online Client's **RmlUi migration** — the ongoing
+replacement of the client's three legacy UI frameworks with [RmlUi](https://github.com/mikke89/RmlUi)
+(HTML/CSS-driven UI middleware), migrated window-by-window while the old systems keep running for
+everything not yet migrated.
+
+This documentation covers the render/system-interface implementation, the frame lifecycle, the
+theming/modding architecture, and a catalog of real bugs found (and fixed) during the pilot
+migration — written so a future migration phase doesn't have to rediscover the same gotchas.
+
+---
+
+## Why this exists
+
+The client's game UI was implemented across three separate, simultaneously-alive widget
+frameworks that accumulated over the project's history — `UI/Widgets` (`CWin`/`CButton`),
+`UI/Legacy/UIControls` (`CUIControl`/`CUIMessage`), and `UI/NewUI` (`CNewUIObj`/`CNewUIManager`,
+~90 windows). None of the three has a layout engine, a retained scene graph, or a data-binding
+layer. RmlUi is being adopted as the long-term replacement, migrated incrementally with old and
+new systems coexisting — not a big-bang rewrite.
+
+The login/character-select dialog (`CLoginWin`) is the **Phase 1 pilot**: the first real
+migrated window, and the one this documentation set is written against. It exercises the full
+pipeline — render interface, input arbitration, data binding, and (added later) the theming
+system — end to end.
+
+## Document Index
+
+1. **[Architecture](architecture.md)**
+   *How RmlUi is wired into this engine's renderer and frame loop.* Covers the render/system
+   interface implementation, vertex format conversion, the frame render-order contract (and why
+   getting it wrong is easy to miss), input arbitration, and the coexistence model with the two
+   legacy UI tiers.
+
+2. **[Theming & Modding](theming-and-modding.md)**
+   *How the swappable-theme system works, and how to add a new theme without touching engine
+   code.* Covers the theme-folder convention, `LoadThemedDocument()`'s RML/RCSS resolution
+   mechanism, the `theme.ini` manifest format, and a step-by-step guide for modders.
+
+3. **[Gotchas & Bug Catalog](gotchas-and-patterns.md)**
+   *Real bugs found during the pilot migration, with root cause and fix.* Read this before
+   migrating the next window — several of these are non-obvious traps that cost real debugging
+   time once and don't need to cost it again.
+
+---
+
+## Architectural Highlights
+
+- **Coexistence, not replacement-in-place.** RmlUi renders as an overlay on top of (or instead
+  of) legacy sprite chrome, driven by the same underlying game state via a small model/binder
+  layer (`UI::RmlBridge`). Legacy call sites keep working unchanged.
+- **Custom `RHI::`-backed render interface**, not RmlUi's bundled OpenGL/D3D backends — RmlUi's
+  `RenderGeometry` draws through this engine's own `RHI::DrawIndexed` / `PassthroughShader`,
+  sharing the same `GlobalUBO` every other 2D/3D draw call uses, rather than maintaining a second,
+  parallel rendering pipeline.
+- **Only the "required" `Rml::RenderInterface` functions are implemented** — layers, filters, and
+  transforms are left at their base-class no-op defaults. This is a deliberate MVP scope cut, not
+  an oversight, but it has real consequences (see [Gotchas](gotchas-and-patterns.md) — `box-shadow`
+  blur is the concrete example that bit the modern theme).
+- **Pluggable, data-driven theming.** A theme is a folder name, not a closed enum or a C++
+  allowlist — see [Theming & Modding](theming-and-modding.md).
+- **Event-driven input arbitration** at the SDL-event level (`Winmain.cpp`), using RmlUi's own
+  official SDL backend for keycode/modifier mapping rather than a hand-rolled bridge.
+
+## Primary Subsystems & Source Map
+
+| Subsystem | Key Files | Description |
+|---|---|---|
+| **Runtime lifecycle** | [`Render/RmlUi/RmlUiRuntime.h/.cpp`](../../src/source/Render/RmlUi/RmlUiRuntime.h) | Owns the `Rml::Context`; the single per-frame `Update()`/`Render()` entry point and SDL event bridge. |
+| **Render interface** | [`Render/RmlUi/RmlUiRenderInterface.h/.cpp`](../../src/source/Render/RmlUi/RmlUiRenderInterface.h) | `Rml::RenderInterface` implementation targeting `RHI::` directly — vertex conversion, texture loading, scissor. |
+| **System interface** | [`Render/RmlUi/RmlUiSystemInterface.h/.cpp`](../../src/source/Render/RmlUi/RmlUiSystemInterface.h) | `Rml::SystemInterface` implementation — clock, logging, clipboard. |
+| **Model/binder layer** | [`UI/RmlBridge/RmlModelBinder.h`](../../src/source/UI/RmlBridge/RmlModelBinder.h) | Generic per-window `Rml::DataModel` wrapper — owns the model instance and `DataModelHandle`, exposes `MarkDirty()`. |
+| **Theme framework** | [`UI/RmlBridge/RmlTheme.h/.cpp`](../../src/source/UI/RmlBridge/RmlTheme.h) | Active-theme resolution, per-theme `theme.ini` manifest reading, `LoadThemedDocument()`. |
+| **Pilot window** | [`UI/Windows/LoginWin.h/.cpp`](../../src/source/UI/Windows/LoginWin.h) | The Phase 1 pilot — hybrid `CWin` + RmlUi overlay, the reference implementation every pattern in this doc set is drawn from. |
+| **Frame hook** | [`Scenes/SceneManager.cpp`](../../src/source/Scenes/SceneManager.cpp), [`Scenes/LoadingScene.cpp`](../../src/source/Scenes/LoadingScene.cpp) | Where `RmlUiRuntime::Update()/Render()` (and the post-render cursor/text draws) are called per scene. |
+| **RML/RCSS assets** | [`bin/Data/Interface/RmlUi/`](../../src/bin/Data/Interface/RmlUi/) | `login.rml` (shared, theme-agnostic) + `themes/<name>/` (per-theme RCSS + optional manifest). |
+
+---
+
+## Configuration
+
+### `config.ini` — `[UI]` section
+
+| Key | Default | Meaning |
+|---|---|---|
+| `RmlTheme` | `legacy` | Active RmlUi theme name — any folder under `Data/Interface/RmlUi/themes/`. Read once at startup by `GameConfig::GetRmlTheme()`; **not yet a live in-game hot-swap** — change it and relaunch. See [Theming & Modding](theming-and-modding.md). |
+
+### Per-theme `theme.ini` (optional)
+
+Lives at `Data/Interface/RmlUi/themes/<name>/theme.ini`, read directly via `GetPrivateProfileIntW`
+(not through `GameConfig`):
+
+| Key | Default | Meaning |
+|---|---|---|
+| `[Theme] UsesLegacySpriteChrome` | `0` | `1` keeps the legacy `CWin` background sprite and `CUITextInputBox` frame sprites drawn underneath the RmlUi overlay (the `legacy` theme's shape). `0` (or no `theme.ini` at all) means the theme is fully programmatic — RCSS draws everything itself, no sprite dependency. |
+
+See [Theming & Modding](theming-and-modding.md) for the full mechanism and a step-by-step guide to
+adding a new theme.
+
+## Vendored Dependency
+
+RmlUi is vendored as a git submodule at `src/ThirdParty/RmlUi`, pinned to release tag `6.2` (not
+tracking a moving branch). Built via `src/CMakeLists.txt` following the existing
+SDL/SDL_mixer `mu_ensure_submodule` pattern — static link, no bundled samples, no Lua bindings.
+FreeType is vendored alongside it (`src/ThirdParty/freetype`) to satisfy RmlUi's default
+`RMLUI_FONT_ENGINE=freetype` requirement.

--- a/docs/rmlui-ui-system/architecture.md
+++ b/docs/rmlui-ui-system/architecture.md
@@ -194,3 +194,50 @@ replacements — a harmless redundant detection path — while `RmlClickOk()`/`R
 etc. (invoked from RmlUi's `data-event-click` bindings) set the same underlying state the legacy
 buttons would have. `SyncRmlModel()` runs every `RenderControls()` call, diffing legacy state
 against the bound model and only dirtying fields that actually changed.
+
+## 7. Reusable interaction helpers (`UI::RmlBridge`)
+
+**Standing design principle**: any interaction pattern more than one migrated window will
+plausibly want belongs in `UI::RmlBridge` as a shared, generic primitive — not hand-rolled per
+window. `RmlModelBinder` (data binding) and `RmlTheme` (theming) already follow this; draggability
+is the newest example, added specifically because re-implementing `CWin::Update()`'s `WS_MOVE`
+state machine (title-bar hit-rect, mouse-delta tracking, `SetPosition()` calls) for every future
+panel that wants to move would be exactly the duplicated logic `docs/CODING_RULES.md` warns
+against.
+
+### `UI::RmlBridge::MakeDraggable` (`UI/RmlBridge/RmlDraggable.h/.cpp`)
+
+Built on RmlUi's own native drag events (`Style::Drag::Drag`, `EventId::Dragstart`/`Drag` —
+`Source/Core/Context.cpp`'s `UpdateHoverChain`, which already carries the current mouse position
+as event parameters) rather than hand-rolled `mousedown`/`mousemove`/`mouseup` tracking.
+`MakeDraggable(handle, panel, onMove = nullptr)`:
+
+- Sets `drag: drag` **and** `pointer-events: auto` on `handle` itself, so the caller doesn't need
+  matching RCSS for either. The second one is not optional decoration — a handle that inherited
+  `pointer-events: none` (the normal state for anything under a full-window document following the
+  pointer-events fix, [Gotchas](gotchas-and-patterns.md#pointer-events-swallows-every-click-on-screen))
+  never becomes `hover` at all, so `dragstart`/`drag` never fire regardless of the `drag` property
+  — confirmed the hard way during a real test (zero events reached the listener, not even
+  `mouseover`, until `pointer-events: auto` was forced).
+- Repositions `panel` by setting its `left`/`top` properties directly from each `drag` event's
+  `mouse_x`/`mouse_y` parameters, relative to the position captured at `dragstart`.
+- **`handle` should be a dedicated grab area, not the whole panel** — for any window whose panel
+  inherited `pointer-events: none` for the click-passthrough fix (true of every full-window
+  document so far), the panel itself can't be dragged directly without reintroducing that exact
+  bug for whatever's underneath it. This isn't a workaround; it's the same reason real UI
+  toolkits use a title bar instead of "drag from anywhere on the window body" — content inside a
+  panel (buttons, text fields) needs to keep receiving its own clicks.
+- **The optional `onMove` callback exists because RmlUi and legacy chrome are NOT actually
+  linked beyond a one-time position sync.** A hybrid window's legacy `CWin` background sprite and
+  its RmlUi overlay are two independently-rendered things that merely started at the same
+  position (both set once from the same `CWin::SetPosition()` call) — RmlUi has no knowledge of
+  `CWin::m_ptPos`, and moving one never moves the other. Confirmed by a real test: dragging via
+  `MakeDraggable()` alone moved the RmlUi checkboxes/buttons/labels correctly, while the legacy
+  background sprite underneath them stayed exactly where it started, immediately and visibly
+  desyncing. `onMove(newLeft, newTop)` fires on every drag tick specifically so a hybrid window's
+  caller can also update its legacy position in lockstep; a fully migrated, sprite-free panel has
+  nothing to sync and can omit it.
+
+Verified against a real build+run using the login screen's document as a test bed (a temporary
+handle wired to `.trust-warning`, since `#panel` itself can't be its own handle for the reason
+above) — not wired up as a real feature there, since the login screen is meant to stay static.

--- a/docs/rmlui-ui-system/architecture.md
+++ b/docs/rmlui-ui-system/architecture.md
@@ -15,22 +15,27 @@ graph TD
         NewUI["UI/NewUI — CNewUIObj/CNewUIManager<br>(~90 in-game windows, main HUD)"]
     end
     RmlUi["RmlUi overlay<br>(Rml::Context, one per Rml runtime)"]
+    PureRml["Pure-RmlUi window, no CWin at all<br>(RememberPasswordPrompt)"]
 
-    CWin -.->|"pilot: hybrid overlay"| RmlUi
+    CWin -.->|"hybrid overlay (4 windows):<br>CLoginWin, CLoginMainWin,<br>CSysMenuWin, COptionWin"| RmlUi
+    PureRml --> RmlUi
     CUIControl -.->|"not yet migrated"| CUIControl
     NewUI -.->|"not yet migrated"| NewUI
 ```
 
-No window has been fully retired yet — the login screen is a **hybrid**: `CWin` still owns the
-window's position/size/z-order bookkeeping (and its `CursorInWin` hit-testing), but draws nothing
-visual at all (`CWin::Create()` is always called with `nTexID=-2`). RmlUi renders 100% of the
-visible panel — background, input-box frames, checkboxes, buttons, labels — in every theme; a
-"legacy-look" theme reproduces the original art by pointing its own RCSS decorators at the same
-image files the old `CWin`/`CSprite` objects used to draw (see
+No window has been fully retired yet. Two structural shapes exist for a migrated window so far, not
+one: the **hybrid** shape, where `CWin` still owns the window's position/size/z-order bookkeeping
+(and its `CursorInWin` hit-testing) but draws nothing visual at all (`CWin::Create()` is always
+called with `nTexID=-2`) — `CLoginWin` (the Phase 1 pilot), plus `CLoginMainWin`/`CSysMenuWin`/
+`COptionWin` (Batch 2) — and the **pure-RmlUi** shape, with no `CWin`/`CUIMng` involvement
+whatsoever (`RememberPasswordPrompt`, see [§6a](#6a-a-pure-rmlui-window-with-no-cwin-at-all)).
+Either way, RmlUi renders 100% of the visible panel — background, input-box frames, checkboxes,
+buttons, labels — in every theme; a "legacy-look" theme reproduces the original art by pointing its
+own RCSS decorators at the same image files the old `CWin`/`CSprite` objects used to draw (see
 [Theming & Modding](theming-and-modding.md)), it just isn't `CWin` doing the drawing anymore.
-Retiring a window means removing its remaining legacy dependency (position/hit-testing), not
+Retiring a hybrid window means removing its remaining legacy dependency (position/hit-testing), not
 swapping frameworks atomically — see the migration plan's Retirement criteria for the full
-checklist.
+checklist; a pure-RmlUi window like `RememberPasswordPrompt` has no such dependency left to remove.
 
 ## 2. Render interface: why a custom one, and what it doesn't do
 
@@ -103,7 +108,7 @@ two separate real bugs (see [Gotchas](gotchas-and-patterns.md)):
 ```mermaid
 sequenceDiagram
     participant Scene as RenderCurrentScene()<br>(3D world + legacy 2D)
-    participant UIMng as CUIMng::Render()<br>(CWin draws nothing;<br>CUITextInputBox text stays for later)
+    participant UIMng as CUIMng::Render()<br>(CWin draws nothing,<br>CUITextInputBox text stays for later)
     participant Rml as RmlUiRuntime::Render()<br>(the whole panel: bg, frames, controls)
     participant Post as Post-RmlUi draws<br>(cursor, RenderTextOnTop)
 
@@ -227,7 +232,31 @@ backdrop in RmlUi (`#backdrop`, see [Theming & Modding](theming-and-modding.md#b
 and switching their own `CWin::Create()` call to `-2`. Their `CWinEx m_winBack` member stays alive
 purely for its quantized-height geometry math (`SetLine()`/`GetWidth()`/`GetHeight()`) — never
 rendered, the same "legacy object survives only as bookkeeping" shape `CLoginWin`'s own
-`CButton`s already established.
+`CButton`s already established. Unlike `CLoginWin`'s own checkboxes/buttons (deliberately flat,
+even in the legacy theme — see §2's note and `login.rcss`'s header comment), both windows'
+legacy-theme panel chrome and buttons reproduce the *real* sprite art
+(`op1_stone.jpg`/`op1_back1-2.tga`/`op2_back1.tga`/`op1_b_all.tga`) as three stacked elements
+(a fixed top-cap image, a `repeat`-tiled middle band, a fixed bottom-cap image) — **not** RmlUi's
+`tiled-vertical` decorator, which an earlier version of this used and turned out wrong: confirmed
+by reading `DecoratorTiled(Vertical).cpp`, `tiled-vertical` never registers RmlUi's fit-mode
+sub-property for any of its tiles, so every tile (including the center) is hardcoded to `FILL`
+(stretch), never `REPEAT` — the center tile rendered as one blurry stretched copy instead of a
+tiled pattern, reading as "no texture" in a real run. See
+[Theming & Modding §Shared cross-window RCSS](theming-and-modding.md#shared-cross-window-rcss-basercss)
+for the corrected mechanism and what it does/doesn't reproduce (the two 5px left/right edge trim
+strips are the one still-omitted piece).
+
+**`COptionWin` is migrated but currently unreachable dead code — a disclosed, open product
+decision, not silently fixed or worked around.** No live path in this codebase shows it
+(grep-confirmed): `CSysMenuWin`'s Option button opens a separate, already-modern window,
+`SEASON3B::CNewUIOptionWindow`, via `g_pNewUISystem->Show(SEASON3B::INTERFACE_OPTION)`. Both
+windows read/write the same underlying state through the `g_pOption` macro
+(`CNewUISystem::GetInstance()->GetUI_NewOptionWindow()`), so `COptionWin` is a second, dead,
+alternate *view* over state the live window owns — its checkboxes/sliders genuinely work (see §7's
+`MakeDraggable` discussion below), it's just never shown. This migration deliberately did **not**
+rewire `CSysMenuWin`'s Option button to point at it. Retiring one of the two implementations (or
+resurrecting this one as the real Options screen) is a real product decision, left open on
+purpose — see the [Roadmap](roadmap.md#open-decisions-need-a-human-call)'s Open Decisions.
 
 `CLoginMainWin` is the one variant on this pattern worth calling out: it has no dynamic state or
 I18N text at all (two pure image buttons), so it skips `RmlModelBinder`/`SyncRmlModel()` entirely

--- a/docs/rmlui-ui-system/architecture.md
+++ b/docs/rmlui-ui-system/architecture.md
@@ -22,10 +22,15 @@ graph TD
 ```
 
 No window has been fully retired yet — the login screen is a **hybrid**: `CWin` still owns the
-window's position/size/z-order bookkeeping and (theme-dependent) background sprite; RmlUi renders
-the interactive overlay (checkboxes, buttons, labels) on top. Retiring a window means removing its
-last legacy dependency, not swapping frameworks atomically — see the migration plan's Retirement
-criteria for the full checklist.
+window's position/size/z-order bookkeeping (and its `CursorInWin` hit-testing), but draws nothing
+visual at all (`CWin::Create()` is always called with `nTexID=-2`). RmlUi renders 100% of the
+visible panel — background, input-box frames, checkboxes, buttons, labels — in every theme; a
+"legacy-look" theme reproduces the original art by pointing its own RCSS decorators at the same
+image files the old `CWin`/`CSprite` objects used to draw (see
+[Theming & Modding](theming-and-modding.md)), it just isn't `CWin` doing the drawing anymore.
+Retiring a window means removing its remaining legacy dependency (position/hit-testing), not
+swapping frameworks atomically — see the migration plan's Retirement criteria for the full
+checklist.
 
 ## 2. Render interface: why a custom one, and what it doesn't do
 
@@ -41,6 +46,21 @@ backends. Reasons:
 - `RenderGeometry` binds the same `PassthroughShader` every other 2D/3D draw call in this engine
   uses, and translates via `GlobalUBO::SetModel(origin, scale)` — a uniform that already existed
   for exactly this purpose. There is no RmlUi-specific shader.
+
+### Two texture "kinds" with two different id spaces
+
+Every `Rml::TextureHandle` this class hands out is backed by one of two kinds, tracked internally
+(`TextureRecord::kind`): `Generated` (RmlUi's own rasterized content — font glyph atlases — where
+`id` is a real `RHI::TextureHandle`/GL name straight from `RHI::CreateTexture`), and `FileBacked`
+(any image loaded through `CGlobalBitmap`, e.g. a themed panel's background) where **`id` is a
+`CGlobalBitmap` bitmap-*index*, not a GL name at all** — resolving it to something bindable
+requires `Bitmaps.GetTexture(id)->TextureNumber`. `ReleaseTexture` dispatches correctly on `kind`;
+`RenderGeometry`'s texture-binding line originally didn't (bound `id` directly as a GL name for
+both kinds), which went unnoticed for the whole migration until the first `FileBacked` texture was
+actually rendered (see [Gotchas](gotchas-and-patterns.md#filebacked-textures-rendered-using-the-wrong-gl-texture-object)
+for the full incident) — now fixed, but worth knowing as an invariant if this class grows a third
+texture source: **the two id spaces are never interchangeable, and every method that consumes
+`TextureRecord::id` needs to dispatch on `kind`, not just some of them.**
 
 **Only the "required functions for basic rendering" section of `Rml::RenderInterface` is
 implemented.** The optional advanced functions — `SetTransform`, layers, filters — are left at
@@ -83,14 +103,14 @@ two separate real bugs (see [Gotchas](gotchas-and-patterns.md)):
 ```mermaid
 sequenceDiagram
     participant Scene as RenderCurrentScene()<br>(3D world + legacy 2D)
-    participant UIMng as CUIMng::Render()<br>(CWin background sprite,<br>CUITextInputBox text)
-    participant Rml as RmlUiRuntime::Render()<br>(the overlay)
+    participant UIMng as CUIMng::Render()<br>(CWin draws nothing;<br>CUITextInputBox text stays for later)
+    participant Rml as RmlUiRuntime::Render()<br>(the whole panel: bg, frames, controls)
     participant Post as Post-RmlUi draws<br>(cursor, RenderTextOnTop)
 
     Scene->>Scene: 3D terrain/objects/characters
     Scene->>UIMng: BeginBitmap() 2D ortho pass
-    UIMng->>UIMng: CWin::Render() → background sprite<br>(theme-gated, legacy sprite chrome only)
-    UIMng->>UIMng: RenderControls() → checkboxes/buttons FRAME sprites<br>(theme-gated)
+    UIMng->>UIMng: CWin::Render() → m_psprBg is null, draws nothing
+    UIMng->>UIMng: RenderControls() → SyncRmlModel() only, no legacy drawing left
     Scene->>Scene: EndBitmap() — restores pre-2D 3D perspective
     Note over Scene,Rml: control returns all the way up to MainScene()
     Rml->>Rml: GlobalUBO::PushModel()<br>SetOrtho(top-down)<br>m_Context->Render()<br>PopModel() / restore blend+scissor/Proj/View
@@ -100,12 +120,17 @@ sequenceDiagram
     Post->>Post: EndBitmap()
 ```
 
-Why this matters concretely: the login screen's **legacy** theme has a fully transparent RmlUi
-`#panel` background, so whatever legacy content rendered underneath it (input text, cursor) stayed
-visible regardless of draw order — the ordering bug was invisible for the entire time only the
-legacy theme existed. The **modern** theme gives `#panel` an opaque `background-color`, which
-immediately covered the cursor and input text the first time it was tested. Both symptoms were the
-*same* underlying ordering fact, just newly exposed by an opaque panel.
+Why this matters concretely: at the time this ordering bug was found, the login screen's
+**legacy** theme had a fully transparent RmlUi `#panel` background, so whatever legacy content
+rendered underneath it (input text, cursor) stayed visible regardless of draw order — the bug was
+invisible for the entire time only that transparent panel existed. The **modern** theme gave
+`#panel` an opaque `background-color`, which immediately covered the cursor and input text the
+first time it was tested. Both symptoms were the *same* underlying ordering fact, just newly
+exposed by an opaque panel — which is exactly why the `legacy` theme's panel (now also opaque,
+since it draws the original background image via `decorator: image(...)` instead of relying on a
+transparent RmlUi panel over a CWin-drawn sprite) still renders correctly today: `RenderTextOnTop()`
+already runs after `RmlUiRuntime::Render()`, so the input text is never covered regardless of which
+theme's panel is opaque.
 
 **Practical rule for any future migrated window**: if a window's RmlUi overlay might ever have an
 opaque background over a region where legacy content (text, a cursor, anything not itself RmlUi)
@@ -227,16 +252,21 @@ as event parameters) rather than hand-rolled `mousedown`/`mousemove`/`mouseup` t
   bug for whatever's underneath it. This isn't a workaround; it's the same reason real UI
   toolkits use a title bar instead of "drag from anywhere on the window body" — content inside a
   panel (buttons, text fields) needs to keep receiving its own clicks.
-- **The optional `onMove` callback exists because RmlUi and legacy chrome are NOT actually
-  linked beyond a one-time position sync.** A hybrid window's legacy `CWin` background sprite and
-  its RmlUi overlay are two independently-rendered things that merely started at the same
-  position (both set once from the same `CWin::SetPosition()` call) — RmlUi has no knowledge of
-  `CWin::m_ptPos`, and moving one never moves the other. Confirmed by a real test: dragging via
-  `MakeDraggable()` alone moved the RmlUi checkboxes/buttons/labels correctly, while the legacy
-  background sprite underneath them stayed exactly where it started, immediately and visibly
-  desyncing. `onMove(newLeft, newTop)` fires on every drag tick specifically so a hybrid window's
-  caller can also update its legacy position in lockstep; a fully migrated, sprite-free panel has
-  nothing to sync and can omit it.
+- **The optional `onMove` callback exists because RmlUi and any remaining legacy state are NOT
+  actually linked beyond a one-time position sync.** At the time this was built and tested, the
+  login window still had a `CWin`-drawn background sprite alongside the RmlUi overlay — two
+  independently-rendered things that merely started at the same position (both set once from the
+  same `CWin::SetPosition()` call). RmlUi has no knowledge of `CWin::m_ptPos`, and moving one never
+  moves the other. Confirmed by a real test: dragging via `MakeDraggable()` alone moved the RmlUi
+  checkboxes/buttons/labels correctly, while the legacy background sprite underneath them stayed
+  exactly where it started, immediately and visibly desyncing. `onMove(newLeft, newTop)` fires on
+  every drag tick specifically so a caller can update whatever legacy state still needs to track
+  the panel (a `CWin::SetPosition()` call, hit-test bookkeeping, etc.) in lockstep. The login
+  window no longer has a `CWin`-drawn sprite to desync from (see §1 — `CWin` draws nothing for it
+  in any theme now), but `CWin` still owns this window's position/hit-testing, so the same
+  reasoning would still apply the moment position itself needs to move with the panel; a fully
+  migrated window with no remaining legacy state at all has nothing to sync and can omit the
+  callback entirely.
 
 Verified against a real build+run using the login screen's document as a test bed (a temporary
 handle wired to `.trust-warning`, since `#panel` itself can't be its own handle for the reason

--- a/docs/rmlui-ui-system/architecture.md
+++ b/docs/rmlui-ui-system/architecture.md
@@ -220,6 +220,52 @@ etc. (invoked from RmlUi's `data-event-click` bindings) set the same underlying 
 buttons would have. `SyncRmlModel()` runs every `RenderControls()` call, diffing legacy state
 against the bound model and only dirtying fields that actually changed.
 
+`CSysMenuWin` and `COptionWin` follow the identical shape, with one addition: both previously
+relied on `CWin::Create()`'s *default* `nTexID=-1` (a real full-screen alpha=128 black
+`m_psprBg`) rather than `CLoginWin`'s `-2`, so migrating them also meant reproducing that dim
+backdrop in RmlUi (`#backdrop`, see [Theming & Modding](theming-and-modding.md#backdrop-usage))
+and switching their own `CWin::Create()` call to `-2`. Their `CWinEx m_winBack` member stays alive
+purely for its quantized-height geometry math (`SetLine()`/`GetWidth()`/`GetHeight()`) — never
+rendered, the same "legacy object survives only as bookkeeping" shape `CLoginWin`'s own
+`CButton`s already established.
+
+`CLoginMainWin` is the one variant on this pattern worth calling out: it has no dynamic state or
+I18N text at all (two pure image buttons), so it skips `RmlModelBinder`/`SyncRmlModel()` entirely
+and wires clicks via a plain `Rml::Element::AddEventListener` + a small self-owning listener class
+(the same shape `RmlDraggable.cpp`'s own listener uses internally — see §7). The model/binder
+layer is the right tool for a window with state to keep in sync, not a mandatory part of the
+pattern.
+
+## 6a. A pure-RmlUi window with no `CWin` at all
+
+`RememberPasswordPrompt` (`UI/Windows/RememberPasswordPrompt.h/.cpp`) is a different shape from
+every window above: it was never a `CWin`/`CUIMng` window to begin with (previously built on the
+shared `SEASON3B::CNewUICommonMessageBox`/`g_MessageBox` engine — a stack shared with ~80
+unrelated dialogs elsewhere in the codebase), so migrating it meant no legacy position/hit-testing
+state to bridge at all. It's a handful of free functions in `namespace UI::Login` plus file-static
+state (a lazily-created `Rml::ElementDocument*` + `RmlModelBinder`, following the same
+`if (!doc && RmlUiRuntime::Instance().IsCreated())` creation guard every other window uses, just
+without an owning class's `Create()` to hang it on). Its public API
+(`OpenRememberPasswordPrompt()`/`RememberPasswordChoiceState()`/`ClearRememberPasswordChoice()`)
+stayed byte-identical across the migration — every external call site (all four, in `LoginWin.cpp`)
+needed zero changes.
+
+Two things this shape has to solve that a hybrid window doesn't:
+- **No `CWin::SetPosition()` to piggyback on for centering.** The panel is centered once, in C++,
+  at document-creation time, reading `#panel`'s own RCSS-declared `width`/`height` back via
+  `Rml::Element::GetProperty()` and `CInput::Instance().GetScreenWidth()/GetScreenHeight()`. There
+  is currently no resize hook — a live resolution change while the dialog is open leaves it
+  off-center until the next open. A known, accepted gap, not a hidden one.
+- **No natural per-frame tick call site, and no verified RmlUi `Keydown` routing to an unfocused
+  document.** The dialog needs to resolve on Enter/Esc the same way its OK/Cancel buttons do, but
+  has no naturally-focused element the way `CLoginWin`'s text inputs give it one. Rather than
+  introduce RmlUi document-level `Keydown` listening as a new, unverified pattern, it exposes
+  `UI::Login::Tick()` — polls `CInput::Instance().IsKeyDown(VK_RETURN/VK_ESCAPE)` while the dialog
+  is `Pending` — called once per frame from `CLoginWin::UpdateWhileShow()` (which already ticks
+  while this dialog is open, for the same reason `ApplyRememberPasswordChoice()` does). A future
+  window that genuinely needs RmlUi-native keyboard focus routing would be the first real test of
+  whether that unverified path works; this one deliberately didn't become that test.
+
 ## 7. Reusable interaction helpers (`UI::RmlBridge`)
 
 **Standing design principle**: any interaction pattern more than one migrated window will
@@ -268,6 +314,19 @@ as event parameters) rather than hand-rolled `mousedown`/`mousemove`/`mouseup` t
   migrated window with no remaining legacy state at all has nothing to sync and can omit the
   callback entirely.
 
-Verified against a real build+run using the login screen's document as a test bed (a temporary
-handle wired to `.trust-warning`, since `#panel` itself can't be its own handle for the reason
-above) — not wired up as a real feature there, since the login screen is meant to stay static.
+First proven against a real build+run using the login screen's document as a throwaway test bed (a
+temporary handle wired to `.trust-warning`, since `#panel` itself can't be its own handle for the
+reason above) — not wired up as a real feature there, since the login screen is meant to stay
+static. Its first real production use is `COptionWin`'s two sliders (Batch 2): each slider's thumb
+is its own `handle` *and* `panel` (there's nothing else to move), with the `onMove` callback
+clamping to the track's real travel distance and snapping to the slider's discrete step count —
+the same discrete-position math `CSlider::Update()` does for the legacy widget, just applied to a
+hand-rolled RmlUi element instead. This surfaced a real gotcha `MakeDraggable` itself doesn't
+solve: it tracks **both** axes (sets `left` *and* `top` from the drag delta), which is correct for
+a freely-draggable panel but wrong for a horizontal-only slider track — the caller has to reset
+`top` back to a fixed value on every drag tick, or the thumb visibly drifts vertically with the
+cursor. See
+[Gotchas](gotchas-and-patterns.md#makedraggable-tracks-both-axes-a-horizontal-only-slider-has-to-fight-that)
+for the full writeup. `CSlider`'s legacy widget stays alive alongside the RmlUi thumb purely for
+input-detection redundancy (mirrored via `SetSlidePos()` after every drag), the same pattern every
+other migrated control in this codebase follows.

--- a/docs/rmlui-ui-system/architecture.md
+++ b/docs/rmlui-ui-system/architecture.md
@@ -1,0 +1,196 @@
+# Architecture
+
+How RmlUi is wired into this engine's renderer, frame loop, and input pipeline. Every claim here
+is grounded in the actual pilot implementation (`CLoginWin`) and the vendored RmlUi 6.2 source,
+not general RmlUi documentation — where this engine's integration deviates from "how RmlUi
+normally works," that's called out explicitly.
+
+## 1. The three-tier coexistence model
+
+```mermaid
+graph TD
+    subgraph Legacy["Three pre-existing UI tiers (still alive)"]
+        CWin["UI/Widgets — CWin/CButton<br>(login/character-select screens)"]
+        CUIControl["UI/Legacy/UIControls — CUIControl<br>(gatekeeper/guardsman/guild windows)"]
+        NewUI["UI/NewUI — CNewUIObj/CNewUIManager<br>(~90 in-game windows, main HUD)"]
+    end
+    RmlUi["RmlUi overlay<br>(Rml::Context, one per Rml runtime)"]
+
+    CWin -.->|"pilot: hybrid overlay"| RmlUi
+    CUIControl -.->|"not yet migrated"| CUIControl
+    NewUI -.->|"not yet migrated"| NewUI
+```
+
+No window has been fully retired yet — the login screen is a **hybrid**: `CWin` still owns the
+window's position/size/z-order bookkeeping and (theme-dependent) background sprite; RmlUi renders
+the interactive overlay (checkboxes, buttons, labels) on top. Retiring a window means removing its
+last legacy dependency, not swapping frameworks atomically — see the migration plan's Retirement
+criteria for the full checklist.
+
+## 2. Render interface: why a custom one, and what it doesn't do
+
+`RmlUiRenderInterface` (`Render/RmlUi/RmlUiRenderInterface.h/.cpp`) implements `Rml::RenderInterface`
+directly against this engine's `RHI::` abstraction — it does **not** use any of RmlUi's bundled
+backends. Reasons:
+
+- RmlUi's vertex format (`pos2 + premultiplied-alpha rgba8 + uv2`, 20 bytes) doesn't match this
+  engine's only implemented `RHI::VertexLayout` (`PosUvColor`: `pos3+uv2+rgba4`, all floats, 36
+  bytes). `CompileGeometry` converts once per compiled-geometry handle (RmlUi's contract is
+  compile-once/render-many, not per-frame), rather than adding a 5th vertex layout that would need
+  a new shader variant on every backend (including the in-progress D3D11 branch).
+- `RenderGeometry` binds the same `PassthroughShader` every other 2D/3D draw call in this engine
+  uses, and translates via `GlobalUBO::SetModel(origin, scale)` — a uniform that already existed
+  for exactly this purpose. There is no RmlUi-specific shader.
+
+**Only the "required functions for basic rendering" section of `Rml::RenderInterface` is
+implemented.** The optional advanced functions — `SetTransform`, layers, filters — are left at
+their base-class no-op defaults. This is a deliberate MVP scope cut, but it has a sharp edge: any
+RCSS property whose real implementation routes through those optional functions will silently
+misrender instead of gracefully degrading. `box-shadow` with a nonzero blur radius is the
+concrete example that hit this (see [Gotchas](gotchas-and-patterns.md#box-shadow-blur-renders-as-a-solid-white-block)) —
+`Source/Core/GeometryBoxShadow.cpp` calls `RenderManager::PushLayer()`/`CompileFilter("blur")`/
+`CompositeLayers()` for any blur ≥ 0.5px, and none of that has anywhere correct to go. CSS
+`transform` and `backdrop-filter` are unverified but presumed to have the same problem until
+someone actually implements the layer/filter path.
+
+### Premultiplied alpha
+
+RmlUi's own vertex format documents `ColourbPremultiplied` (`Include/RmlUi/Core/Vertex.h`) — genuinely
+premultiplied alpha, confirmed against `Colour<>::ToPremultiplied()`'s real formula
+(`premult = (straight * alpha) / 255`). Every existing straight-alpha `RHI::BlendMode` (`Blend3` —
+`SRC_ALPHA, ONE_MINUS_SRC_ALPHA`) expects **un-premultiplied** colour, so `CompileGeometry`
+un-premultiplies once at compile time (dividing RGB by alpha, guarded against `alpha == 0`) rather
+than adding a premultiplied-alpha `BlendMode`. This is mathematically exact for a single blend pass
+with no layer/filter compositing — revisit only if/when layers or filters are actually
+implemented, which genuinely need premultiplied compositing semantics.
+
+### Blend mode: `Blend3`, not `AlphaTest`
+
+`RenderGeometry` uses `RHI::BlendMode::Blend3`, not the seemingly-obvious `AlphaTest`.
+`AlphaTest` enables the shader's alpha-test discard threshold (`g_AlphaRef`) as a side effect —
+built for hard-cutout foliage sprites, it would silently clip RmlUi's anti-aliased text/element
+edges (low-but-nonzero alpha) instead of blending them. `Blend3` is the same
+`SRC_ALPHA/ONE_MINUS_SRC_ALPHA` blend func with alpha-test explicitly disabled.
+
+## 3. Frame lifecycle — the render-order contract
+
+This is the single most consequential architectural fact in this whole system, and the source of
+two separate real bugs (see [Gotchas](gotchas-and-patterns.md)):
+
+> **RmlUi always renders LAST in the frame**, after all legacy 2D/3D content for that scene has
+> already been drawn.
+
+```mermaid
+sequenceDiagram
+    participant Scene as RenderCurrentScene()<br>(3D world + legacy 2D)
+    participant UIMng as CUIMng::Render()<br>(CWin background sprite,<br>CUITextInputBox text)
+    participant Rml as RmlUiRuntime::Render()<br>(the overlay)
+    participant Post as Post-RmlUi draws<br>(cursor, RenderTextOnTop)
+
+    Scene->>Scene: 3D terrain/objects/characters
+    Scene->>UIMng: BeginBitmap() 2D ortho pass
+    UIMng->>UIMng: CWin::Render() → background sprite<br>(theme-gated, legacy sprite chrome only)
+    UIMng->>UIMng: RenderControls() → checkboxes/buttons FRAME sprites<br>(theme-gated)
+    Scene->>Scene: EndBitmap() — restores pre-2D 3D perspective
+    Note over Scene,Rml: control returns all the way up to MainScene()
+    Rml->>Rml: GlobalUBO::PushModel()<br>SetOrtho(top-down)<br>m_Context->Render()<br>PopModel() / restore blend+scissor/Proj/View
+    Post->>Post: BeginBitmap() (fresh — the earlier one already closed)
+    Post->>Post: CLoginWin::RenderTextOnTop() → CUITextInputBox text
+    Post->>Post: RenderCursor()
+    Post->>Post: EndBitmap()
+```
+
+Why this matters concretely: the login screen's **legacy** theme has a fully transparent RmlUi
+`#panel` background, so whatever legacy content rendered underneath it (input text, cursor) stayed
+visible regardless of draw order — the ordering bug was invisible for the entire time only the
+legacy theme existed. The **modern** theme gives `#panel` an opaque `background-color`, which
+immediately covered the cursor and input text the first time it was tested. Both symptoms were the
+*same* underlying ordering fact, just newly exposed by an opaque panel.
+
+**Practical rule for any future migrated window**: if a window's RmlUi overlay might ever have an
+opaque background over a region where legacy content (text, a cursor, anything not itself RmlUi)
+needs to stay visible, that legacy content's render call must be moved to run *after*
+`RmlUiRuntime::Render()`, in its own `BeginBitmap()/EndBitmap()` bracket — the bracket that was
+active during the window's own earlier render pass will already be closed by the time control
+returns this far up the call stack (`EndBitmap()` restores `GlobalUBO`'s Proj/View to the 3D
+perspective active before `BeginBitmap()` was called, so 2D `ConvertX`/`ConvertY`-based rendering
+needs a fresh bracket, not the old one).
+
+### `GlobalUBO` save/restore — three state pieces, not two
+
+`RmlUiRuntime::Render()` brackets its own `m_Context->Render()` call with save/restore for **three**
+pieces of `GlobalUBO` state: Proj, View, *and* Model. The first version of this code only
+saved/restored Proj/View — `RmlUiRenderInterface::RenderGeometry` calls
+`GlobalUBO::SetModel(origin, scale)` once per compiled-geometry draw (translation), and without a
+matching restore, whatever the frame's *last* RmlUi draw set Model to (e.g. the login panel's OK
+button origin) leaked into every legacy 2D/3D draw issued afterward — visibly shifting legacy UI
+elements and the clickable area toward whatever direction that leftover translation pointed.
+`GlobalUBO::PushModel()`/`PopModel()` (a stack-based save/restore that already existed for exactly
+this shape) now brackets the whole render pass alongside the Proj/View save/restore. See
+[Gotchas](gotchas-and-patterns.md#globalubo-model-matrix-leak) for the full incident.
+
+## 4. Input arbitration
+
+Built at the SDL-event level (`Winmain.cpp`'s event switch), not as a per-object polling shim
+inside `CNewUIManager`'s frame walk. Each mouse-button/wheel/text/key event is offered to RmlUi
+first via `RmlUiRuntime::ProcessSdlEvent()`; if RmlUi consumed it, the corresponding legacy call
+(`HandleMouseButton`, `FeedPortableKey`, etc.) is skipped for that event.
+
+- **Mouse button down/up and mouse motion are handled directly**, not through RmlUi's own vendored
+  `RmlSDL::InputEventHandler` — that handler calls `SDL_CaptureMouse()` on every button press/
+  release (breaks this engine's own cursor-clip handling) and scales motion coordinates by
+  `SDL_GetWindowPixelDensity()` (this engine's `Rml::Context` is already sized in real pixels, so
+  that scaling double-applies). Wheel/key/text events still route through the vendored handler —
+  its SDL-keycode/modifier mapping is reused as-is.
+- `Rml::Context::IsMouseInteracting()` backs a third click-to-move gate in `Input/Selection.cpp`,
+  alongside the two legacy tiers' own flags (`MouseOnWindow`, `g_pNewUISystem->CheckMouseUse()`).
+
+### The `pointer-events` trap
+
+`Context::IsMouseInteracting()` returns `true` whenever the current hover target is **any** RmlUi
+element other than the document root — not just elements with an actual click listener. A
+document's `body` sized `width/height: 100%` (the normal pattern for a full-screen RmlUi document)
+therefore makes *every* click anywhere on screen register as "RmlUi handled this," silently
+swallowing clicks meant for legacy content sitting underneath or beside it — including clicks that
+should transfer focus to a legacy text input. See
+[Gotchas](gotchas-and-patterns.md#pointer-events-swallows-every-click-on-screen) for the fix
+(`pointer-events: none` on `body`, opted back in per interactive element) — **this is not
+optional for any future full-window RmlUi document**, not a one-off fix scoped to the login
+screen.
+
+## 5. Data binding: model/binder pattern
+
+Nothing like a data-binding layer existed before RmlUi. `UI::RmlBridge::RmlModelBinder<Model>`
+(`UI/RmlBridge/RmlModelBinder.h`) generalizes the one existing precedent for this shape
+(`UI/NewUI/HUD/Skills/SkillTooltipModel.h/.cpp`) into a reusable per-window wrapper:
+
+```
+Game state → BuildModel() → UI::<Domain>::<Concern>Model (plain data)
+                                    │  bound via Rml::DataModelConstructor
+                                    ▼
+                          Rml::DataModel  →  RML template
+```
+
+- `RmlModelBinder::Create(context, modelName, registerFieldsLambda)` creates the
+  `Rml::DataModelHandle` and hands the caller a lambda to register each field by name — RmlUi's
+  own `DataModelConstructor::Bind()` API requires explicit per-field registration, there is no
+  reflection.
+- **The data model must be created *before* the document that references it is loaded.** RmlUi
+  resolves `data-model="..."` and `{{bindings}}` while *parsing* the RML — a model created after
+  `LoadDocument()`/`LoadDocumentFromMemory()` is too late, and every `{{...}}` in the document falls
+  back to rendering its own literal source text. See
+  [Gotchas](gotchas-and-patterns.md#data-model-created-after-the-document-that-references-it).
+- Click/toggle actions are **not** modeled through `Rml::DataModel` (it's one-directional,
+  model→view) — each migrated window registers `data-event-click` callbacks via
+  `DataModelConstructor::BindEventCallback`, whose bodies call the exact same free
+  functions/methods the legacy UI already calls. This is what keeps day-one call sites unchanged.
+
+## 6. Coexistence bridging (`CLoginWin`'s specific pattern)
+
+`CLoginWin` (`UI/Windows/LoginWin.h/.cpp`) is a `CWin`-derived class that owns *both* the legacy
+state (position/size, `CButton`s, `CUITextInputBox`) and the RmlUi document/model. The legacy
+`CButton`s for OK/Cancel/checkboxes stay registered and positioned identically to their RmlUi
+replacements — a harmless redundant detection path — while `RmlClickOk()`/`RmlToggleRememberMe()`/
+etc. (invoked from RmlUi's `data-event-click` bindings) set the same underlying state the legacy
+buttons would have. `SyncRmlModel()` runs every `RenderControls()` call, diffing legacy state
+against the bound model and only dirtying fields that actually changed.

--- a/docs/rmlui-ui-system/gotchas-and-patterns.md
+++ b/docs/rmlui-ui-system/gotchas-and-patterns.md
@@ -311,3 +311,65 @@ See [Theming & Modding](theming-and-modding.md#a-third-case-a-theme-with-its-own
 for the full workflow and the open (not yet built) follow-up: vendoring `stb_image.h` to give
 `LoadTexture` a plain-PNG/JPG/BMP fallback for RmlUi-referenced theme assets specifically, without
 touching the legacy OZT/OZJ pipeline everything else still depends on.
+
+---
+
+## Interaction helpers
+
+### A drag handle that inherited `pointer-events: none` never fires drag events at all
+
+**Symptom**: `UI::RmlBridge::MakeDraggable()`, first wired to a test handle, produced no reaction
+whatsoever to click-and-drag — not `dragstart`, not `drag`, not even `mouseover` when a temporary
+diagnostic listener was added for every event type.
+
+**Root cause**: the exact same inheritance mechanism as the
+[`pointer-events` click-swallowing bug](#pointer-events-swallows-every-click-on-screen) above, but
+biting from the opposite direction. A handle element positioned inside a full-window document
+following that fix inherits `pointer-events: none` from `body` by default (only specific
+interactive elements opt back in to `auto`). `Context::GetElementAtPoint` (`Source/Core/Context.cpp`)
+explicitly skips any element whose computed `pointer_events()` is `None` — so an unmodified handle
+is invisible to RmlUi's own hit-testing, never becomes `hover`, and `dragstart`/`drag` (which only
+dispatch on the hover chain) never fire, regardless of whether `drag: drag` is set correctly.
+
+**Fix**: `MakeDraggable()` forces `pointer-events: auto` on `handle` itself, so a caller doesn't
+need to remember a matching RCSS rule.
+
+**Diagnostic approach that actually found it**: rather than keep guessing after three failed
+"still not moving" reports, added a temporary listener logging *every* event type reaching the
+handle (not just drag-specific ones) and a temporary log confirming the handle/panel element
+pointers themselves were non-null. The first version of that logging still showed *zero* events,
+even `mouseover` — a much stronger signal than "the drag didn't work," since it ruled out
+`Style::Drag`/event-ID mistakes entirely and pointed straight at hit-testing. Once `mouseover`
+was confirmed reaching the listener but `dragstart` still wasn't happening from a *different*
+handle candidate (`#panel` itself), that isolated the second, separate finding below.
+
+### Dragging the RmlUi overlay does not move a hybrid window's legacy sprite chrome
+
+**Not a bug in `MakeDraggable()`** — a real architectural fact about how hybrid windows are built,
+worth being explicit about since it's easy to assume RmlUi "contains" or is otherwise linked to
+the legacy chrome underneath it.
+
+A hybrid window's legacy `CWin` background sprite and its RmlUi overlay are two **independently
+rendered things** that merely start at the same screen position — both set once, from the same
+`CWin::SetPosition()` call (see [Architecture §6](architecture.md#6-coexistence-bridging-cloginwins-specific-pattern)).
+RmlUi has no knowledge of `CWin::m_ptPos`, and nothing keeps the two in sync afterward. Confirmed
+by a real test: dragging via `MakeDraggable()` moved the RmlUi checkboxes/buttons/labels correctly
+frame to frame, while the legacy background sprite stayed exactly where it started, immediately
+and visibly desyncing from the content now floating away from it.
+
+**Fix**: `MakeDraggable()` takes an optional `onMove(newLeft, newTop)` callback, fired on every
+drag tick, specifically so a hybrid window's caller can also reposition its legacy chrome (e.g.
+call `CWin::SetPosition()`) in lockstep. A fully migrated, sprite-free panel has nothing to sync
+and can simply omit the callback.
+
+### A whole panel can't usually be its own drag handle
+
+Corollary of the pointer-events gotcha above, but worth stating as its own lesson: for any window
+whose panel inherited `pointer-events: none` for the click-passthrough fix (true of every
+full-window document built so far), the panel **can't be dragged by clicking anywhere on it**
+without forcing its `pointer-events` back to `auto` — which would reintroduce the exact
+click-swallowing bug that fix exists to prevent, for anything underneath the panel (input boxes,
+other legacy content). Use a dedicated handle element instead (a title bar, a specific label) —
+this isn't a workaround for a limitation, it's the same reason real UI toolkits use a title bar
+rather than "grab anywhere on the window body": content inside a panel needs to keep receiving
+its own clicks independently of the drag gesture.

--- a/docs/rmlui-ui-system/gotchas-and-patterns.md
+++ b/docs/rmlui-ui-system/gotchas-and-patterns.md
@@ -484,3 +484,28 @@ other legacy content). Use a dedicated handle element instead (a title bar, a sp
 this isn't a workaround for a limitation, it's the same reason real UI toolkits use a title bar
 rather than "grab anywhere on the window body": content inside a panel needs to keep receiving
 its own clicks independently of the drag gesture.
+
+### `MakeDraggable` tracks both axes: a horizontal-only slider has to fight that
+
+**Symptom**: while building `COptionWin`'s volume/render-level sliders (`MakeDraggable`'s first
+real production use, beyond the throwaway test handle described above), a slider thumb dragged
+horizontally also visibly drifted up/down, tracking the cursor's Y movement even though the track
+itself never moves vertically.
+
+**Root cause**: `MakeDraggable`'s internal `DragMoveListener` unconditionally sets **both** `left`
+and `top` from the `drag` event's mouse delta (`RmlDraggable.cpp`) — correct, and the whole point,
+for a freely-draggable panel (its only use case until now), but a slider thumb is constrained to
+one axis, and `MakeDraggable` itself has no concept of that constraint — it always tracks the
+cursor on both axes regardless of what `handle`/`panel` conceptually represent.
+
+**Fix**: not a change to `MakeDraggable` itself (both-axis tracking is correct for its actual
+job — panel dragging). Each slider's `onMove` callback (`COptionWin::OnSliderThumbDragged`)
+recomputes and overwrites `left` with the clamped/snapped value as intended, *and* also resets
+`top` back to a fixed `"0px"` on every tick, undoing whatever vertical value `MakeDraggable` just
+set moments earlier in the same event.
+
+**Practical rule for the next 1D-constrained draggable element** (a slider, a horizontal scroll
+thumb, anything that isn't a freely-draggable panel): `MakeDraggable`'s `onMove` callback is the
+right place to clamp/snap the axis you care about, but remember to also reset the axis you *don't*
+care about — it will otherwise silently drift with the cursor, since `MakeDraggable` has no way to
+know your handle is axis-constrained.

--- a/docs/rmlui-ui-system/gotchas-and-patterns.md
+++ b/docs/rmlui-ui-system/gotchas-and-patterns.md
@@ -1,0 +1,279 @@
+# Gotchas & Bug Catalog
+
+Real bugs found during the Phase 1 pilot migration (the login screen), with root cause and fix.
+Read this before migrating the next window — several of these are non-obvious traps that will
+reproduce identically on any new RmlUi window built the same way, and cost real debugging time
+once already.
+
+Ordered roughly by when a future migration is likely to hit them: build/integration issues first,
+then rendering, then input, then theming-specific.
+
+---
+
+## Build & integration
+
+### `RMLUI_BACKEND "none"` is not a valid CMake value
+
+RmlUi's own `CMakeLists.txt` validates this cache variable unconditionally, even when
+`RMLUI_SAMPLES=OFF` (it only actually selects which backend RmlUi's *samples* build against).
+**Fix**: use `"auto"` instead — a no-op since samples are disabled, but a value RmlUi's own
+validation accepts.
+
+### FreeType not found
+
+RmlUi's default font engine (`RMLUI_FONT_ENGINE=freetype`) requires FreeType via `find_package`,
+and none was installed. **Fix**: vendored `src/ThirdParty/freetype` as a git submodule with
+`add_library(Freetype::Freetype ALIAS freetype)`, satisfying RmlUi's
+`if(NOT TARGET Freetype::Freetype)` check regardless of how that target got created.
+
+### Wrong CMake target name silently accepted
+
+`target_link_libraries(MuClient PUBLIC RmlCore)` referenced a target that doesn't exist — the real
+one is `rmlui_core`, aliased `RmlUi::Core`. **CMake accepted the wrong bare name with no error at
+configure time** (it doesn't validate that a linked "library" name actually resolves to anything
+until link time), and the failure only surfaced once every RmlUi-including source file couldn't
+find `RmlUi/Core/Context.h` (the nonexistent `RmlCore` target propagated no include paths).
+**Fix**: use `RmlUi::Core`. **Lesson**: a `target_link_libraries` typo on a nonexistent target
+name is a silent no-op in CMake, not a configure error — if new RmlUi-adjacent link errors show up
+as missing headers rather than missing symbols, check the target name first.
+
+### Legacy macro collision: `Vector4`/`DotProduct`
+
+`Core/Math/ZzzMathLib.h` used to `#define` `Vector4(a,b,c,d,target)` and `DotProduct(x,y)` as
+legacy C-style macros for this engine's own `vec3_t`/`vec4_t` math. Both names collided textually
+with `Rml::Vector4` (a class) and `Rml::Vector3/Vector4::DotProduct()` (methods) — macros ignore
+C++ namespaces entirely. Confirmed via raw `/P` preprocessor output
+(`warning C4003: not enough arguments for function-like macro invocation`), not guessed.
+
+**First fix** (later replaced): a `push_macro`/`undef`/`pop_macro` guard pair
+(`RmlUiMacroGuardBegin.h`/`End.h`, deliberately no include guards so they'd be reprocessed at
+every include site) wrapped around every direct `#include <RmlUi/...>` line across 7 files.
+Functional, but a growing tax on every future RmlUi include site, and easy to forget on a new one.
+
+**Real fix**: renamed the macros — `Vector4` → `Vector4Set`, `DotProduct` → `VectorDotProduct`
+(matching `ZzzMathLib.h`'s own `VectorXxx` naming convention) — after first confirming the actual
+blast radius (only 3 `Vector4(...)` call sites, all in `ZzzBMD.cpp`, and ~45 `DotProduct(...)`
+sites across 10 files; no unrelated identically-named symbol collided anywhere in `src/source`).
+Updated every real call site, then deleted both guard files and their `#include` wrapping — no
+file needs to guard an RmlUi include anymore, because the collision no longer exists.
+
+**A mechanical mistake caught before it shipped**: the first attempt at this rename used
+PowerShell (`Get-Content -Raw` + `-replace` + `[System.IO.File]::WriteAllText()`, no explicit
+encoding) to batch-edit all 10 files. This silently mangled non-ASCII characters already present
+in those files (em dashes, arrows in comments) into mojibake (`—` → `â€"`) — caught by inspecting
+`git diff` before committing (every line in the touched region showed as changed, not just the
+macro-name lines — a tell that something broader than intended had changed) rather than assuming
+a mechanical find-and-replace was safe. Reverted and redid the rename file-by-file with an
+encoding-safe edit tool. **Lesson**: a raw PowerShell read/write round-trip on a file whose actual
+encoding you haven't checked can silently corrupt non-ASCII content — verify with a diff before
+trusting a batch text edit, especially across many files at once.
+
+### RHI dispatch-shim layer missed
+
+`RHI_GL.cpp` only implements the `RHI_GL_Impl` namespace; the real `namespace RHI { ... }`
+functions that satisfy `RHI.h`'s public declarations live in a *separate* file, `RHI.cpp`, as thin
+forwarding calls. The first pass adding `RHI::SetScissorEnabled`/`SetScissorRect` (needed for
+RmlUi's `EnableScissorRegion`/`SetScissorRegion`) only added the `RHI_GL_Impl` half and missed the
+forwarding pair in `RHI.cpp` — a straightforward omission once the two-file split is understood,
+but easy to repeat on the next RHI addition if it isn't.
+
+---
+
+## Rendering
+
+### GlobalUBO Model matrix leak
+
+**Symptom**: after the RmlUi migration's blend-mode and mouse-capture fixes landed, legacy UI
+elements and the clickable/"responsive" screen area appeared to have shifted toward the
+upper-right of the window, while RmlUi's own elements rendered in the correct position. The 3D
+tour-camera background also appeared cropped to its lower-left quadrant.
+
+**Root cause**: `RmlUiRenderInterface::RenderGeometry` calls `GlobalUBO::SetModel(origin, scale)`
+once per compiled-geometry draw (translating it to its element's screen position — necessary and
+correct). `RmlUiRuntime::Render()` saved and restored `GlobalUBO`'s Proj and View around the whole
+render pass, but never did the same for Model. After the frame's *last* RmlUi draw call, Model was
+left holding that element's translation (e.g. the login panel's OK button origin), with nothing to
+reset it. Legacy 2D/3D rendering (`BeginBitmap`/`BeginOpengl`-based sprite, text, and world draws)
+never sets Model itself — it assumes Model is identity, exactly as it always was before RmlUi
+existed. Every legacy draw issued after RmlUi's render pass inherited that leftover translation.
+
+**Fix**: bracket the whole render pass with `GlobalUBO::PushModel()`/`PopModel()` — a stack-based
+save/restore that already existed in `GlobalUBO` for exactly this shape, just never used by
+`RmlUiRuntime::Render()` — the same way the existing `savedProj`/`savedView` locals already
+bracket Proj/View.
+
+**How it was actually found**: not guessed. A one-shot diagnostic log confirmed `WindowWidth`/
+`WindowHeight` (the "stale dimension" theory) were consistent and correct, ruling that out first.
+The real clue was that RmlUi's *own* elements rendered correctly while only legacy content shifted
+— which narrowed the search to "what does RmlUi mutate that legacy code assumes stays constant,"
+directly pointing at `GlobalUBO`'s per-draw Model mutation with no matching restore.
+
+### Blend mode never restored
+
+**Symptom**: the 3D background scene "did not display well" specifically on the continuously
+re-rendering login screen (not the one-shot loading screen).
+
+**Root cause**: `RmlUiRenderInterface::RenderGeometry` calls `RHI::SetBlendMode(RHI::BlendMode::Blend3)`
+for every draw (cull off, depth-write off, alpha blend on), and nothing restored it afterward.
+`BeginOpengl()` (the per-frame 3D setup) was confirmed via direct read to unconditionally reset
+`ALPHA_TEST`/`TEXTURE_2D`/`DEPTH_TEST`/`CULL_FACE`/`DEPTH_MASK`/`DEPTH_FUNC`/fog every frame, but
+**never touches `GL_BLEND`/`AlphaBlendType`** — confirmed via direct grep, zero hits. The leftover
+alpha-blended/no-cull/no-depth-write state from one frame's RmlUi render bled directly into the
+next frame's opaque terrain/character rendering, every frame.
+
+**Fix**: `RHI::SetBlendMode(RHI::BlendMode::Opaque)` explicitly at the end of
+`RmlUiRuntime::Render()`.
+
+### Render order: content behind an opaque RmlUi panel
+
+**Symptom**: after fixing an unrelated theming bug, the mouse cursor and the login screen's
+username/password text both rendered invisibly, seemingly "under" the RmlUi panel.
+
+**Root cause**: RmlUi always renders **last** in the frame (see
+[Architecture §3](architecture.md#3-frame-lifecycle--the-render-order-contract) for the full
+diagram). The cursor and the legacy `CUITextInputBox` text both used to render much earlier,
+inside `RenderInfomation()` (`SceneCommon.cpp`) — called from deep inside `RenderCurrentScene()`,
+well before RmlUi's own render call. This was invisible for as long as the login screen's RmlUi
+`#panel` had **no background at all** (fully transparent) — whatever rendered underneath stayed
+visible no matter the draw order. The moment a theme gave `#panel` an opaque background (the
+"modern" theme), the pre-existing ordering issue became visible for the first time. It was never a
+new bug the modern theme introduced — just the first content to expose it.
+
+**Fix**: moved both draws to run explicitly *after* `RmlUiRuntime::Render()` in `SceneManager.cpp`'s
+`MainScene()`, in their own fresh `BeginBitmap()/EndBitmap()` bracket (the original bracket from
+the window's own render pass is already closed by this point — `EndBitmap()` restores `GlobalUBO`'s
+Proj/View to the 3D perspective active before `BeginBitmap()`, so the 2D ortho state
+`ConvertX`/`ConvertY`-based rendering needs is gone unless re-established). Added
+`CLoginWin::RenderTextOnTop()` (called directly, not through `RenderControls()`'s normal virtual
+dispatch) to carry just the `CUITextInputBox::Render()` calls that moved.
+
+**Practical rule for the next migrated window**: any legacy content that must stay visible on top
+of an RmlUi overlay needs its render call moved to after `RmlUiRuntime::Render()`, in its own
+bracket — don't assume "it worked before" proves the ordering is correct, only that nothing opaque
+happened to sit on top of it yet.
+
+### `box-shadow` blur renders as a solid white block
+
+**Symptom**: the login screen's "modern" theme's panel, styled with
+`box-shadow: 0px 6px 24px rgba(0,0,0,160);`, rendered as a solid, washed-out white rectangle
+instead of a dark panel with a soft shadow.
+
+**Root cause**: `box-shadow` with a blur radius ≥ 0.5px doesn't render as plain geometry. RmlUi's
+real implementation (`Source/Core/GeometryBoxShadow.cpp`) calls `RenderManager::PushLayer()`,
+`CompileFilter("blur", ...)`, and `CompositeLayers(...)` — exactly the "optional advanced
+rendering functions" (layers/filters) that `RmlUiRenderInterface` deliberately leaves as no-op
+stubs (see [Architecture §2](architecture.md#2-render-interface-why-a-custom-one-and-what-it-doesnt-do)).
+This was actually already documented in `RmlUiRenderInterface.h`'s own header comment from the
+original groundwork work ("box-shadow-blur are not yet supported") — the bug was adding
+`box-shadow` to a theme without that limitation being front of mind, not a newly-discovered engine
+gap.
+
+Before concluding this, several other theories were investigated and ruled out with evidence
+(don't re-check these on a future "translucent color looks wrong" bug — they're confirmed fine):
+RmlUi's `rgba()` parser (`PropertyParserColour.cpp::ParseRGBColour`) takes all four channels as
+0-255 integers, not standard CSS 0-1 alpha, so the RCSS itself parses exactly as authored — this
+is *not* a syntax gotcha. The premultiplied-alpha un-premultiply math in `CompileGeometry` checked
+out algebraically. `EnableAlphaBlend3()` is a genuine `glBlendFunc(GL_SRC_ALPHA,
+GL_ONE_MINUS_SRC_ALPHA)`, not accidentally additive.
+
+**Fix**: don't use `box-shadow` with a nonzero blur radius in any theme until layer/filter
+compositing is actually implemented in `RmlUiRenderInterface`. `background-color`/`border`/
+`border-radius` are all pure geometry and render correctly — they're what should carry a themed
+panel's look instead.
+
+---
+
+## Input
+
+### `pointer-events` swallows every click on screen
+
+**Symptom**: clicking the login screen's legacy username/password input boxes never transferred
+keyboard focus to them, and (in a related manifestation of the same bug) the OK/Cancel buttons
+appeared to respond to `:hover` but not to an actual left click.
+
+**Root cause**: `pointer-events` is an **inherited** RCSS property in RmlUi (default `auto`,
+confirmed via `StyleSheetSpecification.cpp`'s `RegisterProperty` call — comparing its `inherited`
+flag position against `color` (inherited) vs. `display` (not inherited) in the same file).
+`login.rcss`'s `body` rule spans the *whole real window* (`width/height: 100%`, the normal pattern
+for a full-screen RmlUi document), not just the visible panel, and never set `pointer-events` — so
+it stayed `auto` everywhere on screen. `Context::IsMouseInteracting()` (`Source/Core/Context.cpp`)
+returns `true` whenever the current hover target is anything other than RmlUi's root element, and
+this engine's SDL input arbitration (`RmlUiRuntime::ProcessSdlEvent`) treats that as "RmlUi handled
+this click," skipping legacy handling for the event entirely. Since `body` covers the full window,
+*every* click on screen while the document is shown qualified.
+
+**Fix**: `pointer-events: none` on `body`, with `pointer-events: auto` explicitly re-enabled only
+on the specific elements that should claim clicks (`.checkbox-row`, `.btn`) — child elements
+(`.checkbox-box`, `.checkbox-label`) inherit `auto` from their styled parent, no separate rule
+needed for them.
+
+**This is not optional for any future full-window RmlUi document** — any document whose
+root/body spans the full window needs this same treatment, or it will silently swallow every click
+on screen for legacy-input purposes the moment it's shown. It only surfaced on the login screen
+because that's the first (and so far only) full-window RmlUi document with legacy content
+underneath it that needs real clicks.
+
+### SDL_CaptureMouse side effect
+
+**Symptom**: after choosing a server/channel (the first real click-driven scene transition),
+mouse clicks throughout the game stopped tracking correctly.
+
+**Root cause**: RmlUi's own vendored SDL backend (`RmlSDL::InputEventHandler`,
+`ThirdParty/RmlUi/Backends/RmlUi_Platform_SDL.cpp`) calls `SDL_CaptureMouse(true)`/`(false)` on
+every mouse button down/up — correct for a sample app that owns the whole window, but this engine
+has its own cursor rendering/clip handling (`Winmain.cpp`'s `UpdateCursorClip()`) that was never
+designed to expect SDL's capture mode being toggled externally, and every mouse click in the game
+(not just clicks on RmlUi elements) was routed through this handler.
+
+**Fix**: handle `SDL_EVENT_MOUSE_BUTTON_DOWN`/`UP` directly in `RmlUiRuntime::ProcessSdlEvent`
+(calling `Context::ProcessMouseButtonDown`/`Up` with `RmlSDL::ConvertMouseButton`/
+`GetKeyModifierState`, both pure/side-effect-free) instead of delegating those two event types to
+the vendored handler. Wheel/key/text events still route through it unchanged.
+
+### Mouse motion `pixel_density` scaling mismatch
+
+**Root cause**: `RmlSDL::InputEventHandler`'s motion case multiplies event coordinates by
+`SDL_GetWindowPixelDensity()` — correct for a backend whose `Rml::Context` was created in
+DPI-independent points, but this engine's `Rml::Context` is created directly from real-pixel
+`WindowWidth`/`WindowHeight`, and its own `HandleMouseMotion()` applies no such scaling. On any
+display where pixel density isn't exactly 1.0, this double-applies scaling and drifts RmlUi's
+internal cursor position away from the real one (surfaced as "mouse only seems to work in some
+screen regions").
+
+**Fix**: handle `SDL_EVENT_MOUSE_MOTION` directly too, feeding unscaled coordinates matching
+`HandleMouseMotion`'s own convention. Only wheel/key/text events still route through the vendored
+handler.
+
+---
+
+## Data binding
+
+### Data model created after the document that references it
+
+**Symptom**: every `{{binding}}` in the login document (`{{account_label}}`, `{{server_name}}`,
+`{{ok_label}}`, etc.) rendered as its own literal source text instead of resolving to the bound
+value.
+
+**Root cause**: `CLoginWin::Create()` called `Context::LoadDocument()` *before*
+`RmlModelBinder::Create()` (which internally calls `Context::CreateDataModel("login")`). RmlUi
+resolves `data-model="login"` and every `{{binding}}` while *parsing* the RML document, not lazily
+on first render — the named data model must already exist in the `Context` before
+`LoadDocument()`/`LoadDocumentFromMemory()` runs.
+
+**Fix**: create the data model first, capture whether creation succeeded, and only load the
+document if it did — guards against loading a document whose bindings can never resolve, rather
+than loading it unconditionally and hoping the model shows up in time.
+
+### Missing font — `Rml::LoadFontFace()` never called
+
+**Symptom**: checkbox/button *shapes* rendered correctly, but every text string (labels, button
+text, trust warning) was completely blank.
+
+**Root cause**: nothing ever called `Rml::LoadFontFace()` — this is normal, non-crashing RmlUi
+behavior when no font face is loaded at all, not an error condition that surfaces any diagnostic.
+
+**Fix**: load the same bundled fonts this engine already ships for its portable GDI-text shim
+(`fonts/LiberationSans-{Regular,Bold}.ttf`) in `RmlUiRuntime::Create()`, marking the regular weight
+as a fallback face. Also fix any RCSS `font-family` that doesn't match a loaded family name exactly
+(`"Tahoma"` was never loaded — even with *some* font loaded elsewhere, an RCSS rule naming an
+unloaded family still renders no text for that element).

--- a/docs/rmlui-ui-system/gotchas-and-patterns.md
+++ b/docs/rmlui-ui-system/gotchas-and-patterns.md
@@ -181,6 +181,82 @@ compositing is actually implemented in `RmlUiRenderInterface`. `background-color
 `border-radius` are all pure geometry and render correctly — they're what should carry a themed
 panel's look instead.
 
+### `FileBacked` textures rendered using the wrong GL texture object
+
+**Symptom**: the `legacy` theme's `#panel`/`.input-frame` `decorator: image(...)` backgrounds
+didn't render at all (fully transparent, no error logged anywhere), and separately, unrelated debug
+overlay text appeared blown up and garbled in the middle of the login panel.
+
+**Root cause**: `RmlUiRenderInterface` hands RmlUi an opaque `Rml::TextureHandle` for every texture
+it loads, backed internally by one of two *kinds* (`RmlUiRenderInterface.h`'s own header comment
+already flags this distinction as load-bearing): `Generated` (RmlUi's own font-glyph atlases —
+`id` is a real `RHI::TextureHandle`/GL name straight from `RHI::CreateTexture`) and `FileBacked`
+(anything routed through `CGlobalBitmap` — `id` is a **bitmap *index*** into that cache, e.g. `31009`
+for `login_back.tga`, not a GL name at all). `ReleaseTexture` already dispatched correctly on
+`kind` (`Bitmaps.UnloadImage` for `FileBacked`, `RHI::DestroyTexture` for `Generated`) — but
+`RenderGeometry`'s texture-binding line bound `texIt->second.id` directly as a GL texture name
+**for both kinds**, unconditionally. This was invisible for the entire migration up to this point
+because every texture RmlUi had ever rendered was `Generated` (text only, no images) — the
+`legacy` theme's background/input-frame decorators were the **first `FileBacked` textures RmlUi
+ever rendered**, and binding bitmap-index `31009` as if it were a GL texture name bound whatever
+GL texture object actually happened to hold that numeric name — plausibly explaining the garbled
+debug-overlay-looking text as a side effect of sampling the wrong (but very real) texture.
+
+**How it was actually found**: not guessed after the fact — narrowed down by elimination. A
+temporary diagnostic in `LoadTexture` confirmed the texture *load* itself succeeded (a valid,
+non-`BITMAP_UNKNOWN` bitmap index, correctly ref-counted against the exact same cache slot
+(`BITMAP_LOG_IN+7` = `31009`) the original working `CWin` sprite used) before concluding the bug
+had to be downstream of loading, in the actual render/bind path — reading `RenderGeometry` line by
+line against the class's own header comment (which explicitly warns the two id spaces are "not
+guaranteed disjoint") is what surfaced the mismatch.
+
+**Fix**: `RenderGeometry` now checks `kind` before binding — `FileBacked` resolves through
+`Bitmaps.GetTexture(id)->TextureNumber` to get the real GL name first; `Generated` uses `id`
+directly as before.
+
+**Practical rule for the next migrated window**: any decorator/`<img>` that references a real
+image file (not text) is exercising the `FileBacked` path for the first time in whatever window
+migrates next after this fix — already fixed now, but if a *different*, similarly-shaped id-space
+mismatch bug shows up again, check every place a `TextureRecord`/`kind` is consumed, not just
+`ReleaseTexture` (which was already correct) — a class-wide invariant being enforced in one method
+doesn't guarantee it's enforced in all of them.
+
+### A referenced image's real (unpadded) size must be declared via `@spritesheet`, not assumed
+
+**Symptom**: after fixing the texture-binding bug above, `login_back.tga`'s art appeared squeezed
+into roughly the top-left two-thirds of the panel, with a blank strip along the right/bottom edges
+— not invisible, but visibly wrong.
+
+**Root cause**: this engine's legacy `.OZT` loader (`CGlobalBitmap::OpenTga`) pads every texture up
+to the next power-of-two size (`NextPowerOfTwo`) — confirmed by reading it: 329×245 becomes a
+512×256 texture, with the real image content in the top-left corner and the rest zero-filled. This
+is a leftover constraint from old GPUs; it's invisible to every legacy `CSprite` caller because
+`CSprite::Create()` computes its own UV sub-rect from the *original* dimensions the caller passed
+in (`m_fOrgWidth`/`m_fOrgHeight`), never the padded texture size. RmlUi's plain
+`decorator: image("path/to/file")` has no equivalent caller-supplied sub-rect — a referenced image
+with no matching named sprite always samples the *entire* texture as 0..1 UV — so it stretched the
+real content across a corner of the panel while squishing in a chunk of blank padding on the rest.
+
+**Fix**: declare the image as a named sprite via `@spritesheet`, with an explicit pixel rectangle
+matching its *real* (unpadded) size —
+```rcss
+@spritesheet login-back-sheet
+{
+	src: "../../../login_back.tga";
+	login-back-image: 0px 0px 329px 245px;
+}
+```
+then reference the sprite *name* (not the raw path) in the decorator: `decorator: image(login-back-image);`.
+`DecoratorTiledInstancer::GetTileProperties` (`Source/Core/DecoratorTiled.cpp`) checks for a named
+sprite match *before* falling back to treating the name as a raw image path — a declared sprite's
+`Rectanglef` becomes the tile's UV sub-rect instead of the full texture, exactly mirroring
+`CSprite`'s own original-dimensions approach.
+
+**Practical rule for the next migrated window**: any RCSS `decorator: image(...)` (or `<img>`)
+referencing one of this engine's real (non-power-of-two-dimensioned) legacy art assets needs a
+`@spritesheet` declaration with the asset's *real* pixel size — never reference the raw file path
+directly unless the asset's real dimensions already happen to be an exact power of two.
+
 ---
 
 ## Input
@@ -307,10 +383,41 @@ own `.rcss` file and be referenced with a plain relative path. This part needed 
 works correctly by virtue of how `LoadThemedDocument()` and RmlUi's own stylesheet-loading both
 handle source URLs.
 
-See [Theming & Modding](theming-and-modding.md#a-third-case-a-theme-with-its-own-custom-images)
+See [Theming & Modding](theming-and-modding.md#bringing-your-own-images-to-a-theme)
 for the full workflow and the open (not yet built) follow-up: vendoring `stb_image.h` to give
 `LoadTexture` a plain-PNG/JPG/BMP fallback for RmlUi-referenced theme assets specifically, without
 touching the legacy OZT/OZJ pipeline everything else still depends on.
+
+### A per-theme flag to opt back into `CWin` sprite rendering was the wrong shape
+
+**Not a bug — a design mistake caught and reversed before it caused one.** The theme framework
+originally shipped a per-theme `theme.ini` manifest key, `UsesLegacySpriteChrome`, that let a
+theme tell `CLoginWin::Create()`/`RenderControls()` to keep creating and drawing `CWin`'s
+background sprite and the `CUITextInputBox` frame `CSprite`s underneath the RmlUi overlay, instead
+of RmlUi drawing that chrome itself. The `legacy` theme shipped with this flag set to `1`.
+
+**Why this was wrong**: the entire point of migrating a window to RmlUi is that RmlUi ends up
+owning its rendering — a configurable escape hatch that lets a theme opt back into the *old*
+renderer drawing part of a *migrated* window's visuals works directly against that. It also wasn't
+even necessary: the art files the flag was protecting (`Interface/login_back.tga`,
+`Interface/login_me.tga`) are ordinary standalone images (no sprite-sheet cropping — confirmed by
+reading the `CSprite::Create()` call sites for `BITMAP_LOG_IN+7`/`+8`, both pass `nMaxFrame=0`),
+already preloaded into the shared, ref-counted bitmap cache regardless of theme. RmlUi's own
+`LoadTexture` (`RmlUiRenderInterface.cpp` → `CGlobalBitmap::LoadImage`) finds and ref-counts that
+same cached texture by filename (`CGlobalBitmap::FindTexture(filename)` scans by name across the
+whole cache, not just entries loaded through the named-load path) — so pointing an RCSS decorator
+at the same file was never blocked by anything technical, only by an unnecessary flag.
+
+**Fix**: removed `UsesLegacySpriteChrome` entirely — from `RmlTheme.h/.cpp`, both theme's
+`theme.ini` files (which had no other purpose), and `CLoginWin`. `CWin::Create()` now always passes
+`nTexID=-2` for this window, in every theme, unconditionally. The `legacy` theme reproduces the
+original look by giving `#panel`/`.input-frame` a `decorator: image(...)` pointing at the same
+`Interface/login_back.tga`/`Interface/login_me.tga` files the old sprites drew — same pixels,
+rendered by RmlUi instead of `CWin`. **Lesson**: a data-driven per-theme toggle is the right shape
+for things that are genuinely a visual choice (colors, layout, whether to use vector shapes or
+raster art) — it's the wrong shape for something that contradicts the migration's own goal
+regardless of which value it's set to; that kind of "flexibility" should be caught during design,
+not shipped and left as an unused footgun once nothing exercises the non-default path.
 
 ---
 
@@ -347,7 +454,11 @@ handle candidate (`#panel` itself), that isolated the second, separate finding b
 
 **Not a bug in `MakeDraggable()`** — a real architectural fact about how hybrid windows are built,
 worth being explicit about since it's easy to assume RmlUi "contains" or is otherwise linked to
-the legacy chrome underneath it.
+the legacy chrome underneath it. (At the time this was found, the login window's `legacy` theme
+still had `CWin` drawing the background sprite — that's since been removed, see
+[the entry below](#a-per-theme-flag-to-opt-back-into-cwin-sprite-rendering-was-the-wrong-shape),
+but the underlying fact this section documents is unchanged: RmlUi and whatever legacy state a
+hybrid window still owns are never automatically linked.)
 
 A hybrid window's legacy `CWin` background sprite and its RmlUi overlay are two **independently
 rendered things** that merely start at the same screen position — both set once, from the same
@@ -358,9 +469,9 @@ frame to frame, while the legacy background sprite stayed exactly where it start
 and visibly desyncing from the content now floating away from it.
 
 **Fix**: `MakeDraggable()` takes an optional `onMove(newLeft, newTop)` callback, fired on every
-drag tick, specifically so a hybrid window's caller can also reposition its legacy chrome (e.g.
-call `CWin::SetPosition()`) in lockstep. A fully migrated, sprite-free panel has nothing to sync
-and can simply omit the callback.
+drag tick, specifically so a hybrid window's caller can also reposition whatever legacy state
+still needs to track the panel (e.g. call `CWin::SetPosition()`) in lockstep. A fully migrated
+window with no remaining legacy state has nothing to sync and can simply omit the callback.
 
 ### A whole panel can't usually be its own drag handle
 

--- a/docs/rmlui-ui-system/gotchas-and-patterns.md
+++ b/docs/rmlui-ui-system/gotchas-and-patterns.md
@@ -509,3 +509,209 @@ thumb, anything that isn't a freely-draggable panel): `MakeDraggable`'s `onMove`
 right place to clamp/snap the axis you care about, but remember to also reset the axis you *don't*
 care about — it will otherwise silently drift with the cursor, since `MakeDraggable` has no way to
 know your handle is axis-constrained.
+
+### Getting `SysMenuWin`/`OptionWin`'s panel body to render at all took five attempts — tiling still isn't one of them
+
+**Symptom**: `SysMenuWin`/`OptionWin`'s legacy-theme panel background (`op1_stone.jpg`, meant to
+fill the middle band between the top/bottom caps) went through five real, distinct failure modes
+across several rounds of "fixed, verify" with a real screenshot each time — worth reading in full
+because each one independently produces the *identical* symptom (nothing renders, nothing logs),
+so ruling one out proves nothing about the others.
+
+1. **`tiled-vertical` never repeats.** First attempt used `decorator: tiled-vertical(top, center,
+   bottom);` on a single `#panel` element. Confirmed by reading `DecoratorTiled.cpp`'s
+   `RegisterTileProperty` and `DecoratorTiledVertical`/`Horizontal`/`Box`'s instancer constructors:
+   none of them pass `register_fit_modes = true`, so none of their tiles ever get a `-fit` property
+   registered at all — every tile, including the center, is permanently `FILL` (stretch), with no
+   RCSS-level way to ask for `REPEAT`. Rendered as one heavily stretched, blurry copy — visually
+   close enough to flat that it read as "some areas not have the background texture."
+2. **Wrong shorthand argument position.** Switched to the plain `image()` decorator (the one
+   decorator that *does* register real fit-mode support, via
+   `RegisterTileProperty("image", true)`), but wrote `decorator: image(sprite-name repeat);`. The
+   shorthand's real argument order is `src, orientation, fit, align-x, align-y` — a bare
+   space-separated second token binds to **orientation**, not **fit**; `"repeat"` isn't a valid
+   orientation keyword, the declaration fails to parse, and the *entire* decorator drops. Rendered
+   as fully transparent — strictly worse than attempt 1.
+3. **`repeat` + a named sprite is rejected outright.** Fixed the argument order to
+   `image(sprite-name, none, repeat)`, comma-separated — still fully transparent. `DecoratorTiled.cpp`'s
+   `GetTileProperties` explicitly checks `if (sprite && fit_mode is REPEAT-family) { LT_WARNING;
+   return false; }` — the whole decorator instantiation fails whenever the source resolves through
+   `GetSprite()` (a named `@spritesheet` entry) rather than `GetTexture()` (a raw path), and
+   `op1_stone.jpg` had been declared as a sprite purely for stylistic consistency with every other
+   tile in the file (it never actually needed the padding-workaround a spritesheet exists for —
+   already power-of-two).
+4. **An unrelated sizing bug, found only after 1–3 were genuinely fixed.** Switched the center tile
+   to a raw quoted path (`image("../../../op1_stone.jpg", none, repeat)`) — still transparent, but
+   this time `MuError.log` had *zero* `[RmlUi]`-tagged lines, meaning nothing was failing to parse
+   or instantiate anymore. The next suspect: `.panel-middle` had no explicit `height`, relying on
+   both `top` and `bottom` being set on a `position: absolute` element to derive height from the
+   gap between them (legitimate CSS 2.1 behavior in principle, never actually confirmed to compute
+   correctly in this specific RmlUi 6.2 integration). Fixed by giving `#panel_middle` a real `id`
+   and pushing `top`/`height` explicitly from C++, the same proven technique `#panel` itself
+   already uses — **still transparent after this fix too**, ruling out sizing as *the* remaining
+   blocker (though it's a correctness improvement worth keeping regardless).
+5. **The raw quoted path likely never lost its quotes.** With parsing and sizing both now
+   independently ruled out, the last live theory: `PropertyParserString::ParseValue`
+   (`PropertyParserString.cpp`) does **zero quote-stripping** — it stores the raw token verbatim.
+   `font-family: "Liberation Sans"` works elsewhere in this codebase, but that's a top-level
+   property parsed through a different code path than a value embedded inside a shorthand function
+   call like `image(...)`. A quoted literal used as a shorthand argument may retain its literal
+   quote characters as part of the resolved "path" — which then fails to resolve to any real file,
+   and this engine's texture loader fails **100% silently** on a bad path (already documented in
+   [Theming & Modding](theming-and-modding.md#bringing-your-own-images-to-a-theme)) — consistent
+   with everything observed (no art, no warning anywhere). Not proven with a live debugger, but
+   consistent with every fact gathered, and further chasing it stopped being worth the cost — see
+   the fix below.
+
+**Actual fix shipped**: none of the above, deliberately. After four straight misses on the same
+visible symptom, the tiling ambition itself was set aside in favor of the one decorator form
+already *proven* to render correctly everywhere else in this exact document — a **named sprite**
+with **plain `FILL`** (`decorator: image(legacy-panel-center);`, no fit-mode argument at all),
+identical in form to `.panel-cap-bottom`/`.btn`/`.checkbox-box`, all of which render correctly.
+This stretches the 128×128 source across the middle band instead of tiling it — a real, disclosed
+visual downgrade from the original goal, not a hidden one — but ships something that actually
+renders instead of a fifth unverified theory. True tiling is a deliberate, isolated follow-up
+experiment for later, not something to keep blocking on.
+
+**Practical rule for the next tiled-background attempt**: prefer the decorator form with the most
+existing proof of working in this codebase over the theoretically-more-correct one, especially
+after two or more silent-failure rounds on the same rule — every one of the five failure modes
+above produces the *identical* symptom (nothing renders, and 4 of 5 produce zero log output too),
+so a screenshot alone cannot distinguish between them; each fix has to be argued from source and
+then independently re-verified, and "still broken" after a source-grounded fix is real information
+(it rules that theory out), not proof the theory was worthless reasoning.
+
+### Sixth issue, a genuinely different category: the center tile was never modeled as spanning the whole panel
+
+**Symptom**: after fix 5 above (fallback to plain `FILL` + named sprite) actually got the stone
+texture rendering, a real screenshot showed it *only* in the gap between the top/bottom caps —
+"the mid section (horizontal) has texture, the top and bottom part are still transparent." The
+scrollwork linework on the caps rendered correctly (as it had in every earlier screenshot too), but
+the space around/behind that linework showed through to whatever's behind the document, exactly as
+if the caps' own art has genuine alpha transparency around the ornate line pattern (not a solid
+background) — which turned out to be exactly the case.
+
+**Root cause**: not a decorator bug at all this time — a structural modeling error, caught only by
+going back to the *actual* legacy `CWinEx` source (`UI/Widgets/WinEx.h`/`.cpp`) instead of
+continuing to iterate on the RmlUi side. `WE_BG_CENTER = 0` and `CWinEx::Render()`'s loop
+(`for (i = 0; i < WE_BG_MAX; ++i) m_psprBg[i].Render();`) draws the center tile **first**, before
+top/bottom/left/right — and `SetPosition()`/`SetLine()` size and position it to span **nearly the
+entire panel** (inset by `WE_CENTER_SPR_POS` = 3px on every side), not confined to the gap between
+the caps. The cap images are drawn *on top of* that already-drawn center tile, and since the caps'
+own art has transparent space around the scrollwork linework, the center shows through underneath
+them by design — this is how the ornate-border-over-solid-texture look is actually achieved in the
+original widget. The RmlUi reconstruction had modeled this as three independent, non-overlapping
+stacked bands (`.panel-cap-top` 0–64px, `.panel-middle` the literal gap, `.panel-cap-bottom` the
+last 43px) — internally consistent and exactly what fixes 1–5 above were spent getting to render
+correctly, but built on a structural assumption about the composite that was never actually checked
+against the widget it was meant to reproduce.
+
+**Fix**: reordered `#panel_middle` to be the *first* child in the RML (before both cap elements, so
+it paints first), and gave it the same 3px inset `CWinEx` uses via plain RCSS —
+`left: 3px; top: 3px; right: 3px; bottom: 3px;`, no explicit `width`/`height` at all. This first
+shipped with the inset pushed from C++ instead (`SysMenuWin`/`OptionWin`'s `SetPosition()`,
+mirroring fix 4's earlier "don't trust opposing-edge auto-sizing" caution) — reverted once that
+caution was actually checked against `Layout/LayoutDetails.cpp`'s `BuildBoxWidth`/`BuildBoxHeight`
+and confirmed to be unfounded: `position: absolute` elements with `left`+`right` (or `top`+`bottom`)
+set and no explicit size *do* correctly derive their box dimensions from the containing block minus
+those insets — standard CSS 2.1 behavior, genuinely implemented, not an untested corner case. Kept
+in C++ initially "to be safe," it was actually the wrong default: this project's stated goal is
+that a theme (including a modder's) needs zero C++ changes and zero recompilation, and a
+hardcoded-in-C++ inset value meant a future theme wanting a different one couldn't express that
+without an engine change. Moved back to RCSS once the caution was disproven, matching every other
+per-element position rule in this codebase. The caps' own rules didn't need to change beyond that —
+only `panel_middle`'s DOM order and inset expression did.
+
+**Practical rule for the next multi-piece legacy-widget reproduction**: when translating a
+composite legacy `CWin`/`CWinEx`-family widget into RmlUi elements, check the *original* render
+loop's draw order and each piece's real geometry before modeling the RmlUi structure — don't infer
+the composite's shape from what the *visible* gaps between labeled pieces suggest. A background
+piece that's drawn first and spans the full area, with foreground pieces with their own
+transparency layered over it, looks structurally different from independent non-overlapping bands
+even though a static screenshot of the *original* widget can look identical to either model until
+one of them is actually missing.
+
+## Window lifecycle
+
+### `CWin::Release()` has no idea `m_pRmlDoc` exists — a hybrid window can outlive its own scene
+
+**Symptom**: after building `CLoginMainWin` (Batch 2), transitioning from the login scene to
+character-select left its Menu/Credit icon buttons visibly overlapping `CharSelMainWin`'s own
+button bar on the *next* scene — described from a real screenshot as "the Create button... overlaid
+with an older painting of the menu button."
+
+**Root cause**: `CUIMng::RemoveWinList()` — called at the top of every `Create*Scene()` function,
+i.e. on every scene transition — walks every window still in `m_WinList` and calls `Release()` on
+it unconditionally. `CWin::Release()`/the virtual `PreRelease()` hook it calls predate RmlUi
+entirely and know nothing about `m_pRmlDoc`; they release legacy `CButton`s and `CSprite`s but
+never touch the RmlUi document. Since a migrated window's document is deliberately created **once**
+and reused across repeated `Create()` calls (see `Create()`'s own `if (!m_pRmlDoc && ...)` guard,
+the same pattern `CLoginWin` established), `Release()` leaves it exactly as visible as it was the
+moment `Release()` ran — and because RmlUi always renders **last** in the frame (see
+[Architecture §3](architecture.md#3-frame-lifecycle--the-render-order-contract)), that stale
+document paints on top of whatever the *next* scene's windows draw, indefinitely, until something
+else happens to call `Show()`/`Hide()` on it again.
+
+This reproduced 100% of the time for `CLoginMainWin` specifically because it's unconditionally
+visible for the entire login flow, so it's *guaranteed* to still be shown at the exact moment
+`CreateCharacterScene()`'s `RemoveWinList()` runs. `CSysMenuWin`/`COptionWin` have the identical
+gap but only manifest it if the player happens to have the menu open at the exact instant a scene
+transition fires — a much rarer window, not a safer design. `CLoginWin` (the Phase 1 pilot) turned
+out to have the same latent gap too, currently masked only by the fact that both of its real
+show→hide paths (`RequestLogin()`, `CancelLogin()`) happen to call `CUIMng::HideWin(this)` before
+any scene transition can occur — an incidental property of those two call sites, not something
+`CLoginWin`'s own lifecycle actually guaranteed.
+
+**Fix**: every hybrid `CWin` + RmlUi window's `PreRelease()` override now unconditionally calls
+`if (m_pRmlDoc) m_pRmlDoc->Hide();` — `Hide()`, not unload/destroy, consistent with the
+create-once-reuse-forever document lifecycle already established. Applied to `CLoginWin`,
+`CLoginMainWin`, `CSysMenuWin`, `COptionWin` — every current hybrid window. `RememberPasswordPrompt`
+is unaffected (never a `CWin`, never touched by `CUIMng::RemoveWinList()` at all).
+
+**Practical rule for the next hybrid `CWin` + RmlUi window**: `PreRelease()` isn't optional
+boilerplate to skip when a window has no legacy sprites to clean up — if it owns an `m_pRmlDoc`,
+`PreRelease()` must hide it, full stop, regardless of whether some other call site *currently*
+happens to hide it first. A window whose only "proof" of correct hide behavior is "nothing has
+hit the gap yet" is exactly the shape of bug this entry describes.
+
+## Scene-conditional visibility
+
+### `.hidden` vs `.disabled`: a dimmed button can still visually collide with its neighbor
+
+**Symptom**: in the modern theme, `CSysMenuWin`'s dialog on the login screen showed the Select
+Server button rendering at 50% opacity directly behind the Option button — not just visually
+adjacent, but overlapping enough that Option's text was legible through Select Server's own.
+
+**Root cause**: real layout math, not a rendering bug. `CSysMenuWin::SetPosition()` stacks its four
+buttons at fixed offsets that assume the panel is tall enough to fit all four with real spacing —
+true when the panel is opened from the character-select scene (`SetLine(10)`), but the *login*
+scene's panel is shorter (`SetLine(6)`, since it has one less real reason to be tall), which puts
+Select Server at `top≈67px` and Option at `top≈69px` — almost exactly on top of each other. This
+overlap already existed before this migration; it was invisible only because the legacy `CButton`
+Select Server used while disabled rendered fully opaque-grey, visually reading as "one solid
+button," not two stacked ones. `.btn.disabled { opacity: 0.5; }` (added generically, for any future
+disabled button, not specifically vetted against this one collision) made the underlying overlap
+show through for the first time.
+
+**Fix**: added a `.hidden { display: none; }` utility class to both themes' `base.rcss`, and
+switched Select Server to use it (instead of `.disabled`) specifically in the login scene, where
+the button doesn't apply at all (you can't switch servers before logging into one) rather than
+merely being temporarily unavailable. `display: none` removes the element from layout entirely —
+no overlap possible, because there's nothing there to overlap with. Renamed the underlying model
+field end-to-end to match its real meaning: `selectServerDisabled`/`select_server_disabled` (bool
+field, model binding key) → `selectServerHidden`/`select_server_hidden`; `sys_menu.rml`'s
+`data-class-disabled="select_server_disabled"` → `data-class-hidden="select_server_hidden"` on the
+`btn_select_server` element. `.btn.disabled` itself was untouched and remains available for any
+future button that genuinely wants dim-but-clickable-elsewhere semantics.
+
+**Practical rule for the next scene-conditional button**: `.disabled` and `.hidden` are not
+interchangeable "make this button go away" options — `.disabled` keeps the element in layout
+(taking up space, able to visually collide with a neighbor if the layout was never actually
+spaced for the button being both present *and* dimmed) and communicates "temporarily unavailable,
+might become clickable later in this same view." `.hidden` removes it from layout entirely and
+communicates "does not apply to this view/scene at all." Reach for `.hidden` (and a model field
+name that says *hidden*, not *disabled*) whenever the reason a button shouldn't be clickable is
+"this scene doesn't have this feature," not "this feature is temporarily off." Getting this
+distinction right up front also avoids the trap this bug fell into: a generic `.disabled` style
+change (adding opacity) silently exposing a pre-existing layout assumption that was never actually
+true for every panel height the button could appear at.

--- a/docs/rmlui-ui-system/gotchas-and-patterns.md
+++ b/docs/rmlui-ui-system/gotchas-and-patterns.md
@@ -181,6 +181,26 @@ compositing is actually implemented in `RmlUiRenderInterface`. `background-color
 `border-radius` are all pure geometry and render correctly — they're what should carry a themed
 panel's look instead.
 
+### `transform` parses fine and silently never renders
+
+**Symptom**: `transform: rotate(45deg)` on a border corner (the classic CSS checkmark trick)
+rendered as a static, un-rotated corner. Zero `[RmlUi]` warnings in `MuError.log` — the
+declaration parses and is accepted without complaint.
+
+**Root cause**: same category of gap as `box-shadow` blur above — `SetTransform` is one of the
+"optional advanced-rendering functions" `RmlUiRenderInterface` leaves at the base class's no-op
+default (its own header comment names it explicitly). Unlike `box-shadow`, there's no
+blur-radius-zero threshold that makes it "work by accident" — `transform` is unconditionally
+inert here. The property still parses and is stored correctly
+(`StyleSheetSpecification.cpp`/`PropertyParserTransform.cpp`); nothing downstream ever applies it.
+
+**Fix**: don't use `transform` (rotate/skew/translate/scale) in any theme until
+`RmlUiRenderInterface::SetTransform` is implemented. For an angled shape, use real bitmap art
+(`decorator: image(...)`) or an axis-aligned approximation from plain positioned rectangles (e.g.
+a blocky pixel-art checkmark from several small `background-color` squares). Check
+`RmlUiRenderInterface.h`'s header comment for "left at their base-class no-op defaults" before
+reaching for an unfamiliar CSS property — it lists every such gap up front.
+
 ### `FileBacked` textures rendered using the wrong GL texture object
 
 **Symptom**: the `legacy` theme's `#panel`/`.input-frame` `decorator: image(...)` backgrounds

--- a/docs/rmlui-ui-system/gotchas-and-patterns.md
+++ b/docs/rmlui-ui-system/gotchas-and-patterns.md
@@ -277,3 +277,37 @@ behavior when no font face is loaded at all, not an error condition that surface
 as a fallback face. Also fix any RCSS `font-family` that doesn't match a loaded family name exactly
 (`"Tahoma"` was never loaded — even with *some* font loaded elsewhere, an RCSS rule naming an
 unloaded family still renders no text for that element).
+
+---
+
+## Theming & modding
+
+### Custom theme images silently require a proprietary format, not plain PNG/JPG
+
+**Not a bug that was fixed** — a real constraint discovered while designing the modding workflow,
+documented here so it isn't rediscovered the hard way by a modder (or a future dev helping one).
+
+A theme's own images (a custom background, custom button art) go through the exact same
+`RmlUiRenderInterface::LoadTexture` → `CGlobalBitmap::LoadImage` path as every other texture in the
+game — a deliberate Phase 0 design choice, so RmlUi-referenced images share the same ref-counted
+cache/eviction. The consequence: `CGlobalBitmap::LoadImage` (`Render/Sprites/GlobalBitmap.cpp`)
+only recognizes two extensions, `.jpg`/`.tga` — and **both internally swap the extension to this
+engine's proprietary container format before opening** (`.OZJ`/`.OZT`). An RCSS rule referencing
+`panel_bg.tga` actually needs a file named `panel_bg.OZT` on disk, not a real `.tga`; plain
+`.png`/`.bmp` aren't handled at all, and there's no converter tool in this repo. Worse: a missing
+file or unrecognized extension fails with **zero logging anywhere in the chain** — `LoadImage`
+returns `false` silently, `LoadTexture` returns a null handle, and the element just renders with no
+image and no diagnostic.
+
+**What does work, confirmed against RmlUi's real source**: a relative image path inside an RCSS
+rule (`decorator: image(...)`, `background-image`) resolves against *that stylesheet's own
+resolved location* (`StyleSheetParser.cpp`/`ElementEffects.cpp`/`Decorator.cpp`), not the shared
+`login.rml`'s virtual per-theme source URL — so a custom theme's image can sit right next to its
+own `.rcss` file and be referenced with a plain relative path. This part needed no fix; it already
+works correctly by virtue of how `LoadThemedDocument()` and RmlUi's own stylesheet-loading both
+handle source URLs.
+
+See [Theming & Modding](theming-and-modding.md#a-third-case-a-theme-with-its-own-custom-images)
+for the full workflow and the open (not yet built) follow-up: vendoring `stb_image.h` to give
+`LoadTexture` a plain-PNG/JPG/BMP fallback for RmlUi-referenced theme assets specifically, without
+touching the legacy OZT/OZJ pipeline everything else still depends on.

--- a/docs/rmlui-ui-system/roadmap.md
+++ b/docs/rmlui-ui-system/roadmap.md
@@ -23,6 +23,10 @@ about what's ahead, not how the finished parts function.
   panel).
 - **Theming framework.** Pluggable, data-driven, modder-pluggable theme folders; two real themes
   (`legacy`, `modern`) covering all five migrated windows.
+- **Login-scene bugfix round.** Real bugs found post-Batch-2: a legacy-`CButton` double-toggle
+  fighting the RmlUi checkbox click handler, a non-modal confirmation dialog, missing hover/sprite
+  art, and a real engine limitation (`RmlUiRenderInterface::SetTransform` unimplemented — see
+  `gotchas-and-patterns.md`). All fixed.
 
 ## Not started: the rest of the `CUIMng`-tier screens
 

--- a/docs/rmlui-ui-system/roadmap.md
+++ b/docs/rmlui-ui-system/roadmap.md
@@ -1,0 +1,299 @@
+# Roadmap
+
+What's actually done, what's next, and the decisions still open — distilled from the full
+internal migration plan for anyone continuing this work without access to that plan directly.
+For *how* the parts that exist actually work, see [Architecture](architecture.md),
+[Theming & Modding](theming-and-modding.md), and [Gotchas](gotchas-and-patterns.md) — this doc is
+about what's ahead, not how the finished parts function.
+
+---
+
+## Done so far
+
+- **Phase 0 — groundwork.** RHI scissor support, vertex format conversion, the render/system
+  interface, the build system, `UI::RmlBridge::RmlModelBinder`.
+- **Phase 0.8 — input arbitration.** Event-driven, at the SDL-event level; RmlUi offered every
+  event first, ahead of the two legacy UI tiers.
+- **Phase 1 pilot.** The loading screen and `CLoginWin` (the login/character-select dialog) —
+  the reference implementation most of this doc set is written against.
+- **Batch 2.** The rest of the login scene: `CLoginMainWin`, `CSysMenuWin`, `COptionWin`,
+  `RememberPasswordPrompt`. Together with the pilot, this is **Loading Screen + Login Screen,
+  scene-complete** — including `CSysMenuWin`/`COptionWin`, which are shared instances also reachable
+  from the Character Select scene (opened via the same in-game Menu button there, against a taller
+  panel).
+- **Theming framework.** Pluggable, data-driven, modder-pluggable theme folders; two real themes
+  (`legacy`, `modern`) covering all five migrated windows.
+
+## Not started: the rest of the `CUIMng`-tier screens
+
+Everything above is `UI/Windows`/`UI/Legacy/UIMng`-tier (`CWin`-based). The remaining windows in
+that same tier are still fully legacy: `CCharSelMainWin`, `CCharMakeWin`, `ServerSelWin`,
+`CreditWin`, `CMsgWin`, `CServerMsgWin`.
+
+**Next natural slice: Character Select.** Because Batch 2's scope happens to line up with actual
+scenes, the natural next unit is the Character Select scene — but most of what it needs is already
+covered: `CSysMenuWin`/`COptionWin` are the same shared instances Login already migrated. What's
+actually left is `CCharSelMainWin` (the character-slot screen: Create/Menu/Connect/Delete) and
+`CCharMakeWin` (character creation). `CMsgWin`/`CServerMsgWin` are small and scene-local — not the
+same class as the shared `NewUICommonMessageBox` engine Phase 2a targets below, so migrating them
+doesn't pull that larger engine in early.
+
+`CCharMakeWin` is a real edge case worth flagging explicitly: it renders its 3D character preview
+full-screen-behind the UI, the same shape the login screen's 3D tour camera already uses — it's
+technically migratable *without* whatever Phase 4 ends up building. It's being kept out of the
+Character Select slice anyway, deliberately, so "has a 3D preview → waits for Phase 4" stays a
+clean rule instead of a case-by-case judgment call repeated for every future 3D-adjacent window —
+inventory item-hover and character info are the two Phase 4 actually exists to unblock, and unlike
+`CCharMakeWin`'s full-screen-behind preview, both place 3D content *inside* a bounded panel, which
+is exactly the case Phase 4's still-open design question (see below) is about.
+
+---
+
+## Phase 2 — Message-box engine, then a slice of the HUD
+
+**2a.** Migrate the generic engine first: `NewUICustomMessageBox.cpp` (7,690 lines) and
+`NewUICommonMessageBox.cpp` (3,773 lines) become one or two parameterized RML templates plus one
+adapter. Highest-leverage step in the whole plan — dozens of call sites across
+`UI/NewUI/Events/`, `GameLogic/Events/`, and `GameShop/MsgBoxIGS*.cpp` just configure the generic
+box, so each becomes a small mechanical follow-up once the engine exists, not a fresh migration
+per call site.
+
+**Real, not-yet-verified dependency this phase inherits**: `NewUICustomMessageBox` owns a
+`CUITextInputBox* m_pInputBox` (`UI/Legacy/UIControls.h`) for its text-input mode —
+`UI/NewUI` has no text-input widget of its own anywhere; `UI/Legacy` is the engine's only owner of
+real text rendering (GDI `TextOut`), and every real text field in `NewUI`, this one included,
+borrows that one widget rather than reimplementing it. `CLoginWin` already solved "where does real
+text input come from" once, with RmlUi's native `<input>` — but that's proven only for the login
+screen so far. Re-verify it holds for a message box's input mode specifically before assuming it
+does; don't inherit the assumption silently the way the render-to-texture one in Phase 4 almost
+was.
+
+**2b.** Migrate one or two HUD sub-widgets with genuinely per-frame-changing data — the
+health/mana bars inside `NewUIMainFrameWindow.cpp` — without migrating the whole HUD yet. Validates
+the `MarkDirty` binding path against real hot-path data at small scale before Phase 3 commits the
+whole HUD to the same primitive.
+
+**Blocking prerequisite, not yet built — read this before starting Phase 2.** Every window
+migrated so far is `CWin`/`CUIMng`-tier. Phase 2 onward targets `UI/NewUI`
+(`CNewUIObj`/`CNewUIManager`, ~90 windows) — a different manager, a different base interface, and a
+pattern that has **never been proven in real code**. See the next section before treating anything
+below as a settled design.
+
+### The NewUI-tier adapter/facade pattern — designed, never implemented
+
+The original plan's pilot was supposed to be two things together: `CLoginWin` (to prove the
+`CUIMng`-tier coexistence design) *and* one small, low-traffic `UI/NewUI/Events/` dialog (to prove this
+pattern, against `CNewUIManager`). Only the first half happened. Confirmed by direct search: zero
+RmlUi references anywhere under `UI/NewUI/Events/`, zero `RmlAdapter`-suffixed classes anywhere under
+`UI/NewUI/`. Every phase from here on depends on a pattern that currently exists only as a design
+sketch.
+
+The sketch, worked example (inventory): `g_pMyInventory` today expands to
+`CNewUISystem::GetInstance()->GetUI_NewMyInventory()`, returning `CNewUIMyInventory*`. Introduce
+`CNewUIMyInventoryRmlAdapter : public CNewUIObj` (satisfying the same `INewUIBase` interface —
+`Render`/`Update`/`UpdateMouseEvent`/`UpdateKeyEvent`/`GetLayerDepth`/`IsVisible`, confirmed in
+`UI/NewUI/NewUIBase.h`) that:
+
+- Owns an `Rml::ElementDocument*` and an `RmlModelBinder<InventoryModel>` — same primitive the
+  `CWin`-tier windows already use.
+- Re-implements the exact public methods legacy callers use (`InsertItem`, `EquipItem`,
+  `DeleteItem`) — bodies update the underlying item state, then call `MarkDirty("items")`.
+- Makes `UpdateMouseEvent()`/`UpdateKeyEvent()` no-ops that always report "not consumed" (RmlUi's
+  own context does hit-testing); the adapter only needs to exist in `CNewUIManager`'s list so
+  z-order slotting and `Show()`/`Hide()` keep working unmodified.
+
+Then change **one line** — the `g_pMyInventory` macro's target — to resolve to the adapter. Every
+existing call site keeps compiling and working unchanged.
+
+**Before committing Phase 2's real scope to this**: build a small real example first (the
+originally-intended `UI/NewUI/Events/` dialog, or an equally low-blast-radius `CNewUIObj`-tier window) and
+get it manually verified working, the same way `CLoginWin` proved the `CWin`-tier pattern before
+Batch 2 scaled it up. No amount of documentation substitutes for one working reference
+implementation a contributor can copy from.
+
+## Phase 3 — HUD
+
+With 2b having validated the binding layer's hot-path cost, migrate the rest of
+`NewUIMainFrameWindow.cpp` (hotkeys; minimap chrome likely stays `<img>`-hosted, since the
+minimap's rendered content is itself a texture) plus closely-related always-on pieces
+(`NewUIBuffWindow.cpp`, `NewUIQuickCommandWindow.cpp`). First highly-visible, always-on
+migration — treat it as a checkpoint for a broader perf/visual sign-off before continuing.
+
+## Phase 4 — 3D-in-UI bridge (design open: direct composite vs. render-to-texture)
+
+`CNewUI3DRenderMng`/`INewUI3DRenderObj::Render3D()` lets panels host real 3D content (rotating
+item/character previews) — something plain HTML/CSS can't express, and a prerequisite for most of
+what's left (character info, inventory item-hover, item-explanation windows).
+
+**Original plan assumed an offscreen render-to-texture bridge**: keep `Render3D()` rendering
+exactly as today but target an offscreen render target sized to the preview panel, then expose
+that texture to RmlUi via an `<img>` (or custom element) pointed at the existing GPU texture
+handle — no CPU readback. **Reading the actual mechanism first suggests something simpler might
+already work.** `CNewUI3DCamera::Render()` (`UI/NewUI/NewUI3DRenderMng.cpp`) doesn't render to a
+texture at all — it's the same shape as the login screen's 3D tour camera: `EndBitmap()` → a
+full-window-viewport perspective pass with its own depth clear, drawing every registered
+`INewUI3DRenderObj` directly into the backbuffer → `BeginBitmap()` to resume 2D, all sandwiched
+into the existing frame *before* RmlUi's own render call. Since RmlUi always renders **last** in
+the frame (see [Architecture §3](architecture.md#3-frame-lifecycle--the-render-order-contract)),
+3D content going through this existing pass should already composite correctly underneath a
+transparent-background RmlUi panel — the same trick already proven for the login screen's tour
+camera, and found (but not exploited) for `CCharMakeWin`'s character preview.
+
+**Confirmed directly against `NewUIInventoryCtrl`**: `CNewUIInventoryCtrl` and the picked-item
+class `CNewUIPickedItem` (`UI/NewUI/Inventory/NewUIInventoryCtrl.h`) are both real
+`INewUI3DRenderObj` implementers — inventory items are live 3D models per slot, not icon textures,
+and the picked-up item's `Render3D()` re-centers on raw `MouseX`/`MouseY` every frame, i.e. it
+genuinely follows the cursor once picked up (see Phase 5 below — the two phases are more coupled
+than the original split suggested).
+
+**Before committing to either design**: run a cheap early test — put a transparent-background
+RmlUi panel over one `Render3D()`-driven item slot and confirm it composites correctly, the same
+way the login tour camera already does. If it holds, Phase 4 shrinks from "build a new bridge" to
+"verify the existing direct-composite pattern holds for per-slot content." Two real open questions
+that test won't answer by itself, though: `CNewUI3DCamera::Render()` sets **one** full-window
+viewport/perspective for every registered object at once, not one scoped to each panel — so
+per-panel clipping (an item peeking outside its own inventory panel during scroll, say) isn't
+automatic the way a true render-to-texture target would bound it "for free"; and "3D always
+renders before all RmlUi" only works cleanly if nothing ever needs an RmlUi element to sit
+*behind* some 3D content and *in front of* other 3D content — true for a flat item grid, not
+guaranteed for something more layered later. A real render-to-texture bridge may still end up the
+right long-term answer for those cases — this is a reason to test cheaply and early, not a reason
+to assume the direct-composite trick is a final design.
+
+Build against one real consumer first (`NewUICharacterInfoWindow.cpp`, simpler than inventory's
+item-hover preview since it isn't entangled with drag/drop too), then reuse whichever design that
+proves out for every subsequent window that needs it. No window with a 3D-preview dependency
+should attempt migration before this is settled — `CCharMakeWin` is the one documented exception
+(see above), and it's being held out anyway for consistency.
+
+## Phase 5 — Shared inventory/drag-drop controller
+
+`NewUIInventoryCtrl`/`NewUIInventoryActionController` is shared by inventory, storage, shop, and
+trade, already parameterized by `STORAGE_TYPE` and an owning `CNewUIObj*`. Recommended: adapt the
+shared controller so consumers can migrate independently (factor slot-drawing apart from
+drag-state/interaction logic), rather than moving all four atomically — see Open Decisions below,
+this is a real tradeoff, not a settled call. Main risk to validate early: cross-window drag/drop
+between a migrated and a still-legacy consumer. Favorable signal, now directly confirmed rather
+than assumed: `ms_pPickedItem` (`CNewUIInventoryCtrl::ms_pPickedItem`,
+`UI/NewUI/Inventory/NewUIInventoryCtrl.cpp`) is a shared static `CNewUIPickedItem*` independent of
+which grid the item came from, and `CNewUIPickedItem::Render3D()` (see Phase 4 above) drives the
+"picked item follows the cursor" behavior purely off raw `MouseX`/`MouseY` — no dependency on
+whichever grid's UI framework is currently drawing the slot underneath it. That's a real, load-
+bearing reason to expect a migrated grid and a still-legacy one can share one picked-item state
+correctly. Still needs a real cross-window test before trusting it for the actual drag gesture,
+though — input arbitration (which side's hit-testing claims the mouse-down that starts a pick, and
+the mouse-up that ends one) is a separate question this finding doesn't answer by itself.
+
+---
+
+## Not scoped anywhere: the `CUIControl` tier
+
+Distinct from everything above, and easy to miss because it shares a folder name with something
+else. `UI/Legacy/` physically contains **two unrelated legacy systems**, not one:
+`UIMng.h/.cpp` (Phase 1's target — the `CWin`-tier manager, above) and a completely separate
+manager, `CUIManager` (`UIManager.h/.cpp`, a distinct class from `CUIMng`), driving
+`CUIControl`/`CUIMessage`-derived windows: `UIGateKeeper`, `UIGuardsMan`, `UIJewelHarmony`,
+`UISenatus`, plus chat/friend-list/letter-box windows (`UIWindows.h`). ~17,300 lines combined —
+larger than everything Phase 2a's message-box engine targets. Confirmed genuinely live, not dead
+code: `g_pUIManager->UpdateInput()` runs every frame in the main gameplay scene
+(`MainScene.cpp:250`), alongside `CNewUIManager`'s and `CUIMng`'s own per-frame calls — three
+fully independent UI systems live simultaneously today, not two. Zero code relationship to
+`UI/NewUI/` (confirmed by grep, zero cross-references either direction) or to the `CWin`/`CUIMng`
+tier.
+
+**Neither the original plan nor this roadmap assigns this tier to any phase.** Under the plan as
+it currently stands, it would stay permanently legacy — not a deliberate deferral the way
+`COptionWin`'s fate or Phase 4's design question are, but an actual planning gap: a whole third UI
+framework the phased plan never scoped work for. Flagged here as a disclosed omission rather than
+something a future contributor has to rediscover the way this entry was found.
+
+Files, if this ever gets its own phase: `src/source/UI/Legacy/UIManager.h/.cpp` (the manager),
+`UIControls.h/.cpp` (the `CUIControl`/`CUIMessage` base classes and most concrete controls),
+`UIWindows.h/.cpp` (chat/friend-list/letter-box windows, `CUIWindowMgr`), `UIGateKeeper.*`/
+`UIGuardsMan.*`/`UIJewelHarmony.*`/`UISenatus.*`/`UIPopup.*`/`UIMapName.*` (individual screens).
+
+---
+
+## Retirement criteria (per window, before deleting the legacy class)
+
+1. Visual parity signed off against the legacy render (side-by-side, not just "looks right").
+2. All inbound packet-handler call sites still compile and behave correctly against the
+   adapter's/window's unchanged public methods.
+3. All outbound action call sites reach the network layer with identical packet contents.
+4. Input arbitration verified against both legacy tiers and other migrated windows at the
+   assigned z-order band; world click-to-move correctly gated.
+5. Any 3D-preview dependency verified against the Phase 4 bridge.
+6. Localization strings render correctly in at least two locales.
+7. No remaining reference to the legacy class outside its own file/the adapter (grep-checkable).
+
+No generalized runtime A/B toggle by default — the adapter/hybrid pattern itself is the revert
+mechanism (swapping construction back to the legacy class is a one-line change during PR review).
+A real side-by-side toggle is a per-phase judgment call for the highest-blast-radius phases (2a,
+3), not a standing policy.
+
+---
+
+## Open decisions (need a human call)
+
+1. **Phase ordering.** The plan front-loads pipeline-risk retirement (the pilot, done) before
+   value/visibility work (message-box engine, then HUD), with inventory deliberately last. An
+   alternative would front-load the HUD for earlier stakeholder-visible progress, accepting more
+   pipeline risk on a high-traffic target first. Never explicitly confirmed one way or the other —
+   execution has proceeded on the plan's own recommended default (pipeline-risk-first) by default,
+   not by an explicit decision.
+2. **Inventory migration strategy (Phase 5).** Incremental (adapt the shared controller, migrate
+   consumers independently, validate mixed-mode drag/drop) vs. atomic (migrate inventory/storage/
+   shop/trade together, larger single change, zero mixed-mode risk). Recommended: incremental —
+   a real tradeoff between blast radius and review-unit size, not a clear-cut call.
+3. **Z-order banding.** The current design gives every migrated window one contiguous depth band
+   ("above the 3D world, below every still-legacy window") rather than a full cross-system
+   per-widget z-order authority. This will visibly break if a still-legacy window ever needs to
+   render *between* two migrated ones — treat as fine until a concrete case in Phase 2/3 makes it
+   not fine; don't pre-build a general authority against a hypothetical.
+4. **`COptionWin` vs. `SEASON3B::CNewUIOptionWindow`.** `COptionWin` was migrated faithfully in
+   Batch 2 (its checkboxes/sliders genuinely work) but is currently unreachable dead code — the
+   live in-game Options screen is a separate, already-modern window,
+   `SEASON3B::CNewUIOptionWindow`, opened from `CSysMenuWin`'s Option button, sharing the same
+   underlying state via the `g_pOption` macro. Retiring one of the two, or rewiring `CSysMenuWin`'s
+   Option button to the migrated one, is unresolved on purpose — see
+   [Architecture §6](architecture.md#6-coexistence-bridging-cloginwins-specific-pattern).
+5. ~~**D3D11 scissor twin.**~~ RESOLVED — not a coordination dependency. `RHI::` is the real
+   abstraction boundary; this migration only needs to build/verify against GL (the only backend
+   live on `main`), and a D3D11 backend implements the same `SetScissorEnabled`/`SetScissorRect`
+   entry points independently, whenever that work is ready.
+6. **Whether/when the `CUIControl` tier gets a phase at all.** Not a design tradeoff like 1-4
+   above — genuinely unscoped. See [Not scoped anywhere: the `CUIControl` tier](#not-scoped-anywhere-the-cuicontrol-tier).
+
+## Scaling & DPI — documented, not implemented
+
+Legacy `NewUI` panels visibly stretch on non-4:3 resolutions
+(`Render/Textures/ZzzOpenglUtil.cpp`'s `ConvertX`/`ConvertY` scale `x`/`y` independently, with no
+uniform-fit correction anywhere). Not something this migration needs to fix directly, but every
+window this migration retires stops stretching as a side effect, for free. RmlUi's own real,
+built-in scaling primitives (`%`, `vw`/`vh`, `dp` via
+`Context::SetDensityIndependentPixelRatio()`) are verified present in the vendored 6.2 source but
+**nothing wires them up yet** — using `dp` in a theme's RCSS today has zero visible effect. A
+future window with no sprite dependency should use `dp` driven by a single uniform fit factor
+(`min(WindowWidth/refWidth, WindowHeight/refHeight)`) once something actually computes and applies
+that ratio — never independent per-axis scaling, which is the exact bug being avoided.
+
+## Critical files for Phase 2 onward
+
+- `src/source/UI/NewUI/NewUIBase.h` — `INewUIBase`/`CNewUIObj`, the interface every future adapter
+  must satisfy.
+- `src/source/UI/NewUI/NewUIManager.cpp` — the front-to-back-first-consumer-wins loop the input
+  bridge already plugs into for the `CUIMng` tier; the same shape a NewUI-tier adapter needs to
+  slot into.
+- `src/source/UI/NewUI/HUD/Skills/SkillTooltipModel.h/.cpp` — the one existing precedent (pre-dates
+  RmlUi) for a plain-data model built once from game state and consumed by more than one renderer;
+  `RmlModelBinder` generalized this shape, not invented it from nothing.
+- `src/source/UI/NewUI/Events/` (e.g. `NewUIBloodCastleTime.cpp`, `NewUICatapultWindow.cpp`) — small,
+  self-contained candidates for the still-undone adapter-pattern pilot dialog.
+- `src/source/UI/NewUI/Dialogs/NewUICustomMessageBox.cpp`, `NewUICommonMessageBox.cpp` — Phase 2a's
+  target.
+- `src/source/UI/NewUI/HUD/NewUIMainFrameWindow.cpp` — Phase 2b/3's target.
+- `src/source/UI/NewUI/NewUI3DRenderMng.h/.cpp` — Phase 4's target.
+- `src/source/UI/NewUI/Inventory/NewUIInventoryCtrl.h`, `NewUIInventoryActionController.cpp` —
+  central to the Phase 5 decision.
+- `src/source/UI/NewUI/NewUISystem.h` — the ~90 global-macro definitions retargeted one at a time
+  as each window migrates.

--- a/docs/rmlui-ui-system/theming-and-modding.md
+++ b/docs/rmlui-ui-system/theming-and-modding.md
@@ -142,6 +142,71 @@ lookup fails, specifically for RmlUi-referenced theme assets. This would make cu
 theming meaningfully easier for modders (no proprietary-format conversion step) without touching
 the legacy game-asset pipeline everything else still uses. Flagged as a real option, not started.
 
+## Coordinates, scaling, and positioning — what a theme actually controls
+
+A natural question once you're authoring custom sprites: if I supply an image at a fixed pixel
+size, will the engine scale it correctly for me across resolutions? And separately, does my
+theme's RCSS decide where the whole panel sits on screen, or whether it can be dragged? The
+honest answers are more specific than "yes, handled automatically" — worth being precise about,
+since they shape what a theme author should and shouldn't expect to control.
+
+### Scaling and aspect ratio: nothing is automatic today
+
+Every coordinate in both existing themes (`legacy` and `modern`) is **fixed pixels**
+(`left: 150px`, `width: 54px`, ...), and nothing scales those values based on resolution or
+window size. A 1920×1080 window and a 1024×768 window render the login panel at the *exact same
+physical pixel size* — the only thing that changes is the panel's on-screen position, and that's
+recentered by legacy C++ code (see below), not by any scaling RmlUi does.
+
+RmlUi itself does have real scaling primitives — `%` (relative to the containing block), `vw`/`vh`
+(true viewport-percentage units), and `dp` (density-independent pixels, globally rescaled via a
+single `Context::SetDensityIndependentPixelRatio()` call — RmlUi's own built-in mechanism for a
+modern-game-style "UI Scale" option, confirmed against `Source/Core/ComputeProperty.cpp`/
+`Context.cpp`). **None of this is wired up in this engine yet.** Using `dp` instead of `px` in a
+theme's RCSS today would have zero visible effect, because nothing ever calls
+`SetDensityIndependentPixelRatio()` with anything other than its default. Making a theme actually
+scale with resolution needs two things together: the theme author using relative units, *and* an
+engine-side driver computing and applying a ratio — only the first half is available today. See
+the migration plan's "Scaling & DPI" section for the intended direction (a **uniform** fit factor,
+`min(WindowWidth/refWidth, WindowHeight/refHeight)`, never independent per-axis scaling — that
+non-uniform scaling is a confirmed, separate legacy bug, not something to reproduce; see
+[Gotchas](gotchas-and-patterns.md)).
+
+Practically: fixed `px` is also just the *correct* choice for a raster sprite regardless of
+whether scaling is wired up — an image has a native resolution, and stretching it non-uniformly or
+upscaling it blurs/pixelates. Real resolution-independence for sprite art means authoring multiple
+resolution variants or switching to vector-friendly RCSS (flat colors, `border-radius`), not
+scaling one fixed image. A custom-sprite theme should expect to look the same physical size at
+every resolution, the same way the `legacy` theme's original artwork always has.
+
+### Panel position vs. element layout vs. draggability — three different owners
+
+These are easy to conflate but are controlled by three different, independent things:
+
+- **Layout of elements *within* the panel** (where a label, button, or checkbox sits relative to
+  the panel's own top-left corner) — this is fully expressed in RCSS (`.btn-ok { left: 150px; top:
+  200px; }`, etc.) and is exactly what a theme controls. Change these values and the layout
+  changes, no C++ involved.
+- **The panel's own position on screen** (centered, edge-pinned, or anywhere else) — for the
+  current login pilot, this is **not** theme-controlled at all. `CLoginWin::SetPosition()` pushes
+  the panel's `left`/`top` values in from C++ every frame/resize, driven by the legacy `CUIMng`
+  centering math (`(GetScreenWidth() - panelWidth) / 2`-style) — the exact same math that
+  positions the legacy background sprite. A theme's RCSS receives this position; it doesn't choose
+  it. This is a consequence of the login screen still being a *hybrid* window (part `CWin`, part
+  RmlUi) — a window built without any leftover `CWin` positioning dependency could express its own
+  anchoring purely in RCSS (`position: absolute; right: 0; bottom: 0;` for a corner-pinned HUD
+  element, for example), but that's not how this pilot is built.
+- **Draggability** — purely a legacy `CWin` concept (`CWin::Update()`'s `WS_MOVE` state machine,
+  gated by `CursorInWin(WA_MOVE)`), entirely unrelated to RmlUi or RCSS. `CLoginWin` explicitly
+  hardcodes this off (`CursorInWin` always returns `false` for `WA_MOVE`) — a deliberate choice for
+  a login screen, not a limitation of the framework. RmlUi/RCSS has no built-in "make this
+  draggable" concept the way a desktop UI toolkit might; a future window wanting drag behavior
+  through RmlUi would need to implement it itself via mouse-event handlers, not a CSS property.
+
+**Bottom line for a modder**: your theme's RCSS fully controls what's *inside* the panel and (for
+the login screen specifically) nothing about *where the panel is* or *whether it moves* — those
+are inherited from the legacy window this pilot hasn't fully cut ties with yet.
+
 ## Known limitations (as of the Phase 1 pilot)
 
 - **Not yet a live in-game hot-swap.** Switching themes today means editing `config.ini` and
@@ -158,6 +223,11 @@ the legacy game-asset pipeline everything else still uses. Flagged as a real opt
   see [A third case: a theme with its own custom images](#a-third-case-a-theme-with-its-own-custom-images)
   above. No converter tool exists in this repo today, and a missing/wrong-format image fails
   completely silently.
+- **No scaling is wired up, and the panel's on-screen position isn't theme-controlled** — see
+  [Coordinates, scaling, and positioning](#coordinates-scaling-and-positioning--what-a-theme-actually-controls)
+  above. Themes are fixed-`px` and always render at the same physical size regardless of
+  resolution; the login panel's own screen position and draggability are inherited from the
+  legacy `CWin` this pilot is still hybrid with, not something a theme's RCSS decides.
 - **Only the login screen has a theme system today.** Every other window (still-legacy or a
   future RmlUi migration) doesn't participate in theme selection yet — extending
   `LoadThemedDocument()` to a new window is the same pattern `CLoginWin` already uses, not new

--- a/docs/rmlui-ui-system/theming-and-modding.md
+++ b/docs/rmlui-ui-system/theming-and-modding.md
@@ -65,8 +65,62 @@ its own, is a drop-a-folder operation.
    [Architecture](architecture.md) §2 for which RCSS properties are safe to use — **avoid
    `box-shadow` with a blur radius**, it isn't supported (see
    [Gotchas](gotchas-and-patterns.md#box-shadow-blur-renders-as-a-solid-white-block)).
-3. Edit `config.ini`'s `[UI]` section: `RmlTheme=<your-theme-name>`.
-4. Relaunch. No rebuild needed — this is a pure data/config change.
+3. Write `base.rcss` in the same folder — every window migrated since the login pilot links it
+   (see [Shared cross-window RCSS](#shared-cross-window-rcss-basercss)), so a theme missing it
+   renders those windows' buttons/checkboxes/backdrop completely unstyled. `login.rcss` itself is
+   the one exception (doesn't link `base.rcss`, see that section).
+4. Write the remaining per-window `.rcss` files this theme should cover
+   (`login_main.rcss`/`sys_menu.rcss`/`option.rcss`/`remember_password_prompt.rcss`) — a theme
+   missing one of these still loads (RmlUi doesn't error on a missing stylesheet), it just renders
+   that one window unstyled, not the whole theme.
+5. Edit `config.ini`'s `[UI]` section: `RmlTheme=<your-theme-name>`.
+6. Relaunch. No rebuild needed — this is a pure data/config change.
+
+## Shared cross-window RCSS: `base.rcss`
+
+`login.rcss` (both themes) proved out a set of generic, non-positional rules —
+`.btn`/`.btn:hover`, `.checkbox-row`/`.checkbox-box`/`.checkbox-box.checked`/`.checkbox-label` —
+that every subsequently-migrated window also needs. Rather than re-deriving them per window,
+Batch 2 introduced `themes/<name>/base.rcss`, holding exactly those shared rules plus two new
+ones: `body { pointer-events: none; }` (the mandatory click-passthrough reset every full-window
+document needs, see
+[Gotchas](gotchas-and-patterns.md#pointer-events-swallows-every-click-on-screen)) and `#backdrop`
+(a full-screen semi-transparent dim overlay, for any window that previously relied on `CWin`'s own
+default-`nTexID=-1` dim sprite — `CSysMenuWin`/`COptionWin` both do; `CLoginWin`/`CLoginMainWin`
+never did, they use `nTexID=-2`).
+
+A new migrated window's `<head>` links `base.rcss` first, then its own positional `.rcss`:
+
+```html
+<link type="text/rcss" href="base.rcss"/>
+<link type="text/rcss" href="sys_menu.rcss"/>
+```
+
+`.btn` in `base.rcss` is sized for the 108×30 `BITMAP_TEXT_BTN` shape (`CSysMenuWin`'s 4 buttons,
+`COptionWin`'s Close button) — a window with a different button size (like `CLoginMainWin`'s 54×30
+icon buttons) defines its own class instead of overriding `.btn`'s dimensions.
+
+**`login.rcss`/`login.rml` themselves deliberately don't link `base.rcss`** and still define their
+own copies of these rules — they're the only files in the whole migration verified against a real
+run, and retrofitting them for pure dedup risked an RCSS cascade/specificity regression for zero
+functional gain. Fold them in as a fast-follow once `base.rcss`'s shape has proven stable against
+more consumers than it has today.
+
+### `#backdrop` usage
+
+```html
+<div id="backdrop"></div>
+<div id="panel" data-model="...">
+    ...
+</div>
+```
+
+Placed as the *first* child of `<body>`, before `#panel`, so it paints underneath. Unlike
+`#panel`'s children, `#backdrop` sets `pointer-events: auto` directly (not inherited) — this is
+intentional, not an oversight: `CWin::CursorInWin(WA_ALL)` already treats the whole screen as "in
+this window" while a full-screen legacy window like this is shown, so `#backdrop` consuming clicks
+(without doing anything with them) reproduces existing behavior rather than introducing a new
+click-through hole.
 
 ## Bringing your own images to a theme
 
@@ -239,7 +293,10 @@ are inherited from the legacy window this pilot hasn't fully cut ties with yet.
   above. Themes are fixed-`px` and always render at the same physical size regardless of
   resolution; the login panel's own screen position and draggability are inherited from the
   legacy `CWin` this pilot is still hybrid with, not something a theme's RCSS decides.
-- **Only the login screen has a theme system today.** Every other window (still-legacy or a
-  future RmlUi migration) doesn't participate in theme selection yet — extending
-  `LoadThemedDocument()` to a new window is the same pattern `CLoginWin` already uses, not new
-  design work.
+- **Five windows have a theme system today**: the login pilot (`CLoginWin`) plus Batch 2's
+  `CLoginMainWin`/`CSysMenuWin`/`COptionWin`/`RememberPasswordPrompt`, all routed through
+  `LoadThemedDocument()`. Every other window (still-legacy or a future RmlUi migration) doesn't
+  participate in theme selection yet — extending `LoadThemedDocument()` to a new window is the
+  same pattern already established, not new design work. See
+  [Shared cross-window RCSS](#shared-cross-window-rcss-basercss) below for what a new window
+  should reuse rather than re-derive.

--- a/docs/rmlui-ui-system/theming-and-modding.md
+++ b/docs/rmlui-ui-system/theming-and-modding.md
@@ -81,13 +81,20 @@ its own, is a drop-a-folder operation.
 `login.rcss` (both themes) proved out a set of generic, non-positional rules —
 `.btn`/`.btn:hover`, `.checkbox-row`/`.checkbox-box`/`.checkbox-box.checked`/`.checkbox-label` —
 that every subsequently-migrated window also needs. Rather than re-deriving them per window,
-Batch 2 introduced `themes/<name>/base.rcss`, holding exactly those shared rules plus two new
+Batch 2 introduced `themes/<name>/base.rcss`, holding exactly those shared rules plus three new
 ones: `body { pointer-events: none; }` (the mandatory click-passthrough reset every full-window
 document needs, see
-[Gotchas](gotchas-and-patterns.md#pointer-events-swallows-every-click-on-screen)) and `#backdrop`
+[Gotchas](gotchas-and-patterns.md#pointer-events-swallows-every-click-on-screen)), `#backdrop`
 (a full-screen semi-transparent dim overlay, for any window that previously relied on `CWin`'s own
 default-`nTexID=-1` dim sprite — `CSysMenuWin`/`COptionWin` both do; `CLoginWin`/`CLoginMainWin`
-never did, they use `nTexID=-2`).
+never did, they use `nTexID=-2`), and `.hidden { display: none; }` — for a button that doesn't
+apply to the *current scene at all* (as opposed to `.btn.disabled`, which keeps the element in
+layout, dimmed, for something that's merely temporarily unclickable). Use `.hidden` when the
+reason isn't "not yet," it's "not in this view" — see
+[Gotchas](gotchas-and-patterns.md#hidden-vs-disabled-a-dimmed-button-can-still-visually-collide-with-its-neighbor)
+for the real bug this distinction fixed (`CSysMenuWin`'s Select Server button, hidden via a bound
+model field rather than a hardcoded RCSS rule, so it's still shown normally once the same panel is
+opened from a scene where it does apply).
 
 A new migrated window's `<head>` links `base.rcss` first, then its own positional `.rcss`:
 
@@ -99,6 +106,18 @@ A new migrated window's `<head>` links `base.rcss` first, then its own positiona
 `.btn` in `base.rcss` is sized for the 108×30 `BITMAP_TEXT_BTN` shape (`CSysMenuWin`'s 4 buttons,
 `COptionWin`'s Close button) — a window with a different button size (like `CLoginMainWin`'s 54×30
 icon buttons) defines its own class instead of overriding `.btn`'s dimensions.
+
+**Unlike `login.rcss`'s own checkboxes/buttons (deliberately flat, even in the `legacy` theme — a
+documented scope cut for the Phase 1 pilot), `base.rcss`'s `legacy`-theme `.btn`/`.checkbox-box`
+reproduce the real sprite art** (`op1_b_all.tga`'s 3-frame idle/hover/active strip,
+`op2_ch.tga`'s 2-frame checked/unchecked pair — both already loaded unconditionally at startup by
+`ZzzOpenData.cpp`'s `OpenBasicData()`, confirmed not scene-gated). The distinguishing factor
+wasn't caution about the mechanism — it's that `base.rcss` is genuinely shared across windows
+using the *identical* asset (`CSysMenuWin` and `COptionWin`'s buttons are the same
+`BITMAP_TEXT_BTN` texture), so reproducing it once here pays for itself immediately, whereas
+`login.rcss`'s buttons/checkboxes have no other consumer. `themes/modern/base.rcss` stays fully
+flat/programmatic — real sprite reproduction is a `legacy`-theme-only concern; modern is where a
+theme author's own customized/experimental look belongs.
 
 **`login.rcss`/`login.rml` themselves deliberately don't link `base.rcss`** and still define their
 own copies of these rules — they're the only files in the whole migration verified against a real

--- a/docs/rmlui-ui-system/theming-and-modding.md
+++ b/docs/rmlui-ui-system/theming-and-modding.md
@@ -31,12 +31,15 @@ graph TD
     SourceUrl --> LFM["Rml::Context::LoadDocumentFromMemory(text, sourceUrl)"]
     LFM --> LinkResolve["&lt;link href='login.rcss'&gt; resolves<br>relative to sourceUrl"]
     LinkResolve --> RealFile["Data/Interface/RmlUi/themes/modern/login.rcss<br>(this file DOES need to exist on disk)"]
-
-    Cache --> SpriteCheck["UI::RmlBridge::UsesLegacySpriteChrome(themeName)"]
-    SpriteCheck --> Manifest["GetPrivateProfileIntW against<br>themes/modern/theme.ini<br>[Theme] UsesLegacySpriteChrome"]
-    Manifest -->|"1"| Sprites["CWin::Create() creates the legacy<br>background sprite + input-frame sprites"]
-    Manifest -->|"0 or file/key absent (default)"| NoSprites["CWin::Create(w,h,-2) — sentinel<br>skips the sprite entirely;<br>RCSS draws the whole look"]
 ```
+
+`CWin::Create()` always passes `nTexID=-2` for this window — CWin never draws background/frame
+chrome, in any theme. A "legacy-look" theme (like `themes/legacy/login.rcss`) reproduces the
+original look with its own `decorator: image(...)` rules pointing at the same art files the old
+sprites used; a "modern" theme uses flat colors/vector shapes instead. Either way, RmlUi renders
+100% of it — see [Core principle](#core-principle-rml-is-theme-agnostic-rcss-is-the-swappable-unit)
+above and the note on an earlier, removed mechanism in
+[Gotchas](gotchas-and-patterns.md#a-per-theme-flag-to-opt-back-into-cwin-sprite-rendering-was-the-wrong-shape).
 
 The key mechanism, `UI::RmlBridge::LoadThemedDocument()` (`UI/RmlBridge/RmlTheme.h/.cpp`), is what
 keeps RML shared and un-duplicated: it reads the RML file's text once, then calls
@@ -49,54 +52,34 @@ wraps the string in a `StreamMemory` and calls `SetSourceURL()` on it before par
 (`Data/Interface/RmlUi/themes/<name>/login.rml`) never needs to exist as a real file — only the
 `.rcss` it resolves to does.
 
-## `theme.ini` manifest
-
-Optional. Lives at `Data/Interface/RmlUi/themes/<name>/theme.ini`:
-
-```ini
-[Theme]
-UsesLegacySpriteChrome=1
-```
-
-Read directly via `GetPrivateProfileIntW` against that theme's own file — **not** a hardcoded C++
-allowlist. Absence of the file, or absence of the key inside it, both default to `0`
-(fully programmatic). This is deliberately data-driven per theme folder: a theme that wants to
-reuse legacy sprite chrome (the `legacy` theme's shape) ships one line in its own `theme.ini`; a
-theme that doesn't (the common case — a reskin, seasonal theme, accessibility theme, or a mod)
-needs no manifest at all.
-
 ## Adding a new theme — step by step
 
-**The common case: a fully programmatic (sprite-free) theme.** No source changes, no
-recompilation.
+No source changes, no recompilation — every theme, whether it reuses the original art or brings
+its own, is a drop-a-folder operation.
 
 1. Create `src/bin/Data/Interface/RmlUi/themes/<your-theme-name>/`.
 2. Write `login.rcss` in that folder, styling the same class names the shared `login.rml` uses
    (`#panel`, `.label`, `.checkbox-row`, `.checkbox-box`, `.btn`, `.trust-warning`,
-   `.input-frame` — see `themes/modern/login.rcss` for a complete real example, and
+   `.input-frame` — see `themes/modern/login.rcss` for a flat-color/vector-shape example, and
+   `themes/legacy/login.rcss` for an image-decorator example — and
    [Architecture](architecture.md) §2 for which RCSS properties are safe to use — **avoid
    `box-shadow` with a blur radius**, it isn't supported (see
    [Gotchas](gotchas-and-patterns.md#box-shadow-blur-renders-as-a-solid-white-block)).
-3. (Optional) Add a `theme.ini` if you want `UsesLegacySpriteChrome=1` — most new themes won't.
-4. Edit `config.ini`'s `[UI]` section: `RmlTheme=<your-theme-name>`.
-5. Relaunch. No rebuild needed — this is a pure data/config change.
+3. Edit `config.ini`'s `[UI]` section: `RmlTheme=<your-theme-name>`.
+4. Relaunch. No rebuild needed — this is a pure data/config change.
 
-**The rarer case: a theme that reuses legacy sprite chrome.** Same as above, plus set
-`UsesLegacySpriteChrome=1` in that theme's `theme.ini`. Note this only affects the *background*
-sprite and the input-box *frame* sprites for windows built the way `CLoginWin` is (a `CWin`
-subclass whose `Create()` checks `UsesLegacySpriteChrome` before creating those specific sprites)
-— a future migrated window that never had legacy sprite chrome to begin with has nothing to gate.
+## Bringing your own images to a theme
 
-## A third case: a theme with its own custom images
-
-`UsesLegacySpriteChrome` only controls whether the *old, hardcoded, non-authorable* legacy
-bitmaps (`BITMAP_LOG_IN+7`, `BITMAP_CHECK_BTN`, `BITMAP_BUTTON` — literal C++ constants a modder
-cannot add to without a source change) get drawn underneath the RmlUi overlay. It has nothing to
-do with whether a theme can have **its own new image assets** — a custom background photo, custom
-button art, a logo. That's a separate, already-working capability: RmlUi's own `LoadTexture`
-(`RmlUiRenderInterface.cpp`) already routes any image an RCSS file references through this
-engine's normal texture pipeline. No engine changes are needed to use it — but there are two real
-constraints worth knowing before you do, and they're rougher than the sprite-free case above.
+Every migrated window's background/frame chrome is drawn by RmlUi itself, in every theme — never
+by `CWin` or any other legacy widget (see [Gotchas](gotchas-and-patterns.md) for why an earlier
+per-theme flag that let a theme opt back into `CWin`-drawn chrome was removed). A theme is free to
+either reuse the original hardcoded legacy bitmaps (`BITMAP_LOG_IN+7`'s file,
+`Interface/login_back.tga`, is exactly what `themes/legacy/login.rcss`'s `#panel` decorator
+references — see it for a complete real example) or bring **its own new image assets** — a custom
+background photo, custom button art, a logo. Both go through the same, already-working path:
+RmlUi's own `LoadTexture` (`RmlUiRenderInterface.cpp`) routes any image an RCSS file references
+through this engine's normal texture pipeline. No engine changes are needed to use it — but there
+are three real constraints worth knowing before you do.
 
 **How the image reference resolves.** Confirmed against RmlUi's real source
 (`Source/Core/StyleSheetParser.cpp`, `ElementEffects.cpp`, `Decorator.cpp`): a relative image path
@@ -116,6 +99,10 @@ themes/<your-theme-name>/
 }
 ```
 
+This is enough to prove path resolution, but not necessarily enough to render correctly as-is —
+read the next two constraints (format, and non-power-of-two sizing) before trusting a direct
+path reference like this in a real theme.
+
 **The real constraint: only this engine's proprietary OZT/OZJ containers are supported, not plain
 PNG/JPG/BMP.** `RmlUiRenderInterface::LoadTexture` routes through `CGlobalBitmap::LoadImage`
 (`Render/Sprites/GlobalBitmap.cpp`) — the same loader every other texture in the game uses, so
@@ -127,6 +114,31 @@ exist on disk is `panel_bg.OZT`, not a real `.tga`. Any other extension (`.png`,
 handled at all. There is no PNG/JPG→OZT/OZJ converter in this repository — a modder needs an
 external tool from the wider MU private-server modding community (this format predates this
 project) to produce one.
+
+**A non-power-of-two-sized image needs an explicit `@spritesheet` declaration, or it will render
+squished with visible padding.** This engine's `.OZT`/`.OZJ` loaders pad every texture up to the
+next power-of-two size internally (a 329×245 image becomes a 512×256 texture, real content in the
+top-left corner, the rest zero-filled) — invisible to legacy `CSprite` callers (which track their
+own real dimensions separately) but **not** invisible to a plain `decorator: image("file.tga")`,
+which always samples the *entire* stored texture as 0..1 UV. The fix is to declare the image as a
+named sprite with its real pixel rectangle, and reference the sprite name instead of the raw path:
+
+```rcss
+@spritesheet panel-bg-sheet
+{
+    src: panel_bg.tga;
+    panel-bg-image: 0px 0px 329px 245px;  /* the image's REAL, unpadded pixel size */
+}
+
+#panel {
+    decorator: image(panel-bg-image);   /* the sprite name, not "panel_bg.tga" directly */
+}
+```
+
+If the image's real dimensions genuinely are an exact power of two (256×256, 512×128, ...), this
+step is unnecessary — the padding is a no-op and a direct path reference renders correctly. See
+[Gotchas](gotchas-and-patterns.md#a-referenced-images-real-unpadded-size-must-be-declared-via-spritesheet-not-assumed)
+for the full root-cause writeup.
 
 **Failures are completely silent.** A missing file or an unsupported extension returns `false`
 from `LoadImage` with **no log line at all** — `RmlUiRenderInterface::LoadTexture` then returns a
@@ -211,18 +223,17 @@ are inherited from the legacy window this pilot hasn't fully cut ties with yet.
 
 - **Not yet a live in-game hot-swap.** Switching themes today means editing `config.ini` and
   relaunching. A true runtime toggle needs each migrated window to tear down and rebuild its
-  `Rml::ElementDocument`/`DataModel` against the new theme (and, for sprite-backed themes, its
-  `CWin` background/frame sprites) — the teardown/rebuild lifecycle (`Context::RemoveDataModel`
-  semantics, `CSprite` re-`Create()` safety) hasn't been verified safe enough to build yet. Real
+  `Rml::ElementDocument`/`DataModel` against the new theme — the teardown/rebuild lifecycle
+  (`Context::RemoveDataModel` semantics) hasn't been verified safe enough to build yet. Real
   follow-up work, not started.
 - **`box-shadow` with a blur radius is unsupported** — see
   [Gotchas](gotchas-and-patterns.md#box-shadow-blur-renders-as-a-solid-white-block). Stick to
-  `background-color`, `border`, and `border-radius` for a themed panel's look; all three are pure
-  geometry and render correctly.
+  `background-color`, `border`, `border-radius`, and `decorator: image(...)` for a themed panel's
+  look; all render correctly.
 - **Custom theme images require this engine's proprietary OZT/OZJ format, not plain PNG/JPG** —
-  see [A third case: a theme with its own custom images](#a-third-case-a-theme-with-its-own-custom-images)
-  above. No converter tool exists in this repo today, and a missing/wrong-format image fails
-  completely silently.
+  see [Bringing your own images to a theme](#bringing-your-own-images-to-a-theme) above. No
+  converter tool exists in this repo today, and a missing/wrong-format image fails completely
+  silently.
 - **No scaling is wired up, and the panel's on-screen position isn't theme-controlled** — see
   [Coordinates, scaling, and positioning](#coordinates-scaling-and-positioning--what-a-theme-actually-controls)
   above. Themes are fixed-`px` and always render at the same physical size regardless of

--- a/docs/rmlui-ui-system/theming-and-modding.md
+++ b/docs/rmlui-ui-system/theming-and-modding.md
@@ -87,6 +87,61 @@ sprite and the input-box *frame* sprites for windows built the way `CLoginWin` i
 subclass whose `Create()` checks `UsesLegacySpriteChrome` before creating those specific sprites)
 — a future migrated window that never had legacy sprite chrome to begin with has nothing to gate.
 
+## A third case: a theme with its own custom images
+
+`UsesLegacySpriteChrome` only controls whether the *old, hardcoded, non-authorable* legacy
+bitmaps (`BITMAP_LOG_IN+7`, `BITMAP_CHECK_BTN`, `BITMAP_BUTTON` — literal C++ constants a modder
+cannot add to without a source change) get drawn underneath the RmlUi overlay. It has nothing to
+do with whether a theme can have **its own new image assets** — a custom background photo, custom
+button art, a logo. That's a separate, already-working capability: RmlUi's own `LoadTexture`
+(`RmlUiRenderInterface.cpp`) already routes any image an RCSS file references through this
+engine's normal texture pipeline. No engine changes are needed to use it — but there are two real
+constraints worth knowing before you do, and they're rougher than the sprite-free case above.
+
+**How the image reference resolves.** Confirmed against RmlUi's real source
+(`Source/Core/StyleSheetParser.cpp`, `ElementEffects.cpp`, `Decorator.cpp`): a relative image path
+inside an RCSS rule resolves against **that stylesheet's own location** — not the shared `login.rml`'s
+virtual per-theme URL. So a custom theme's background image can simply sit next to its own
+`login.rcss`:
+
+```
+themes/<your-theme-name>/
+    login.rcss
+    panel_bg.tga      <- referenced from login.rcss below
+```
+
+```rcss
+#panel {
+    decorator: image( panel_bg.tga );
+}
+```
+
+**The real constraint: only this engine's proprietary OZT/OZJ containers are supported, not plain
+PNG/JPG/BMP.** `RmlUiRenderInterface::LoadTexture` routes through `CGlobalBitmap::LoadImage`
+(`Render/Sprites/GlobalBitmap.cpp`) — the same loader every other texture in the game uses, so
+RmlUi-referenced images share its ref-counted cache/eviction. That loader only handles two
+extensions: `.jpg` (via `OpenJpegTurbo`) and `.tga` (via `OpenTga`) — and **both internally swap
+the extension to this engine's own container format before opening** (`.OZJ`/`.OZT`
+respectively). Concretely: if your RCSS references `panel_bg.tga`, the file that actually needs to
+exist on disk is `panel_bg.OZT`, not a real `.tga`. Any other extension (`.png`, `.bmp`, ...) isn't
+handled at all. There is no PNG/JPG→OZT/OZJ converter in this repository — a modder needs an
+external tool from the wider MU private-server modding community (this format predates this
+project) to produce one.
+
+**Failures are completely silent.** A missing file or an unsupported extension returns `false`
+from `LoadImage` with **no log line at all** — `RmlUiRenderInterface::LoadTexture` then returns a
+null texture handle, and the element just renders with no image, no error, no diagnostic. If a
+custom theme's image isn't showing up, double-check the extension-swap rule above (a real `.tga`
+file, or a file with the wrong internal container, both fail exactly the same silent way) before
+assuming something else is wrong.
+
+**Open follow-up, not yet decided or built**: vendoring `stb_image.h` (a small, permissively-licensed
+single-header decoder — not currently vendored anywhere in this repo, confirmed by search) to give
+`RmlUiRenderInterface::LoadTexture` a fallback path for plain PNG/JPG/BMP/TGA when the OZT/OZJ
+lookup fails, specifically for RmlUi-referenced theme assets. This would make custom-sprite
+theming meaningfully easier for modders (no proprietary-format conversion step) without touching
+the legacy game-asset pipeline everything else still uses. Flagged as a real option, not started.
+
 ## Known limitations (as of the Phase 1 pilot)
 
 - **Not yet a live in-game hot-swap.** Switching themes today means editing `config.ini` and
@@ -99,6 +154,10 @@ subclass whose `Create()` checks `UsesLegacySpriteChrome` before creating those 
   [Gotchas](gotchas-and-patterns.md#box-shadow-blur-renders-as-a-solid-white-block). Stick to
   `background-color`, `border`, and `border-radius` for a themed panel's look; all three are pure
   geometry and render correctly.
+- **Custom theme images require this engine's proprietary OZT/OZJ format, not plain PNG/JPG** —
+  see [A third case: a theme with its own custom images](#a-third-case-a-theme-with-its-own-custom-images)
+  above. No converter tool exists in this repo today, and a missing/wrong-format image fails
+  completely silently.
 - **Only the login screen has a theme system today.** Every other window (still-legacy or a
   future RmlUi migration) doesn't participate in theme selection yet — extending
   `LoadThemedDocument()` to a new window is the same pattern `CLoginWin` already uses, not new

--- a/docs/rmlui-ui-system/theming-and-modding.md
+++ b/docs/rmlui-ui-system/theming-and-modding.md
@@ -1,0 +1,105 @@
+# Theming & Modding
+
+How the swappable-theme system works, and how to add a new theme — including a modder-supplied
+one — without touching engine source code.
+
+## Design goal
+
+The owner's requirement (referencing Dota 2's Panorama UI as the model): start with the current
+legacy sprite/texture look, but be able to swap in modernized themes later, and — once actually
+tried — support **multiple real themes side by side** to prototype the switching mechanism itself,
+not just ship one theme. The framework below is the result: a theme is identified by **folder
+name**, not a closed C++ enum, specifically so that adding a theme (including a fully
+programmatic, sprite-free one) is normally a zero-source-change, drop-a-folder operation.
+
+## Core principle: RML is theme-agnostic, RCSS is the swappable unit
+
+RML files describe structure/content/data-bindings only — what elements exist, what they're bound
+to. They never hardcode a visual look inline. All actual appearance (colors, borders, backgrounds,
+button/checkbox art) belongs in RCSS, so **a new theme is a new RCSS file (or folder of them)
+reusing the same class names, not a new RML file.**
+
+## How theme resolution actually works
+
+```mermaid
+graph TD
+    Config["config.ini<br>[UI] RmlTheme=modern"] --> GetTheme["GameConfig::GetRmlTheme()"]
+    GetTheme --> Cache["UI::RmlBridge::GetActiveThemeName()<br>(cached on first call)"]
+    Cache --> Load["UI::RmlBridge::LoadThemedDocument(context, 'Data/Interface/RmlUi/login.rml')"]
+    Load --> ReadFile["Read login.rml's raw text<br>(one shared file, never duplicated per theme)"]
+    ReadFile --> SourceUrl["Build a virtual source URL:<br>Data/Interface/RmlUi/themes/modern/login.rml<br>(need not exist on disk)"]
+    SourceUrl --> LFM["Rml::Context::LoadDocumentFromMemory(text, sourceUrl)"]
+    LFM --> LinkResolve["&lt;link href='login.rcss'&gt; resolves<br>relative to sourceUrl"]
+    LinkResolve --> RealFile["Data/Interface/RmlUi/themes/modern/login.rcss<br>(this file DOES need to exist on disk)"]
+
+    Cache --> SpriteCheck["UI::RmlBridge::UsesLegacySpriteChrome(themeName)"]
+    SpriteCheck --> Manifest["GetPrivateProfileIntW against<br>themes/modern/theme.ini<br>[Theme] UsesLegacySpriteChrome"]
+    Manifest -->|"1"| Sprites["CWin::Create() creates the legacy<br>background sprite + input-frame sprites"]
+    Manifest -->|"0 or file/key absent (default)"| NoSprites["CWin::Create(w,h,-2) — sentinel<br>skips the sprite entirely;<br>RCSS draws the whole look"]
+```
+
+The key mechanism, `UI::RmlBridge::LoadThemedDocument()` (`UI/RmlBridge/RmlTheme.h/.cpp`), is what
+keeps RML shared and un-duplicated: it reads the RML file's text once, then calls
+`Rml::Context::LoadDocumentFromMemory(text, perThemeVirtualSourceUrl)`. RmlUi resolves a
+document's relative asset/`<link>` paths against whatever `source_url` was passed to
+`LoadDocumentFromMemory` (confirmed against RmlUi 6.2 source — `Context::LoadDocumentFromMemory`
+wraps the string in a `StreamMemory` and calls `SetSourceURL()` on it before parsing;
+`XMLNodeHandlerHead.cpp`'s `MakeExternalResource()` resolves `<link href>` via
+`Absolutepath(path, parser->GetSourceURL())`). The virtual source URL itself
+(`Data/Interface/RmlUi/themes/<name>/login.rml`) never needs to exist as a real file — only the
+`.rcss` it resolves to does.
+
+## `theme.ini` manifest
+
+Optional. Lives at `Data/Interface/RmlUi/themes/<name>/theme.ini`:
+
+```ini
+[Theme]
+UsesLegacySpriteChrome=1
+```
+
+Read directly via `GetPrivateProfileIntW` against that theme's own file — **not** a hardcoded C++
+allowlist. Absence of the file, or absence of the key inside it, both default to `0`
+(fully programmatic). This is deliberately data-driven per theme folder: a theme that wants to
+reuse legacy sprite chrome (the `legacy` theme's shape) ships one line in its own `theme.ini`; a
+theme that doesn't (the common case — a reskin, seasonal theme, accessibility theme, or a mod)
+needs no manifest at all.
+
+## Adding a new theme — step by step
+
+**The common case: a fully programmatic (sprite-free) theme.** No source changes, no
+recompilation.
+
+1. Create `src/bin/Data/Interface/RmlUi/themes/<your-theme-name>/`.
+2. Write `login.rcss` in that folder, styling the same class names the shared `login.rml` uses
+   (`#panel`, `.label`, `.checkbox-row`, `.checkbox-box`, `.btn`, `.trust-warning`,
+   `.input-frame` — see `themes/modern/login.rcss` for a complete real example, and
+   [Architecture](architecture.md) §2 for which RCSS properties are safe to use — **avoid
+   `box-shadow` with a blur radius**, it isn't supported (see
+   [Gotchas](gotchas-and-patterns.md#box-shadow-blur-renders-as-a-solid-white-block)).
+3. (Optional) Add a `theme.ini` if you want `UsesLegacySpriteChrome=1` — most new themes won't.
+4. Edit `config.ini`'s `[UI]` section: `RmlTheme=<your-theme-name>`.
+5. Relaunch. No rebuild needed — this is a pure data/config change.
+
+**The rarer case: a theme that reuses legacy sprite chrome.** Same as above, plus set
+`UsesLegacySpriteChrome=1` in that theme's `theme.ini`. Note this only affects the *background*
+sprite and the input-box *frame* sprites for windows built the way `CLoginWin` is (a `CWin`
+subclass whose `Create()` checks `UsesLegacySpriteChrome` before creating those specific sprites)
+— a future migrated window that never had legacy sprite chrome to begin with has nothing to gate.
+
+## Known limitations (as of the Phase 1 pilot)
+
+- **Not yet a live in-game hot-swap.** Switching themes today means editing `config.ini` and
+  relaunching. A true runtime toggle needs each migrated window to tear down and rebuild its
+  `Rml::ElementDocument`/`DataModel` against the new theme (and, for sprite-backed themes, its
+  `CWin` background/frame sprites) — the teardown/rebuild lifecycle (`Context::RemoveDataModel`
+  semantics, `CSprite` re-`Create()` safety) hasn't been verified safe enough to build yet. Real
+  follow-up work, not started.
+- **`box-shadow` with a blur radius is unsupported** — see
+  [Gotchas](gotchas-and-patterns.md#box-shadow-blur-renders-as-a-solid-white-block). Stick to
+  `background-color`, `border`, and `border-radius` for a themed panel's look; all three are pure
+  geometry and render correctly.
+- **Only the login screen has a theme system today.** Every other window (still-legacy or a
+  future RmlUi migration) doesn't participate in theme selection yet — extending
+  `LoadThemedDocument()` to a new window is the same pattern `CLoginWin` already uses, not new
+  design work.

--- a/scripts/build-and-run.ps1
+++ b/scripts/build-and-run.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+  Configures, builds, and runs the MU client via the CMake presets in
+  CMakePresets.json, from a plain PowerShell prompt (no Developer Command
+  Prompt required -- this script imports the VC dev environment itself).
+
+.EXAMPLE
+  ./scripts/build-and-run.ps1
+  Build+run the x64 Debug client, blocking until it exits (console attached).
+
+.EXAMPLE
+  ./scripts/build-and-run.ps1 -Detached
+  Build the x64 Debug client, then launch it detached and return immediately.
+
+.EXAMPLE
+  ./scripts/build-and-run.ps1 -Arch x86 -Config Release -Editor
+  Build+run the x86 Release MuEditor client.
+
+.EXAMPLE
+  ./scripts/build-and-run.ps1 -NoBuild -Detached
+  Skip the build, just (re)launch the already-built exe detached.
+
+.EXAMPLE
+  ./scripts/build-and-run.ps1 -- connect /u192.168.0.20 /p55902
+  Pass extra arguments through to Main.exe (after --).
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('x64', 'x86')]
+    [string]$Arch = 'x64',
+
+    [ValidateSet('Debug', 'Release')]
+    [string]$Config = 'Debug',
+
+    [switch]$Editor,
+    [switch]$Clean,
+    [switch]$NoBuild,
+    [switch]$Detached,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ClientArgs = @()
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+
+function Import-VcVars {
+    param([string]$Arch)
+
+    $vswhereCandidates = @(
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe"
+    )
+    $vswhere = $vswhereCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if (-not $vswhere) {
+        throw 'vswhere.exe not found. Install Visual Studio with the C++ workload.'
+    }
+
+    $vsInstallPath = & $vswhere -latest -prerelease -products * `
+        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+        -property installationPath
+    if (-not $vsInstallPath) {
+        throw 'No Visual Studio installation with the C++ Tools component was found.'
+    }
+
+    $vcvarsall = Join-Path $vsInstallPath 'VC\Auxiliary\Build\vcvarsall.bat'
+    if (-not (Test-Path $vcvarsall)) {
+        throw "vcvarsall.bat not found at '$vcvarsall'."
+    }
+
+    # x86 is cross-compiled from the x64 host toolchain (x64_x86) rather than
+    # requiring a separate native x86 host install.
+    $archArg = if ($Arch -eq 'x64') { 'x64' } else { 'x64_x86' }
+
+    # Run vcvarsall in a child cmd.exe, then dump its resulting environment so
+    # we can import it into *this* PowerShell process -- everything launched
+    # afterwards (cmake, ninja, cl, link, dotnet publish) inherits it.
+    $envDump = cmd /c "call `"$vcvarsall`" $archArg >nul 2>&1 && set"
+    if ($LASTEXITCODE -ne 0 -or -not $envDump) {
+        throw "vcvarsall.bat failed for arch '$archArg'."
+    }
+    foreach ($line in $envDump) {
+        if ($line -match '^([^=]+)=(.*)$') {
+            [System.Environment]::SetEnvironmentVariable($Matches[1], $Matches[2], 'Process')
+        }
+    }
+}
+
+$presetBase = "windows-$Arch" + $(if ($Editor) { '-mueditor' } else { '' })
+$buildPreset = "$presetBase-$($Config.ToLower())"
+$buildDir = Join-Path $repoRoot "out\build\$presetBase"
+$exeDir = Join-Path $buildDir "src\$Config"
+$exePath = Join-Path $exeDir 'Main.exe'
+
+if (-not $NoBuild) {
+    if ($Clean -and (Test-Path $buildDir)) {
+        Write-Host "Removing $buildDir ..."
+        Remove-Item -Recurse -Force $buildDir
+    }
+
+    Write-Host "Setting up VC environment for $Arch ..."
+    Import-VcVars -Arch $Arch
+
+    Push-Location $repoRoot
+    try {
+        Write-Host "Configuring preset '$presetBase' ..."
+        cmake --preset $presetBase
+        if ($LASTEXITCODE -ne 0) { throw 'cmake configure failed.' }
+
+        Write-Host "Building preset '$buildPreset' ..."
+        cmake --build --preset $buildPreset
+        if ($LASTEXITCODE -ne 0) { throw 'cmake build failed.' }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+if (-not (Test-Path $exePath)) {
+    throw "Main.exe not found at '$exePath'. Run without -NoBuild first."
+}
+
+$launchArgs = @()
+if ($Editor) { $launchArgs += '--editor' }
+$launchArgs += $ClientArgs
+
+if ($Detached) {
+    $startProcessArgs = @{
+        FilePath         = $exePath
+        WorkingDirectory = $exeDir
+        PassThru         = $true
+    }
+    if ($launchArgs.Count -gt 0) { $startProcessArgs['ArgumentList'] = $launchArgs }
+    $proc = Start-Process @startProcessArgs
+    Write-Host "Launched detached: $exePath (PID $($proc.Id))"
+}
+else {
+    Push-Location $exeDir
+    try {
+        & $exePath @launchArgs
+    }
+    finally {
+        Pop-Location
+    }
+}

--- a/scripts/build-and-run.sh
+++ b/scripts/build-and-run.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Configures, builds, and runs the MU client for native Linux, mirroring
+# docs/build/linux/console.md and .github/workflows/linux-build.yml.
+#
+# Usage:
+#   ./scripts/build-and-run.sh [options] [-- extra args passed to Main]
+#
+# Options:
+#   -c, --config <Debug|Release>   Build configuration (default: Release)
+#   -e, --editor                   Enable the ImGui in-game editor (ENABLE_EDITOR=ON,
+#                                   launches with --editor)
+#       --clean                    Remove the build directory first
+#       --no-build                 Skip configure/build, just (re)launch the existing binary
+#       --detached                 Launch the client detached instead of blocking
+#   -h, --help                     Show this help and exit
+#
+# Examples:
+#   ./scripts/build-and-run.sh
+#   ./scripts/build-and-run.sh --editor --config Debug
+#   ./scripts/build-and-run.sh --no-build --detached
+#   ./scripts/build-and-run.sh -- connect /u192.168.0.20 /p55902
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+repo_root="$(dirname -- "$script_dir")"
+
+config="Release"
+editor="OFF"
+clean=0
+no_build=0
+detached=0
+client_args=()
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/build-and-run.sh [options] [-- extra args passed to Main]
+
+Options:
+  -c, --config <Debug|Release>   Build configuration (default: Release)
+  -e, --editor                   Enable the ImGui in-game editor (ENABLE_EDITOR=ON,
+                                  launches with --editor)
+      --clean                    Remove the build directory first
+      --no-build                 Skip configure/build, just (re)launch the existing binary
+      --detached                 Launch the client detached instead of blocking
+  -h, --help                     Show this help and exit
+
+Examples:
+  ./scripts/build-and-run.sh
+  ./scripts/build-and-run.sh --editor --config Debug
+  ./scripts/build-and-run.sh --no-build --detached
+  ./scripts/build-and-run.sh -- connect /u192.168.0.20 /p55902
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c|--config)
+            config="$2"
+            shift 2
+            ;;
+        -e|--editor)
+            editor="ON"
+            shift
+            ;;
+        --clean)
+            clean=1
+            shift
+            ;;
+        --no-build)
+            no_build=1
+            shift
+            ;;
+        --detached)
+            detached=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            client_args=("$@")
+            break
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+case "$config" in
+    Debug|Release) ;;
+    *)
+        echo "Invalid --config '$config' (expected Debug or Release)" >&2
+        exit 1
+        ;;
+esac
+
+build_dir="$repo_root/build-linux"
+exe_dir="$build_dir/src"
+exe_path="$exe_dir/Main"
+
+if [[ $no_build -eq 0 ]]; then
+    if [[ $clean -eq 1 && -d "$build_dir" ]]; then
+        echo "Removing $build_dir ..."
+        rm -rf "$build_dir"
+    fi
+
+    echo "Configuring (config=$config, editor=$editor) ..."
+    cmake -S "$repo_root" -B "$build_dir" -G Ninja \
+        -DCMAKE_BUILD_TYPE="$config" \
+        -DENABLE_EDITOR="$editor"
+
+    echo "Building ..."
+    cmake --build "$build_dir" -j"$(nproc)"
+fi
+
+if [[ ! -x "$exe_path" ]]; then
+    echo "Main not found (or not executable) at '$exe_path'. Run without --no-build first." >&2
+    exit 1
+fi
+
+launch_args=()
+if [[ "$editor" == "ON" ]]; then
+    launch_args+=("--editor")
+fi
+launch_args+=("${client_args[@]}")
+
+if [[ $detached -eq 1 ]]; then
+    ( cd "$exe_dir" && nohup "$exe_path" "${launch_args[@]}" >/dev/null 2>&1 & )
+    echo "Launched detached: $exe_path"
+else
+    cd "$exe_dir"
+    exec "$exe_path" "${launch_args[@]}"
+fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,18 +45,41 @@ set(SDLMIXER_MIDI OFF CACHE BOOL "" FORCE)
 set(SDLMIXER_GME OFF CACHE BOOL "" FORCE)
 add_subdirectory(ThirdParty/SDL_mixer EXCLUDE_FROM_ALL)
 
+mu_ensure_submodule("ThirdParty/freetype"
+  INDICATOR "CMakeLists.txt"
+  URL "https://github.com/freetype/freetype.git")
+
+# FreeType -- vendored solely because RmlUi's default font engine (below) requires it and
+# find_package(Freetype) found nothing on this machine. RmlUi's own Dependencies.cmake only
+# checks `if(NOT TARGET Freetype::Freetype)` (CMake/Utilities.cmake's
+# report_dependency_found_or_error) -- it doesn't care whether that target came from
+# find_package or was created here, so add_subdirectory + an ALIAS matching FreeType's own
+# target name ("freetype", CMakeLists.txt) satisfies it. Must run before RmlUi's
+# add_subdirectory below.
+set(FT_DISABLE_ZLIB ON CACHE BOOL "" FORCE)
+set(FT_DISABLE_BZIP2 ON CACHE BOOL "" FORCE)
+set(FT_DISABLE_PNG ON CACHE BOOL "" FORCE)
+set(FT_DISABLE_HARFBUZZ ON CACHE BOOL "" FORCE)
+set(FT_DISABLE_BROTLI ON CACHE BOOL "" FORCE)
+add_subdirectory(ThirdParty/freetype EXCLUDE_FROM_ALL)
+add_library(Freetype::Freetype ALIAS freetype)
+
 mu_ensure_submodule("ThirdParty/RmlUi"
   INDICATOR "CMakeLists.txt"
   URL "https://github.com/mikke89/RmlUi.git")
 
-# RmlUi -- static link, no bundled backends/samples/Lua bindings. We supply our own
+# RmlUi -- static link, no bundled samples/Lua bindings. We supply our own
 # Rml::RenderInterface/SystemInterface (source/Render/RmlUi/) targeting this engine's RHI::
-# abstraction instead of one of RmlUi's stock backends. Font engine left at RmlUi's default
-# for now -- see the RmlUi migration plan's Open Decisions for the FreeType-vs-GDI-bridge call.
-# Not gated behind ENABLE_EDITOR (unlike imgui below): this ships in the real game, not just
-# admin/editor builds.
+# abstraction instead of one of RmlUi's stock backends -- RMLUI_BACKEND only selects which
+# backend the SAMPLES build against (RmlUi's own CMakeLists.txt validates it unconditionally
+# regardless of RMLUI_SAMPLES though, so it must still be left at a valid value from
+# CMake/OptionsLists.cmake; "auto" is a no-op here since RMLUI_SAMPLES is OFF). Font engine
+# left at RmlUi's own default (freetype, vendored above) rather than building a custom bridge
+# to this engine's GDI/stb_truetype text rasterizer -- see the RmlUi migration plan's Open
+# Decisions. Not gated behind ENABLE_EDITOR (unlike imgui below): this ships in the real game,
+# not just admin/editor builds.
 set(RMLUI_SAMPLES OFF CACHE BOOL "" FORCE)
-set(RMLUI_BACKEND "none" CACHE STRING "" FORCE)
+set(RMLUI_BACKEND "auto" CACHE STRING "" FORCE)
 set(RMLUI_LUA_BINDINGS OFF CACHE BOOL "" FORCE)
 set(RMLUI_INSTALL OFF CACHE BOOL "" FORCE)
 add_subdirectory(ThirdParty/RmlUi EXCLUDE_FROM_ALL)
@@ -112,8 +135,8 @@ file(GLOB_RECURSE MU_CLIENT_SOURCES
 )
 
 # RmlUi's official SDL input-event backend (RmlSDL::InputEventHandler/ConvertKey/
-# ConvertMouseButton/GetKeyModifierState) -- not part of RmlCore itself (RMLUI_BACKEND=none
-# above skips RmlUi's bundled renderer/platform backends), but there is no reason to hand-roll
+# ConvertMouseButton/GetKeyModifierState) -- not part of RmlUi::Core itself (RMLUI_SAMPLES=OFF
+# above skips building any of RmlUi's bundled renderer/platform backends), but there is no reason to hand-roll
 # an SDL-keycode-to-Rml::Input::KeyIdentifier mapping table when RmlUi ships a tested one. Only
 # this one file is compiled, not the rest of ThirdParty/RmlUi/Backends/ (which also contains
 # GL2/GL3/GPU/Vulkan renderer backends this project doesn't use, and whose own SystemInterface_SDL
@@ -846,10 +869,13 @@ target_link_libraries(MuClient PUBLIC
   SDL3_mixer::SDL3_mixer
 )
 
-# Link RmlUi (game UI middleware) on all platforms. RmlCore's own CMake exports its Include/
-# directory as a PUBLIC usage requirement, so no manual target_include_directories entry is
-# needed here -- verify this holds during first bring-up rather than adding a redundant path.
-target_link_libraries(MuClient PUBLIC RmlCore)
+# Link RmlUi (game UI middleware) on all platforms. The real target is rmlui_core, aliased as
+# RmlUi::Core (Source/Core/CMakeLists.txt) -- NOT "RmlCore", which silently passed through
+# target_link_libraries as a bare (nonexistent) name with no compile error until every RmlUi-
+# including source file failed on a missing Include/ path, caught during a real build. RmlUi::Core
+# exports its Include/ directory as a genuine INTERFACE usage requirement, so no manual
+# target_include_directories entry is needed on top of linking the correct target.
+target_link_libraries(MuClient PUBLIC RmlUi::Core)
 
 # Link ImGui for all platforms when editor is enabled. imgui carries its own
 # opengl32/dwmapi link dependencies (see its definition above), so the engine

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,22 @@ set(SDLMIXER_MIDI OFF CACHE BOOL "" FORCE)
 set(SDLMIXER_GME OFF CACHE BOOL "" FORCE)
 add_subdirectory(ThirdParty/SDL_mixer EXCLUDE_FROM_ALL)
 
+mu_ensure_submodule("ThirdParty/RmlUi"
+  INDICATOR "CMakeLists.txt"
+  URL "https://github.com/mikke89/RmlUi.git")
+
+# RmlUi -- static link, no bundled backends/samples/Lua bindings. We supply our own
+# Rml::RenderInterface/SystemInterface (source/Render/RmlUi/) targeting this engine's RHI::
+# abstraction instead of one of RmlUi's stock backends. Font engine left at RmlUi's default
+# for now -- see the RmlUi migration plan's Open Decisions for the FreeType-vs-GDI-bridge call.
+# Not gated behind ENABLE_EDITOR (unlike imgui below): this ships in the real game, not just
+# admin/editor builds.
+set(RMLUI_SAMPLES OFF CACHE BOOL "" FORCE)
+set(RMLUI_BACKEND "none" CACHE STRING "" FORCE)
+set(RMLUI_LUA_BINDINGS OFF CACHE BOOL "" FORCE)
+set(RMLUI_INSTALL OFF CACHE BOOL "" FORCE)
+add_subdirectory(ThirdParty/RmlUi EXCLUDE_FROM_ALL)
+
 # Determine architecture if CMAKE_SIZEOF_VOID_P isn't set
 if (NOT DEFINED CMAKE_SIZEOF_VOID_P OR CMAKE_SIZEOF_VOID_P EQUAL 0)
   # Try to detect from compiler path
@@ -815,6 +831,11 @@ target_link_libraries(MuClient PUBLIC
   SDL3::SDL3
   SDL3_mixer::SDL3_mixer
 )
+
+# Link RmlUi (game UI middleware) on all platforms. RmlCore's own CMake exports its Include/
+# directory as a PUBLIC usage requirement, so no manual target_include_directories entry is
+# needed here -- verify this holds during first bring-up rather than adding a redundant path.
+target_link_libraries(MuClient PUBLIC RmlCore)
 
 # Link ImGui for all platforms when editor is enabled. imgui carries its own
 # opengl32/dwmapi link dependencies (see its definition above), so the engine

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,16 @@ file(GLOB_RECURSE MU_CLIENT_SOURCES
         "source/*.cpp"
 )
 
+# RmlUi's official SDL input-event backend (RmlSDL::InputEventHandler/ConvertKey/
+# ConvertMouseButton/GetKeyModifierState) -- not part of RmlCore itself (RMLUI_BACKEND=none
+# above skips RmlUi's bundled renderer/platform backends), but there is no reason to hand-roll
+# an SDL-keycode-to-Rml::Input::KeyIdentifier mapping table when RmlUi ships a tested one. Only
+# this one file is compiled, not the rest of ThirdParty/RmlUi/Backends/ (which also contains
+# GL2/GL3/GPU/Vulkan renderer backends this project doesn't use, and whose own SystemInterface_SDL
+# class this project doesn't need -- see RmlUiSystemInterface). Not picked up by the GLOB_RECURSE
+# above since it globs "source/*.cpp", not ThirdParty/.
+list(APPEND MU_CLIENT_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/RmlUi/Backends/RmlUi_Platform_SDL.cpp")
+
 # Per-platform entry points (App/Platform/<OS>/Winmain.cpp, main.cpp, main.mm)
 # belong to the executable, not the engine library. Removing them keeps the
 # library free of a WinMain/main() so it can be linked into test binaries that
@@ -459,6 +469,9 @@ target_include_directories(MuClient PUBLIC
   "${CMAKE_BINARY_DIR}/generated"
   # stb_truetype backs the portable GDI text rasterizer (issue #462).
   "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/stb"
+  # RmlUi's official SDL input backend (RmlUi_Platform_SDL.h) -- see the RmlUi_Platform_SDL.cpp
+  # addition to MU_CLIENT_SOURCES above.
+  "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/RmlUi/Backends"
   $<$<BOOL:${ENABLE_EDITOR}>:${CMAKE_CURRENT_SOURCE_DIR}/MuEditor>
 )
 
@@ -472,6 +485,7 @@ target_compile_definitions(MuClient PUBLIC
   $<$<CONFIG:Debug>:_DEBUG;_FOREIGN_DEBUG>
   $<$<CONFIG:Release>:NDEBUG;_FOREIGN_NDEBUG;LDS_PATCH_GLOBAL_100520>
   $<$<BOOL:${ENABLE_EDITOR}>:_EDITOR>  # Editor features for admin builds
+  RMLUI_SDL_VERSION_MAJOR=3  # RmlUi_Platform_SDL.h's SDL2-vs-SDL3 API switch -- this project is SDL3-only
 )
 
 if (MSVC)

--- a/src/bin/Data/Interface/RmlUi/loading.rcss
+++ b/src/bin/Data/Interface/RmlUi/loading.rcss
@@ -1,0 +1,29 @@
+/* Reproduces CLoadingScene's 4-tile 800x600 reference-canvas layout
+   (LoadingScene.cpp's m_asprBack[0..3] positions/sizes) using percentage
+   sizing instead of the old fScaleX/fScaleY sprite scaling -- RmlUi scales
+   the whole document to the real Context/window size the same way. */
+
+body {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	background-color: #000000;
+}
+
+#bg {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
+}
+
+.tile {
+	position: absolute;
+}
+
+/* 400/800 = 50%, 512/600 = 85.3333%, 88/600 = 14.6667% */
+.tile-top-left     { left: 0%;  top: 0%;       width: 50%; height: 85.3333%; }
+.tile-top-right    { left: 50%; top: 0%;       width: 50%; height: 85.3333%; }
+.tile-bottom-left  { left: 0%;  top: 85.3333%; width: 50%; height: 14.6667%; }
+.tile-bottom-right { left: 50%; top: 85.3333%; width: 50%; height: 14.6667%; }

--- a/src/bin/Data/Interface/RmlUi/loading.rml
+++ b/src/bin/Data/Interface/RmlUi/loading.rml
@@ -1,0 +1,14 @@
+<rml>
+<head>
+	<title>Loading</title>
+	<link type="text/rcss" href="loading.rcss"/>
+</head>
+<body>
+	<div id="bg">
+		<img class="tile tile-top-left" src="/Interface/LSBg01.JPG"/>
+		<img class="tile tile-top-right" src="/Interface/LSBg02.JPG"/>
+		<img class="tile tile-bottom-left" src="/Interface/LSBg03.JPG"/>
+		<img class="tile tile-bottom-right" src="/Interface/LSBg04.JPG"/>
+	</div>
+</body>
+</rml>

--- a/src/bin/Data/Interface/RmlUi/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/login.rcss
@@ -1,0 +1,79 @@
+/* Overlay for CLoginWin's checkboxes/buttons/labels/trust-warning text. The legacy panel
+   background sprite (CWin::m_psprBg, BITMAP_LOG_IN+7) still renders underneath this, unchanged
+   -- see LoginWin.h's class comment. #panel's left/top are set from C++ (LoginWin.cpp's
+   SetPosition()) to track the same real-window-pixel origin the legacy panel sprite uses; every
+   child below uses fixed-pixel offsets relative to that container, matching "the login
+   background is fixed artwork and does not scale with window size" (LoginWin.cpp). */
+
+body {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+}
+
+#panel {
+	position: absolute;
+	width: 329px;
+	height: 245px;
+	font-family: "Tahoma";
+	font-size: 12px;
+	color: white;
+}
+
+.label {
+	position: absolute;
+}
+.label-server  { left: 111px; top: 80px; }
+.label-account { left: 30px; top: 113px; }
+.label-password{ left: 30px; top: 139px; }
+
+.checkbox-row {
+	position: absolute;
+	cursor: pointer;
+}
+.checkbox-remember-me  { left: 109px; top: 156px; }
+.checkbox-save-password{ left: 109px; top: 176px; }
+
+.checkbox-box {
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	border: 1px #808080;
+	background-color: #202020;
+}
+.checkbox-box.checked {
+	background-color: #c0a050;
+}
+
+.checkbox-label {
+	position: absolute;
+	left: 21px;
+	top: 1px;
+	white-space: nowrap;
+}
+
+.btn {
+	position: absolute;
+	width: 54px;
+	height: 30px;
+	text-align: center;
+	vertical-align: middle;
+	line-height: 30px;
+	cursor: pointer;
+	background-color: #402c1a;
+	border: 1px #806040;
+}
+.btn:hover {
+	background-color: #5a4026;
+}
+.btn-ok     { left: 150px; top: 200px; }
+.btn-cancel { left: 211px; top: 200px; }
+
+/* Below the fixed-size panel, matching the legacy "no room inside it" comment. */
+.trust-warning {
+	position: absolute;
+	left: 30px;
+	top: 252px;
+	width: 280px;
+	color: #ffd23c;
+}

--- a/src/bin/Data/Interface/RmlUi/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/login.rcss
@@ -9,6 +9,14 @@ body {
 	width: 100%;
 	height: 100%;
 	margin: 0;
+	/* pointer-events is inherited in RmlUi. body spans the whole real window (not just the
+	   login panel), so leaving it at the default "auto" makes every click anywhere on screen
+	   register as hovering a non-root RmlUi element -- Context::IsMouseInteracting() (which
+	   this engine's SDL input arbitration checks) then reports "handled" for every click,
+	   including ones landing on the legacy username/password input boxes underneath, so they
+	   never receive the click needed to transfer focus. "none" here lets clicks pass through
+	   to legacy input everywhere except the specific elements below that opt back in. */
+	pointer-events: none;
 }
 
 #panel {
@@ -33,6 +41,9 @@ body {
 .checkbox-row {
 	position: absolute;
 	cursor: pointer;
+	/* Opt back in to hit-testing (inherited "none" from body above, see its comment) --
+	   checkbox-box/checkbox-label below inherit "auto" from this, no separate rule needed. */
+	pointer-events: auto;
 }
 .checkbox-remember-me  { left: 109px; top: 156px; }
 .checkbox-save-password{ left: 109px; top: 176px; }
@@ -65,6 +76,8 @@ body {
 	cursor: pointer;
 	background-color: #402c1a;
 	border: 1px #806040;
+	/* Opt back in to hit-testing -- see body's pointer-events comment above. */
+	pointer-events: auto;
 }
 .btn:hover {
 	background-color: #5a4026;

--- a/src/bin/Data/Interface/RmlUi/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/login.rcss
@@ -15,7 +15,10 @@ body {
 	position: absolute;
 	width: 329px;
 	height: 245px;
-	font-family: "Tahoma";
+	/* Matches the family actually loaded via Rml::LoadFontFace (RmlUiRuntime::Create) --
+	   "Tahoma" was never loaded and rendered no text at all (confirmed from a real screenshot:
+	   shapes rendered, every label/button/warning string was blank). */
+	font-family: "Liberation Sans";
 	font-size: 12px;
 	color: white;
 }

--- a/src/bin/Data/Interface/RmlUi/login.rml
+++ b/src/bin/Data/Interface/RmlUi/login.rml
@@ -9,6 +9,15 @@
 		<span class="label label-account">{{account_label}}</span>
 		<span class="label label-password">{{password_label}}</span>
 
+		<!-- Purely decorative frame standing in for the input boxes' visual backing -- inert
+		     under the legacy theme (its background sprite already provides one), styled by the
+		     modern theme only. See themes/modern/login.rcss's .input-frame comment for why this
+		     is safe to draw after the legacy text underneath without covering it. Shared here
+		     (not theme-specific RML) since it's meaningful structure, not visual styling -- the
+		     theme decides whether it's visible, not whether it exists. -->
+		<div class="input-frame input-account"></div>
+		<div class="input-frame input-password"></div>
+
 		<div class="checkbox-row checkbox-remember-me" data-event-click="login_toggle_remember_me">
 			<div class="checkbox-box" data-class-checked="remember_me_checked"></div>
 			<span class="checkbox-label">{{remember_me_label}}</span>

--- a/src/bin/Data/Interface/RmlUi/login.rml
+++ b/src/bin/Data/Interface/RmlUi/login.rml
@@ -1,0 +1,27 @@
+<rml>
+<head>
+	<title>Login</title>
+	<link type="text/rcss" href="login.rcss"/>
+</head>
+<body>
+	<div id="panel" data-model="login">
+		<span class="label label-server">{{server_name}}</span>
+		<span class="label label-account">{{account_label}}</span>
+		<span class="label label-password">{{password_label}}</span>
+
+		<div class="checkbox-row checkbox-remember-me" data-event-click="login_toggle_remember_me">
+			<div class="checkbox-box" data-class-checked="remember_me_checked"></div>
+			<span class="checkbox-label">{{remember_me_label}}</span>
+		</div>
+		<div class="checkbox-row checkbox-save-password" data-event-click="login_toggle_save_password">
+			<div class="checkbox-box" data-class-checked="save_password_checked"></div>
+			<span class="checkbox-label">{{save_password_label}}</span>
+		</div>
+
+		<div class="btn btn-ok" data-event-click="login_ok_click">{{ok_label}}</div>
+		<div class="btn btn-cancel" data-event-click="login_cancel_click">{{cancel_label}}</div>
+
+		<span class="trust-warning">{{trust_warning}}</span>
+	</div>
+</body>
+</rml>

--- a/src/bin/Data/Interface/RmlUi/login.rml
+++ b/src/bin/Data/Interface/RmlUi/login.rml
@@ -18,12 +18,32 @@
 		<div class="input-frame input-account"></div>
 		<div class="input-frame input-password"></div>
 
+		<!-- .checkbox-tick is the real checkmark glyph: legacy hides it (checked-state art already
+		     has the tick baked in). Modern draws it from axis-aligned .tick-px blocks, not a
+		     rotated shape -- this engine's RmlUi doesn't implement CSS transform (see
+		     gotchas-and-patterns.md). -->
 		<div class="checkbox-row checkbox-remember-me" data-event-click="login_toggle_remember_me">
-			<div class="checkbox-box" data-class-checked="remember_me_checked"></div>
+			<div class="checkbox-box" data-class-checked="remember_me_checked">
+				<div class="checkbox-tick">
+					<div class="tick-px tick-px-1"></div>
+					<div class="tick-px tick-px-2"></div>
+					<div class="tick-px tick-px-3"></div>
+					<div class="tick-px tick-px-4"></div>
+					<div class="tick-px tick-px-5"></div>
+				</div>
+			</div>
 			<span class="checkbox-label">{{remember_me_label}}</span>
 		</div>
 		<div class="checkbox-row checkbox-save-password" data-event-click="login_toggle_save_password">
-			<div class="checkbox-box" data-class-checked="save_password_checked"></div>
+			<div class="checkbox-box" data-class-checked="save_password_checked">
+				<div class="checkbox-tick">
+					<div class="tick-px tick-px-1"></div>
+					<div class="tick-px tick-px-2"></div>
+					<div class="tick-px tick-px-3"></div>
+					<div class="tick-px tick-px-4"></div>
+					<div class="tick-px tick-px-5"></div>
+				</div>
+			</div>
 			<span class="checkbox-label">{{save_password_label}}</span>
 		</div>
 

--- a/src/bin/Data/Interface/RmlUi/login_main.rml
+++ b/src/bin/Data/Interface/RmlUi/login_main.rml
@@ -1,0 +1,15 @@
+<rml>
+<head>
+	<title>Login Main Bar</title>
+	<link type="text/rcss" href="base.rcss"/>
+	<link type="text/rcss" href="login_main.rcss"/>
+</head>
+<body>
+	<div id="panel">
+		<div id="btn_menu" class="btn-icon btn-icon-menu"></div>
+		<div id="btn_credit" class="btn-icon btn-icon-credit">
+			<div class="btn-credit-deco"></div>
+		</div>
+	</div>
+</body>
+</rml>

--- a/src/bin/Data/Interface/RmlUi/login_main.rml
+++ b/src/bin/Data/Interface/RmlUi/login_main.rml
@@ -5,10 +5,15 @@
 	<link type="text/rcss" href="login_main.rcss"/>
 </head>
 <body>
+	<!-- .btn-icon-label only matters for the modern theme (legacy hides it -- its real icon art
+	     already gives these buttons a visual identity, see themes/legacy/login_main.rcss). -->
 	<div id="panel">
-		<div id="btn_menu" class="btn-icon btn-icon-menu"></div>
+		<div id="btn_menu" class="btn-icon btn-icon-menu">
+			<span class="btn-icon-label">M</span>
+		</div>
 		<div id="btn_credit" class="btn-icon btn-icon-credit">
 			<div class="btn-credit-deco"></div>
+			<span class="btn-icon-label">C</span>
 		</div>
 	</div>
 </body>

--- a/src/bin/Data/Interface/RmlUi/option.rml
+++ b/src/bin/Data/Interface/RmlUi/option.rml
@@ -1,0 +1,44 @@
+<rml>
+<head>
+	<title>Options</title>
+	<link type="text/rcss" href="base.rcss"/>
+	<link type="text/rcss" href="option.rcss"/>
+</head>
+<body>
+	<div id="backdrop"></div>
+	<div id="panel" data-model="option">
+		<div id="panel_middle" class="panel-middle"></div>
+		<div class="panel-cap-top"></div>
+		<div class="panel-cap-bottom"></div>
+		<span class="option-title">{{title_label}}</span>
+
+		<div id="checkbox_auto_attack" class="checkbox-row" data-event-click="option_toggle_auto_attack">
+			<div class="checkbox-box" data-class-checked="auto_attack_checked"></div>
+			<span class="checkbox-label">{{auto_attack_label}}</span>
+		</div>
+		<div id="checkbox_whisper_alarm" class="checkbox-row" data-event-click="option_toggle_whisper_alarm">
+			<div class="checkbox-box" data-class-checked="whisper_alarm_checked"></div>
+			<span class="checkbox-label">{{whisper_alarm_label}}</span>
+		</div>
+		<div id="checkbox_slide_help" class="checkbox-row" data-event-click="option_toggle_slide_help">
+			<div class="checkbox-box" data-class-checked="slide_help_checked"></div>
+			<span class="checkbox-label">{{slide_help_label}}</span>
+		</div>
+
+		<div id="slider_volume" class="slider">
+			<span class="slider-label">{{volume_label}}</span>
+			<span class="slider-value">{{volume_value_text}}</span>
+			<div class="slider-track"></div>
+			<div id="volume_thumb" class="slider-thumb" data-style-left="volume_thumb_left + 'px'"></div>
+		</div>
+		<div id="slider_render" class="slider">
+			<span class="slider-label">{{render_label}}</span>
+			<span class="slider-value">{{render_value_text}}</span>
+			<div class="slider-track"></div>
+			<div id="render_thumb" class="slider-thumb" data-style-left="render_thumb_left + 'px'"></div>
+		</div>
+
+		<div id="btn_close" class="btn" data-event-click="option_close_click">{{close_label}}</div>
+	</div>
+</body>
+</rml>

--- a/src/bin/Data/Interface/RmlUi/remember_password_prompt.rml
+++ b/src/bin/Data/Interface/RmlUi/remember_password_prompt.rml
@@ -1,0 +1,15 @@
+<rml>
+<head>
+	<title>Remember Password Prompt</title>
+	<link type="text/rcss" href="base.rcss"/>
+	<link type="text/rcss" href="remember_password_prompt.rcss"/>
+</head>
+<body>
+	<div id="panel" data-model="remember_password_prompt">
+		<span class="prompt-title">{{title_text}}</span>
+		<span class="prompt-body">{{body_text}}</span>
+		<div class="btn btn-ok" data-event-click="prompt_ok_click">{{ok_label}}</div>
+		<div class="btn btn-cancel" data-event-click="prompt_cancel_click">{{cancel_label}}</div>
+	</div>
+</body>
+</rml>

--- a/src/bin/Data/Interface/RmlUi/sys_menu.rml
+++ b/src/bin/Data/Interface/RmlUi/sys_menu.rml
@@ -1,0 +1,19 @@
+<rml>
+<head>
+	<title>System Menu</title>
+	<link type="text/rcss" href="base.rcss"/>
+	<link type="text/rcss" href="sys_menu.rcss"/>
+</head>
+<body>
+	<div id="backdrop"></div>
+	<div id="panel" data-model="sys_menu">
+		<div id="panel_middle" class="panel-middle"></div>
+		<div class="panel-cap-top"></div>
+		<div class="panel-cap-bottom"></div>
+		<div id="btn_exit_game" class="btn" data-event-click="sysmenu_exit_game_click">{{exit_game_label}}</div>
+		<div id="btn_select_server" class="btn" data-class-hidden="select_server_hidden" data-event-click="sysmenu_select_server_click">{{select_server_label}}</div>
+		<div id="btn_option" class="btn" data-event-click="sysmenu_option_click">{{option_label}}</div>
+		<div id="btn_close" class="btn" data-event-click="sysmenu_close_click">{{close_label}}</div>
+	</div>
+</body>
+</rml>

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/base.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/base.rcss
@@ -1,0 +1,232 @@
+/* Shared, cross-window RCSS -- generic (non-positional) rules reused by more than one migrated
+   window, extracted from themes/legacy/login.rcss's originals (which stay self-contained and
+   unretrofitted -- see the RmlUi migration plan's "Batch 2" section). Every new migrated
+   window's <head> links this file first, then its own per-window positional .rcss.
+
+   Unlike login.rcss's own checkboxes/buttons (deliberately flat -- see that file's header
+   comment), .btn/.checkbox-box here reproduce the real legacy sprite art, since this file is
+   genuinely shared across windows (SysMenuWin/OptionWin's buttons are the exact same
+   BITMAP_TEXT_BTN asset -- "shared component" in the literal sense) and both source assets are
+   already loaded unconditionally at startup (Engine/Object/ZzzOpenData.cpp's OpenBasicData(),
+   not scene-gated). Kept for the legacy theme only -- modern stays fully flat/programmatic, see
+   themes/modern/base.rcss. */
+
+/* This engine's legacy .OZT loader pads every non-power-of-two texture up to the next power-of-
+   two size (see login.rcss's identical note) -- op1_b_all.tga (108x120, padded to 128x128) and
+   op2_ch.tga (already 16x32, both dimensions POT, so technically un-padded -- declared as a
+   spritesheet anyway purely to select a single frame's sub-rect, the same mechanism, different
+   reason) both need named sub-rects rather than direct decorator: image() references. */
+@spritesheet legacy-btn-sheet
+{
+	src: "../../../op1_b_all.tga";
+	/* CButton::Create(108, 30, BITMAP_TEXT_BTN, 4, 2, 1) -- frames stack vertically at
+	   y = frameHeight * frameIndex (Button.cpp). Frame 0 = idle/up, 1 = active/hover,
+	   2 = down/pressed; frame 3 exists in the art (4 frames total) but this engine's own
+	   CButton::Create call never assigns a disabled frame (nDisableFrame left default), so
+	   .btn.disabled below stays an opacity dim over the idle frame rather than a 4th art state. */
+	legacy-btn-idle:   0px  0px 108px 30px;
+	legacy-btn-hover:  0px 30px 108px 30px;
+	legacy-btn-active: 0px 60px 108px 30px;
+}
+
+@spritesheet legacy-checkbox-sheet
+{
+	src: "../../../op2_ch.tga";
+	/* CButton::Create(16, 16, BITMAP_CHECK_BTN, 2, 0, 0, -1, 1, 1, 1) -- frame 0 (up/down/active
+	   all mapped to it) = unchecked, frame 1 (every check-* slot mapped to it) = checked. */
+	legacy-checkbox-unchecked: 0px  0px 16px 16px;
+	legacy-checkbox-checked:   0px 16px 16px 16px;
+}
+
+/* Shared panel-chrome art for SysMenuWin/OptionWin's CWinEx backing (Engine/Object/ZzzOpenData.cpp
+   BITMAP_SYS_WIN family) -- both windows use the identical center/bottom-cap images, differing
+   only in their own top-cap image (op1_back1.tga for SysMenuWin, op2_back1.tga for OptionWin --
+   declared per-window, see sys_menu.rcss/option.rcss).
+
+   Reproduces 3 of CWinEx's 5 real pieces as three stacked elements (.panel-cap-top/.panel-middle/
+   .panel-cap-bottom below), NOT RmlUi's tiled-vertical decorator -- an earlier version of this
+   file used tiled-vertical(top, center, bottom) on a single #panel element, which turned out
+   wrong: confirmed by reading DecoratorTiled(Vertical).cpp, tiled-vertical's tile property never
+   registers RmlUi's fit-mode sub-property at all (RegisterTileProperty is called without its
+   register_fit_modes flag), so every tile -- including the center -- is hardcoded to FILL
+   (stretch-to-fit), never REPEAT. The center tile rendered as a single blurry stretched copy of a
+   128x128 texture instead of a repeating pattern, which read as "no texture" in-game. The plain
+   `image` decorator (DecoratorTiledImage), by contrast, DOES register fit-mode support
+   (RegisterTileProperty("image", true)) including a real `repeat` keyword -- so the fix is three
+   separate elements, each using `image()`, rather than one tiled-vertical call. The two remaining
+   real pieces, the 5px left/right edge trim strips (op1_back3.jpg/op1_back4.jpg), are still NOT
+   reproduced -- would need two more absolutely-positioned strip elements; at 5px wide the visual
+   cost of omitting them is minor, flagged here and in the migration task log as a fast-follow. */
+@spritesheet legacy-panel-bottom-sheet
+{
+	src: "../../../op1_back2.tga";
+	legacy-panel-bottom: 0px 0px 213px 43px;
+}
+@spritesheet legacy-panel-center-sheet
+{
+	/* op1_stone.jpg is already 128x128 (exact power-of-two) -- declared as a named sprite for the
+	   same reason every other tile in this file is: it's the only reliably-working reference form
+	   confirmed in this codebase. A raw quoted path was tried instead (to unlock RmlUi's `repeat`
+	   fit mode, which explicitly rejects sprite sources -- see the removed comment this replaced,
+	   kept in git history/the migration task log) and rendered nothing, most likely because
+	   PropertyParserString.cpp's ParseValue does zero quote-stripping -- a quoted literal inside a
+	   decorator shorthand argument (unlike a top-level property like font-family, which goes
+	   through a different parse path) may retain its literal quote characters as part of the
+	   "path", which then fails to resolve to any real file -- and this engine's texture loader
+	   fails 100% silently on a bad path (documented in theming-and-modding.md), matching exactly
+	   what was observed: no visible art, no warning anywhere in MuError.log. Not fully confirmed
+	   (would need a live debugger to prove definitively), but the sprite/FILL form below is the
+	   one every other decorator in this file already proves reliable, so it's the one this uses
+	   -- tiling is a nice-to-have deferred behind actually rendering, not the other way around. */
+	src: "../../../op1_stone.jpg";
+	legacy-panel-center: 0px 0px 128px 128px;
+}
+
+/* Structural shape shared by SysMenuWin/OptionWin's panel background -- top/bottom heights and
+   the top image are window-specific (see sys_menu.rcss/option.rcss), the bottom image and the
+   tiling center are identical for both and declared once here. */
+.panel-cap-top {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+}
+.panel-cap-bottom {
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	width: 100%;
+	height: 43px;
+	decorator: image(legacy-panel-bottom);
+}
+/* NOT a band confined to the gap between the two caps -- confirmed against the real CWinEx source
+   (Win widgets, not RmlUi) that this replaces: WinEx.cpp's CWinEx::Render() draws WE_BG_CENTER
+   FIRST (enum value 0, drawn before WE_BG_TOP/BOTTOM/LEFT/RIGHT in the same loop), and
+   SetPosition()/SetLine() size and position it to span nearly the FULL panel -- inset by
+   WE_CENTER_SPR_POS (3px) on every side, not confined between the caps. The top/bottom cap
+   images are drawn ON TOP of it afterward; their own art has transparent "negative space" around
+   the ornate scrollwork linework, so the center tile shows through underneath in the cap regions
+   too, not just the visible gap. An earlier version of this file modeled the three pieces as
+   non-overlapping stacked bands (top 0-64px, middle 64px-to-bottom-cap, bottom cap) -- this
+   rendered the middle band correctly but left the cap regions showing through to whatever's
+   behind the document, because that model never gave the center tile any presence under the caps
+   to begin with. Fixed by reordering panel_middle to be the FIRST child in the RML
+   (sys_menu.rml/option.rml), so it paints before both caps.
+
+   The 3px inset itself is expressed here in pure RCSS (left/top/right/bottom, no width/height) --
+   NOT pushed from C++, despite an earlier version doing exactly that out of unconfirmed caution
+   about whether RmlUi correctly derives width/height from opposing edges on a position:absolute
+   element. It does: confirmed by reading LayoutDetails::BuildBoxWidth/BuildBoxHeight
+   (Layout/LayoutDetails.cpp) directly, which implement the standard CSS 2.1 algorithm --
+   `absolutely_positioned` elements use left+right (and top+bottom) as an explicit width/height
+   constraint when no width/height is set, not an unverified corner case. Keeping this in RCSS
+   matters beyond tidiness: this project's stated goal is that a theme -- including a modder's --
+   needs zero C++ changes and zero recompilation (see theming-and-modding.md). A hardcoded C++
+   inset would mean any future theme wanting a similar real-art composite, with a different inset
+   than 3px, couldn't express that without engine changes; this way it's exactly the same kind of
+   per-theme override any other positioned element in this file already is. */
+.panel-middle {
+	position: absolute;
+	left: 3px;
+	top: 3px;
+	right: 3px;
+	bottom: 3px;
+	/* Plain FILL (stretch-to-fit, the default -- no fit-mode argument at all), matching every
+	   other decorator in this file exactly. This stretches the 128x128 source across its box
+	   instead of tiling it -- visually softer than a true repeating pattern, but this is the one
+	   form already proven to actually render in this codebase (buttons/checkboxes/caps all use
+	   it). A `repeat`-tiled version was attempted first and hit three separate real bugs in
+	   sequence (wrong shorthand argument order; repeat rejected outright for sprite sources; then
+	   a raw-path attempt that most likely lost its quoting) -- full writeup in
+	   docs/rmlui-ui-system/gotchas-and-patterns.md and the migration task log. Revisit true
+	   tiling later as a deliberate, isolated experiment, not blocking on it now. */
+	decorator: image(legacy-panel-center);
+}
+
+body {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	/* See login.rcss's identical comment -- body spans the whole real window, so this must stay
+	   "none" with specific elements opting back in, or every click on screen gets swallowed for
+	   legacy-input purposes the moment a full-window document is shown. */
+	pointer-events: none;
+}
+
+/* Full-screen dim overlay for modal-style windows (SysMenuWin/OptionWin) that previously relied
+   on CWin::Create()'s default nTexID=-1 (a real alpha=128 black CSprite, Win.cpp:19-31). Placed
+   as the first child of <body>, before #panel, so it paints underneath. pointer-events:auto (not
+   inherited "none") because CWin::CursorInWin(WA_ALL) already spans the whole screen while either
+   legacy window is shown -- any click anywhere is already treated as "on this UI" today, so this
+   reproduces existing behavior (clicking the dimmed area does nothing but is still consumed)
+   rather than introducing click-through as a side effect of migrating. */
+#backdrop {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 128);
+	pointer-events: auto;
+}
+
+.checkbox-row {
+	position: absolute;
+	cursor: pointer;
+	pointer-events: auto;
+}
+.checkbox-box {
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	decorator: image(legacy-checkbox-unchecked);
+}
+.checkbox-box.checked {
+	decorator: image(legacy-checkbox-checked);
+}
+.checkbox-label {
+	position: absolute;
+	left: 21px;
+	top: 1px;
+	white-space: nowrap;
+}
+
+/* Sized for the 108x30 BITMAP_TEXT_BTN shape shared by SysMenuWin's 4 buttons and OptionWin's
+   Close button -- login's own 54x30 image buttons stay defined in login.rcss's own .btn rule,
+   unaffected since login.rml/.rcss don't link this file. */
+.btn {
+	position: absolute;
+	width: 108px;
+	height: 30px;
+	text-align: center;
+	vertical-align: middle;
+	line-height: 30px;
+	cursor: pointer;
+	decorator: image(legacy-btn-idle);
+	pointer-events: auto;
+}
+.btn:hover {
+	decorator: image(legacy-btn-hover);
+}
+.btn:active {
+	decorator: image(legacy-btn-active);
+}
+/* Reproduces CButton::SetEnable(false) -- blocks the click at RmlUi's own hit-test level rather
+   than relying solely on the C++ handler's own guard. Opacity dim over the idle art rather than a
+   distinct art frame -- see the spritesheet comment above for why. */
+.btn.disabled {
+	pointer-events: none;
+	opacity: 0.5;
+	cursor: default;
+}
+
+/* For a button that should be genuinely absent (not clickable-but-grayed) in the current context
+   -- SysMenuWin's Select Server button, hidden entirely in the login scene rather than disabled,
+   since a dimmed-but-still-drawn button visibly collided with the Option button when the panel
+   uses the login scene's shorter height (CWinEx::SetLine(6) leaves no real vertical room for 4
+   button slots). Every button here is position:absolute with no shared flow, so display:none
+   removing this element from layout doesn't shift any sibling's position -- safe to use for any
+   future conditionally-absent element in this shape, not just this one case. */
+.hidden {
+	display: none;
+}

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/login.rcss
@@ -1,9 +1,35 @@
-/* Overlay for CLoginWin's checkboxes/buttons/labels/trust-warning text. The legacy panel
-   background sprite (CWin::m_psprBg, BITMAP_LOG_IN+7) still renders underneath this, unchanged
-   -- see LoginWin.h's class comment. #panel's left/top are set from C++ (LoginWin.cpp's
-   SetPosition()) to track the same real-window-pixel origin the legacy panel sprite uses; every
-   child below uses fixed-pixel offsets relative to that container, matching "the login
-   background is fixed artwork and does not scale with window size" (LoginWin.cpp). */
+/* Full RmlUi overlay for the login dialog -- panel background, input-box frames, checkboxes,
+   buttons, labels, and trust-warning text are ALL rendered here now. CWin no longer draws
+   anything for this window (CLoginWin::Create() always passes nTexID=-2); this theme reproduces
+   the original legacy look by pointing #panel/.input-frame's decorators at the *same* art files
+   the old CWin sprites used (Interface/login_back.tga, Interface/login_me.tga) -- same pixels,
+   different renderer. #panel's left/top are set from C++ (LoginWin.cpp's SetPosition()) to track
+   the window's real-pixel origin; every child below uses fixed-pixel offsets relative to that
+   container, matching "the login background is fixed artwork and does not scale with window
+   size" (LoginWin.cpp). */
+
+/* This engine's legacy .OZT loader (CGlobalBitmap::OpenTga) pads every texture up to the next
+   power-of-two size (e.g. 329x245 -> 512x256), leaving the real image in the top-left corner and
+   the rest zero-filled -- a leftover constraint from old GPUs, invisible to every legacy CSprite
+   caller because CSprite computes its own UV sub-rect from the ORIGINAL dimensions it was given
+   (see CSprite::Create's m_fOrgWidth/m_fOrgHeight-based texcoord math), not the padded texture
+   size. RmlUi's plain `decorator: image(...)` has no such caller-supplied sub-rect -- it always
+   samples the FULL texture as 0..1 UV -- so referencing these files directly stretched the real
+   329x245/156x23 art across a small corner of the panel while squishing in a chunk of blank
+   padding. Fix: declare each image as a named sprite with an explicit pixel rectangle matching its
+   REAL (unpadded) size -- RmlUi's sprite path uses that rectangle for UV math instead of the full
+   texture, exactly like CSprite's own original-dimensions approach. */
+@spritesheet login-back-sheet
+{
+	src: "../../../login_back.tga";
+	login-back-image: 0px 0px 329px 245px;
+}
+
+@spritesheet login-input-frame-sheet
+{
+	src: "../../../login_me.tga";
+	login-input-frame-image: 0px 0px 156px 23px;
+}
 
 body {
 	width: 100%;
@@ -29,6 +55,14 @@ body {
 	font-family: "Liberation Sans";
 	font-size: 12px;
 	color: white;
+	/* The exact same 329x245 artwork CWin::m_psprBg used to draw (BITMAP_LOG_IN+7) -- loaded
+	   through RmlUiRenderInterface::LoadTexture -> CGlobalBitmap::LoadImage, which finds and
+	   ref-counts the same cached texture by filename (it's already resident, preloaded
+	   unconditionally by ZzzOpenData.cpp regardless of which theme is active), so this is not a
+	   second GPU upload of the same file. References the named sprite (see @spritesheet above),
+	   not the raw file path directly -- required to get correct UV coordinates against this
+	   texture's power-of-two-padded real size. */
+	decorator: image(login-back-image);
 }
 
 .label {
@@ -38,12 +72,22 @@ body {
 .label-account { left: 30px; top: 113px; }
 .label-password{ left: 30px; top: 139px; }
 
-/* Inert under this theme -- the legacy input-box frame sprites (CLoginWin's m_asprInputBox,
-   BITMAP_LOG_IN+8) already provide the visual backing. See login.rml's comment and the modern
-   theme's login.rcss for where this class is actually styled. */
+/* Same art file the old CLoginWin::m_asprInputBox CSprites drew (Interface/login_me.tga,
+   BITMAP_LOG_IN+8), now rendered by RmlUi instead. pointer-events stays "none" (inherited from
+   body) -- purely visual, must not intercept clicks meant for the legacy CUITextInputBox
+   underneath. Renders as part of RmlUi's pass (after all legacy 2D content, before
+   CLoginWin::RenderTextOnTop()'s later call -- see SceneManager.cpp), so the input text drawn on
+   top afterward is never covered, same ordering the modern theme's border-only version relies on. */
 .input-frame {
-	display: none;
+	position: absolute;
+	width: 156px;
+	height: 23px;
+	/* Same named-sprite note as #panel above -- see @spritesheet login-input-frame-sheet. */
+	decorator: image(login-input-frame-image);
+	pointer-events: none;
 }
+.input-account  { left: 109px; top: 106px; }
+.input-password { left: 109px; top: 131px; }
 
 .checkbox-row {
 	position: absolute;

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/login.rcss
@@ -38,6 +38,13 @@ body {
 .label-account { left: 30px; top: 113px; }
 .label-password{ left: 30px; top: 139px; }
 
+/* Inert under this theme -- the legacy input-box frame sprites (CLoginWin's m_asprInputBox,
+   BITMAP_LOG_IN+8) already provide the visual backing. See login.rml's comment and the modern
+   theme's login.rcss for where this class is actually styled. */
+.input-frame {
+	display: none;
+}
+
 .checkbox-row {
 	position: absolute;
 	cursor: pointer;

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/login.rcss
@@ -31,6 +31,16 @@
 	login-input-frame-image: 0px 0px 156px 23px;
 }
 
+/* Real checkbox tick art (BITMAP_CHECK_BTN, ZzzOpenData.cpp:5443) -- same source/frames as
+   base.rcss's legacy-checkbox-sheet, declared locally since login.rcss doesn't link base.rcss
+   (see this file's header comment). Frame 0 = unchecked, frame 1 = checked. */
+@spritesheet login-checkbox-sheet
+{
+	src: "../../../op2_ch.tga";
+	login-checkbox-unchecked: 0px  0px 16px 16px;
+	login-checkbox-checked:   0px 16px 16px 16px;
+}
+
 body {
 	width: 100%;
 	height: 100%;
@@ -103,11 +113,17 @@ body {
 	display: inline-block;
 	width: 16px;
 	height: 16px;
-	border: 1px #808080;
-	background-color: #202020;
+	/* Same named-sprite note as #panel above -- see @spritesheet login-checkbox-sheet. */
+	decorator: image(login-checkbox-unchecked);
 }
 .checkbox-box.checked {
-	background-color: #c0a050;
+	decorator: image(login-checkbox-checked);
+}
+
+/* The real tick is baked into login-checkbox-checked's art above -- .checkbox-tick only matters
+   for the modern theme (see themes/modern/login.rcss). */
+.checkbox-tick {
+	display: none;
 }
 
 .checkbox-label {
@@ -115,6 +131,28 @@ body {
 	left: 21px;
 	top: 1px;
 	white-space: nowrap;
+}
+
+/* Real OK/Cancel button art (ZzzOpenData.cpp:5431-5432: message_ok_b_all.tga/
+   loding_cancel_b_all.tga, BITMAP_BUTTON+0/+1) -- label text is baked in (original CButton::Create
+   calls never used SetText()), so login.rml's {{ok_label}}/{{cancel_label}} text node (shared with
+   the modern theme, which needs it) is made transparent here instead.
+   3 frames, same convention as base.rcss's legacy-btn-sheet: frame 0 = idle, frame 1 = hover,
+   frame 2 = pressed (CButton::Create(54, 30, BITMAP_BUTTON+i, 3, 2, 1)'s nDownFrame=2/
+   nActiveFrame=1, per Button.cpp's Update()). */
+@spritesheet login-ok-sheet
+{
+	src: "../../../message_ok_b_all.tga";
+	login-ok-idle:   0px  0px 54px 30px;
+	login-ok-hover:  0px 30px 54px 30px;
+	login-ok-active: 0px 60px 54px 30px;
+}
+@spritesheet login-cancel-sheet
+{
+	src: "../../../loding_cancel_b_all.tga";
+	login-cancel-idle:   0px  0px 54px 30px;
+	login-cancel-hover:  0px 30px 54px 30px;
+	login-cancel-active: 0px 60px 54px 30px;
 }
 
 .btn {
@@ -125,16 +163,30 @@ body {
 	vertical-align: middle;
 	line-height: 30px;
 	cursor: pointer;
-	background-color: #402c1a;
-	border: 1px #806040;
+	color: transparent;
 	/* Opt back in to hit-testing -- see body's pointer-events comment above. */
 	pointer-events: auto;
 }
-.btn:hover {
-	background-color: #5a4026;
+.btn-ok {
+	left: 150px; top: 200px;
+	decorator: image(login-ok-idle);
 }
-.btn-ok     { left: 150px; top: 200px; }
-.btn-cancel { left: 211px; top: 200px; }
+.btn-ok:hover {
+	decorator: image(login-ok-hover);
+}
+.btn-ok:active {
+	decorator: image(login-ok-active);
+}
+.btn-cancel {
+	left: 211px; top: 200px;
+	decorator: image(login-cancel-idle);
+}
+.btn-cancel:hover {
+	decorator: image(login-cancel-hover);
+}
+.btn-cancel:active {
+	decorator: image(login-cancel-active);
+}
 
 /* Below the fixed-size panel, matching the legacy "no room inside it" comment. */
 .trust-warning {

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/login_main.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/login_main.rcss
@@ -67,3 +67,9 @@
 	pointer-events: none;
 	decorator: image(login-main-deco-image);
 }
+
+/* Only the modern theme needs a text glyph -- these buttons' real icon art above already gives
+   them a visual identity (see themes/modern/login_main.rcss's own .btn-icon-label rule). */
+.btn-icon-label {
+	display: none;
+}

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/login_main.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/login_main.rcss
@@ -1,0 +1,69 @@
+/* RmlUi overlay for the login-scene menu/credit button bar (CLoginMainWin). CWin draws nothing
+   for this window (CWin::Create() uses nTexID=-2, same sentinel as login.rcss's panel). Only the
+   IDLE frame of each button's 3-frame art is reproduced (no RmlUi decorator swap for hover/press
+   frames in this pass) -- same simplification precedent login.rcss's own checkboxes/buttons
+   already established (flat/static art standing in for the legacy frame-based sprite system,
+   documented there as "out of scope for proving the pipeline"). Source art per
+   Engine/Object/ZzzOpenData.cpp's OpenLoginSceneData(): server_menu_b_all.tga /
+   server_credit_b_all.tga (each a 54x30-per-frame, 3-frame vertical strip -- CButton::Create lays
+   frames out at Y = nHeight * frameIndex, so the idle frame is the sheet's top 54x30 rect) and
+   deco.tga (189x103, single frame). Same @spritesheet-with-explicit-rect technique login.rcss
+   uses, for the same reason (this engine's .OZT loader pads textures to the next power-of-two
+   size; a plain decorator:image() would sample the whole padded texture, not just the real art). */
+
+@spritesheet login-main-menu-sheet
+{
+	src: "../../../server_menu_b_all.tga";
+	login-main-menu-icon: 0px 0px 54px 30px;
+}
+@spritesheet login-main-credit-sheet
+{
+	src: "../../../server_credit_b_all.tga";
+	login-main-credit-icon: 0px 0px 54px 30px;
+}
+@spritesheet login-main-deco-sheet
+{
+	src: "../../../deco.tga";
+	login-main-deco-image: 0px 0px 189px 103px;
+}
+
+#panel {
+	position: absolute;
+	/* Width/height are pushed from C++ (CLoginMainWin::SetPosition/Create) -- the bar spans
+	   (screen width - 60px) and is exactly one button tall, both screen-size-dependent, unlike
+	   login's fixed 329x245 panel. */
+}
+
+.btn-icon {
+	position: absolute;
+	width: 54px;
+	height: 30px;
+	cursor: pointer;
+	pointer-events: auto;
+}
+.btn-icon-menu {
+	left: 0px;
+	top: 0px;
+	decorator: image(login-main-menu-icon);
+}
+/* left is pushed from C++ (screen-width dependent right-alignment, matching the legacy
+   CButton::SetPosition math in CLoginMainWin::SetPosition). */
+.btn-icon-credit {
+	top: 0px;
+	decorator: image(login-main-credit-icon);
+}
+
+/* Stands in for CSprite m_sprDeco -- decorative only, must not intercept clicks meant for the
+   credit button beneath/around it. Original CSprite::Create's trailing (105, 59) args are this
+   engine's sprite anchor-point offset (the pixel within the 189x103 art that lines up with
+   SetPosition()'s coords); reproduced here as a fixed offset from the credit button's own
+   top-left, since deco is a child of #btn_credit and inherits its positioning context. */
+.btn-credit-deco {
+	position: absolute;
+	left: -105px;
+	top: -59px;
+	width: 189px;
+	height: 103px;
+	pointer-events: none;
+	decorator: image(login-main-deco-image);
+}

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/option.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/option.rcss
@@ -1,0 +1,100 @@
+/* RmlUi overlay for the (currently unreachable -- see OptionWin.h's class comment) Options
+   window. Panel chrome and control positions mirror the exact legacy layout math
+   (OptionWin.cpp's Create()/SetPosition()) as fixed px offsets -- unlike CSysMenuWin, this
+   window's layout is never scene-conditional (m_winBack.SetLine(30) is the only value ever
+   used), so nothing here needs to be pushed from C++ beyond #panel's own left/top/width/height.
+   Panel background is three stacked elements (.panel-cap-top/.panel-middle/.panel-cap-bottom,
+   structural rules in base.rcss, same shape SysMenuWin uses) rather than a single tiled-vertical()
+   decorator -- see base.rcss's header comment for why (tiled-vertical hardcodes FILL/stretch for
+   every tile, never REPEAT). Only this window's own top-cap height/image differ from SysMenuWin's
+   (op2_back1.tga vs op1_back1.tga); center/bottom are the shared sprites base.rcss declares.
+   Checkboxes/buttons reproduce the real legacy art via base.rcss, shared with SysMenuWin. Sliders
+   reproduce the real track/thumb art too (op2_volume1.tga/op2_volume3.tga) -- the one piece NOT
+   reproduced is the gauge fill (op2_volume2.jpg), which would need a third, dynamically-widthed
+   element tracking the thumb position; deferred as a minor cosmetic gap, not required for the
+   slider to read correctly (the thumb position alone already conveys the value). */
+
+@spritesheet option-top-sheet
+{
+	src: "../../../op2_back1.tga";
+	/* op2_back1.tga is 213x65 -- not power-of-two, needs the named-rect workaround (see
+	   base.rcss's identical note). OptionWin's own top cap; center/bottom are the same shared
+	   sprites SysMenuWin uses, declared once in base.rcss. */
+	option-top: 0px 0px 213px 65px;
+}
+
+@spritesheet option-slider-sheet
+{
+	src: "../../../op2_volume1.tga";
+	option-slider-track: 0px 0px 98px 13px;
+}
+@spritesheet option-slider-thumb-sheet
+{
+	src: "../../../op2_volume3.tga";
+	option-slider-thumb: 0px 0px 13px 13px;
+}
+
+#panel {
+	position: absolute;
+	font-family: "Liberation Sans";
+	font-size: 12px;
+	color: white;
+}
+
+.panel-cap-top {
+	height: 65px;
+	decorator: image(option-top);
+}
+/* .panel-middle's inset is pure RCSS, declared once in base.rcss -- nothing window-specific to
+   override here. */
+
+.option-title {
+	position: absolute;
+	left: 0px;
+	top: 10px;
+	width: 100%;
+	text-align: center;
+}
+
+#checkbox_auto_attack   { left: 52px; top: 52px; }
+#checkbox_whisper_alarm { left: 52px; top: 93px; }
+#checkbox_slide_help    { left: 52px; top: 134px; }
+
+.slider {
+	position: absolute;
+	width: 98px;
+	height: 13px;
+}
+#slider_volume { left: 52px; top: 198px; }
+#slider_render { left: 52px; top: 259px; }
+
+.slider-label {
+	position: absolute;
+	left: 0px;
+	top: -18px;
+	white-space: nowrap;
+}
+.slider-value {
+	position: absolute;
+	left: 85px;
+	top: -18px;
+	white-space: nowrap;
+}
+.slider-track {
+	position: absolute;
+	left: 0px;
+	top: 0px;
+	width: 98px;
+	height: 13px;
+	decorator: image(option-slider-track);
+}
+.slider-thumb {
+	position: absolute;
+	top: 0px;
+	width: 13px;
+	height: 13px;
+	decorator: image(option-slider-thumb);
+	cursor: pointer;
+}
+
+#btn_close { left: 52px; top: 301px; }

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/remember_password_prompt.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/remember_password_prompt.rcss
@@ -1,0 +1,39 @@
+/* RmlUi overlay for the "remember password" OK/Cancel confirmation (UI/Windows/
+   RememberPasswordPrompt.cpp). Previously drawn by the shared SEASON3B::CNewUICommonMessageBox
+   engine's own generic frame art -- this dialog has no dedicated sprite asset of its own to
+   reproduce (it's one of ~80 consumers of a shared, generically-drawn message-box shape), so both
+   themes here use flat/programmatic panel art, matching the precedent login.rcss's own
+   checkboxes/buttons already established for exactly this "no dedicated art to point at" case.
+   Palette matches login.rcss's legacy .btn colors for visual consistency within this theme. */
+
+#panel {
+	position: absolute;
+	width: 340px;
+	height: 150px;
+	font-family: "Liberation Sans";
+	font-size: 12px;
+	color: white;
+	background-color: #1a140a;
+	border: 1px #806040;
+}
+
+.prompt-title {
+	position: absolute;
+	left: 20px;
+	top: 15px;
+	width: 300px;
+	color: #ffd23c;
+	font-weight: bold;
+}
+
+.prompt-body {
+	position: absolute;
+	left: 20px;
+	top: 40px;
+	width: 300px;
+	color: #ff9c40;
+	white-space: normal;
+}
+
+.btn-ok     { left: 52px;  top: 105px; }
+.btn-cancel { left: 180px; top: 105px; }

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/sys_menu.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/sys_menu.rcss
@@ -1,0 +1,32 @@
+/* RmlUi overlay for the login/character-scene system menu (UI/Windows/SysMenuWin.cpp). Panel
+   chrome reproduces the real CWinEx art via three stacked elements (.panel-cap-top/.panel-middle/
+   .panel-cap-bottom, structural rules in base.rcss) -- see base.rcss's header comment for why this
+   replaced an earlier single tiled-vertical() attempt (that decorator hardcodes FILL/stretch, not
+   REPEAT, for every tile including the center). Only this window's own top-cap height/image
+   differ from OptionWin's; center/bottom are the shared sprites base.rcss already declares.
+   Buttons rely entirely on base.rcss's shared .btn (this window's 4 buttons are the exact
+   BITMAP_TEXT_BTN/108x30 shape base.rcss's .btn is sized for, and the same real art now) -- no
+   per-button classes here since their positions are pushed from C++ (SysMenuWin::SetPosition),
+   scene-conditional via m_winBack's own quantized-line-count height. */
+
+@spritesheet sys-menu-top-sheet
+{
+	src: "../../../op1_back1.tga";
+	/* op1_back1.tga is 213x64 -- not power-of-two, needs the named-rect workaround (see
+	   base.rcss's identical note). */
+	sys-menu-top: 0px 0px 213px 64px;
+}
+
+#panel {
+	position: absolute;
+	font-family: "Liberation Sans";
+	font-size: 12px;
+	color: white;
+}
+
+.panel-cap-top {
+	height: 64px;
+	decorator: image(sys-menu-top);
+}
+/* .panel-middle's inset is pure RCSS, declared once in base.rcss -- nothing window-specific to
+   override here. */

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/theme.ini
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/theme.ini
@@ -1,5 +1,0 @@
-; Read by UI::RmlBridge::UsesLegacySpriteChrome (RmlTheme.cpp) -- a theme with no theme.ini at
-; all defaults to fully programmatic/sprite-free, which is the common case. This theme reuses
-; the original sprite/texture look, so it opts in explicitly.
-[Theme]
-UsesLegacySpriteChrome=1

--- a/src/bin/Data/Interface/RmlUi/themes/legacy/theme.ini
+++ b/src/bin/Data/Interface/RmlUi/themes/legacy/theme.ini
@@ -1,0 +1,5 @@
+; Read by UI::RmlBridge::UsesLegacySpriteChrome (RmlTheme.cpp) -- a theme with no theme.ini at
+; all defaults to fully programmatic/sprite-free, which is the common case. This theme reuses
+; the original sprite/texture look, so it opts in explicitly.
+[Theme]
+UsesLegacySpriteChrome=1

--- a/src/bin/Data/Interface/RmlUi/themes/modern/base.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/base.rcss
@@ -1,0 +1,81 @@
+/* Shared, cross-window RCSS -- generic (non-positional) rules reused by more than one migrated
+   window, extracted from themes/modern/login.rcss's originals (which stay self-contained and
+   unretrofitted -- see the RmlUi migration plan's "Batch 2" section). Every new migrated
+   window's <head> links this file first, then its own per-window positional .rcss. Colors here
+   match login.rcss's existing modern-theme palette so windows sharing a theme look consistent. */
+
+body {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	pointer-events: none;
+}
+
+/* See themes/legacy/base.rcss's identical #backdrop comment for the CWin::Create() nTexID=-1
+   parity rationale. */
+#backdrop {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 128);
+	pointer-events: auto;
+}
+
+.checkbox-row {
+	position: absolute;
+	cursor: pointer;
+	pointer-events: auto;
+}
+.checkbox-box {
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	border: 1px rgba(255, 255, 255, 60);
+	border-radius: 3px;
+	background-color: rgba(255, 255, 255, 20);
+}
+.checkbox-box.checked {
+	background-color: #c0a050;
+	border: 1px #c0a050;
+}
+.checkbox-label {
+	position: absolute;
+	left: 21px;
+	top: 1px;
+	white-space: nowrap;
+}
+
+/* Sized for the 108x30 BITMAP_TEXT_BTN shape shared by SysMenuWin's 4 buttons and OptionWin's
+   Close button -- login's own 54x30 image buttons stay defined in login.rcss's own .btn rule,
+   unaffected since login.rml/.rcss don't link this file. */
+.btn {
+	position: absolute;
+	width: 108px;
+	height: 30px;
+	text-align: center;
+	vertical-align: middle;
+	line-height: 30px;
+	cursor: pointer;
+	background-color: rgba(255, 255, 255, 15);
+	border: 1px rgba(255, 255, 255, 50);
+	border-radius: 4px;
+	pointer-events: auto;
+}
+.btn:hover {
+	background-color: #c0a050;
+	border: 1px #c0a050;
+}
+.btn.disabled {
+	pointer-events: none;
+	opacity: 0.5;
+	cursor: default;
+}
+
+/* See themes/legacy/base.rcss's identical comment -- SysMenuWin's Select Server button uses this
+   in the login scene instead of .disabled, since a dimmed-but-still-drawn button visibly
+   collided with Option there. */
+.hidden {
+	display: none;
+}

--- a/src/bin/Data/Interface/RmlUi/themes/modern/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/login.rcss
@@ -76,6 +76,7 @@ body {
 
 .checkbox-box {
 	display: inline-block;
+	position: relative;
 	width: 16px;
 	height: 16px;
 	border: 1px rgba(255, 255, 255, 60);
@@ -85,6 +86,32 @@ body {
 .checkbox-box.checked {
 	background-color: #c0a050;
 	border: 1px #c0a050;
+}
+
+/* Real tick glyph, not just the color swap above. This engine's RmlUiRenderInterface does not
+   implement SetTransform (CSS `transform` parses but never renders -- see
+   gotchas-and-patterns.md's "transform parses fine and silently never renders" entry), so no
+   rotation is available for a true diagonal stroke. Built instead from 5 small 2x2px axis-aligned
+   "pixels" (.tick-px) stair-stepping into a blocky checkmark approximation. */
+.tick-px {
+	position: absolute;
+	width: 2px;
+	height: 2px;
+	background-color: #12141c;
+}
+.tick-px-1 { left: 3px;  top: 7px; }
+.tick-px-2 { left: 5px;  top: 9px; }
+.tick-px-3 { left: 7px;  top: 7px; }
+.tick-px-4 { left: 9px;  top: 5px; }
+.tick-px-5 { left: 11px; top: 3px; }
+
+.checkbox-tick {
+	display: none;
+	position: absolute;
+	left: 0; top: 0; width: 16px; height: 16px;
+}
+.checkbox-box.checked .checkbox-tick {
+	display: block;
 }
 
 .checkbox-label {

--- a/src/bin/Data/Interface/RmlUi/themes/modern/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/login.rcss
@@ -1,0 +1,122 @@
+/* "Modern" theme -- fully programmatic, no legacy sprite dependency at all. Unlike the "legacy"
+   theme (themes/legacy/login.rcss), CWin's background sprite and the CUITextInputBox frame
+   sprites are never created for this theme (see UI::RmlBridge::UsesLegacySpriteChrome and
+   CLoginWin::Create()/RenderControls()) -- #panel below draws the entire panel look itself, and
+   .input-frame stands in for the input boxes' visual frame.
+
+   Same class names/structure as the legacy theme throughout -- this file is the swappable unit,
+   not login.rml (see the RmlUi migration plan's Theming section). Still fixed-px, same as legacy,
+   for this first pass -- see the plan's Scaling & DPI section for the dp-based follow-up this
+   theme is the natural candidate for, once resolution scaling is actually being built. */
+
+body {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	/* See the legacy theme's identical comment -- body spans the whole real window, so this
+	   must stay "none" with specific elements opting back in, or every click on screen gets
+	   swallowed for legacy-input purposes the moment this document is shown. */
+	pointer-events: none;
+}
+
+#panel {
+	position: absolute;
+	width: 329px;
+	height: 245px;
+	font-family: "Liberation Sans";
+	font-size: 12px;
+	color: white;
+	/* The panel's entire visual look -- no background sprite exists behind this theme.
+	   Deliberately no box-shadow here: RmlUiRenderInterface.h's own header comment already
+	   documents that layers/filters are left as no-op stubs (this engine only implements the
+	   "required" RenderInterface functions), and RmlUi's real box-shadow blur path
+	   (Source/Core/GeometryBoxShadow.cpp) calls RenderManager::PushLayer/CompileFilter("blur")/
+	   CompositeLayers whenever blur-radius >= 0.5px -- exactly the unimplemented path. A first
+	   attempt using box-shadow here rendered as a solid, incorrect white block covering the
+	   whole panel (confirmed against a real screenshot) instead of a shadow. Do not reintroduce
+	   box-shadow (with a nonzero blur radius) in any theme until layer/filter compositing is
+	   actually implemented in RmlUiRenderInterface. */
+	background-color: rgba(18, 20, 28, 235);
+	border: 1px rgba(255, 255, 255, 30);
+	border-radius: 10px;
+}
+
+.label {
+	position: absolute;
+}
+.label-server  { left: 111px; top: 80px; }
+.label-account { left: 30px; top: 113px; }
+.label-password{ left: 30px; top: 139px; }
+
+/* Purely decorative outline standing in for the legacy input-box frame sprite -- border only, no
+   background-color, so it never covers the legacy CUITextInputBox text drawn underneath (that
+   text is rendered by legacy code earlier in the same frame; RmlUi renders last, so a *filled*
+   box here would visibly cover it -- a border-only outline paints just the edge pixels and
+   leaves the interior transparent, which is safe). pointer-events stays "none" (inherited from
+   body) -- purely visual, must not intercept clicks meant for the legacy input box beneath it. */
+.input-frame {
+	position: absolute;
+	width: 156px;
+	height: 23px;
+	border: 1px rgba(255, 255, 255, 60);
+	border-radius: 4px;
+	pointer-events: none;
+}
+.input-account  { left: 109px; top: 106px; }
+.input-password { left: 109px; top: 131px; }
+
+.checkbox-row {
+	position: absolute;
+	cursor: pointer;
+	pointer-events: auto;
+}
+.checkbox-remember-me  { left: 109px; top: 156px; }
+.checkbox-save-password{ left: 109px; top: 176px; }
+
+.checkbox-box {
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	border: 1px rgba(255, 255, 255, 60);
+	border-radius: 3px;
+	background-color: rgba(255, 255, 255, 20);
+}
+.checkbox-box.checked {
+	background-color: #c0a050;
+	border: 1px #c0a050;
+}
+
+.checkbox-label {
+	position: absolute;
+	left: 21px;
+	top: 1px;
+	white-space: nowrap;
+}
+
+.btn {
+	position: absolute;
+	width: 54px;
+	height: 30px;
+	text-align: center;
+	vertical-align: middle;
+	line-height: 30px;
+	cursor: pointer;
+	background-color: rgba(255, 255, 255, 15);
+	border: 1px rgba(255, 255, 255, 50);
+	border-radius: 4px;
+	pointer-events: auto;
+}
+.btn:hover {
+	background-color: #c0a050;
+	border: 1px #c0a050;
+}
+.btn-ok     { left: 150px; top: 200px; }
+.btn-cancel { left: 211px; top: 200px; }
+
+.trust-warning {
+	position: absolute;
+	left: 30px;
+	top: 252px;
+	width: 280px;
+	color: #ffd23c;
+}

--- a/src/bin/Data/Interface/RmlUi/themes/modern/login.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/login.rcss
@@ -1,8 +1,9 @@
-/* "Modern" theme -- fully programmatic, no legacy sprite dependency at all. Unlike the "legacy"
-   theme (themes/legacy/login.rcss), CWin's background sprite and the CUITextInputBox frame
-   sprites are never created for this theme (see UI::RmlBridge::UsesLegacySpriteChrome and
-   CLoginWin::Create()/RenderControls()) -- #panel below draws the entire panel look itself, and
-   .input-frame stands in for the input boxes' visual frame.
+/* "Modern" theme -- fully programmatic, using flat colors/vector shapes instead of the legacy
+   art files (contrast with themes/legacy/login.rcss, which reproduces the original look by
+   pointing its decorators at the same sprite images CWin used to draw). CWin never draws
+   anything for this window in any theme (CLoginWin::Create() always passes nTexID=-2) --
+   #panel below draws the entire panel look itself, and .input-frame stands in for the input
+   boxes' visual frame.
 
    Same class names/structure as the legacy theme throughout -- this file is the swappable unit,
    not login.rml (see the RmlUi migration plan's Theming section). Still fixed-px, same as legacy,

--- a/src/bin/Data/Interface/RmlUi/themes/modern/login_main.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/login_main.rcss
@@ -1,10 +1,15 @@
-/* "Modern" theme for the login-scene menu/credit button bar -- flat programmatic icon buttons,
-   no reproduction of the legacy frame-based sprite art (same approach as login.rcss's modern
-   theme). Text-free by design (the legacy buttons are pure image buttons with no I18N label), so
-   each gets a simple glyph-like mark via border/background only -- no font glyph needed. */
+/* "Modern" theme for the login-scene menu/credit button bar -- flat programmatic icon buttons, no
+   legacy sprite art (same approach as login.rcss's modern theme). No reserved I18N string exists
+   for these icon-only buttons, so each gets a plain single-letter monogram (.btn-icon-label,
+   "M"/"C") instead -- plain ASCII, not a Unicode symbol, since glyph coverage in the loaded font
+   isn't guaranteed (see login.rcss's checkmark comment). */
 
 #panel {
 	position: absolute;
+	/* Needed for .btn-icon-label's text -- matches login.rcss's #panel rather than relying on
+	   RmlUiRuntime's regular-weight fallback face to also resolve bold correctly. */
+	font-family: "Liberation Sans";
+	font-size: 14px;
 }
 
 .btn-icon {
@@ -16,10 +21,16 @@
 	background-color: rgba(255, 255, 255, 15);
 	border: 1px rgba(255, 255, 255, 50);
 	border-radius: 4px;
+	text-align: center;
+	line-height: 30px;
 }
 .btn-icon:hover {
 	background-color: #c0a050;
 	border: 1px #c0a050;
+}
+.btn-icon-label {
+	color: white;
+	font-weight: bold;
 }
 .btn-icon-menu {
 	left: 0px;

--- a/src/bin/Data/Interface/RmlUi/themes/modern/login_main.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/login_main.rcss
@@ -1,0 +1,38 @@
+/* "Modern" theme for the login-scene menu/credit button bar -- flat programmatic icon buttons,
+   no reproduction of the legacy frame-based sprite art (same approach as login.rcss's modern
+   theme). Text-free by design (the legacy buttons are pure image buttons with no I18N label), so
+   each gets a simple glyph-like mark via border/background only -- no font glyph needed. */
+
+#panel {
+	position: absolute;
+}
+
+.btn-icon {
+	position: absolute;
+	width: 54px;
+	height: 30px;
+	cursor: pointer;
+	pointer-events: auto;
+	background-color: rgba(255, 255, 255, 15);
+	border: 1px rgba(255, 255, 255, 50);
+	border-radius: 4px;
+}
+.btn-icon:hover {
+	background-color: #c0a050;
+	border: 1px #c0a050;
+}
+.btn-icon-menu {
+	left: 0px;
+	top: 0px;
+}
+/* left is pushed from C++ (screen-width dependent right-alignment). */
+.btn-icon-credit {
+	top: 0px;
+}
+
+/* No legacy deco art in this theme -- the modern theme is intentionally flat, matching
+   login.rcss's modern .input-frame precedent of standing in with a plain shape rather than
+   reproducing decorative sprite art pixel-for-pixel. */
+.btn-credit-deco {
+	display: none;
+}

--- a/src/bin/Data/Interface/RmlUi/themes/modern/option.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/option.rcss
@@ -1,0 +1,68 @@
+/* "Modern" theme for the Options window -- flat programmatic panel/sliders, matching login.rcss's
+   modern theme's translucent-dark-panel-with-border look. Layout offsets are identical to the
+   legacy theme's (see that file's comment for why they're fixed px, not pushed from C++). */
+
+#panel {
+	position: absolute;
+	font-family: "Liberation Sans";
+	font-size: 12px;
+	color: white;
+	background-color: rgba(18, 20, 28, 235);
+	border: 1px rgba(255, 255, 255, 30);
+	border-radius: 10px;
+}
+
+.option-title {
+	position: absolute;
+	left: 0px;
+	top: 10px;
+	width: 100%;
+	text-align: center;
+}
+
+#checkbox_auto_attack   { left: 52px; top: 52px; }
+#checkbox_whisper_alarm { left: 52px; top: 93px; }
+#checkbox_slide_help    { left: 52px; top: 134px; }
+
+.slider {
+	position: absolute;
+	width: 98px;
+	height: 13px;
+}
+#slider_volume { left: 52px; top: 198px; }
+#slider_render { left: 52px; top: 259px; }
+
+.slider-label {
+	position: absolute;
+	left: 0px;
+	top: -18px;
+	white-space: nowrap;
+}
+.slider-value {
+	position: absolute;
+	left: 85px;
+	top: -18px;
+	white-space: nowrap;
+}
+.slider-track {
+	position: absolute;
+	left: 0px;
+	top: 0px;
+	width: 98px;
+	height: 13px;
+	background-color: rgba(255, 255, 255, 20);
+	border: 1px rgba(255, 255, 255, 60);
+	border-radius: 3px;
+}
+.slider-thumb {
+	position: absolute;
+	top: 0px;
+	width: 13px;
+	height: 13px;
+	background-color: #c0a050;
+	border: 1px #c0a050;
+	border-radius: 3px;
+	cursor: pointer;
+}
+
+#btn_close { left: 52px; top: 301px; }

--- a/src/bin/Data/Interface/RmlUi/themes/modern/remember_password_prompt.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/remember_password_prompt.rcss
@@ -1,0 +1,36 @@
+/* "Modern" theme for the "remember password" confirmation -- flat programmatic panel, matching
+   login.rcss's modern theme's translucent-dark-panel-with-border look for visual consistency
+   across modern-theme windows. */
+
+#panel {
+	position: absolute;
+	width: 340px;
+	height: 150px;
+	font-family: "Liberation Sans";
+	font-size: 12px;
+	color: white;
+	background-color: rgba(18, 20, 28, 235);
+	border: 1px rgba(255, 255, 255, 30);
+	border-radius: 10px;
+}
+
+.prompt-title {
+	position: absolute;
+	left: 20px;
+	top: 15px;
+	width: 300px;
+	color: #ffd23c;
+	font-weight: bold;
+}
+
+.prompt-body {
+	position: absolute;
+	left: 20px;
+	top: 40px;
+	width: 300px;
+	color: rgba(255, 255, 255, 200);
+	white-space: normal;
+}
+
+.btn-ok     { left: 52px;  top: 105px; }
+.btn-cancel { left: 180px; top: 105px; }

--- a/src/bin/Data/Interface/RmlUi/themes/modern/sys_menu.rcss
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/sys_menu.rcss
@@ -1,0 +1,13 @@
+/* "Modern" theme for the system menu -- flat programmatic panel, matching login.rcss's modern
+   theme's translucent-dark-panel-with-border look for visual consistency across modern windows.
+   Buttons rely entirely on base.rcss's shared .btn (see the legacy theme's identical note). */
+
+#panel {
+	position: absolute;
+	font-family: "Liberation Sans";
+	font-size: 12px;
+	color: white;
+	background-color: rgba(18, 20, 28, 235);
+	border: 1px rgba(255, 255, 255, 30);
+	border-radius: 10px;
+}

--- a/src/bin/Data/Interface/RmlUi/themes/modern/theme.ini
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/theme.ini
@@ -1,0 +1,5 @@
+; Read by UI::RmlBridge::UsesLegacySpriteChrome (RmlTheme.cpp). This line is not strictly required
+; -- omitting theme.ini entirely defaults to the same fully-programmatic behavior -- but stated
+; explicitly here so this theme's intent is documented in its own folder, not just in code.
+[Theme]
+UsesLegacySpriteChrome=0

--- a/src/bin/Data/Interface/RmlUi/themes/modern/theme.ini
+++ b/src/bin/Data/Interface/RmlUi/themes/modern/theme.ini
@@ -1,5 +1,0 @@
-; Read by UI::RmlBridge::UsesLegacySpriteChrome (RmlTheme.cpp). This line is not strictly required
-; -- omitting theme.ini entirely defaults to the same fully-programmatic behavior -- but stated
-; explicitly here so this theme's intent is documented in its own folder, not just in code.
-[Theme]
-UsesLegacySpriteChrome=0

--- a/src/bin/config.ini.template
+++ b/src/bin/config.ini.template
@@ -16,3 +16,4 @@ ServerPort=44406
 [UI]
 Locale=en
 Font=
+RmlTheme=legacy

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -1139,17 +1139,29 @@ MSG MainLoop()
                 Destroy = true;
                 break;
             case SDL_EVENT_MOUSE_MOTION:
+                // Always forwarded and always still applied to legacy position tracking --
+                // motion isn't an "action" to arbitrate, and legacy hit-testing (CNewUIManager
+                // etc.) needs MouseX/MouseY current regardless of what's hovered. RmlUi still
+                // needs this call to drive its own :hover state/hit-testing.
+                RmlUiRuntime::Instance().ProcessSdlEvent(event, g_sdlWindow);
                 HandleMouseMotion(event.motion.x, event.motion.y);
                 break;
             case SDL_EVENT_MOUSE_BUTTON_DOWN:
             case SDL_EVENT_MOUSE_BUTTON_UP:
-                HandleMouseButton(event);
+                // RmlUi migration plan Phase 0.8: first consumer wins. If an RmlUi element
+                // claimed this click (returns false -- "no longer propagating"), don't also let
+                // it reach legacy button-state tracking/click-to-move.
+                if (RmlUiRuntime::Instance().ProcessSdlEvent(event, g_sdlWindow))
+                    HandleMouseButton(event);
                 break;
             case SDL_EVENT_MOUSE_WHEEL:
-                // SDL does not pre-correct flipped (natural) scrolling; invert.
-                MouseWheel = (event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
-                    ? -static_cast<int>(event.wheel.y)
-                    : static_cast<int>(event.wheel.y);
+                if (RmlUiRuntime::Instance().ProcessSdlEvent(event, g_sdlWindow))
+                {
+                    // SDL does not pre-correct flipped (natural) scrolling; invert.
+                    MouseWheel = (event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
+                        ? -static_cast<int>(event.wheel.y)
+                        : static_cast<int>(event.wheel.y);
+                }
                 break;
             case SDL_EVENT_WINDOW_RESIZED:
                 HandleWindowResize(event.window.data1, event.window.data2);
@@ -1169,15 +1181,30 @@ MSG MainLoop()
                 HandleFocusChange(false);
                 break;
             case SDL_EVENT_TEXT_INPUT:
-                // Committed characters for the focused portable text field (#447).
-                FeedPortableTextInput(event.text.text);
+                // Committed characters for the focused portable text field (#447). Gated the
+                // same way as key-down below -- if an RmlUi text input has focus and consumed
+                // this, don't also feed it into a legacy portable text field.
+                if (RmlUiRuntime::Instance().ProcessSdlEvent(event, g_sdlWindow))
+                    FeedPortableTextInput(event.text.text);
                 break;
             case SDL_EVENT_TEXT_EDITING:
                 // IME composition preview for the focused portable field (#447).
                 if (auto* box = CUITextInputBox::GetFocusedPortable())
                     box->OnTextEditing(Utf8ToWide(event.edit.text).c_str());
                 break;
+            case SDL_EVENT_KEY_UP:
+                // Legacy input has no key-up consumer, but RmlUi needs both halves of a
+                // press/release pair for correct modifier-key and held-key state tracking.
+                RmlUiRuntime::Instance().ProcessSdlEvent(event, g_sdlWindow);
+                break;
             case SDL_EVENT_KEY_DOWN:
+            {
+                // RmlUi migration plan Phase 0.8: only the final portable-field delivery below
+                // is gated on this -- the F10/Enter system-hotkey handling right after stays
+                // unconditional (camera zoom lock and the Enter-press latch are not text-editing
+                // concerns, and gating them risks breaking behavior those comments already
+                // carefully explain).
+                const bool rmlUiConsumed = !RmlUiRuntime::Instance().ProcessSdlEvent(event, g_sdlWindow);
 #ifndef _WIN32
                 // These mirror what WndProc does from Win32 messages, for the
                 // SDL-only input path. On Windows WndProc is still driven (via
@@ -1202,8 +1229,10 @@ MSG MainLoop()
                 }
 #endif
                 // Navigation/erase/clipboard for the focused portable field (#447).
-                FeedPortableKey(event.key);
+                if (!rmlUiConsumed)
+                    FeedPortableKey(event.key);
                 break;
+            }
             default:
                 break;
             }

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -17,6 +17,7 @@
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Textures/ZzzTexture.h"
 #include "Render/RHI/RHI.h"
+#include "Render/RmlUi/RmlUiRuntime.h"
 #include "Engine/Object/ZzzOpenData.h"
 #include "Scenes/SceneCore.h"
 #include "Network/Reconnect/ReconnectManager.h"
@@ -898,6 +899,7 @@ namespace
         OpenglWindowWidth = WindowWidth;
         OpenglWindowHeight = WindowHeight;
         RHI::OnResize(WindowWidth, WindowHeight); // no-op on GL
+        RmlUiRuntime::Instance().OnResize(static_cast<int>(WindowWidth), static_cast<int>(WindowHeight));
         ReinitializeFonts();
         UpdateResolutionDependentSystems();
         UpdateCursorClip();
@@ -1812,6 +1814,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
 
     SDL_GL_MakeCurrent(g_sdlWindow, g_sdlGLContext);
     RHI::Init(nullptr, static_cast<int>(WindowWidth), static_cast<int>(WindowHeight));
+    RmlUiRuntime::Instance().Create(static_cast<int>(WindowWidth), static_cast<int>(WindowHeight)); // after RHI::Init -- the render interface issues RHI:: calls
 
 #if defined(_DEBUG) && ENABLE_GL_KHR_DEBUG_CALLBACK
     // DXP-08: register the KHR_debug callback now that a current context exists.
@@ -2044,6 +2047,10 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
     g_MuEditorCore.Shutdown();
 #endif
     UnregisterBundledFonts();   // mirror the startup registration
+    // Before RHI::Shutdown() -- Rml::Shutdown() (called from Destroy()) releases every
+    // outstanding compiled-geometry/texture handle via RmlUiRenderInterface, which issues
+    // RHI::DestroyBuffer/DestroyTexture calls that must run while RHI is still valid.
+    RmlUiRuntime::Instance().Destroy();
     RHI::Shutdown();
     KillGLWindow();
     DestroyWindow();

--- a/src/source/Camera/Frustum.cpp
+++ b/src/source/Camera/Frustum.cpp
@@ -200,18 +200,18 @@ void Frustum::CalculatePlanes(const vec3_t position, const vec3_t forward,
         VectorCopy(m_Vertices[planeDefs[i].v2], v2);
         VectorCopy(m_Vertices[planeDefs[i].v3], v3);
         FaceNormalize(v1, v2, v3, m_Planes[i].normal);
-        m_Planes[i].distance = -DotProduct(position, m_Planes[i].normal);
+        m_Planes[i].distance = -VectorDotProduct(position, m_Planes[i].normal);
     }
 
     // Near plane: forward direction
     VectorCopy(forward, m_Planes[4].normal);
-    m_Planes[4].distance = -DotProduct(nearCenter, m_Planes[4].normal);
+    m_Planes[4].distance = -VectorDotProduct(nearCenter, m_Planes[4].normal);
 
     // Far plane: negative forward direction (VectorScale needs non-const input)
     vec3_t forwardMut;
     VectorCopy(forward, forwardMut);
     VectorScale(forwardMut, -1.0f, m_Planes[5].normal);
-    m_Planes[5].distance = -DotProduct(farCenter, m_Planes[5].normal);
+    m_Planes[5].distance = -VectorDotProduct(farCenter, m_Planes[5].normal);
 }
 
 bool Frustum::TestSphere(const vec3_t center, float radius) const
@@ -219,7 +219,7 @@ bool Frustum::TestSphere(const vec3_t center, float radius) const
     // Test sphere against all 6 planes
     for (int i = 0; i < 6; i++)
     {
-        float distance = DotProduct(center, m_Planes[i].normal) + m_Planes[i].distance;
+        float distance = VectorDotProduct(center, m_Planes[i].normal) + m_Planes[i].distance;
 
         // If sphere is completely outside this plane, it's culled
         if (distance < -radius)
@@ -241,7 +241,7 @@ bool Frustum::TestAABB(const AABB& box) const
         pVertex[2] = (m_Planes[i].normal[2] >= 0.0f) ? box.max[2] : box.min[2];
 
         // If p-vertex is outside, entire box is outside
-        if (DotProduct(pVertex, m_Planes[i].normal) + m_Planes[i].distance < 0.0f)
+        if (VectorDotProduct(pVertex, m_Planes[i].normal) + m_Planes[i].distance < 0.0f)
             return false;
     }
 
@@ -253,7 +253,7 @@ bool Frustum::TestPoint(const vec3_t point) const
     // Test point against all 6 planes
     for (int i = 0; i < 6; i++)
     {
-        float distance = DotProduct(point, m_Planes[i].normal) + m_Planes[i].distance;
+        float distance = VectorDotProduct(point, m_Planes[i].normal) + m_Planes[i].distance;
 
         // If point is outside this plane, it's culled
         if (distance < 0.0f)

--- a/src/source/Core/Math/ZzzMathLib.cpp
+++ b/src/source/Core/Math/ZzzMathLib.cpp
@@ -282,9 +282,9 @@ void R_ConcatTransforms(const float in1[3][4], const float in2[3][4], float out[
 void VectorRotate(const vec3_t in1, const float in2[3][4], vec3_t out)
 {
     assert(in1 != out && "VectorRotate!");
-    out[0] = DotProduct(in1, in2[0]);
-    out[1] = DotProduct(in1, in2[1]);
-    out[2] = DotProduct(in1, in2[2]);
+    out[0] = VectorDotProduct(in1, in2[0]);
+    out[1] = VectorDotProduct(in1, in2[1]);
+    out[2] = VectorDotProduct(in1, in2[2]);
 }
 
 // rotate by the inverse of the matrix
@@ -304,9 +304,9 @@ void VectorTranslate(const vec3_t in1, const float in2[3][4], vec3_t out)
 
 void VectorTransform(const vec3_t in1, const float in2[3][4], vec3_t out)
 {
-    out[0] = DotProduct(in1, in2[0]) + in2[0][3];
-    out[1] = DotProduct(in1, in2[1]) + in2[1][3];
-    out[2] = DotProduct(in1, in2[2]) + in2[2][3];
+    out[0] = VectorDotProduct(in1, in2[0]) + in2[0][3];
+    out[1] = VectorDotProduct(in1, in2[1]) + in2[1][3];
+    out[2] = VectorDotProduct(in1, in2[2]) + in2[2][3];
 }
 
 void AngleQuaternion(const vec3_t angles, vec4_t quaternion)

--- a/src/source/Core/Math/ZzzMathLib.h
+++ b/src/source/Core/Math/ZzzMathLib.h
@@ -24,7 +24,12 @@ extern "C" {
     bool QuaternionCompare(const vec4_t v1, const vec4_t v2);
 
 #define Vector(a,b,c,d) {(d)[0]=a;(d)[1]=b;(d)[2]=c;}
-#define Vector4(a,b,c,d,target) {(target)[0]=a;(target)[1]=b;(target)[2]=c;(target)[3]=d;}
+// Named Vector4Set (not Vector4) -- Rml::Vector4 is a real class in RmlUi's Core namespace, and
+// since macros ignore C++ namespaces, a macro literally named Vector4 textually replaces every
+// occurrence of that identifier anywhere ZzzMathLib.h is visible, including inside RmlUi's own
+// headers. Previously worked around with a push_macro/undef/pop_macro guard wrapped around every
+// RmlUi include site; renamed instead so no such guard is needed at all.
+#define Vector4Set(a,b,c,d,target) {(target)[0]=a;(target)[1]=b;(target)[2]=c;(target)[3]=d;}
 #define VectorAvg(a) ( ( (a)[0] + (a)[1] + (a)[2] ) / 3 )
 #define VectorSubtract(a,b,c) {(c)[0]=(a)[0]-(b)[0];(c)[1]=(a)[1]-(b)[1];(c)[2]=(a)[2]-(b)[2];}
 #define VectorSubtractScaled(a,b,c,d) {(c)[0]=(a)[0]-(b)[0]*(d);(c)[1]=(a)[1]-(b)[1]*(d);(c)[2]=(a)[2]-(b)[2]*(d);}
@@ -33,7 +38,9 @@ extern "C" {
 #define VectorCopy(a,b) {(b)[0]=(a)[0];(b)[1]=(a)[1];(b)[2]=(a)[2];}
 #define QuaternionCopy(a,b) {(b)[0]=(a)[0];(b)[1]=(a)[1];(b)[2]=(a)[2];(b)[3]=(a)[3];}
 #define VectorScale(a,b,c) {(c)[0]=(b)*(a)[0];(c)[1]=(b)*(a)[1];(c)[2]=(b)*(a)[2];}
-#define DotProduct(x,y) ((x)[0]*(y)[0]+(x)[1]*(y)[1]+(x)[2]*(y)[2])
+// Named VectorDotProduct (not DotProduct) -- see the Vector4Set comment above; Rml::Vector3/
+// Vector4::DotProduct() are real methods RmlUi's headers define, textually collided the same way.
+#define VectorDotProduct(x,y) ((x)[0]*(y)[0]+(x)[1]*(y)[1]+(x)[2]*(y)[2])
 #define VectorFill(a,b) { (a)[0]=(b); (a)[1]=(b); (a)[2]=(b);}
 
     inline void SETLIMITS(float& VALUE_, const float MAX_, const float MIN_)

--- a/src/source/Core/Utilities/StringUtils.h
+++ b/src/source/Core/Utilities/StringUtils.h
@@ -3,6 +3,15 @@
 #include <string>
 #include "Core/Platform/WinCompat.h"
 
+// Deliberately separate from Data/Translation/MultiLanguage.h's CMultiLanguage::ConvertFromUtf8/
+// ConvertToUtf8, not a duplicate of it: CMultiLanguage's converters write into a caller-owned
+// fixed-size buffer (matching network-packet/struct string fields like Data->ID[MAX_USERNAME_SIZE]),
+// while these return an owned std::string/std::wstring for callers with no natural fixed size to
+// target (RmlUi label/log text, file paths). CMultiLanguage also separately owns UI-language
+// selection state (byLanguage) unrelated to generic encoding conversion -- folding these into it
+// would conflate the two concerns. Both ultimately call the same Win32 MultiByteToWideChar/
+// WideCharToMultiByte; if a third conversion need ever appears, extend one of these two, don't add
+// a third implementation.
 namespace StringUtils
 {
     // Convert wide string (UTF-16) to narrow string (UTF-8)
@@ -16,5 +25,23 @@ namespace StringUtils
         std::string result(size, 0);
         WideCharToMultiByte(CP_UTF8, 0, wstr, (int)len, &result[0], size, NULL, NULL);
         return result;
+    }
+
+    // Convert narrow string (UTF-8) to wide string (UTF-16)
+    inline std::wstring NarrowToWide(const char* str)
+    {
+        if (!str) return L"";
+        size_t len = strlen(str);
+        if (len == 0) return L"";
+
+        int size = MultiByteToWideChar(CP_UTF8, 0, str, (int)len, NULL, 0);
+        std::wstring result(size, 0);
+        MultiByteToWideChar(CP_UTF8, 0, str, (int)len, &result[0], size);
+        return result;
+    }
+
+    inline std::wstring NarrowToWide(const std::string& str)
+    {
+        return NarrowToWide(str.c_str());
     }
 }

--- a/src/source/Data/GameConfig/GameConfig.cpp
+++ b/src/source/Data/GameConfig/GameConfig.cpp
@@ -72,6 +72,7 @@ void GameConfig::Load()
 
     m_uiLocale = ReadString(CfgSectionUI, CfgKeyUILocale, CfgDefaultUILocale);
     m_fontSelection = ReadString(CfgSectionUI, CfgKeyFont, CfgDefaultFont);
+    m_rmlTheme = ReadString(CfgSectionUI, CfgKeyRmlTheme, CfgDefaultRmlTheme);
 
     m_zoom = ReadInt(CfgSectionCamera, CfgKeyZoom, CfgDefaultZoom);
 
@@ -112,6 +113,7 @@ void GameConfig::Save()
 
     WriteString(CfgSectionUI, CfgKeyUILocale, m_uiLocale);
     WriteString(CfgSectionUI, CfgKeyFont, m_fontSelection);
+    WriteString(CfgSectionUI, CfgKeyRmlTheme, m_rmlTheme);
 
     WriteInt(CfgSectionCamera, CfgKeyZoom, m_zoom);
 }
@@ -163,6 +165,11 @@ void GameConfig::SetLanguageSelection(const std::wstring& lang)
 void GameConfig::SetUILocale(const std::wstring& locale)
 {
     m_uiLocale = locale;
+}
+
+void GameConfig::SetRmlTheme(const std::wstring& theme)
+{
+    m_rmlTheme = theme;
 }
 
 void GameConfig::SetFontSelection(const std::wstring& font)

--- a/src/source/Data/GameConfig/GameConfig.h
+++ b/src/source/Data/GameConfig/GameConfig.h
@@ -68,6 +68,10 @@ public:
     std::wstring GetFontSelection() const { return m_fontSelection; }
     void SetFontSelection(const std::wstring& font);
 
+    // Active RmlUi theme name ("legacy"/"modern") -- see UI::RmlBridge::RmlTheme.
+    std::wstring GetRmlTheme() const { return m_rmlTheme; }
+    void SetRmlTheme(const std::wstring& theme);
+
     // Camera
     int GetZoom() const { return m_zoom; }
     void SetZoom(int zoom);
@@ -104,6 +108,7 @@ private:
 
     std::wstring m_uiLocale;
     std::wstring m_fontSelection;
+    std::wstring m_rmlTheme;
 
     int m_zoom;
 

--- a/src/source/Data/GameConfig/GameConfigConstants.h
+++ b/src/source/Data/GameConfig/GameConfigConstants.h
@@ -37,6 +37,10 @@ namespace CfgKeys
     // UI
     inline constexpr wchar_t CfgKeyUILocale[] = L"Locale";
     inline constexpr wchar_t CfgKeyFont[]     = L"Font";
+    // Active RmlUi theme name ("legacy" or "modern") -- resolves to
+    // Data/Interface/RmlUi/themes/<name>/ (see the RmlUi migration plan's Scaling & DPI /
+    // Theming sections). Not yet a full runtime hot-swap -- read once at startup.
+    inline constexpr wchar_t CfgKeyRmlTheme[] = L"RmlTheme";
 
     // Camera
     inline constexpr wchar_t CfgKeyZoom[] = L"Zoom";
@@ -77,6 +81,11 @@ namespace CfgDefaults
     // Windows, fontconfig "sans-serif" on Linux), so the look is unchanged until
     // the user picks a font. Any value is passed through as the GDI face name.
     inline constexpr wchar_t CfgDefaultFont[] = L"";
+
+    // "legacy" reproduces the original sprite/texture look; "modern" is fully
+    // programmatic RCSS with no sprite dependency. Defaults to legacy so nothing
+    // changes for existing players until they opt in.
+    inline constexpr wchar_t CfgDefaultRmlTheme[] = L"legacy";
 
     // DXP-08 Stage G: flipped to default-on after DXP-08a/DXP-09 prerequisites were fixed and
     // soak-confirmed clean under CoreProfile=1 (2026-08-01). Set CoreProfile=0 in config.ini to

--- a/src/source/Input/Selection.cpp
+++ b/src/source/Input/Selection.cpp
@@ -185,7 +185,7 @@ int SelectCharacter(BYTE Kind)
                     vec3_t vSub;
                     VectorSubtract(o->Position, g_Camera.Position, vSub);
 
-                    float fNewDist = DotProduct(vSub, vSub);
+                    float fNewDist = VectorDotProduct(vSub, vSub);
 
                     if (fNewDist < fNearestDist)
                     {

--- a/src/source/Input/Selection.cpp
+++ b/src/source/Input/Selection.cpp
@@ -23,6 +23,7 @@
 #include "Render/Effects/ZzzEffect.h"
 #include "Scenes/SceneCore.h"
 #include "Engine/Pathing/ZzzPath.h"
+#include "Render/RmlUi/RmlUiRuntime.h"
 #include "Audio/DSPlaySound.h"
 #include "I18N/All.h"
 #include "GameLogic/Events/MatchEvent.h"
@@ -307,7 +308,11 @@ void SelectObjects()
     SelectedNpc = -1;
     SelectedOperate = -1;
 
-    if (!MouseOnWindow && false == g_pNewUISystem->CheckMouseUse() && SEASON3B::CheckMouseIn(0, 0, GetScreenWidth(), 429))
+    // Third click-gating flag alongside the two legacy ones, per the RmlUi migration plan's
+    // Phase 0.8 -- MouseOnWindow (Legacy/CUIMng tier) and CheckMouseUse() (NewUI tier) are each
+    // owned by their own tier with their own lifecycle, so this adds a flag rather than trying
+    // to unify three ownership models into one right now.
+    if (!MouseOnWindow && false == g_pNewUISystem->CheckMouseUse() && !RmlUiRuntime::Instance().IsMouseOverUI() && SEASON3B::CheckMouseIn(0, 0, GetScreenWidth(), 429))
     {
         if (Core::Input::IsKeyDown(VK_MENU))
         {

--- a/src/source/Render/Effects/ZzzEffectBlurSpark.cpp
+++ b/src/source/Render/Effects/ZzzEffectBlurSpark.cpp
@@ -581,7 +581,7 @@ void AnimationFlag()
 
                 vec3_t DeltaV;
                 VectorSubtract(v1->v, v2->v, DeltaV);
-                float Dterm = (DotProduct(DeltaV, DeltaP) * Kd) / dist;
+                float Dterm = (VectorDotProduct(DeltaV, DeltaP) * Kd) / dist;
 
                 vec3_t SpringForce;
                 VectorScale(DeltaP, 1.f / dist, SpringForce);

--- a/src/source/Render/Models/ShadowVolume.cpp
+++ b/src/source/Render/Models/ShadowVolume.cpp
@@ -60,7 +60,7 @@ void CShadowVolume::DeterminateSilhouette(short nMesh, vec3_t ppVertexTransforme
         pVertex[2] = &ppVertexTransformed[nMesh][pnVertexIndex[2]];
         vec3_t Normal;
         FaceNormalize(*pVertex[0], *pVertex[1], *pVertex[2], Normal);
-        if (DotProduct(Normal, m_vLight) <= 0.f)
+        if (VectorDotProduct(Normal, m_vLight) <= 0.f)
             pTriangle->Front = true;
         else
             pTriangle->Front = false;

--- a/src/source/Render/Models/ZzzBMD.cpp
+++ b/src/source/Render/Models/ZzzBMD.cpp
@@ -489,7 +489,7 @@ void BMD::EnsureCpuNormals(int mesh) const
         VectorRotate(sn->Normal, m_pCurrentBoneTransform[sn->Node], tn);
         if (LightEnable)
         {
-            float Luminosity = DotProduct(tn, m_LastLightPosition) * 0.8f + 0.4f;
+            float Luminosity = VectorDotProduct(tn, m_LastLightPosition) * 0.8f + 0.4f;
             if (Luminosity < 0.2f) Luminosity = 0.2f;
             IntensityTransform[mesh][j] = Luminosity;
         }
@@ -584,7 +584,7 @@ void BMD::Transform(float(*BoneMatrix)[3][4], vec3_t BoundingBoxMin, vec3_t Boun
             if (LightEnable)
             {
                 float Luminosity;
-                Luminosity = DotProduct(tn, m_LastLightPosition) * 0.8f + 0.4f;
+                Luminosity = VectorDotProduct(tn, m_LastLightPosition) * 0.8f + 0.4f;
 
                 if (Luminosity < 0.2f) Luminosity = 0.2f;
                 IntensityTransform[i][j] = Luminosity;
@@ -1000,10 +1000,10 @@ void BMD::Chrome(float* pchrome, int bone, vec3_t normal)
         g_chromeage[bone] = g_smodels_total;
     }
 
-    n = DotProduct(normal, g_chromeright[bone]);
+    n = VectorDotProduct(normal, g_chromeright[bone]);
     pchrome[0] = (n + 1.f); // FIX: make this a float
 
-    n = DotProduct(normal, g_chromeup[bone]);
+    n = VectorDotProduct(normal, g_chromeup[bone]);
     pchrome[1] = (n + 1.f); // FIX: make this a float
 }
 
@@ -1013,7 +1013,7 @@ void BMD::Lighting(float* pLight, Light_t* lp, vec3_t Position, vec3_t Normal)
     VectorSubtract(lp->Position, Position, Light);
     float Length = sqrtf(Light[0] * Light[0] + Light[1] * Light[1] + Light[2] * Light[2]);
 
-    float LightCos = (DotProduct(Normal, Light) / Length) * 0.8f + 0.3f;
+    float LightCos = (VectorDotProduct(Normal, Light) / Length) * 0.8f + 0.3f;
     if (Length > lp->Range) LightCos -= (Length - lp->Range) * 0.01f;
     if (LightCos < 0.f) LightCos = 0.f;
     pLight[0] += LightCos * lp->Color[0];
@@ -1084,7 +1084,7 @@ void BMD::CreateLightMapSurface(Light_t* lp, Mesh_t* m, int i, int j, int MapWid
     Triangle_t* tp = &m->Triangles[j];
     float* np = NormalTransform[i][tp->NormalIndex[0]];
     float* vp = VertexTransform[i][tp->VertexIndex[0]];
-    float d = -DotProduct(vp, np);
+    float d = -VectorDotProduct(vp, np);
 
     Bitmap_t* lmp = &LightMaps[NumLightMaps];
     if (lmp->Buffer == nullptr)
@@ -1272,7 +1272,7 @@ int BMD::AddToCoinHeap(int coinIndex, int target_vertex_index)
 
             VectorCopy(VertexTransform[meshIndex][source_vertex_index], vertices[target_vertex_index]);
 
-            Vector4(BodyLight[0], BodyLight[1], BodyLight[2], alpha, colors[target_vertex_index]);
+            Vector4Set(BodyLight[0], BodyLight[1], BodyLight[2], alpha, colors[target_vertex_index]);
 
             auto texco = m->TexCoords[triangle->TexCoordIndex[k]];
             texCoords[target_vertex_index][0] = texco.TexCoordU;
@@ -1642,20 +1642,20 @@ void BMD::RenderMesh(int meshIndex, int renderFlags, float alpha, int blendMeshI
                 }
                 else if ((renderFlags & RENDER_CHROME3) == RENDER_CHROME3)
                 {
-                    g_chrome[j][0] = DotProduct(normal, LightVector);
-                    g_chrome[j][1] = 1.f - DotProduct(normal, LightVector);
+                    g_chrome[j][0] = VectorDotProduct(normal, LightVector);
+                    g_chrome[j][1] = 1.f - VectorDotProduct(normal, LightVector);
                 }
                 else if ((renderFlags & RENDER_CHROME4) == RENDER_CHROME4)
                 {
-                    g_chrome[j][0] = DotProduct(normal, L);
-                    g_chrome[j][1] = 1.f - DotProduct(normal, L);
+                    g_chrome[j][0] = VectorDotProduct(normal, L);
+                    g_chrome[j][1] = 1.f - VectorDotProduct(normal, L);
                     g_chrome[j][1] -= normal[2] * 0.5f + wave * 3.f;
                     g_chrome[j][0] += normal[1] * 0.5f + L[1] * 3.f;
                 }
                 else if ((renderFlags & RENDER_CHROME5) == RENDER_CHROME5)
                 {
-                    g_chrome[j][0] = DotProduct(normal, L);
-                    g_chrome[j][1] = 1.f - DotProduct(normal, L);
+                    g_chrome[j][0] = VectorDotProduct(normal, L);
+                    g_chrome[j][1] = 1.f - VectorDotProduct(normal, L);
                     g_chrome[j][1] -= normal[2] * 2.5f + wave * 1.f;
                     g_chrome[j][0] += normal[1] * 3.f + L[1] * 5.f;
                 }
@@ -1942,7 +1942,7 @@ void BMD::RenderMesh(int meshIndex, int renderFlags, float alpha, int blendMeshI
 
             VectorCopy(VertexTransform[meshIndex][source_vertex_index], vertices[target_vertex_index]);
 
-            Vector4(BodyLight[0], BodyLight[1], BodyLight[2], alpha, colors[target_vertex_index]);
+            Vector4Set(BodyLight[0], BodyLight[1], BodyLight[2], alpha, colors[target_vertex_index]);
 
             auto texco = m->TexCoords[triangle->TexCoordIndex[k]];
             texCoords[target_vertex_index][0] = texco.TexCoordU;
@@ -1963,7 +1963,7 @@ void BMD::RenderMesh(int meshIndex, int renderFlags, float alpha, int blendMeshI
                     if (enableLight)
                     {
                         auto light = LightTransform[meshIndex][normalIndex];
-                        Vector4(light[0], light[1], light[2], alpha, colors[target_vertex_index]);
+                        Vector4Set(light[0], light[1], light[2], alpha, colors[target_vertex_index]);
                     }
 
                     break;

--- a/src/source/Render/RHI/RHI.cpp
+++ b/src/source/Render/RHI/RHI.cpp
@@ -38,6 +38,8 @@ namespace RHI_GL_Impl {
     void SetDepthWriteEnabled(bool enabled);
     void SetFogEnabled(bool enabled);
     void SetPolygonOffset(bool enabled, float factor, float units);
+    void SetScissorEnabled(bool enabled);
+    void SetScissorRect(int x, int y, int w, int h);
 
     void BindVertexBuffer(RHI::BufferHandle handle, RHI::VertexLayout layout);
     void BindIndexBuffer(RHI::BufferHandle handle);
@@ -179,6 +181,16 @@ void SetFogEnabled(bool enabled)
 void SetPolygonOffset(bool enabled, float factor, float units)
 {
     RHI_GL_Impl::SetPolygonOffset(enabled, factor, units);
+}
+
+void SetScissorEnabled(bool enabled)
+{
+    RHI_GL_Impl::SetScissorEnabled(enabled);
+}
+
+void SetScissorRect(int x, int y, int w, int h)
+{
+    RHI_GL_Impl::SetScissorRect(x, y, w, h);
 }
 
 void BindVertexBuffer(BufferHandle handle, VertexLayout layout)

--- a/src/source/Render/RHI/RHI.h
+++ b/src/source/Render/RHI/RHI.h
@@ -143,6 +143,21 @@ void SetDepthWriteEnabled(bool);
 void SetFogEnabled(bool);
 void SetPolygonOffset(bool enabled, float factor = -1.f, float units = -1.f); // PlanarShadowShader's one caller
 
+// ---- Scissor (2D clip regions) ----
+// No caller anywhere in the tree until the RmlUi integration (RmlUi's RenderInterface contract
+// requires EnableScissorRegion/SetScissorRegion). (x, y) is TOP-LEFT origin, y-down -- the same
+// top-down contract SetViewport's callers and ReadColorFramebuffer already use; RHI_GL flips to
+// GL's bottom-left glScissor internally using the last SetViewport height, mirroring how
+// ReadColorFramebuffer flips row order for the same reason. Do not pass GL-native coordinates.
+//
+// Unlike every other piece of GL state this header exposes, there is no BindState-style cache
+// backing this -- whatever enables scissor MUST unconditionally disable it before returning
+// control to any other renderer this frame (an RAII guard at the call site, not caller
+// discipline), or every subsequent 2D/3D draw silently inherits a stale clip rect with nothing
+// to catch it.
+void SetScissorEnabled(bool enabled);
+void SetScissorRect(int x, int y, int w, int h);
+
 // ---- Shaders ----
 // The 5 existing shader classes KEEP their bespoke Bind(...) signatures (design doc Q1,
 // decided: BMDMeshShader::Bind()'s 16-param signature stays as-is for the first RHI pass).

--- a/src/source/Render/RHI/RHI_GL.cpp
+++ b/src/source/Render/RHI/RHI_GL.cpp
@@ -878,6 +878,32 @@ void SetPolygonOffset(bool enabled, float factor, float units)
     }
 }
 
+// ---- Scissor ----
+static bool s_ScissorEnabled = false;
+
+void SetScissorEnabled(bool enabled)
+{
+    if (enabled == s_ScissorEnabled) return;
+    // Scissor has no BindState-style cache to self-correct a leak (RHI.h's comment on this
+    // pair) -- flush any pending IR:: batch first so a quad built before this state change
+    // can't get silently merged into one draw call with a quad built after it, the same
+    // discipline Draw()/DrawIndexed()/UpdateTexture() already apply to other state that isn't
+    // part of IR::'s own batch-key snapshot.
+    IR::Flush();
+    s_ScissorEnabled = enabled;
+    if (enabled) glEnable(GL_SCISSOR_TEST);
+    else         glDisable(GL_SCISSOR_TEST);
+}
+
+void SetScissorRect(int x, int y, int w, int h)
+{
+    IR::Flush();
+    // RHI.h's contract is top-left origin, y-down (matches SetViewport's callers); GL's
+    // glScissor is bottom-left origin. Flip using the height from the last SetViewport call,
+    // the same backend-side flip ReadColorFramebuffer applies to row order for the same reason.
+    glScissor(x, g_Height - y - h, w, h);
+}
+
 // ---- Vertex layout + binding ----
 typedef void (APIENTRY* PFNGLGENVERTEXARRAYSPROC)(GLsizei n, GLuint* arrays);
 typedef void (APIENTRY* PFNGLDELETEVERTEXARRAYSPROC)(GLsizei n, const GLuint* arrays);

--- a/src/source/Render/RmlUi/RmlUiRenderInterface.cpp
+++ b/src/source/Render/RmlUi/RmlUiRenderInterface.cpp
@@ -1,0 +1,187 @@
+#include "stdafx.h"
+#include "RmlUiRenderInterface.h"
+
+#include "Render/Core/GlobalUBO.h"
+#include "Render/Shaders/PassthroughShader.h"
+#include "Render/Sprites/GlobalBitmap.h"
+#include "Core/Globals/_TextureIndex.h"
+
+namespace
+{
+    std::wstring Utf8ToWide(const std::string& s)
+    {
+        if (s.empty()) return std::wstring();
+        const int len = static_cast<int>(s.size());
+        const int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, nullptr, 0);
+        if (n <= 0) return std::wstring();
+        std::wstring out(static_cast<size_t>(n), L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, out.data(), n);
+        return out;
+    }
+}
+
+Rml::CompiledGeometryHandle RmlUiRenderInterface::CompileGeometry(Rml::Span<const Rml::Vertex> vertices, Rml::Span<const int> indices)
+{
+    // Convert RmlUi's native vertex (pos2 + premultiplied-alpha rgba8 + uv2, 20 bytes) into
+    // RHI::VertexLayout::PosUvColor's float layout (pos3+uv2+rgba4, 36 bytes) -- the only layout
+    // implemented on either backend today. See the RmlUi migration plan's Phase 0.2: adding a
+    // 5th VertexLayout instead would need a new HLSL shader variant + RegisterVertexShaderBytecode
+    // call on the in-progress, unmerged D3D11 branch, for a cost this conversion avoids entirely.
+    //
+    // Un-premultiplying alpha here (rather than adding a premultiplied-alpha RHI::BlendMode) is
+    // the same trade: RmlUi vertex colour is premultiplied (Vertex.h), but every existing
+    // straight-alpha BlendMode in RHI.h (Blend3 -- SRC_ALPHA, ONE_MINUS_SRC_ALPHA, see
+    // RenderGeometry below) expects un-premultiplied colour. For a single blend pass with no
+    // layer/filter compositing (this MVP implements none of RenderInterface's optional
+    // layer/filter functions), un-premultiplying here and blending straight-alpha produces the
+    // identical final pixel to blending the original premultiplied colour with (ONE,
+    // ONE_MINUS_SRC_ALPHA) -- revisit only if/when layers or filters are implemented, which
+    // genuinely need premultiplied compositing.
+    std::vector<float> packed(vertices.size() * 9);
+    for (size_t i = 0; i < vertices.size(); ++i)
+    {
+        const Rml::Vertex& v = vertices[i];
+        float* d = &packed[i * 9];
+        d[0] = v.position.x;
+        d[1] = v.position.y;
+        d[2] = 0.0f; // pos3 -- RmlUi is strictly 2D, z is unused by PassthroughShader's ortho pass
+        d[3] = v.tex_coord.x;
+        d[4] = v.tex_coord.y;
+        const float a = v.colour.alpha / 255.0f;
+        if (a > 0.0f)
+        {
+            d[5] = (v.colour.red / 255.0f) / a;
+            d[6] = (v.colour.green / 255.0f) / a;
+            d[7] = (v.colour.blue / 255.0f) / a;
+        }
+        else
+        {
+            // Alpha is zero -- this pixel contributes nothing to the blend result regardless of
+            // RGB, so any finite value is harmless. Avoid a divide-by-zero producing inf/NaN,
+            // which could otherwise pollute interpolation across a triangle edge.
+            d[5] = d[6] = d[7] = 0.0f;
+        }
+        d[8] = a;
+    }
+
+    std::vector<uint32_t> idx32(indices.begin(), indices.end()); // RHI index buffers are u32-only
+
+    CompiledGeom* geom = new CompiledGeom{};
+    geom->vbo = RHI::CreateVertexBuffer(packed.data(), packed.size() * sizeof(float), RHI::BufferUsage::Static);
+    geom->ibo = RHI::CreateIndexBuffer(idx32.data(), idx32.size() * sizeof(uint32_t), RHI::BufferUsage::Static);
+    geom->indexCount = static_cast<uint32_t>(idx32.size());
+
+    auto handle = reinterpret_cast<Rml::CompiledGeometryHandle>(geom);
+    m_Geometry.emplace(handle, geom);
+    return handle;
+}
+
+void RmlUiRenderInterface::RenderGeometry(Rml::CompiledGeometryHandle geometry, Rml::Vector2f translation, Rml::TextureHandle texture)
+{
+    auto it = m_Geometry.find(geometry);
+    if (it == m_Geometry.end()) return;
+    CompiledGeom* geom = it->second;
+
+    PassthroughShader::Instance().Bind();
+    // Blend3, not AlphaTest: AlphaTest (RHI::BlendMode::AlphaTest) enables the shader's alpha-test
+    // discard threshold (g_AlphaRef) as a side effect -- built for hard-cutout foliage sprites, it
+    // would silently clip RmlUi's anti-aliased text/element edges (low but nonzero alpha) instead
+    // of blending them. Blend3 is the same SRC_ALPHA/ONE_MINUS_SRC_ALPHA blend func with alpha-test
+    // explicitly disabled (see EnableAlphaBlend3(), ZzzOpenglUtil.cpp) -- confirmed by reading its
+    // implementation, not assumed from the RHI.h enum comment alone.
+    RHI::SetBlendMode(RHI::BlendMode::Blend3);
+
+    auto texIt = m_Textures.find(texture);
+    if (texture != 0 && texIt != m_Textures.end())
+    {
+        PassthroughShader::Instance().SetTexture(static_cast<GLuint>(texIt->second.id), 0);
+        PassthroughShader::Instance().SetUseTexture(true);
+    }
+    else
+    {
+        PassthroughShader::Instance().SetUseTexture(false);
+    }
+    PassthroughShader::Instance().SetUseFog(false);
+
+    // GlobalUBO::SetModel(origin, scale) already exists purely for "translate without a new
+    // uniform" (per-draw offset without introducing a dedicated RmlUi uniform) -- see the RmlUi
+    // migration plan's Phase 0.3.
+    const float origin[3] = { translation.x, translation.y, 0.0f };
+    GlobalUBO::Instance().SetModel(origin, 1.0f);
+
+    RHI::BindVertexBuffer(geom->vbo, RHI::VertexLayout::PosUvColor);
+    RHI::BindIndexBuffer(geom->ibo);
+    RHI::DrawIndexed(RHI::Topology::TriangleList, geom->indexCount);
+}
+
+void RmlUiRenderInterface::ReleaseGeometry(Rml::CompiledGeometryHandle geometry)
+{
+    auto it = m_Geometry.find(geometry);
+    if (it == m_Geometry.end()) return;
+    RHI::DestroyBuffer(it->second->vbo);
+    RHI::DestroyBuffer(it->second->ibo);
+    delete it->second;
+    m_Geometry.erase(it);
+}
+
+Rml::TextureHandle RmlUiRenderInterface::RegisterTexture(TextureKind kind, uint32_t id)
+{
+    const Rml::TextureHandle handle = m_NextTextureHandle++;
+    m_Textures.emplace(handle, TextureRecord{ kind, id });
+    return handle;
+}
+
+Rml::TextureHandle RmlUiRenderInterface::LoadTexture(Rml::Vector2i& texture_dimensions, const Rml::String& source)
+{
+    // Routed through CGlobalBitmap (the same ref-counted, OZJ/OZT-aware pipeline every other
+    // texture in the game uses -- GlobalBitmap.cpp) rather than loading the file directly, so
+    // RmlUi-referenced images (RML/RCSS <img>/background-image) share its cache/eviction/ref-
+    // counting instead of bypassing it. See the RmlUi migration plan's Phase 0.3.
+    const std::wstring wpath = Utf8ToWide(source); // Rml::String is std::string (RmlUi/Config/Config.h)
+    const GLuint bitmapIndex = Bitmaps.LoadImage(wpath, GL_LINEAR, GL_CLAMP_TO_EDGE);
+    if (bitmapIndex == BITMAP_UNKNOWN) return 0;
+
+    BITMAP_t* bmp = Bitmaps.GetTexture(bitmapIndex);
+    if (!bmp) return 0;
+
+    texture_dimensions = { static_cast<int>(bmp->Width), static_cast<int>(bmp->Height) };
+    return RegisterTexture(TextureKind::FileBacked, bitmapIndex);
+}
+
+Rml::TextureHandle RmlUiRenderInterface::GenerateTexture(Rml::Span<const Rml::byte> source, Rml::Vector2i source_dimensions)
+{
+    // Raw RGBA8 straight from RmlUi itself (rasterized text/SVG, no filename to cache by) --
+    // goes straight through RHI::CreateTexture, bypassing CGlobalBitmap entirely (there is
+    // nothing to ref-count by name).
+    RHI::TextureDesc desc{ source_dimensions.x, source_dimensions.y, RHI::TexFilter::Linear, RHI::TexWrap::Clamp };
+    RHI::TextureHandle h = RHI::CreateTexture(desc, source.data());
+    if (!h.IsValid()) return 0;
+    return RegisterTexture(TextureKind::Generated, h.id);
+}
+
+void RmlUiRenderInterface::ReleaseTexture(Rml::TextureHandle texture)
+{
+    auto it = m_Textures.find(texture);
+    if (it == m_Textures.end()) return;
+
+    if (it->second.kind == TextureKind::FileBacked)
+    {
+        Bitmaps.UnloadImage(it->second.id, /*bForce=*/false); // ref-counted; frees + RHI::DestroyTexture at Ref==0
+    }
+    else
+    {
+        RHI::DestroyTexture(RHI::TextureHandle{ it->second.id }); // already invalidates BindState's cache
+    }
+    m_Textures.erase(it);
+}
+
+void RmlUiRenderInterface::EnableScissorRegion(bool enable)
+{
+    m_ScissorEnabled = enable;
+    RHI::SetScissorEnabled(enable);
+}
+
+void RmlUiRenderInterface::SetScissorRegion(Rml::Rectanglei region)
+{
+    RHI::SetScissorRect(region.Left(), region.Top(), region.Width(), region.Height());
+}

--- a/src/source/Render/RmlUi/RmlUiRenderInterface.cpp
+++ b/src/source/Render/RmlUi/RmlUiRenderInterface.cpp
@@ -5,21 +5,8 @@
 #include "Render/Shaders/PassthroughShader.h"
 #include "Render/Sprites/GlobalBitmap.h"
 #include "Core/Globals/_TextureIndex.h"
+#include "Core/Utilities/StringUtils.h"
 #include <algorithm>
-
-namespace
-{
-    std::wstring Utf8ToWide(const std::string& s)
-    {
-        if (s.empty()) return std::wstring();
-        const int len = static_cast<int>(s.size());
-        const int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, nullptr, 0);
-        if (n <= 0) return std::wstring();
-        std::wstring out(static_cast<size_t>(n), L'\0');
-        MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, out.data(), n);
-        return out;
-    }
-}
 
 Rml::CompiledGeometryHandle RmlUiRenderInterface::CompileGeometry(Rml::Span<const Rml::Vertex> vertices, Rml::Span<const int> indices)
 {
@@ -158,7 +145,7 @@ Rml::TextureHandle RmlUiRenderInterface::LoadTexture(Rml::Vector2i& texture_dime
     // (and this engine's Linux port's) forward-slash tolerance extends to this legacy loader too.
     std::string normalized = source;
     std::replace(normalized.begin(), normalized.end(), '/', '\\');
-    const std::wstring wpath = Utf8ToWide(normalized); // Rml::String is std::string (RmlUi/Config/Config.h)
+    const std::wstring wpath = StringUtils::NarrowToWide(normalized); // Rml::String is std::string (RmlUi/Config/Config.h)
     const GLuint bitmapIndex = Bitmaps.LoadImage(wpath, GL_LINEAR, GL_CLAMP_TO_EDGE);
     if (bitmapIndex == BITMAP_UNKNOWN) return 0;
 

--- a/src/source/Render/RmlUi/RmlUiRenderInterface.cpp
+++ b/src/source/Render/RmlUi/RmlUiRenderInterface.cpp
@@ -95,7 +95,21 @@ void RmlUiRenderInterface::RenderGeometry(Rml::CompiledGeometryHandle geometry, 
     auto texIt = m_Textures.find(texture);
     if (texture != 0 && texIt != m_Textures.end())
     {
-        PassthroughShader::Instance().SetTexture(static_cast<GLuint>(texIt->second.id), 0);
+        // FileBacked's stored id is a CGlobalBitmap bitmap-index, not a GL texture name -- must be
+        // resolved through Bitmaps.GetTexture()->TextureNumber to get the real bindable handle
+        // (see this class's header comment on why the two id spaces are never interchangeable).
+        // Generated's id is already a real RHI::TextureHandle/GL name from RHI::CreateTexture, so
+        // it's used as-is. This distinction was already respected in ReleaseTexture below but was
+        // missed here -- latent since RmlUi's only textures until now were Generated (font glyph
+        // atlases); the first FileBacked decorator image exposed it.
+        GLuint glTextureName = static_cast<GLuint>(texIt->second.id);
+        if (texIt->second.kind == TextureKind::FileBacked)
+        {
+            BITMAP_t* bmp = Bitmaps.GetTexture(texIt->second.id);
+            glTextureName = bmp ? static_cast<GLuint>(bmp->TextureNumber) : 0;
+        }
+
+        PassthroughShader::Instance().SetTexture(glTextureName, 0);
         PassthroughShader::Instance().SetUseTexture(true);
     }
     else

--- a/src/source/Render/RmlUi/RmlUiRenderInterface.cpp
+++ b/src/source/Render/RmlUi/RmlUiRenderInterface.cpp
@@ -5,6 +5,7 @@
 #include "Render/Shaders/PassthroughShader.h"
 #include "Render/Sprites/GlobalBitmap.h"
 #include "Core/Globals/_TextureIndex.h"
+#include <algorithm>
 
 namespace
 {
@@ -137,7 +138,13 @@ Rml::TextureHandle RmlUiRenderInterface::LoadTexture(Rml::Vector2i& texture_dime
     // texture in the game uses -- GlobalBitmap.cpp) rather than loading the file directly, so
     // RmlUi-referenced images (RML/RCSS <img>/background-image) share its cache/eviction/ref-
     // counting instead of bypassing it. See the RmlUi migration plan's Phase 0.3.
-    const std::wstring wpath = Utf8ToWide(source); // Rml::String is std::string (RmlUi/Config/Config.h)
+    // RML/RCSS conventionally author asset paths with forward slashes; every existing in-tree
+    // caller of Bitmaps.LoadImage passes backslash-separated paths (e.g. "Interface\\Foo.jpg"),
+    // matching this codebase's own path-handling convention -- normalize rather than assume GL's
+    // (and this engine's Linux port's) forward-slash tolerance extends to this legacy loader too.
+    std::string normalized = source;
+    std::replace(normalized.begin(), normalized.end(), '/', '\\');
+    const std::wstring wpath = Utf8ToWide(normalized); // Rml::String is std::string (RmlUi/Config/Config.h)
     const GLuint bitmapIndex = Bitmaps.LoadImage(wpath, GL_LINEAR, GL_CLAMP_TO_EDGE);
     if (bitmapIndex == BITMAP_UNKNOWN) return 0;
 

--- a/src/source/Render/RmlUi/RmlUiRenderInterface.h
+++ b/src/source/Render/RmlUi/RmlUiRenderInterface.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "stdafx.h"
+#include <RmlUi/Core/RenderInterface.h>
+#include "Render/RHI/RHI.h"
+#include <unordered_map>
+
+// Rml::RenderInterface implementation targeting this engine's RHI:: abstraction directly --
+// deliberately bypasses IR:: (ImmediateRenderer)'s per-vertex Begin/Vertex/End API, which is
+// built for CPU-accumulated immediate-mode drawing, not RmlUi's bulk compile-once/render-many
+// contract (a CompiledGeometryHandle is reused across frames until an element's layout/style
+// actually changes, so the conversion cost in CompileGeometry below is not a per-frame cost).
+//
+// Only the "required functions for basic rendering" section of Rml::RenderInterface is
+// implemented -- the optional advanced-rendering functions (SetTransform, layers, filters,
+// shaders) are left at their base-class no-op defaults, meaning CSS transforms/backdrop-filter/
+// box-shadow-blur are not yet supported. See the RmlUi migration plan's Phase 0.3 for the
+// deliberate MVP scope cut.
+class RmlUiRenderInterface : public Rml::RenderInterface
+{
+public:
+    Rml::CompiledGeometryHandle CompileGeometry(Rml::Span<const Rml::Vertex> vertices, Rml::Span<const int> indices) override;
+    void RenderGeometry(Rml::CompiledGeometryHandle geometry, Rml::Vector2f translation, Rml::TextureHandle texture) override;
+    void ReleaseGeometry(Rml::CompiledGeometryHandle geometry) override;
+
+    Rml::TextureHandle LoadTexture(Rml::Vector2i& texture_dimensions, const Rml::String& source) override;
+    Rml::TextureHandle GenerateTexture(Rml::Span<const Rml::byte> source, Rml::Vector2i source_dimensions) override;
+    void ReleaseTexture(Rml::TextureHandle texture) override;
+
+    void EnableScissorRegion(bool enable) override;
+    void SetScissorRegion(Rml::Rectanglei region) override;
+
+private:
+    struct CompiledGeom
+    {
+        RHI::BufferHandle vbo;
+        RHI::BufferHandle ibo;
+        uint32_t indexCount = 0;
+    };
+
+    // RmlUi's TextureHandle is an opaque uintptr_t we hand out ourselves from an incrementing
+    // counter -- never alias it onto a raw CGlobalBitmap index or an RHI::TextureHandle id
+    // directly. Both of those come from independent, not-guaranteed-disjoint counters
+    // (CGlobalBitmap::GenerateTextureIndex() vs RHI_GL.cpp's own GL texture-id counter), so
+    // misrouting a ReleaseTexture() call between the file-backed and generated paths below would
+    // be a real correctness bug (freeing/using the wrong texture), not just a style concern.
+    enum class TextureKind { FileBacked, Generated };
+    struct TextureRecord { TextureKind kind; uint32_t id; };
+
+    Rml::TextureHandle RegisterTexture(TextureKind kind, uint32_t id);
+
+    std::unordered_map<Rml::CompiledGeometryHandle, CompiledGeom*> m_Geometry;
+    std::unordered_map<Rml::TextureHandle, TextureRecord> m_Textures;
+    uintptr_t m_NextTextureHandle = 1;
+
+    bool m_ScissorEnabled = false;
+};

--- a/src/source/Render/RmlUi/RmlUiRuntime.cpp
+++ b/src/source/Render/RmlUi/RmlUiRuntime.cpp
@@ -117,6 +117,13 @@ void RmlUiRuntime::Render()
     // stale clip rect can never survive into the next renderer's draws.
     RHI::SetScissorEnabled(false);
 
+    // RmlUiRenderInterface::RenderGeometry leaves RHI::BlendMode::Blend3 active on the last
+    // draw call (cull+depthmask OFF, alpha blend ON per RHI.h's enum comment) -- nothing resets
+    // this per-frame the way BeginOpengl() forces depth-test/cull/depth-write/alpha-test back on
+    // unconditionally every frame (ZzzOpenglUtil.cpp), so restore a known-good opaque state
+    // explicitly here rather than assuming whatever runs next sets its own blend mode first.
+    RHI::SetBlendMode(RHI::BlendMode::Opaque);
+
     GlobalUBO::Instance().SetProj(savedProj);
     GlobalUBO::Instance().SetView(savedView);
 }

--- a/src/source/Render/RmlUi/RmlUiRuntime.cpp
+++ b/src/source/Render/RmlUi/RmlUiRuntime.cpp
@@ -1,0 +1,110 @@
+#include "stdafx.h"
+#include "RmlUiRuntime.h"
+#include "RmlUiRenderInterface.h"
+#include "RmlUiSystemInterface.h"
+
+#include <RmlUi/Core/Core.h>
+#include "Render/RHI/RHI.h"
+#include "Render/Core/GlobalUBO.h"
+#include "Render/Core/ImmediateRenderer.h"
+#include "Render/Textures/ZzzOpenglUtil.h" // WindowWidth/WindowHeight
+#include <cstring>
+
+RmlUiRuntime& RmlUiRuntime::Instance()
+{
+    static RmlUiRuntime instance;
+    return instance;
+}
+
+RmlUiRuntime::~RmlUiRuntime()
+{
+    Destroy();
+}
+
+void RmlUiRuntime::Create(int windowWidth, int windowHeight)
+{
+    if (m_Context) return;
+
+    m_RenderInterface = std::make_unique<RmlUiRenderInterface>();
+    m_SystemInterface = std::make_unique<RmlUiSystemInterface>();
+
+    Rml::SetRenderInterface(m_RenderInterface.get());
+    Rml::SetSystemInterface(m_SystemInterface.get());
+
+    if (!Rml::Initialise())
+    {
+        m_RenderInterface.reset();
+        m_SystemInterface.reset();
+        return;
+    }
+
+    m_Context = Rml::CreateContext("main", Rml::Vector2i(windowWidth, windowHeight));
+}
+
+void RmlUiRuntime::Destroy()
+{
+    if (!m_Context) return;
+
+    // Rml::Shutdown() releases every context it owns, including m_Context -- do not call
+    // Rml::RemoveContext/delete it separately first.
+    Rml::Shutdown();
+    m_Context = nullptr;
+
+    // Per RenderInterface.h/SystemInterface.h's own contract: the application must keep these
+    // alive until after Rml::Shutdown() and destroy them itself afterward -- RmlUi never takes
+    // ownership.
+    m_RenderInterface.reset();
+    m_SystemInterface.reset();
+}
+
+void RmlUiRuntime::OnResize(int windowWidth, int windowHeight)
+{
+    if (!m_Context) return;
+    m_Context->SetDimensions(Rml::Vector2i(windowWidth, windowHeight));
+}
+
+void RmlUiRuntime::Update()
+{
+    if (!m_Context) return;
+    m_Context->Update();
+}
+
+void RmlUiRuntime::Render()
+{
+    if (!m_Context) return;
+
+    // Mirrors ZzzOpenglUtil.cpp's BeginBitmap()/EndBitmap() pattern (flush IR::, full viewport,
+    // disable depth test, swap GlobalUBO's proj/view to an ortho pair, restore after) with one
+    // deliberate difference: BeginBitmap() sets up a BOTTOM-UP ortho projection (matching legacy
+    // 2D code's manual y = WindowHeight - y flips), but RmlUi's vertices already arrive in
+    // top-left-origin, y-down pixel space and must not be re-flipped per-vertex. So this uses a
+    // TOP-DOWN ortho (top/bottom swapped relative to BeginBitmap()) instead of reusing
+    // BeginBitmap() itself. This is the same technique the in-progress D3D11 branch
+    // (janblade/dx-only-port) already uses to reconcile GL-vs-D3D11 texture Y-origin at the
+    // projection level rather than per-draw -- reusing GlobalUBO here means that fix is
+    // inherited for free once the branches converge. See the RmlUi migration plan's Phase 0.4.
+    IR::Flush();
+    RHI::SetViewport(0, 0, static_cast<int>(WindowWidth), static_cast<int>(WindowHeight));
+    RHI::SetDepthTestEnabled(false);
+
+    float savedProj[16];
+    float savedView[16];
+    memcpy(savedProj, GlobalUBO::Instance().GetProj(), sizeof(savedProj));
+    memcpy(savedView, GlobalUBO::Instance().GetView(), sizeof(savedView));
+
+    // SetOrtho() resets View to identity internally (GlobalUBO.cpp) -- no separate SetView() call
+    // needed here. bottom/top are swapped relative to BeginBitmap()'s (0, W, 0, H) call to get the
+    // top-down flip described above; confirmed against SetOrtho()'s closed-form matrix, not assumed.
+    GlobalUBO::Instance().SetOrtho(0.0f, (float)WindowWidth, (float)WindowHeight, 0.0f);
+
+    m_Context->Render();
+
+    // Scissor has no BindState-style cache to self-correct a leak (RHI.h's comment on
+    // SetScissorEnabled/SetScissorRect) -- force it off here unconditionally rather than trusting
+    // that RmlUi's own EnableScissorRegion(false) was the last scissor call this frame, so a
+    // stale clip rect can never survive into the next renderer's draws.
+    RHI::SetScissorEnabled(false);
+
+    GlobalUBO::Instance().SetProj(savedProj);
+    GlobalUBO::Instance().SetView(savedView);
+}

--- a/src/source/Render/RmlUi/RmlUiRuntime.cpp
+++ b/src/source/Render/RmlUi/RmlUiRuntime.cpp
@@ -39,6 +39,16 @@ void RmlUiRuntime::Create(int windowWidth, int windowHeight)
         return;
     }
 
+    // Reuses the same bundled fonts this engine already ships for its portable GDI-text shim
+    // (Core/Platform/BundledFonts.h, "fonts/LiberationSans-*.ttf", copied next to the exe by the
+    // same asset-copy step as everything else under src/bin/) rather than adding a new font
+    // dependency. fallback_face=true on the regular weight means any RML/RCSS font-family that
+    // doesn't match a loaded face still renders with this one instead of silently rendering no
+    // text at all -- confirmed missing entirely (shapes rendered, text didn't) from a real
+    // screenshot before this fix.
+    Rml::LoadFontFace("fonts/LiberationSans-Regular.ttf", true);
+    Rml::LoadFontFace("fonts/LiberationSans-Bold.ttf");
+
     m_Context = Rml::CreateContext("main", Rml::Vector2i(windowWidth, windowHeight));
 }
 
@@ -89,6 +99,18 @@ bool RmlUiRuntime::ProcessSdlEvent(SDL_Event& event, SDL_Window* window)
         return m_Context->ProcessMouseButtonDown(RmlSDL::ConvertMouseButton(event.button.button), RmlSDL::GetKeyModifierState());
     if (event.type == SDL_EVENT_MOUSE_BUTTON_UP)
         return m_Context->ProcessMouseButtonUp(RmlSDL::ConvertMouseButton(event.button.button), RmlSDL::GetKeyModifierState());
+
+    // Mouse motion is also handled directly rather than through RmlSDL::InputEventHandler, which
+    // multiplies the raw event coordinates by SDL_GetWindowPixelDensity() before forwarding them
+    // -- correct for a backend whose Context was created in DPI-independent "points" and needs
+    // converting up to real pixels, but this engine's own HandleMouseMotion() (Winmain.cpp)
+    // applies no such scaling, and RmlUiRuntime::Create() built the Context directly from
+    // WindowWidth/WindowHeight (already real pixels). Multiplying by density on top of that
+    // double-applies any non-1.0 scaling, drifting RmlUi's notion of the cursor position away
+    // from where the game itself thinks it is -- plausible root cause of a real report ("mouse
+    // only seems to work in some areas"). Feed the same raw coordinates HandleMouseMotion() sees.
+    if (event.type == SDL_EVENT_MOUSE_MOTION)
+        return m_Context->ProcessMouseMove(static_cast<int>(event.motion.x), static_cast<int>(event.motion.y), RmlSDL::GetKeyModifierState());
 
     return RmlSDL::InputEventHandler(m_Context, window, event);
 }

--- a/src/source/Render/RmlUi/RmlUiRuntime.cpp
+++ b/src/source/Render/RmlUi/RmlUiRuntime.cpp
@@ -143,12 +143,27 @@ void RmlUiRuntime::Render()
     memcpy(savedProj, GlobalUBO::Instance().GetProj(), sizeof(savedProj));
     memcpy(savedView, GlobalUBO::Instance().GetView(), sizeof(savedView));
 
+    // RmlUiRenderInterface::RenderGeometry calls GlobalUBO::SetModel(origin, scale) once per
+    // compiled-geometry draw to translate it to its element's screen position -- necessary, but
+    // it leaves Model holding whatever the LAST draw this frame set it to (e.g. the login panel's
+    // OK button origin) with nothing to put it back afterward. Legacy 2D/3D rendering (BeginBitmap/
+    // BeginOpengl-based sprite, text and world draws) never sets Model itself -- it assumes Model
+    // is identity, the way it always was before RmlUi existed. Confirmed as the cause of a real
+    // report: RmlUi's own elements rendered in the right place, but every legacy element and the
+    // "responsive"/clickable area had shifted toward the upper-right -- exactly what a leaked,
+    // never-reset translation does to everything drawn after it. PushModel()/PopModel() (already
+    // built for exactly this save/restore shape) brackets the whole call the same way savedProj/
+    // savedView do above.
+    GlobalUBO::Instance().PushModel();
+
     // SetOrtho() resets View to identity internally (GlobalUBO.cpp) -- no separate SetView() call
     // needed here. bottom/top are swapped relative to BeginBitmap()'s (0, W, 0, H) call to get the
     // top-down flip described above; confirmed against SetOrtho()'s closed-form matrix, not assumed.
     GlobalUBO::Instance().SetOrtho(0.0f, (float)WindowWidth, (float)WindowHeight, 0.0f);
 
     m_Context->Render();
+
+    GlobalUBO::Instance().PopModel();
 
     // Scissor has no BindState-style cache to self-correct a leak (RHI.h's comment on
     // SetScissorEnabled/SetScissorRect) -- force it off here unconditionally rather than trusting

--- a/src/source/Render/RmlUi/RmlUiRuntime.cpp
+++ b/src/source/Render/RmlUi/RmlUiRuntime.cpp
@@ -10,6 +10,8 @@
 #include "Render/Textures/ZzzOpenglUtil.h" // WindowWidth/WindowHeight
 #include <cstring>
 
+#include <RmlUi_Platform_SDL.h> // ThirdParty/RmlUi/Backends -- see the CMakeLists.txt addition
+
 RmlUiRuntime& RmlUiRuntime::Instance()
 {
     static RmlUiRuntime instance;
@@ -67,6 +69,17 @@ void RmlUiRuntime::Update()
 {
     if (!m_Context) return;
     m_Context->Update();
+}
+
+bool RmlUiRuntime::ProcessSdlEvent(SDL_Event& event, SDL_Window* window)
+{
+    if (!m_Context) return true; // nothing to consume it -- let it fall through
+    return RmlSDL::InputEventHandler(m_Context, window, event);
+}
+
+bool RmlUiRuntime::IsMouseOverUI() const
+{
+    return m_Context && m_Context->IsMouseInteracting();
 }
 
 void RmlUiRuntime::Render()

--- a/src/source/Render/RmlUi/RmlUiRuntime.cpp
+++ b/src/source/Render/RmlUi/RmlUiRuntime.cpp
@@ -4,13 +4,12 @@
 #include "RmlUiSystemInterface.h"
 
 #include <RmlUi/Core/Core.h>
+#include <RmlUi_Platform_SDL.h> // ThirdParty/RmlUi/Backends -- see the CMakeLists.txt addition
 #include "Render/RHI/RHI.h"
 #include "Render/Core/GlobalUBO.h"
 #include "Render/Core/ImmediateRenderer.h"
 #include "Render/Textures/ZzzOpenglUtil.h" // WindowWidth/WindowHeight
 #include <cstring>
-
-#include <RmlUi_Platform_SDL.h> // ThirdParty/RmlUi/Backends -- see the CMakeLists.txt addition
 
 RmlUiRuntime& RmlUiRuntime::Instance()
 {

--- a/src/source/Render/RmlUi/RmlUiRuntime.cpp
+++ b/src/source/Render/RmlUi/RmlUiRuntime.cpp
@@ -73,6 +73,23 @@ void RmlUiRuntime::Update()
 bool RmlUiRuntime::ProcessSdlEvent(SDL_Event& event, SDL_Window* window)
 {
     if (!m_Context) return true; // nothing to consume it -- let it fall through
+
+    // Mouse button down/up are handled directly here instead of delegating to
+    // RmlSDL::InputEventHandler, which also calls SDL_CaptureMouse(true/false) on every button
+    // press/release (RmlUi_Platform_SDL.cpp) -- correct for a sample app that owns the whole
+    // window, but a real bug in this engine: it has its own cursor rendering and mouse-clip
+    // handling (Winmain.cpp's UpdateCursorClip()) that was never built to expect SDL's capture
+    // mode being toggled externally, and every mouse click in the game (not just clicks on
+    // RmlUi elements) passes through this function. Confirmed by a real user report: the cursor
+    // stopped tracking correctly ("does not follow where you drag") starting right after the
+    // first click-driven scene transition (server selection -> login) once RmlUi's button-event
+    // path started firing. Still reuses RmlSDL::ConvertMouseButton/GetKeyModifierState (pure,
+    // side-effect-free helpers) for the actual button index/modifier mapping.
+    if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
+        return m_Context->ProcessMouseButtonDown(RmlSDL::ConvertMouseButton(event.button.button), RmlSDL::GetKeyModifierState());
+    if (event.type == SDL_EVENT_MOUSE_BUTTON_UP)
+        return m_Context->ProcessMouseButtonUp(RmlSDL::ConvertMouseButton(event.button.button), RmlSDL::GetKeyModifierState());
+
     return RmlSDL::InputEventHandler(m_Context, window, event);
 }
 

--- a/src/source/Render/RmlUi/RmlUiRuntime.h
+++ b/src/source/Render/RmlUi/RmlUiRuntime.h
@@ -26,9 +26,13 @@ public:
     void Update();
     void Render();
 
-    // Forwards one SDL event to RmlUi via its official RmlSDL::InputEventHandler (vendored at
-    // ThirdParty/RmlUi/Backends/RmlUi_Platform_SDL.cpp -- see the RmlUi migration plan's Phase
-    // 0.8: reusing RmlUi's own tested SDL-keycode/modifier mapping rather than hand-rolling one).
+    // Forwards one SDL event to RmlUi. Motion and button down/up are handled directly (see the
+    // .cpp) to avoid two real bugs in RmlUi's official RmlSDL::InputEventHandler (vendored at
+    // ThirdParty/RmlUi/Backends/RmlUi_Platform_SDL.cpp) that don't fit this engine's own
+    // conventions: it calls SDL_CaptureMouse() on every button press/release, and it scales
+    // motion coordinates by SDL_GetWindowPixelDensity(). Every other event type (wheel/key/text)
+    // still goes through it -- still reusing RmlUi's own tested SDL-keycode/modifier mapping
+    // rather than hand-rolling one (RmlUi migration plan Phase 0.8).
     // @return false if RmlUi consumed the event (an element under the cursor / holding focus
     // claimed it) -- the caller should then skip its own legacy handling for this event. true
     // means RmlUi did not consume it (matches Rml::Context::Process*'s own "still propagating"

--- a/src/source/Render/RmlUi/RmlUiRuntime.h
+++ b/src/source/Render/RmlUi/RmlUiRuntime.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "stdafx.h"
+#include <RmlUi/Core/Context.h>
+#include <memory>
+
+class RmlUiRenderInterface;
+class RmlUiSystemInterface;
+
+// Owns the Rml::Context lifecycle and the one per-frame Update()/Render() entry point. Hooked
+// from SceneManager.cpp's RenderScene() -- see the RmlUi migration plan's Phase 0.4 for why that
+// call site (not a per-Scene hook) is the single choke point every scene funnels through.
+class RmlUiRuntime
+{
+public:
+    static RmlUiRuntime& Instance();
+
+    void Create(int windowWidth, int windowHeight);
+    void Destroy();
+    bool IsCreated() const { return m_Context != nullptr; }
+
+    void OnResize(int windowWidth, int windowHeight);
+
+    void Update();
+    void Render();
+
+    Rml::Context* GetContext() const { return m_Context; }
+
+private:
+    RmlUiRuntime() = default;
+    ~RmlUiRuntime();
+
+    RmlUiRuntime(const RmlUiRuntime&) = delete;
+    RmlUiRuntime& operator=(const RmlUiRuntime&) = delete;
+
+    std::unique_ptr<RmlUiRenderInterface> m_RenderInterface;
+    std::unique_ptr<RmlUiSystemInterface> m_SystemInterface;
+    Rml::Context* m_Context = nullptr; // owned by Rml::Core, released via Rml::Shutdown()
+};

--- a/src/source/Render/RmlUi/RmlUiRuntime.h
+++ b/src/source/Render/RmlUi/RmlUiRuntime.h
@@ -6,6 +6,8 @@
 
 class RmlUiRenderInterface;
 class RmlUiSystemInterface;
+union SDL_Event;
+struct SDL_Window;
 
 // Owns the Rml::Context lifecycle and the one per-frame Update()/Render() entry point. Hooked
 // from SceneManager.cpp's RenderScene() -- see the RmlUi migration plan's Phase 0.4 for why that
@@ -23,6 +25,27 @@ public:
 
     void Update();
     void Render();
+
+    // Forwards one SDL event to RmlUi via its official RmlSDL::InputEventHandler (vendored at
+    // ThirdParty/RmlUi/Backends/RmlUi_Platform_SDL.cpp -- see the RmlUi migration plan's Phase
+    // 0.8: reusing RmlUi's own tested SDL-keycode/modifier mapping rather than hand-rolling one).
+    // @return false if RmlUi consumed the event (an element under the cursor / holding focus
+    // claimed it) -- the caller should then skip its own legacy handling for this event. true
+    // means RmlUi did not consume it (matches Rml::Context::Process*'s own "still propagating"
+    // convention) and legacy handling should proceed as before.
+    //
+    // Ordering caveat (RmlUi migration plan Open Decision #4, not solved here): this always
+    // offers the event to RmlUi first, regardless of whether a legacy CNewUIObj/CWin window is
+    // actually on top of the RmlUi content at that screen position -- correct as long as
+    // migrated-window content and still-legacy windows occupy disjoint z-order bands (Phase
+    // 0.8's "one contiguous band" approach), wrong if a legacy window ever needs to sit visually
+    // on top of migrated RmlUi content. Revisit if that situation arises.
+    bool ProcessSdlEvent(SDL_Event& event, SDL_Window* window);
+
+    // Rml::Context::IsMouseInteracting() -- true while the mouse is hovering/pressed over any
+    // RmlUi element. Intended as a third click-to-move gate alongside MouseOnWindow (Legacy tier)
+    // and g_pNewUISystem->CheckMouseUse() (NewUI tier) at Input/Selection.cpp's world-pick check.
+    bool IsMouseOverUI() const;
 
     Rml::Context* GetContext() const { return m_Context; }
 

--- a/src/source/Render/RmlUi/RmlUiSystemInterface.cpp
+++ b/src/source/Render/RmlUi/RmlUiSystemInterface.cpp
@@ -1,0 +1,63 @@
+#include "stdafx.h"
+#include "RmlUiSystemInterface.h"
+
+#include "Core/Utilities/Log/ErrorReport.h"
+#include <SDL3/SDL.h>
+#include <chrono>
+
+namespace
+{
+    std::wstring Utf8ToWide(const std::string& s)
+    {
+        if (s.empty()) return std::wstring();
+        const int len = static_cast<int>(s.size());
+        const int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, nullptr, 0);
+        if (n <= 0) return std::wstring();
+        std::wstring out(static_cast<size_t>(n), L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, out.data(), n);
+        return out;
+    }
+
+    // Real wall-clock time, independent of game pause/tick state -- matches this codebase's own
+    // established pattern for render-frequency timing (std::chrono::steady_clock, see the
+    // FPS_ANIMATION_FACTOR gotchas in docs/GPU Skinning/gotchas-and-patterns.md) rather than
+    // reusing a game-simulation time global like WorldTime, which RmlUi's own animations/
+    // transitions/double-click detection should not be coupled to.
+    const std::chrono::steady_clock::time_point g_StartTime = std::chrono::steady_clock::now();
+}
+
+double RmlUiSystemInterface::GetElapsedTime()
+{
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - g_StartTime).count();
+}
+
+bool RmlUiSystemInterface::LogMessage(Rml::Log::Type type, const Rml::String& message)
+{
+    const wchar_t* tag = L"[RmlUi]";
+    switch (type)
+    {
+        case Rml::Log::LT_ERROR:   tag = L"[RmlUi][Error]";   break;
+        case Rml::Log::LT_ASSERT:  tag = L"[RmlUi][Assert]";  break;
+        case Rml::Log::LT_WARNING: tag = L"[RmlUi][Warning]"; break;
+        case Rml::Log::LT_INFO:    tag = L"[RmlUi][Info]";    break;
+        case Rml::Log::LT_DEBUG:   tag = L"[RmlUi][Debug]";   break;
+        default: break;
+    }
+    g_ErrorReport.Write(L"%s %s\r\n", tag, Utf8ToWide(message).c_str());
+    return true; // continue execution -- never break into the debugger from here
+}
+
+void RmlUiSystemInterface::SetClipboardText(const Rml::String& text)
+{
+    // SDL3's clipboard API (UTF-8, cross-platform) rather than raw Win32 OpenClipboard/
+    // SetClipboardData -- consistent with this engine's SDL-based platform abstraction and its
+    // existing portability discipline (GdiText.cpp etc.).
+    SDL_SetClipboardText(text.c_str());
+}
+
+void RmlUiSystemInterface::GetClipboardText(Rml::String& text)
+{
+    char* clipboard = SDL_GetClipboardText();
+    text = clipboard ? clipboard : "";
+    if (clipboard) SDL_free(clipboard);
+}

--- a/src/source/Render/RmlUi/RmlUiSystemInterface.cpp
+++ b/src/source/Render/RmlUi/RmlUiSystemInterface.cpp
@@ -2,22 +2,12 @@
 #include "RmlUiSystemInterface.h"
 
 #include "Core/Utilities/Log/ErrorReport.h"
+#include "Core/Utilities/StringUtils.h"
 #include <SDL3/SDL.h>
 #include <chrono>
 
 namespace
 {
-    std::wstring Utf8ToWide(const std::string& s)
-    {
-        if (s.empty()) return std::wstring();
-        const int len = static_cast<int>(s.size());
-        const int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, nullptr, 0);
-        if (n <= 0) return std::wstring();
-        std::wstring out(static_cast<size_t>(n), L'\0');
-        MultiByteToWideChar(CP_UTF8, 0, s.c_str(), len, out.data(), n);
-        return out;
-    }
-
     // Real wall-clock time, independent of game pause/tick state -- matches this codebase's own
     // established pattern for render-frequency timing (std::chrono::steady_clock, see the
     // FPS_ANIMATION_FACTOR gotchas in docs/GPU Skinning/gotchas-and-patterns.md) rather than
@@ -43,7 +33,7 @@ bool RmlUiSystemInterface::LogMessage(Rml::Log::Type type, const Rml::String& me
         case Rml::Log::LT_DEBUG:   tag = L"[RmlUi][Debug]";   break;
         default: break;
     }
-    g_ErrorReport.Write(L"%s %s\r\n", tag, Utf8ToWide(message).c_str());
+    g_ErrorReport.Write(L"%s %s\r\n", tag, StringUtils::NarrowToWide(message).c_str());
     return true; // continue execution -- never break into the debugger from here
 }
 

--- a/src/source/Render/RmlUi/RmlUiSystemInterface.h
+++ b/src/source/Render/RmlUi/RmlUiSystemInterface.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "stdafx.h"
+#include <RmlUi/Core/SystemInterface.h>
+
+// Rml::SystemInterface implementation. Every base-class method already has a working default
+// (SystemInterface.h -- none are pure virtual), so only the ones worth redirecting into this
+// engine's existing utilities are overridden here; TranslateString/JoinPath/ActivateKeyboard/
+// DeactivateKeyboard are left at their defaults (no-ops) -- see the RmlUi migration plan's Open
+// Decisions for the separate (unscoped) question of bridging RmlUi's translation hook to this
+// project's own .resx-based I18N system, which is a font/text-pipeline decision, not a system-
+// interface one.
+class RmlUiSystemInterface : public Rml::SystemInterface
+{
+public:
+    double GetElapsedTime() override;
+    bool LogMessage(Rml::Log::Type type, const Rml::String& message) override;
+    void SetClipboardText(const Rml::String& text) override;
+    void GetClipboardText(Rml::String& text) override;
+};

--- a/src/source/Render/Shaders/BMDMeshShader.cpp
+++ b/src/source/Render/Shaders/BMDMeshShader.cpp
@@ -202,7 +202,7 @@ void main() {
         // the translation component (row.xyz only, no homogeneous term).
         skinnedNormal = normalize(vec3(dot(r0.xyz, a_Normal), dot(r1.xyz, a_Normal), dot(r2.xyz, a_Normal)));
         // Per-vertex lighting, ported 1:1 from BMD::Transform's CPU loop:
-        //   Luminosity = DotProduct(tn, LightPosition) * 0.8f + 0.4f; clamp to >= 0.2f (no upper bound)
+        //   Luminosity = VectorDotProduct(tn, LightPosition) * 0.8f + 0.4f; clamp to >= 0.2f (no upper bound)
         //   LightTransform = BodyLight * Luminosity
         // u_LightEnable mirrors RenderMesh's `useLight` (false for RENDER_BRIGHT / !LightEnable /
         // StreamMesh) — those cases use flat u_BodyLight, same as the CPU fallback did.
@@ -220,7 +220,7 @@ void main() {
         v_ChromeUVStatic = skinnedNormal.xy * 0.5 + 0.5;
         if (u_RenderMode == 7) {
             // RENDER_CHROME4 animated UV, ported 1:1 from the CPU g_chrome[] formula (ZzzBMD.cpp):
-            //   g_chrome[j][0] = DotProduct(n,Lp);     g_chrome[j][1] = 1.f - DotProduct(n,Lp);
+            //   g_chrome[j][0] = VectorDotProduct(n,Lp);     g_chrome[j][1] = 1.f - VectorDotProduct(n,Lp);
             //   g_chrome[j][1] -= n[2]*0.5f + waveLoc*3.f; g_chrome[j][0] += n[1]*0.5f + Lp[1]*3.f;
             // (waveLoc is the same CPU value as u_ChromeWave — confirmed identical formula.)
             vec3 Lp = vec3(u_ChromeLightVec, 1.0);

--- a/src/source/Render/Terrain/CSWaterTerrain.cpp
+++ b/src/source/Render/Terrain/CSWaterTerrain.cpp
@@ -94,7 +94,7 @@ void CSWaterTerrain::Render(void)
     for (j = 0; j < m_iTriangleListNum; j++)
     {
         offset = m_iTriangleList[j];
-        alpha = 1.f - DotProduct(m_Normals[offset], m_vLightVector);
+        alpha = 1.f - VectorDotProduct(m_Normals[offset], m_vLightVector);
         IR::Color3f(alpha, alpha * 2.5f, alpha * 3.f);
         IR::TexCoord2f(g_chrome[offset][1], g_chrome[offset][0]);
         IR::Vertex3fv(m_Vertices[offset]);

--- a/src/source/Render/Terrain/ZzzLodTerrain.cpp
+++ b/src/source/Render/Terrain/ZzzLodTerrain.cpp
@@ -530,7 +530,7 @@ void CreateTerrainLight()
         for (int x = 0; x < TERRAIN_SIZE; x++)
         {
             int Index = TERRAIN_INDEX(x, y);
-            float Luminosity = DotProduct(TerrainNormal[Index], Light) + 0.5f;
+            float Luminosity = VectorDotProduct(TerrainNormal[Index], Light) + 0.5f;
             if (Luminosity < 0.f)
                 Luminosity = 0.f;
             else if (Luminosity > 1.f)
@@ -558,7 +558,7 @@ void CreateTerrainLight_Part(int xi, int yi)
         for (int x = xi - 4; x < xi + 4; x++)
         {
             int Index = TERRAIN_INDEX(x, y);
-            float Luminosity = DotProduct(TerrainNormal[Index], Light) + 0.5f;
+            float Luminosity = VectorDotProduct(TerrainNormal[Index], Light) + 0.5f;
             if (Luminosity < 0.f) Luminosity = 0.f;
             else if (Luminosity > 1.f) Luminosity = 1.f;
             for (int i = 0; i < 3; i++)
@@ -2900,11 +2900,11 @@ void CreateFrustrum(float xAspect, float yAspect, vec3_t position)
     FaceNormalize(FrustrumVertex[0], FrustrumVertex[3], FrustrumVertex[4], FrustrumFaceNormal[2]);
     FaceNormalize(FrustrumVertex[0], FrustrumVertex[4], FrustrumVertex[1], FrustrumFaceNormal[3]);
     FaceNormalize(FrustrumVertex[3], FrustrumVertex[2], FrustrumVertex[1], FrustrumFaceNormal[4]);
-    FrustrumFaceD[0] = -DotProduct(FrustrumVertex[0], FrustrumFaceNormal[0]);
-    FrustrumFaceD[1] = -DotProduct(FrustrumVertex[0], FrustrumFaceNormal[1]);
-    FrustrumFaceD[2] = -DotProduct(FrustrumVertex[0], FrustrumFaceNormal[2]);
-    FrustrumFaceD[3] = -DotProduct(FrustrumVertex[0], FrustrumFaceNormal[3]);
-    FrustrumFaceD[4] = -DotProduct(FrustrumVertex[1], FrustrumFaceNormal[4]);
+    FrustrumFaceD[0] = -VectorDotProduct(FrustrumVertex[0], FrustrumFaceNormal[0]);
+    FrustrumFaceD[1] = -VectorDotProduct(FrustrumVertex[0], FrustrumFaceNormal[1]);
+    FrustrumFaceD[2] = -VectorDotProduct(FrustrumVertex[0], FrustrumFaceNormal[2]);
+    FrustrumFaceD[3] = -VectorDotProduct(FrustrumVertex[0], FrustrumFaceNormal[3]);
+    FrustrumFaceD[4] = -VectorDotProduct(FrustrumVertex[1], FrustrumFaceNormal[4]);
 
     CreateFrustrum2D(position);
 
@@ -3119,7 +3119,7 @@ bool TestFrustrum(vec3_t Position, float Range)
 
     for (int i = 0; i < 5; i++)
     {
-        if (DotProduct(Position, FrustrumFaceNormal[i]) + FrustrumFaceD[i] < -Range)
+        if (VectorDotProduct(Position, FrustrumFaceNormal[i]) + FrustrumFaceD[i] < -Range)
         {
             return false;
         }
@@ -3155,11 +3155,11 @@ void CFrustrum::Make(vec3_t vEye, float fFov, float fAspect, float fDist)
     FaceNormalize(FrustrumVertex[0], FrustrumVertex[3], FrustrumVertex[4], m_FrustrumNorm[2]);
     FaceNormalize(FrustrumVertex[0], FrustrumVertex[4], FrustrumVertex[1], m_FrustrumNorm[3]);
     FaceNormalize(FrustrumVertex[3], FrustrumVertex[2], FrustrumVertex[1], m_FrustrumNorm[4]);
-    m_FrustrumD[0] = -DotProduct(FrustrumVertex[0], m_FrustrumNorm[0]);
-    m_FrustrumD[1] = -DotProduct(FrustrumVertex[0], m_FrustrumNorm[1]);
-    m_FrustrumD[2] = -DotProduct(FrustrumVertex[0], m_FrustrumNorm[2]);
-    m_FrustrumD[3] = -DotProduct(FrustrumVertex[0], m_FrustrumNorm[3]);
-    m_FrustrumD[4] = -DotProduct(FrustrumVertex[1], m_FrustrumNorm[4]);
+    m_FrustrumD[0] = -VectorDotProduct(FrustrumVertex[0], m_FrustrumNorm[0]);
+    m_FrustrumD[1] = -VectorDotProduct(FrustrumVertex[0], m_FrustrumNorm[1]);
+    m_FrustrumD[2] = -VectorDotProduct(FrustrumVertex[0], m_FrustrumNorm[2]);
+    m_FrustrumD[3] = -VectorDotProduct(FrustrumVertex[0], m_FrustrumNorm[3]);
+    m_FrustrumD[4] = -VectorDotProduct(FrustrumVertex[1], m_FrustrumNorm[4]);
 }
 
 void CFrustrum::Create(vec3_t vEye, float fFov, float fAspect, float fDist)
@@ -3177,7 +3177,7 @@ bool CFrustrum::Test(vec3_t vPos, float fRange)
     for (int i = 0; i < 5; ++i)
     {
         float fValue;
-        fValue = m_FrustrumD[i] + DotProduct(vPos, m_FrustrumNorm[i]);
+        fValue = m_FrustrumD[i] + VectorDotProduct(vPos, m_FrustrumNorm[i]);
         if (fValue < -fRange) return false;
     }
     return true;

--- a/src/source/Render/Textures/ZzzOpenglUtil.cpp
+++ b/src/source/Render/Textures/ZzzOpenglUtil.cpp
@@ -1849,9 +1849,9 @@ bool CollisionDetectLineToFace(vec3_t Position, vec3_t Target, int Polygon, floa
 {
     vec3_t Direction;
     VectorSubtract(Target, Position, Direction);
-    float a = DotProduct(Direction, Normal);
+    float a = VectorDotProduct(Direction, Normal);
     if (a >= 0.f) return false;
-    float b = DotProduct(Position, Normal) - DotProduct(v1, Normal);
+    float b = VectorDotProduct(Position, Normal) - VectorDotProduct(v1, Normal);
     float t = -b / a;
     if (t >= 0.f && t <= Distance)
     {
@@ -1902,16 +1902,16 @@ bool CollisionDetectLineToFace(vec3_t Position, vec3_t Target, int Polygon, floa
 
 bool ProjectLineBox(vec3_t ax, vec3_t p1, vec3_t p2, OBB_t obb)
 {
-    float P1 = DotProduct(ax, p1);
-    float P2 = DotProduct(ax, p2);
+    float P1 = VectorDotProduct(ax, p1);
+    float P2 = VectorDotProduct(ax, p2);
 
     float mx1 = maxf(P1, P2);
     float mn1 = minf(P1, P2);
 
-    float ST = DotProduct(ax, obb.StartPos);
-    float Q1 = DotProduct(ax, obb.XAxis);
-    float Q2 = DotProduct(ax, obb.YAxis);
-    float Q3 = DotProduct(ax, obb.ZAxis);
+    float ST = VectorDotProduct(ax, obb.StartPos);
+    float Q1 = VectorDotProduct(ax, obb.XAxis);
+    float Q2 = VectorDotProduct(ax, obb.YAxis);
+    float Q3 = VectorDotProduct(ax, obb.ZAxis);
 
     float mx2 = ST;
     float mn2 = ST;

--- a/src/source/Scenes/LoadingScene.cpp
+++ b/src/source/Scenes/LoadingScene.cpp
@@ -14,6 +14,8 @@
 #include "Engine/Object/ZzzInterface.h"
 #include "SceneCommon.h"
 #include "UI/NewUI/Dialogs/ReconnectDialog.h"
+#include "Render/RmlUi/RmlUiRuntime.h"
+#include <RmlUi/Core/ElementDocument.h>
 
 
 #ifdef _EDITOR
@@ -70,31 +72,43 @@ void LoadingScene(HDC hDC)
 {
     g_ConsoleDebug->Write(MCD_NORMAL, L"LoadingScene_Start");
 
-    CUIMng& rUIMng = CUIMng::Instance();
+    // RmlUi migration plan Phase 1 pilot: replaces CLoadingScene's 4-tile CSprite rendering
+    // (the class above is left completely untouched -- not deleted, per the plan's retirement
+    // criteria: don't remove legacy code until parity is confirmed against a real build, which
+    // this environment doesn't have) with an equivalent RmlUi document, Data/Interface/RmlUi/
+    // loading.rml + loading.rcss. Loaded and closed within this single call, matching this
+    // function's own one-shot-per-flash lifecycle (renders exactly one frame, then flips
+    // SceneFlag away below).
+    Rml::ElementDocument* rmlLoadingDoc = nullptr;
+
     if (!InitLoading)
     {
         LoadingWorld = 9999999;
-
         InitLoading = true;
-        LoadBitmap(L"Interface\\LSBg01.JPG", BITMAP_TITLE, GL_LINEAR);
-        LoadBitmap(L"Interface\\LSBg02.JPG", BITMAP_TITLE + 1, GL_LINEAR);
-        LoadBitmap(L"Interface\\LSBg03.JPG", BITMAP_TITLE + 2, GL_LINEAR);
-        LoadBitmap(L"Interface\\LSBg04.JPG", BITMAP_TITLE + 3, GL_LINEAR);
 
         ::StopMp3(MUSIC_LOGIN_THEME);
 
-        rUIMng.m_pLoadingScene = new CLoadingScene;
-        rUIMng.m_pLoadingScene->Create();
+        if (RmlUiRuntime::Instance().IsCreated())
+        {
+            rmlLoadingDoc = RmlUiRuntime::Instance().GetContext()->LoadDocument("Data/Interface/RmlUi/loading.rml");
+            if (rmlLoadingDoc)
+                rmlLoadingDoc->Show();
+        }
     }
 
     FogEnable = true;
     ::BeginOpengl();
     ::ClearColorAndDepthBuffers();
-    ::BeginBitmap();
 
-    rUIMng.m_pLoadingScene->Render();
+    // No explicit BeginBitmap()/EndBitmap() bracket needed here -- RmlUiRuntime::Render() opens
+    // and restores its own equivalent bracket internally (see its Phase 0.4 implementation),
+    // the same way RenderCursor()/UI::Reconnect::RenderDialog() below manage their own.
+    if (RmlUiRuntime::Instance().IsCreated())
+    {
+        RmlUiRuntime::Instance().Update();
+        RmlUiRuntime::Instance().Render();
+    }
 
-    ::EndBitmap();
     ::EndOpengl();
     ::FlushGL();
 #ifdef _EDITOR
@@ -113,11 +127,10 @@ void LoadingScene(HDC hDC)
     UI::Reconnect::RenderDialog();
     PlatformSwapBuffers();
 
-    SAFE_DELETE(rUIMng.m_pLoadingScene);
+    if (rmlLoadingDoc)
+        rmlLoadingDoc->Close();
 
     SceneFlag = MAIN_SCENE;
-    for (int i = 0; i < 4; ++i)
-        ::DeleteBitmap(BITMAP_TITLE + i);
 
     ::ClearInput();
 

--- a/src/source/Scenes/LoginScene.cpp
+++ b/src/source/Scenes/LoginScene.cpp
@@ -480,16 +480,11 @@ bool NewRenderLogInScene(HDC hDC)
         g_pOption->Render();
     }
 
-    // Drive the NewUI message box here too (same reason as the option window):
-    // the login scene skips the full NewUI update, so a confirmation dialog such
-    // as the "Remember Password" prompt would otherwise never update or draw.
-    if (!g_MessageBox->IsEmpty())
-    {
-        g_MessageBox->UpdateMouseEvent();
-        g_MessageBox->UpdateKeyEvent();
-        g_MessageBox->Update();
-        g_MessageBox->Render();
-    }
+    // The "Remember Password" prompt (the one dialog that used to need a manual g_MessageBox
+    // pump here, since the login scene skips the full NewUI update) is now its own RmlUi
+    // document -- see UI/Windows/RememberPasswordPrompt.cpp. It's already driven by
+    // RmlUiRuntime::Instance().Update()/Render(), called unconditionally every frame regardless
+    // of scene, so no equivalent manual pump is needed for it here.
 
     EndBitmap();
 

--- a/src/source/Scenes/SceneCommon.cpp
+++ b/src/source/Scenes/SceneCommon.cpp
@@ -318,10 +318,10 @@ void RenderInfomation()
 
     CUIMng::Instance().Render();
 
-    if (SceneFlag == LOG_IN_SCENE || SceneFlag == CHARACTER_SCENE)
-    {
-        RenderCursor();
-    }
+    // The login/character-scene cursor render that used to happen here moved to
+    // SceneManager.cpp's MainScene(), after RmlUiRuntime::Render() -- see its own comment.
+    // RmlUi always renders after this point in the frame, so drawing the cursor here (before it)
+    // let an opaque RmlUi panel visually cover it.
 
     RenderInfomation3D();
 }

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -1190,6 +1190,31 @@ void MainScene(HDC hDC)
                 RmlUiRuntime::Instance().Render();
             }
 
+            // Content that must always sit visually on top of RmlUi, regardless of theme: the
+            // game cursor, and (login/character scenes specifically) CLoginWin's legacy
+            // CUITextInputBox text. Both used to render earlier, inside RenderInfomation()
+            // (SceneCommon.cpp) for these two scenes -- moved here since RmlUi always renders
+            // last in the frame, and a theme whose RmlUi panel has an opaque background (unlike
+            // the login screen's original "legacy" theme, whose panel is transparent) would
+            // otherwise visually cover both. Confirmed against a real screenshot testing the
+            // login screen's sprite-free "modern" theme, where the cursor and input text
+            // rendered invisibly underneath the now-opaque panel.
+            //
+            // Needs its own BeginBitmap()/EndBitmap() bracket: NewRenderLogInScene()'s own
+            // BeginBitmap() call (LoginScene.cpp) is long since matched by an EndBitmap() before
+            // that function returns (it runs entirely inside RenderCurrentScene(), well before
+            // this point), which restores GlobalUBO's Proj/View back to the 3D perspective that
+            // was active before it -- so by here the 2D ortho ConvertX/ConvertY-based rendering
+            // RenderCursor()/RenderTextOnTop() rely on is gone unless re-established here.
+            if (SceneFlag == LOG_IN_SCENE || SceneFlag == CHARACTER_SCENE)
+            {
+                BeginBitmap();
+                if (CUIMng::Instance().m_LoginWin.IsShow())
+                    CUIMng::Instance().m_LoginWin.RenderTextOnTop();
+                RenderCursor();
+                EndBitmap();
+            }
+
 #ifdef _EDITOR
             // Always render ImGui (shows "Open Editor" button when closed, or full UI when open)
             g_MuEditorCore.Render();

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -56,6 +56,8 @@ FrameTimingState g_frameTiming;
 #include "imgui.h"
 #endif
 
+#include "Render/RmlUi/RmlUiRuntime.h"
+
 // External declarations
 extern int GrabScreen;
 extern int WaterTextureNumber;
@@ -1172,6 +1174,19 @@ void MainScene(HDC hDC)
 
         if (Success)
         {
+            // RmlUi migration plan Phase 0.4: single per-frame choke point, regardless of which
+            // scene is active or which legacy windows have migrated -- fires unconditionally
+            // once real 2D UI/scene rendering for this frame has already happened, before the
+            // editor overlay/cursor and the swap below. Where RmlUi's output should land in
+            // z-order relative to CUIMng::Render()/g_pNewUISystem->Render() is a separate,
+            // later decision (Phase 0.8) -- this only establishes the mechanical "runs once,
+            // after scene rendering, before swap" contract.
+            if (RmlUiRuntime::Instance().IsCreated())
+            {
+                RmlUiRuntime::Instance().Update();
+                RmlUiRuntime::Instance().Render();
+            }
+
 #ifdef _EDITOR
             // Always render ImGui (shows "Open Editor" button when closed, or full UI when open)
             g_MuEditorCore.Render();

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -1174,13 +1174,16 @@ void MainScene(HDC hDC)
 
         if (Success)
         {
-            // RmlUi migration plan Phase 0.4: single per-frame choke point, regardless of which
-            // scene is active or which legacy windows have migrated -- fires unconditionally
-            // once real 2D UI/scene rendering for this frame has already happened, before the
-            // editor overlay/cursor and the swap below. Where RmlUi's output should land in
-            // z-order relative to CUIMng::Render()/g_pNewUISystem->Render() is a separate,
-            // later decision (Phase 0.8) -- this only establishes the mechanical "runs once,
-            // after scene rendering, before swap" contract.
+            // RmlUi migration plan Phase 0.4. CORRECTION (2026-08-15): this is NOT actually a
+            // single per-frame choke point regardless of scene, despite the original comment
+            // here claiming so -- this whole block lives inside the static, unnamed function
+            // that only LOG_IN_SCENE/CHARACTER_SCENE/MAIN_SCENE route through (via MainScene(hDC)
+            // in RenderScene()'s switch below). LOADING_SCENE and WEBZEN_SCENE call LoadingScene()/
+            // WebzenScene() directly instead and never reach this block, each running its own
+            // independent BeginOpengl->render->EndOpengl->PlatformSwapBuffers() cycle. LoadingScene()
+            // now has its own matching Update()/Render() call for exactly this reason -- see
+            // LoadingScene.cpp. WebzenScene() does not yet; add one there the same way if/when
+            // RmlUi content needs to appear during that scene.
             if (RmlUiRuntime::Instance().IsCreated())
             {
                 RmlUiRuntime::Instance().Update();

--- a/src/source/UI/RmlBridge/RmlDraggable.cpp
+++ b/src/source/UI/RmlBridge/RmlDraggable.cpp
@@ -1,0 +1,95 @@
+#include "stdafx.h"
+#include "RmlDraggable.h"
+
+#include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/Event.h>
+#include <RmlUi/Core/EventListener.h>
+#include <RmlUi/Core/Property.h>
+
+namespace UI::RmlBridge
+{
+    namespace
+    {
+        // Self-owning: RmlUi's own contract (Element::AddEventListener's header comment) is that
+        // a listener must stay alive until OnDetach() is called, which happens when the handle
+        // element is destroyed or the listener is explicitly removed -- deleting itself there
+        // means the caller never needs to track or clean this up.
+        class DragMoveListener : public Rml::EventListener
+        {
+        public:
+            DragMoveListener(Rml::Element* panel, OnPanelMoved onMove) : m_Panel(panel), m_OnMove(std::move(onMove)) {}
+
+            void ProcessEvent(Rml::Event& event) override
+            {
+                switch (event.GetId())
+                {
+                case Rml::EventId::Dragstart:
+                    m_DragStartMouseX = event.GetParameter<int>("mouse_x", 0);
+                    m_DragStartMouseY = event.GetParameter<int>("mouse_y", 0);
+                    m_DragStartPanelLeft = ResolvedPx("left");
+                    m_DragStartPanelTop = ResolvedPx("top");
+                    break;
+
+                case Rml::EventId::Drag:
+                {
+                    const int mouseX = event.GetParameter<int>("mouse_x", 0);
+                    const int mouseY = event.GetParameter<int>("mouse_y", 0);
+                    const float newLeft = m_DragStartPanelLeft + static_cast<float>(mouseX - m_DragStartMouseX);
+                    const float newTop = m_DragStartPanelTop + static_cast<float>(mouseY - m_DragStartMouseY);
+                    m_Panel->SetProperty("left", std::to_string(newLeft) + "px");
+                    m_Panel->SetProperty("top", std::to_string(newTop) + "px");
+                    if (m_OnMove)
+                        m_OnMove(newLeft, newTop);
+                    break;
+                }
+
+                default:
+                    break;
+                }
+            }
+
+            void OnDetach(Rml::Element*) override { delete this; }
+
+        private:
+            // m_Panel is always position:absolute with left/top already in fixed px (see this
+            // header's own comment on that constraint) -- Get<float>() on a px-unit Property
+            // returns the raw pixel number directly, no unit conversion needed.
+            float ResolvedPx(const char* property) const
+            {
+                if (const Rml::Property* prop = m_Panel->GetProperty(property))
+                    return prop->Get<float>();
+                return 0.0f;
+            }
+
+            Rml::Element* m_Panel;
+            OnPanelMoved m_OnMove;
+            int m_DragStartMouseX = 0;
+            int m_DragStartMouseY = 0;
+            float m_DragStartPanelLeft = 0.0f;
+            float m_DragStartPanelTop = 0.0f;
+        };
+    }
+
+    void MakeDraggable(Rml::Element* handle, Rml::Element* panel, OnPanelMoved onMove)
+    {
+        // RmlUi only generates dragstart/drag events for an element whose computed `drag` style
+        // is anything but `none` (Context.cpp's ProcessMouseButtonDown walks up from the hover
+        // chain looking for the first such ancestor) -- set it here so the caller doesn't need
+        // to remember a matching RCSS rule just to make this actually fire.
+        handle->SetProperty("drag", "drag");
+
+        // pointer-events is inherited (see docs/rmlui-ui-system/gotchas-and-patterns.md's
+        // pointer-events entry) -- any full-window document following that same fix sets
+        // `body { pointer-events: none; }` with only specific interactive elements opting back
+        // in via `auto`. A handle that inherited `none` is invisible to RmlUi's own hit-testing
+        // (GetElementAtPoint explicitly skips pointer-events:none elements), so it would never
+        // become `hover` and dragstart/drag would never fire at all -- confirmed as a real bug
+        // hit while first testing this against the login screen. Force it here so a handle just
+        // works regardless of what pointer-events state it inherited from its document.
+        handle->SetProperty("pointer-events", "auto");
+
+        DragMoveListener* listener = new DragMoveListener(panel, std::move(onMove));
+        handle->AddEventListener(Rml::EventId::Dragstart, listener);
+        handle->AddEventListener(Rml::EventId::Drag, listener);
+    }
+}

--- a/src/source/UI/RmlBridge/RmlDraggable.h
+++ b/src/source/UI/RmlBridge/RmlDraggable.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <functional>
+
+namespace Rml
+{
+    class Element;
+}
+
+// Makes an RmlUi panel draggable-by-mouse, with zero legacy CWin dependency -- see the
+// migration plan and docs/rmlui-ui-system/architecture.md for why this exists: CWin's own
+// dragging (CWin::Update()'s WS_MOVE state machine, gated by CursorInWin(WA_MOVE)) only works
+// for windows still tied to that legacy positioning system, and re-implementing an equivalent
+// per migrated window would be exactly the kind of duplicated logic Coding Rule #4 warns against.
+// A future migrated panel that wants to be draggable should just call MakeDraggable() once --
+// no per-window state machine, no CWin involvement at all.
+namespace UI::RmlBridge
+{
+    // Fired every time the panel's position changes during a drag, with its new absolute
+    // top-left in real window pixels. Only needed for a *hybrid* window that still has legacy
+    // chrome sharing the same screen position (e.g. a CWin background sprite drawn underneath
+    // the RmlUi overlay, positioned independently via CWin::SetPosition()/m_ptPos) -- MakeDraggable
+    // itself only ever touches the RmlUi element's own left/top, so without this callback a
+    // hybrid window's legacy chrome silently desyncs from the RmlUi overlay as it's dragged
+    // (confirmed by a real test: the RmlUi checkboxes/buttons moved, the legacy background
+    // sprite underneath them did not). A fully migrated, sprite-free panel has nothing to sync
+    // and can omit this entirely.
+    using OnPanelMoved = std::function<void(float newLeft, float newTop)>;
+
+    // `handle` is the element the player grabs -- a dedicated drag handle (a title-bar element,
+    // or in this pilot's test, a label positioned outside the panel's own box), not usually
+    // `panel` itself. Using the whole panel as its own handle only works if the panel's
+    // `pointer-events` is `auto` -- a full-window document following the pointer-events fix
+    // (docs/rmlui-ui-system/gotchas-and-patterns.md) sets its panel to inherit `none` from `body`
+    // by default, specifically so clicks pass through to whatever's underneath, which is exactly
+    // why a dedicated handle is the correct pattern here, not a workaround for a limitation.
+    //
+    // `panel` is the element that actually moves -- must be `position: absolute` with `left`/
+    // `top` already resolved to fixed `px` values (true of every window built so far, see
+    // docs/rmlui-ui-system/theming-and-modding.md's "Coordinates, scaling, and positioning"
+    // section -- a panel positioned in `%`/`vw`/`vh` isn't supported by this helper yet).
+    //
+    // Sets `drag: drag` and `pointer-events: auto` on `handle` itself (the latter confirmed
+    // necessary by a real test -- a handle that inherited `pointer-events: none` never became
+    // `hover` at all, so dragstart/drag never fired) so the caller doesn't need to remember
+    // either as a matching RCSS rule. Registers a self-owning listener for RmlUi's native
+    // `dragstart`/`drag` events (Source/Core/Context.cpp's UpdateHoverChain -- these already
+    // carry the current mouse position as event parameters, no manual mousedown/mousemove/
+    // mouseup tracking needed) that repositions `panel` by directly setting its `left`/`top`
+    // properties as the drag proceeds, then calls `onMove` (if supplied) with the new position.
+    void MakeDraggable(Rml::Element* handle, Rml::Element* panel, OnPanelMoved onMove = nullptr);
+}

--- a/src/source/UI/RmlBridge/RmlModelBinder.h
+++ b/src/source/UI/RmlBridge/RmlModelBinder.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "stdafx.h"
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/DataModelHandle.h>
+
+// Generalizes the model/renderer split already proven by UI::Skills::Tooltip's
+// SkillTooltipModel.h/.cpp (a plain-data Model, consumed today by two independent renderers)
+// into a reusable per-window wrapper for RmlUi's Rml::DataModel binding. See the RmlUi
+// migration plan's Phase 0.6/0.7.
+//
+// This does NOT do reflection-based auto-binding -- RmlUi's own DataModelConstructor::Bind()
+// requires each field to be registered by name explicitly (its actual API, not a limitation of
+// this wrapper), so each window still writes its own small "register my fields" function. What
+// this wrapper standardizes is the surrounding lifecycle: owning the Model instance, creating
+// the Rml::DataModelHandle once, and exposing a single MarkDirty() call so packet-handler/action-
+// controller call sites that mutate Model fields (per the adapter pattern, e.g.
+// CNewUIMyInventoryRmlAdapter::InsertItem()) don't need to know RmlUi's binding API directly --
+// that dependency is isolated to this one header and each window's registration function.
+//
+// Usage (illustrative -- the actual Model type and registration function are written per
+// migrated window, starting with the Phase 1 pilot):
+//
+//   struct PilotModel { Rml::String title; int secondsRemaining = 0; };
+//
+//   RmlModelBinder<PilotModel> binder;
+//   binder.Create(context, "pilot_dialog", [](Rml::DataModelConstructor& c, PilotModel& model) {
+//       c.Bind("title", &model.title);
+//       c.Bind("seconds_remaining", &model.secondsRemaining);
+//   });
+//   ...
+//   binder.Model().secondsRemaining = 30;
+//   binder.MarkDirty("seconds_remaining");
+template <typename Model>
+class RmlModelBinder
+{
+public:
+    // RegisterFn: void(Rml::DataModelConstructor&, Model&) -- binds each field the RML template
+    // needs, exactly once, at creation time.
+    template <typename RegisterFn>
+    bool Create(Rml::Context* context, const Rml::String& modelName, RegisterFn&& registerFields)
+    {
+        Rml::DataModelConstructor constructor = context->CreateDataModel(modelName);
+        if (!constructor) return false;
+
+        registerFields(constructor, m_Model);
+        m_Handle = constructor.GetModelHandle();
+        return true;
+    }
+
+    Model& GetModel() { return m_Model; }
+    const Model& GetModel() const { return m_Model; }
+
+    // "all" is not a magic wildcard here -- per-field DirtyVariable() calls are RmlUi's real
+    // contract (DataModelHandle.h). A window with many fields that all change together (e.g. a
+    // full item-list refresh) should call MarkDirty() once per bound field name it registered,
+    // not rely on this wrapper to enumerate them -- there is no reflection to enumerate from.
+    void MarkDirty(const Rml::String& fieldName)
+    {
+        m_Handle.DirtyVariable(fieldName);
+    }
+
+private:
+    Model m_Model{};
+    Rml::DataModelHandle m_Handle;
+};

--- a/src/source/UI/RmlBridge/RmlTheme.cpp
+++ b/src/source/UI/RmlBridge/RmlTheme.cpp
@@ -1,0 +1,90 @@
+#include "stdafx.h"
+#include "RmlTheme.h"
+#include "Data/GameConfig/GameConfig.h"
+#include "Core/Platform/WinIni.h" // GetPrivateProfileIntW -- reading each theme's own theme.ini
+
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/ElementDocument.h>
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+
+namespace UI::RmlBridge
+{
+    namespace
+    {
+        // Theme names are simple ASCII identifiers ("legacy", "modern", ...) by convention, so a
+        // plain narrow cast is safe here -- no need for the WideToUtf8 machinery LoginWin.cpp
+        // uses for real (possibly non-ASCII) localized strings.
+        std::string NarrowAscii(const std::wstring& s)
+        {
+            std::string out(s.size(), '\0');
+            std::transform(s.begin(), s.end(), out.begin(), [](wchar_t c) { return static_cast<char>(c); });
+            return out;
+        }
+
+        std::string ToLower(std::string s)
+        {
+            std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return (char)std::tolower(c); });
+            return s;
+        }
+
+        std::wstring WidenAscii(const std::string& s)
+        {
+            std::wstring out(s.size(), L'\0');
+            std::transform(s.begin(), s.end(), out.begin(), [](char c) { return static_cast<wchar_t>(c); });
+            return out;
+        }
+    }
+
+    const std::string& GetActiveThemeName()
+    {
+        static const std::string cached = ToLower(NarrowAscii(GameConfig::GetInstance().GetRmlTheme()));
+        return cached;
+    }
+
+    bool UsesLegacySpriteChrome(const std::string& themeName)
+    {
+        // Data-driven, not a hardcoded C++ list -- see this header's own comment on why. Absence
+        // of the manifest file (GetPrivateProfileIntW's own contract) or the key inside it both
+        // fall through to the same default (0/false), so a theme folder with no theme.ini at all
+        // -- the expected shape for a plain sprite-free/modder theme -- just works.
+        const std::wstring manifestPath =
+            L"Data/Interface/RmlUi/themes/" + WidenAscii(ToLower(themeName)) + L"/theme.ini";
+        return GetPrivateProfileIntW(L"Theme", L"UsesLegacySpriteChrome", 0, manifestPath.c_str()) != 0;
+    }
+
+    std::string ThemedDocumentSourceUrl(const char* documentName, const std::string& themeName)
+    {
+        return std::string("Data/Interface/RmlUi/themes/") + ToLower(themeName) + "/" + documentName;
+    }
+
+    Rml::ElementDocument* LoadThemedDocument(Rml::Context* context, const char* documentPath)
+    {
+        std::ifstream file(documentPath, std::ios::binary);
+        if (!file)
+        {
+            g_ErrorReport.Write(L"> [RmlTheme] Failed to open '%hs'.\r\n", documentPath);
+            return nullptr;
+        }
+
+        std::ostringstream buffer;
+        buffer << file.rdbuf();
+
+        // documentPath's basename (the part after the last '/') is what the per-theme source URL
+        // needs -- e.g. "Data/Interface/RmlUi/login.rml" -> "login.rml".
+        const std::string path(documentPath);
+        const size_t lastSlash = path.find_last_of('/');
+        const std::string documentName = (lastSlash == std::string::npos) ? path : path.substr(lastSlash + 1);
+
+        const std::string sourceUrl = ThemedDocumentSourceUrl(documentName.c_str(), GetActiveThemeName());
+        Rml::ElementDocument* doc = context->LoadDocumentFromMemory(buffer.str(), sourceUrl);
+        if (!doc)
+            g_ErrorReport.Write(L"> [RmlTheme] Failed to load '%hs' as theme '%hs' (source url '%hs').\r\n",
+                documentPath, GetActiveThemeName().c_str(), sourceUrl.c_str());
+
+        return doc;
+    }
+}

--- a/src/source/UI/RmlBridge/RmlTheme.cpp
+++ b/src/source/UI/RmlBridge/RmlTheme.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include "RmlTheme.h"
 #include "Data/GameConfig/GameConfig.h"
-#include "Core/Platform/WinIni.h" // GetPrivateProfileIntW -- reading each theme's own theme.ini
 
 #include <RmlUi/Core/Context.h>
 #include <RmlUi/Core/ElementDocument.h>
@@ -30,30 +29,12 @@ namespace UI::RmlBridge
             std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return (char)std::tolower(c); });
             return s;
         }
-
-        std::wstring WidenAscii(const std::string& s)
-        {
-            std::wstring out(s.size(), L'\0');
-            std::transform(s.begin(), s.end(), out.begin(), [](char c) { return static_cast<wchar_t>(c); });
-            return out;
-        }
     }
 
     const std::string& GetActiveThemeName()
     {
         static const std::string cached = ToLower(NarrowAscii(GameConfig::GetInstance().GetRmlTheme()));
         return cached;
-    }
-
-    bool UsesLegacySpriteChrome(const std::string& themeName)
-    {
-        // Data-driven, not a hardcoded C++ list -- see this header's own comment on why. Absence
-        // of the manifest file (GetPrivateProfileIntW's own contract) or the key inside it both
-        // fall through to the same default (0/false), so a theme folder with no theme.ini at all
-        // -- the expected shape for a plain sprite-free/modder theme -- just works.
-        const std::wstring manifestPath =
-            L"Data/Interface/RmlUi/themes/" + WidenAscii(ToLower(themeName)) + L"/theme.ini";
-        return GetPrivateProfileIntW(L"Theme", L"UsesLegacySpriteChrome", 0, manifestPath.c_str()) != 0;
     }
 
     std::string ThemedDocumentSourceUrl(const char* documentName, const std::string& themeName)

--- a/src/source/UI/RmlBridge/RmlTheme.h
+++ b/src/source/UI/RmlBridge/RmlTheme.h
@@ -9,39 +9,30 @@ namespace Rml
 }
 
 // Which RmlUi visual theme is active -- see the RmlUi migration plan's Theming / Scaling & DPI
-// sections. A theme is identified purely by NAME (a folder), and everything about it -- including
-// whether it wants legacy sprite chrome -- is read from that folder, not hardcoded in C++. This
-// is deliberate: it's what makes a theme (including one a modder drops in, not just "legacy"/
-// "modern") a plug-in-a-folder operation with zero source changes or recompilation, for either
-// kind of theme:
+// sections. A theme is identified purely by NAME (a folder), not hardcoded in C++: just
+// Data/Interface/RmlUi/themes/<name>/<document>.rcss, no manifest file needed. This is deliberate:
+// it's what makes a theme (including one a modder drops in, not just "legacy"/"modern") a
+// plug-in-a-folder operation with zero source changes or recompilation.
 //
-//   Data/Interface/RmlUi/themes/<name>/<document>.rcss   -- required, the actual visual styling
-//   Data/Interface/RmlUi/themes/<name>/theme.ini          -- optional, see UsesLegacySpriteChrome
-//
-// A theme with no theme.ini (or no UsesLegacySpriteChrome key in it) defaults to fully
-// programmatic/sprite-free -- the common case for a new reskin, seasonal theme, high-contrast/
-// accessibility theme, or a mod: just drop RCSS files in a new folder and point config.ini's
-// [UI] RmlTheme at it, no C++ involved at all.
+// Every migrated window renders its own visuals entirely through RmlUi -- CWin (and any other
+// legacy widget) never draws background/frame art for a migrated window, in any theme. A
+// "legacy-look" theme reproduces the original art by pointing its own RCSS decorators at the same
+// image files the old sprites used (e.g. themes/legacy/login.rcss's `decorator: image(...)`) --
+// that's a choice of asset, not a choice of renderer. There used to be a per-theme
+// `UsesLegacySpriteChrome` manifest flag letting a theme opt back into CWin drawing the
+// background -- removed (see docs/rmlui-ui-system/gotchas-and-patterns.md) because it worked
+// against the migration's actual point: once a window is migrated, RmlUi owns 100% of its
+// rendering, unconditionally.
 //
 // Read once from GameConfig at startup, not a live in-game hot-swap yet -- switching themes today
 // means editing config.ini's [UI] RmlTheme value and relaunching. A true runtime toggle needs each
 // migrated window to tear down and rebuild its Rml::ElementDocument/DataModel against the new
-// theme's stylesheet path (and, for sprite-backed themes, its CWin background/frame sprites) --
-// a real follow-up, not this increment's scope.
+// theme's stylesheet path -- a real follow-up, not this increment's scope.
 namespace UI::RmlBridge
 {
     // Cached on first call from GameConfig::GetRmlTheme() (e.g. "legacy", "modern", or any
     // modder-supplied folder name -- not a closed set).
     const std::string& GetActiveThemeName();
-
-    // True only for themes that should keep drawing the legacy background/input-frame sprites
-    // (CWin::m_psprBg, the CUITextInputBox frame CSprites) underneath the RmlUi overlay, the way
-    // the original Phase 1 pilot did -- read from that theme's own
-    // Data/Interface/RmlUi/themes/<name>/theme.ini ([Theme] UsesLegacySpriteChrome=1), defaulting
-    // to false (fully programmatic) if the file or key is absent. Data-driven per theme folder,
-    // not a hardcoded C++ allowlist -- a new theme (modder-supplied or not) that wants legacy
-    // sprite chrome just ships that one line in its own theme.ini, no engine changes needed.
-    bool UsesLegacySpriteChrome(const std::string& themeName);
 
     // Builds the virtual source URL a themed document should be loaded against, e.g.
     // "Data/Interface/RmlUi/themes/modern/login.rml" -- this path need not exist on disk (the RML

--- a/src/source/UI/RmlBridge/RmlTheme.h
+++ b/src/source/UI/RmlBridge/RmlTheme.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+
+namespace Rml
+{
+    class Context;
+    class ElementDocument;
+}
+
+// Which RmlUi visual theme is active -- see the RmlUi migration plan's Theming / Scaling & DPI
+// sections. A theme is identified purely by NAME (a folder), and everything about it -- including
+// whether it wants legacy sprite chrome -- is read from that folder, not hardcoded in C++. This
+// is deliberate: it's what makes a theme (including one a modder drops in, not just "legacy"/
+// "modern") a plug-in-a-folder operation with zero source changes or recompilation, for either
+// kind of theme:
+//
+//   Data/Interface/RmlUi/themes/<name>/<document>.rcss   -- required, the actual visual styling
+//   Data/Interface/RmlUi/themes/<name>/theme.ini          -- optional, see UsesLegacySpriteChrome
+//
+// A theme with no theme.ini (or no UsesLegacySpriteChrome key in it) defaults to fully
+// programmatic/sprite-free -- the common case for a new reskin, seasonal theme, high-contrast/
+// accessibility theme, or a mod: just drop RCSS files in a new folder and point config.ini's
+// [UI] RmlTheme at it, no C++ involved at all.
+//
+// Read once from GameConfig at startup, not a live in-game hot-swap yet -- switching themes today
+// means editing config.ini's [UI] RmlTheme value and relaunching. A true runtime toggle needs each
+// migrated window to tear down and rebuild its Rml::ElementDocument/DataModel against the new
+// theme's stylesheet path (and, for sprite-backed themes, its CWin background/frame sprites) --
+// a real follow-up, not this increment's scope.
+namespace UI::RmlBridge
+{
+    // Cached on first call from GameConfig::GetRmlTheme() (e.g. "legacy", "modern", or any
+    // modder-supplied folder name -- not a closed set).
+    const std::string& GetActiveThemeName();
+
+    // True only for themes that should keep drawing the legacy background/input-frame sprites
+    // (CWin::m_psprBg, the CUITextInputBox frame CSprites) underneath the RmlUi overlay, the way
+    // the original Phase 1 pilot did -- read from that theme's own
+    // Data/Interface/RmlUi/themes/<name>/theme.ini ([Theme] UsesLegacySpriteChrome=1), defaulting
+    // to false (fully programmatic) if the file or key is absent. Data-driven per theme folder,
+    // not a hardcoded C++ allowlist -- a new theme (modder-supplied or not) that wants legacy
+    // sprite chrome just ships that one line in its own theme.ini, no engine changes needed.
+    bool UsesLegacySpriteChrome(const std::string& themeName);
+
+    // Builds the virtual source URL a themed document should be loaded against, e.g.
+    // "Data/Interface/RmlUi/themes/modern/login.rml" -- this path need not exist on disk (the RML
+    // itself is loaded from memory, shared across every theme); it only needs to resolve relative
+    // hrefs (<link type="text/rcss" href="login.rcss">) to the real per-theme .rcss file that
+    // does exist, per Rml::Context::LoadDocumentFromMemory's source_url contract.
+    std::string ThemedDocumentSourceUrl(const char* documentName, const std::string& themeName);
+
+    // Reads `documentPath` (e.g. "Data/Interface/RmlUi/login.rml") from disk and instantiates it
+    // against the currently active theme's stylesheet via LoadDocumentFromMemory. This is the one
+    // entry point every migrated window should use instead of calling Context::LoadDocument
+    // directly -- "add a new theme" stays a drop-a-folder-of-RCSS operation for every window
+    // built on this helper, not a per-window special case. Returns nullptr if the file couldn't
+    // be read or the document failed to parse (logged via g_ErrorReport either way).
+    Rml::ElementDocument* LoadThemedDocument(Rml::Context* context, const char* documentPath);
+}

--- a/src/source/UI/Widgets/Win.cpp
+++ b/src/source/UI/Widgets/Win.cpp
@@ -92,6 +92,8 @@ bool CWin::CursorInWin(int nArea)
         break;
 
     case WA_MOVE:
+        if (!m_bMovable)
+            break;
         ::SetRect(&rc, m_ptPos.x, m_ptPos.y, m_ptPos.x + m_Size.cx,
             m_ptPos.y + 26);
         if (::PtInRect(&rc, rInput.GetCursorPos()))

--- a/src/source/UI/Widgets/Win.h
+++ b/src/source/UI/Widgets/Win.h
@@ -37,6 +37,11 @@ protected:
 
     CPList		m_BtnList;
 
+    // Whether WA_MOVE hit-testing (the window's title-bar drag area) can ever report true.
+    // Most CWin-derived dialogs are fixed in place and previously each re-implemented an
+    // identical CursorInWin() override just to force WA_MOVE to false -- see SetMovable().
+    bool		m_bMovable = true;
+
 public:
     CWin();
     virtual ~CWin();
@@ -57,6 +62,10 @@ public:
     virtual void Active(bool bActive) { m_bActive = bActive; }
     bool IsActive() { return m_bActive; }
     void SetDocking(bool bDocking) { m_bDocking = bDocking; }
+    // Subclasses that should never be draggable call this instead of overriding
+    // CursorInWin() to hardcode WA_MOVE -> false (a pattern that was previously
+    // duplicated verbatim across seven CWin subclasses).
+    void SetMovable(bool bMovable) { m_bMovable = bMovable; }
     int GetState() { return m_nState; }
     void Update(double dDeltaTick);
     virtual void Render();

--- a/src/source/UI/Windows/CreditWin.cpp
+++ b/src/source/UI/Windows/CreditWin.cpp
@@ -112,6 +112,7 @@ void CCreditWin::Create()
 
 	CWin::Create(rInput.GetScreenWidth(), rInput.GetScreenHeight());
 	CWin::SetBgAlpha(255);
+	SetMovable(false);
 
 	float fScaleX = (float)rInput.GetScreenWidth() / 800.0f;
 	float fScaleY = (float)rInput.GetScreenHeight() / 600.0f;
@@ -183,20 +184,6 @@ void CCreditWin::Show(bool bShow)
 		Init();
 	else
 		m_eIllustState = HIDE;
-}
-
-bool CCreditWin::CursorInWin(int nArea)
-{
-	if (!CWin::m_bShow)
-		return false;
-
-	switch (nArea)
-	{
-	case WA_MOVE:
-		return false;
-	}
-
-	return CWin::CursorInWin(nArea);
 }
 
 void CCreditWin::UpdateWhileActive(double deltaMilliseconds)

--- a/src/source/UI/Windows/CreditWin.h
+++ b/src/source/UI/Windows/CreditWin.h
@@ -73,7 +73,6 @@ public:
 	void Create();
 	void SetPosition();
 	void Show(bool bShow);
-	bool CursorInWin(int nArea);
 
 protected:
 	void PreRelease();

--- a/src/source/UI/Windows/LoginMainWin.cpp
+++ b/src/source/UI/Windows/LoginMainWin.cpp
@@ -9,6 +9,30 @@
 #include "UI/Legacy/UIMng.h"
 #include "Network/Server/WSclient.h"
 
+#include "Render/RmlUi/RmlUiRuntime.h"
+#include "UI/RmlBridge/RmlTheme.h"
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/Event.h>
+#include <RmlUi/Core/EventListener.h>
+#include <functional>
+
+namespace
+{
+    // Mirrors UI::RmlBridge::RmlDraggable.cpp's self-owning listener pattern -- this window has
+    // no dynamic state to bind (see this class's header comment), so a plain click->callback
+    // listener is simpler than standing up an RmlModelBinder just for two BindEventCallback slots.
+    class ClickCallbackListener : public Rml::EventListener
+    {
+    public:
+        explicit ClickCallbackListener(std::function<void()> callback) : m_Callback(std::move(callback)) {}
+        void ProcessEvent(Rml::Event&) override { m_Callback(); }
+        void OnDetach(Rml::Element*) override { delete this; }
+    private:
+        std::function<void()> m_Callback;
+    };
+}
+
 //=============================================================================
 // Global Variables
 //=============================================================================
@@ -40,16 +64,43 @@ void CLoginMainWin::Create()
         m_aBtn[0].GetHeight(),
         -2
     );
+    SetMovable(false);
 
     for (int i = 0; i < LMW_BTN_MAX; ++i)
         CWin::RegisterButton(&m_aBtn[i]);
 
     m_sprDeco.Create(189, 103, BITMAP_LOG_IN + 6, 0, nullptr, 105, 59);
+
+    // RmlUi migration, Batch 2 -- see this class's header comment. Guarded the same way
+    // CLoginWin::Create() is (CUIMng::RepositionSceneUI() re-runs Create() on resolution change),
+    // so the document is loaded once, ever, and only repositioned/resized afterward.
+    if (!m_pRmlDoc && RmlUiRuntime::Instance().IsCreated())
+    {
+        m_pRmlDoc = UI::RmlBridge::LoadThemedDocument(RmlUiRuntime::Instance().GetContext(), "Data/Interface/RmlUi/login_main.rml");
+        if (m_pRmlDoc)
+        {
+            if (Rml::Element* e = m_pRmlDoc->GetElementById("btn_menu"))
+                e->AddEventListener(Rml::EventId::Click, new ClickCallbackListener([this] { RmlClickMenu(); }));
+            if (Rml::Element* e = m_pRmlDoc->GetElementById("btn_credit"))
+                e->AddEventListener(Rml::EventId::Click, new ClickCallbackListener([this] { RmlClickCredit(); }));
+        }
+    }
 }
 
 void CLoginMainWin::PreRelease()
 {
     m_sprDeco.Release();
+
+    // CUIMng::RemoveWinList() (run on every scene transition) calls Release() on every window
+    // in its list unconditionally -- CWin's own Release()/PreRelease() has no knowledge of
+    // m_pRmlDoc, so without this it silently keeps rendering (still Shown, still in the
+    // Context) on whatever scene comes next. Confirmed the hard way: transitioning from the
+    // login scene to character-select left this window's Menu/Credit icons visibly overlapping
+    // CharSelMainWin's own button bar, since nothing had ever told the RmlUi document to hide.
+    // Hide(), not unload -- the document/model are meant to be created once and reused (see
+    // Create()'s own guard comment), matching CLoginWin's precedent.
+    if (m_pRmlDoc)
+        m_pRmlDoc->Hide();
 }
 
 void CLoginMainWin::SetPosition(int nXCoord, int nYCoord)
@@ -67,6 +118,23 @@ void CLoginMainWin::SetPosition(int nXCoord, int nYCoord)
         m_aBtn[LMW_BTN_CREDIT].GetXPos(),
         m_aBtn[LMW_BTN_CREDIT].GetYPos()
     );
+
+    // RmlUi panel: positioned at the same real window-pixel origin CWin's own bookkeeping uses
+    // (see CLoginWin::SetPosition's identical comment). btn_credit's left is pushed separately
+    // (not a fixed RCSS offset like btn_menu) because it's screen-width-dependent, matching the
+    // legacy CButton positioning math right above.
+    if (m_pRmlDoc)
+    {
+        if (Rml::Element* panel = m_pRmlDoc->GetElementById("panel"))
+        {
+            panel->SetProperty("left", std::to_string(nXCoord) + "px");
+            panel->SetProperty("top", std::to_string(nYCoord) + "px");
+            panel->SetProperty("width", std::to_string(CWin::GetWidth()) + "px");
+            panel->SetProperty("height", std::to_string(CWin::GetHeight()) + "px");
+        }
+        if (Rml::Element* credit = m_pRmlDoc->GetElementById("btn_credit"))
+            credit->SetProperty("left", std::to_string(CWin::GetWidth() - m_aBtn[LMW_BTN_CREDIT].GetWidth()) + "px");
+    }
 }
 
 void CLoginMainWin::Show(bool bShow)
@@ -77,33 +145,27 @@ void CLoginMainWin::Show(bool bShow)
         m_aBtn[i].Show(bShow);
 
     m_sprDeco.Show(bShow);
-}
 
-bool CLoginMainWin::CursorInWin(int nArea)
-{
-    if (!CWin::m_bShow)
-        return false;
-
-    switch (nArea)
+    if (m_pRmlDoc)
     {
-    case WA_MOVE:
-        return false;
+        if (bShow) m_pRmlDoc->Show();
+        else       m_pRmlDoc->Hide();
     }
-
-    return CWin::CursorInWin(nArea);
 }
 
 void CLoginMainWin::UpdateWhileActive(double dDeltaTick)
 {
     CUIMng& rUIMng = CUIMng::Instance();
 
-    if (m_aBtn[LMW_BTN_MENU].IsClick())
+    if (m_aBtn[LMW_BTN_MENU].IsClick() || m_bRmlMenuClicked)
     {
+        m_bRmlMenuClicked = false;
         rUIMng.ShowWin(&rUIMng.m_SysMenuWin);
         rUIMng.SetSysMenuWinShow(true);
     }
-    else if (m_aBtn[LMW_BTN_CREDIT].IsClick())
+    else if (m_aBtn[LMW_BTN_CREDIT].IsClick() || m_bRmlCreditClicked)
     {
+        m_bRmlCreditClicked = false;
         SocketClient->ToConnectServer()->SendServerListRequest();
 
         rUIMng.ShowWin(&rUIMng.m_CreditWin);

--- a/src/source/UI/Windows/LoginMainWin.cpp
+++ b/src/source/UI/Windows/LoginMainWin.cpp
@@ -66,10 +66,11 @@ void CLoginMainWin::Create()
     );
     SetMovable(false);
 
+    // Legacy CButtons stay registered for redundant click detection only -- RenderControls() is
+    // no longer overridden, so CWin::RenderButtons() never runs for them; RmlUi renders 100% of
+    // this bar's visuals in every theme (see the class header comment).
     for (int i = 0; i < LMW_BTN_MAX; ++i)
         CWin::RegisterButton(&m_aBtn[i]);
-
-    m_sprDeco.Create(189, 103, BITMAP_LOG_IN + 6, 0, nullptr, 105, 59);
 
     // RmlUi migration, Batch 2 -- see this class's header comment. Guarded the same way
     // CLoginWin::Create() is (CUIMng::RepositionSceneUI() re-runs Create() on resolution change),
@@ -89,8 +90,6 @@ void CLoginMainWin::Create()
 
 void CLoginMainWin::PreRelease()
 {
-    m_sprDeco.Release();
-
     // CUIMng::RemoveWinList() (run on every scene transition) calls Release() on every window
     // in its list unconditionally -- CWin's own Release()/PreRelease() has no knowledge of
     // m_pRmlDoc, so without this it silently keeps rendering (still Shown, still in the
@@ -112,11 +111,6 @@ void CLoginMainWin::SetPosition(int nXCoord, int nYCoord)
     m_aBtn[LMW_BTN_CREDIT].SetPosition(
         nXCoord + CWin::GetWidth() - m_aBtn[LMW_BTN_CREDIT].GetWidth(),
         nYCoord
-    );
-
-    m_sprDeco.SetPosition(
-        m_aBtn[LMW_BTN_CREDIT].GetXPos(),
-        m_aBtn[LMW_BTN_CREDIT].GetYPos()
     );
 
     // RmlUi panel: positioned at the same real window-pixel origin CWin's own bookkeeping uses
@@ -143,8 +137,6 @@ void CLoginMainWin::Show(bool bShow)
 
     for (int i = 0; i < LMW_BTN_MAX; ++i)
         m_aBtn[i].Show(bShow);
-
-    m_sprDeco.Show(bShow);
 
     if (m_pRmlDoc)
     {
@@ -173,10 +165,4 @@ void CLoginMainWin::UpdateWhileActive(double dDeltaTick)
         ::StopMp3(MUSIC_MAIN_THEME);
         ::PlayMp3(MUSIC_MUTHEME);
     }
-}
-
-void CLoginMainWin::RenderControls()
-{
-    m_sprDeco.Render();
-    CWin::RenderButtons();
 }

--- a/src/source/UI/Windows/LoginMainWin.h
+++ b/src/source/UI/Windows/LoginMainWin.h
@@ -14,6 +14,14 @@
 #define	LMW_BTN_CREDIT		1
 #define	LMW_BTN_MAX			2
 
+namespace Rml { class ElementDocument; }
+
+// RmlUi migration, Batch 2 (see the login/character-select scope in the migration plan): this
+// window's two buttons are pure image buttons with no I18N text and no dynamic state, so unlike
+// CLoginWin/CSysMenuWin/COptionWin it needs no UI::RmlBridge::RmlModelBinder -- click detection is
+// wired directly via Rml::Element::AddEventListener, same idiom UI::RmlBridge::RmlDraggable.cpp
+// already uses for its own self-owning listener. The legacy CButtons stay registered (redundant,
+// harmless detection path); RmlUi renders 100% of this bar's visuals in every theme.
 class CLoginMainWin : public CWin
 {
 protected:
@@ -27,12 +35,22 @@ public:
     void Create();
     void SetPosition(int nXCoord, int nYCoord);
     void Show(bool bShow);
-    bool CursorInWin(int nArea);
+
+    // Invoked from the RmlUi document's click listeners (see Create()). Polled-and-cleared
+    // exactly like the legacy CButton::IsClick() edge triggers they supplement in
+    // UpdateWhileActive() -- mirrors CLoginWin::RmlClickOk()'s shape.
+    void RmlClickMenu() { m_bRmlMenuClicked = true; }
+    void RmlClickCredit() { m_bRmlCreditClicked = true; }
 
 protected:
     void PreRelease();
     void UpdateWhileActive(double dDeltaTick);
     void RenderControls();
+
+private:
+    bool m_bRmlMenuClicked = false;
+    bool m_bRmlCreditClicked = false;
+    Rml::ElementDocument* m_pRmlDoc = nullptr;
 };
 
 #endif // !defined(AFX_LOGINMAINWIN_H__96B05A69_6360_4C8E_BD9C_20FC72EBE1C6__INCLUDED_)

--- a/src/source/UI/Windows/LoginMainWin.h
+++ b/src/source/UI/Windows/LoginMainWin.h
@@ -26,7 +26,6 @@ class CLoginMainWin : public CWin
 {
 protected:
     CButton	m_aBtn[LMW_BTN_MAX];
-    CSprite	m_sprDeco;
 
 public:
     CLoginMainWin();
@@ -45,7 +44,6 @@ public:
 protected:
     void PreRelease();
     void UpdateWhileActive(double dDeltaTick);
-    void RenderControls();
 
 private:
     bool m_bRmlMenuClicked = false;

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -31,6 +31,7 @@
 #include "Data/GameConfig/GameConfigConstants.h"
 
 #include "Render/RmlUi/RmlUiRuntime.h"
+#include "UI/RmlBridge/RmlTheme.h"
 #include <RmlUi/Core/ElementDocument.h>
 #include <RmlUi/Core/Element.h>
 #include <RmlUi/Core/Event.h>
@@ -95,7 +96,12 @@ void CLoginWin::Create()
     // The login background is fixed artwork and does not scale with the window
     // size, so keep the original height. The credential-consent controls fit on
     // the panel and the trust warning is drawn just below it (issue #462).
-    CWin::Create(329, 245, BITMAP_LOG_IN + 7);
+    // Background sprite is theme-gated: the "modern" theme draws the whole panel look itself in
+    // RCSS (themes/modern/login.rcss's #panel), so it never creates one -- CWin::Create's own
+    // nTexID<=-2 sentinel (confirmed precedent: ServerSelWin.cpp's CWin::Create(0,0,-2)) leaves
+    // m_psprBg null, and CWin::Render()'s existing `if (m_psprBg)` guard then draws nothing.
+    const bool bUseLegacySprites = UI::RmlBridge::UsesLegacySpriteChrome(UI::RmlBridge::GetActiveThemeName());
+    CWin::Create(329, 245, bUseLegacySprites ? (BITMAP_LOG_IN + 7) : -2);
 
     m_asprInputBox[LIW_ACCOUNT].Create(156, 23, BITMAP_LOG_IN + 8);
     m_asprInputBox[LIW_PASSWORD].Create(156, 23, BITMAP_LOG_IN + 8);
@@ -192,8 +198,10 @@ void CLoginWin::Create()
                     [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleSavePassword(); });
             });
 
+        // Routed through UI::RmlBridge::LoadThemedDocument (not Context::LoadDocument directly)
+        // so this document resolves against the active theme's stylesheet -- see RmlTheme.h.
         if (modelCreated)
-            m_pRmlDoc = RmlUiRuntime::Instance().GetContext()->LoadDocument("Data/Interface/RmlUi/login.rml");
+            m_pRmlDoc = UI::RmlBridge::LoadThemedDocument(RmlUiRuntime::Instance().GetContext(), "Data/Interface/RmlUi/login.rml");
     }
 }
 
@@ -421,10 +429,16 @@ void CLoginWin::RenderControls()
     // Legacy chrome removed here -- the background panel is still drawn by CWin::Render()'s
     // m_psprBg (unchanged); checkboxes/OK-Cancel buttons/labels/trust-warning text now render
     // via the RmlUi overlay instead (see this class's header comment and login.rml/.rcss).
-    // Input-box frame sprites and the actual CUITextInputBox text rendering are kept exactly as
-    // before -- text entry deliberately did not move to RmlUi.
-    m_asprInputBox[LIW_ACCOUNT].Render();
-    m_asprInputBox[LIW_PASSWORD].Render();
+    // Input-box frame sprites are theme-gated the same way the background sprite is (Create()'s
+    // comment) -- the modern theme draws its own .input-frame outline in RCSS instead
+    // (themes/modern/login.rcss), so rendering the legacy frame sprites there too would draw
+    // both on top of each other. The actual CUITextInputBox text rendering is never gated --
+    // text entry deliberately did not move to RmlUi in either theme.
+    if (UI::RmlBridge::UsesLegacySpriteChrome(UI::RmlBridge::GetActiveThemeName()))
+    {
+        m_asprInputBox[LIW_ACCOUNT].Render();
+        m_asprInputBox[LIW_PASSWORD].Render();
+    }
     m_pUsernameInputBox->Render();
     m_pPasswordInputBox->Render();
 

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -162,33 +162,38 @@ void CLoginWin::Create()
     // SetPosition() below), not recreated.
     if (!m_pRmlDoc && RmlUiRuntime::Instance().IsCreated())
     {
-        m_pRmlDoc = RmlUiRuntime::Instance().GetContext()->LoadDocument("Data/Interface/RmlUi/login.rml");
-        if (m_pRmlDoc)
-        {
-            m_RmlBinder.Create(RmlUiRuntime::Instance().GetContext(), "login",
-                [this](Rml::DataModelConstructor& c, LoginRmlModel& model)
-                {
-                    c.Bind("remember_me_checked", &model.rememberMeChecked);
-                    c.Bind("save_password_checked", &model.savePasswordChecked);
-                    c.Bind("server_name", &model.serverName);
-                    c.Bind("account_label", &model.accountLabel);
-                    c.Bind("password_label", &model.passwordLabel);
-                    c.Bind("remember_me_label", &model.rememberMeLabel);
-                    c.Bind("save_password_label", &model.savePasswordLabel);
-                    c.Bind("trust_warning", &model.trustWarning);
-                    c.Bind("ok_label", &model.okLabel);
-                    c.Bind("cancel_label", &model.cancelLabel);
+        // The data model must exist BEFORE the document referencing it (via data-model="login")
+        // is loaded -- RmlUi resolves data-model/{{bindings}} while PARSING the RML, so a model
+        // created after LoadDocument() is too late: every {{...}} in the document falls back to
+        // rendering its own literal source text instead of the bound value (confirmed from a
+        // real screenshot: "{{account_label}}", "{{server_name}}" etc. rendered verbatim). Create
+        // the model first, then load the document.
+        const bool modelCreated = m_RmlBinder.Create(RmlUiRuntime::Instance().GetContext(), "login",
+            [this](Rml::DataModelConstructor& c, LoginRmlModel& model)
+            {
+                c.Bind("remember_me_checked", &model.rememberMeChecked);
+                c.Bind("save_password_checked", &model.savePasswordChecked);
+                c.Bind("server_name", &model.serverName);
+                c.Bind("account_label", &model.accountLabel);
+                c.Bind("password_label", &model.passwordLabel);
+                c.Bind("remember_me_label", &model.rememberMeLabel);
+                c.Bind("save_password_label", &model.savePasswordLabel);
+                c.Bind("trust_warning", &model.trustWarning);
+                c.Bind("ok_label", &model.okLabel);
+                c.Bind("cancel_label", &model.cancelLabel);
 
-                    c.BindEventCallback("login_ok_click",
-                        [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickOk(); });
-                    c.BindEventCallback("login_cancel_click",
-                        [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickCancel(); });
-                    c.BindEventCallback("login_toggle_remember_me",
-                        [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleRememberMe(); });
-                    c.BindEventCallback("login_toggle_save_password",
-                        [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleSavePassword(); });
-                });
-        }
+                c.BindEventCallback("login_ok_click",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickOk(); });
+                c.BindEventCallback("login_cancel_click",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickCancel(); });
+                c.BindEventCallback("login_toggle_remember_me",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleRememberMe(); });
+                c.BindEventCallback("login_toggle_save_password",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleSavePassword(); });
+            });
+
+        if (modelCreated)
+            m_pRmlDoc = RmlUiRuntime::Instance().GetContext()->LoadDocument("Data/Interface/RmlUi/login.rml");
     }
 }
 

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -32,28 +32,13 @@
 
 #include "Render/RmlUi/RmlUiRuntime.h"
 #include "UI/RmlBridge/RmlTheme.h"
+#include "Core/Utilities/StringUtils.h"
 #include <RmlUi/Core/ElementDocument.h>
 #include <RmlUi/Core/Element.h>
 #include <RmlUi/Core/Event.h>
 
 #define LIW_OK			0
 #define LIW_CANCEL		1
-
-namespace
-{
-    // Mirrors the Narrow() idiom already used elsewhere in this codebase (e.g.
-    // Core/Platform/WinIni.cpp) -- Rml::String is UTF-8 std::string (RmlUi/Config/Config.h).
-    std::string WideToUtf8(const wchar_t* s)
-    {
-        if (!s) return std::string();
-        const int len = static_cast<int>(wcslen(s));
-        const int n = WideCharToMultiByte(CP_UTF8, 0, s, len, nullptr, 0, nullptr, nullptr);
-        if (n <= 0) return std::string();
-        std::string out(static_cast<size_t>(n), '\0');
-        WideCharToMultiByte(CP_UTF8, 0, s, len, out.data(), n, nullptr, nullptr);
-        return out;
-    }
-}
 
 
 
@@ -99,6 +84,7 @@ void CLoginWin::Create()
     // ServerSelWin.cpp's CWin::Create(0,0,-2)) leaves m_psprBg null, and CWin::Render()'s existing
     // `if (m_psprBg)` guard then draws nothing.
     CWin::Create(329, 245, -2);
+    SetMovable(false);
 
     for (int i = 0; i < 2; ++i)
     {
@@ -205,6 +191,21 @@ void CLoginWin::Create()
     }
 }
 
+void CLoginWin::PreRelease()
+{
+    // CUIMng::RemoveWinList() (run on every scene transition) calls Release() on every window
+    // in its list unconditionally -- CWin's own Release()/PreRelease() has no knowledge of
+    // m_pRmlDoc, so without this it can keep rendering into whatever scene comes next if this
+    // window is ever Released() while still shown. In today's real login/cancel flow that
+    // never happens (RequestLogin()/CancelLogin() both call CUIMng::HideWin(this) first), but
+    // that's an incidental property of those two call sites, not something this class's own
+    // lifecycle actually guarantees -- explicit here rather than relying on it staying true.
+    // Hide(), not unload -- the document/model are meant to be created once and reused (see
+    // Create()'s own guard comment above).
+    if (m_pRmlDoc)
+        m_pRmlDoc->Hide();
+}
+
 void CLoginWin::SetPosition(int x, int y)
 {
 	CWin::SetPosition(x, y);
@@ -262,26 +263,14 @@ void CLoginWin::Show(bool bShow)
     }
 }
 
-bool CLoginWin::CursorInWin(int nArea)
-{
-    if (!CWin::m_bShow)
-        return false;
-
-    switch (nArea)
-    {
-    case WA_MOVE:
-        return false;
-    }
-
-    return CWin::CursorInWin(nArea);
-}
-
 void CLoginWin::UpdateWhileActive(double)
 {
 	// While the "Remember Password" confirmation dialog is open, let it own the
 	// input so Enter/Esc/clicks don't also drive the login screen behind it. The
-	// dialog's outcome is applied on the next frame, once it has closed.
-	if (!g_MessageBox->IsEmpty())
+	// dialog's outcome is applied on the next frame, once it has closed. Scoped to this
+	// dialog's own Pending state (not the old shared g_MessageBox->IsEmpty() stack-wide check --
+	// this dialog no longer registers with that engine, see RememberPasswordPrompt.cpp).
+	if (UI::Login::RememberPasswordChoiceState() == UI::Login::RememberPasswordChoice::Pending)
 		return;
 
 	if (m_aBtn[LIW_OK].IsClick() || m_bRmlOkClicked || CInput::Instance().IsKeyDown(VK_RETURN))
@@ -356,6 +345,10 @@ void CLoginWin::UpdateWhileShow(double dDeltaTick)
 {
     m_pUsernameInputBox->DoAction();
     m_pPasswordInputBox->DoAction();
+
+    // Polls the "Remember Password" dialog's own Enter/Esc while it's open -- ticked from here
+    // (not UpdateWhileActive) for the same reason ApplyRememberPasswordChoice() is, right below.
+    UI::Login::Tick();
 
     ApplyRememberPasswordChoice();
     RevokeSavedCredentialsIfEdited();
@@ -448,7 +441,7 @@ void CLoginWin::SyncRmlModel()
     wchar_t szServerName[MAX_TEXT_LENGTH] = {};
     const wchar_t* pServerStatus = g_ServerListManager->GetNonPVPInfo() ? I18N::Game::SDServer : I18N::Game::SDNonPvPServer;
     mu_swprintf(szServerName, pServerStatus, g_ServerListManager->GetSelectServerName(), g_ServerListManager->GetSelectServerIndex());
-    const std::string serverNameUtf8 = WideToUtf8(szServerName);
+    const std::string serverNameUtf8 = StringUtils::WideToNarrow(szServerName);
     if (m_RmlBinder.GetModel().serverName != serverNameUtf8)
     {
         m_RmlBinder.GetModel().serverName = serverNameUtf8;
@@ -460,7 +453,7 @@ void CLoginWin::SyncRmlModel()
     // comparison; only actually dirties the model on an active locale change, which is rare.
     auto syncLabel = [this](Rml::String LoginRmlModel::* field, const char* boundName, const wchar_t* text)
     {
-        const std::string utf8 = WideToUtf8(text);
+        const std::string utf8 = StringUtils::WideToNarrow(text);
         if (m_RmlBinder.GetModel().*field != utf8)
         {
             m_RmlBinder.GetModel().*field = utf8;

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -30,11 +30,32 @@
 #include "Data/GameConfig/GameConfig.h"
 #include "Data/GameConfig/GameConfigConstants.h"
 
+#include "Render/RmlUi/RmlUiRuntime.h"
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/Event.h>
+
 #define	LIW_ACCOUNT		0
 #define	LIW_PASSWORD	1
 
 #define LIW_OK			0
 #define LIW_CANCEL		1
+
+namespace
+{
+    // Mirrors the Narrow() idiom already used elsewhere in this codebase (e.g.
+    // Core/Platform/WinIni.cpp) -- Rml::String is UTF-8 std::string (RmlUi/Config/Config.h).
+    std::string WideToUtf8(const wchar_t* s)
+    {
+        if (!s) return std::string();
+        const int len = static_cast<int>(wcslen(s));
+        const int n = WideCharToMultiByte(CP_UTF8, 0, s, len, nullptr, 0, nullptr, nullptr);
+        if (n <= 0) return std::string();
+        std::string out(static_cast<size_t>(n), '\0');
+        WideCharToMultiByte(CP_UTF8, 0, s, len, out.data(), n, nullptr, nullptr);
+        return out;
+    }
+}
 
 
 
@@ -131,6 +152,44 @@ void CLoginWin::Create()
     m_pPasswordInputBox->GetText(m_prevPassword, _countof(m_prevPassword));
 
     this->FirstLoad = 1;
+
+    // RmlUi migration plan Phase 1 pilot -- see this class's header comment. Guarded on
+    // m_pRmlDoc rather than unconditionally: CUIMng::RepositionSceneUI() re-runs
+    // CreateLoginScene() (and so this Create()) on every resolution change, to refresh the
+    // legacy sprites' stale screen-height-dependent Y-flip cache -- a problem RmlUi's own
+    // layout doesn't have (it already re-flows against the Context's current dimensions), so
+    // the document/data-model are set up once, ever, and only repositioned afterward (see
+    // SetPosition() below), not recreated.
+    if (!m_pRmlDoc && RmlUiRuntime::Instance().IsCreated())
+    {
+        m_pRmlDoc = RmlUiRuntime::Instance().GetContext()->LoadDocument("Data/Interface/RmlUi/login.rml");
+        if (m_pRmlDoc)
+        {
+            m_RmlBinder.Create(RmlUiRuntime::Instance().GetContext(), "login",
+                [this](Rml::DataModelConstructor& c, LoginRmlModel& model)
+                {
+                    c.Bind("remember_me_checked", &model.rememberMeChecked);
+                    c.Bind("save_password_checked", &model.savePasswordChecked);
+                    c.Bind("server_name", &model.serverName);
+                    c.Bind("account_label", &model.accountLabel);
+                    c.Bind("password_label", &model.passwordLabel);
+                    c.Bind("remember_me_label", &model.rememberMeLabel);
+                    c.Bind("save_password_label", &model.savePasswordLabel);
+                    c.Bind("trust_warning", &model.trustWarning);
+                    c.Bind("ok_label", &model.okLabel);
+                    c.Bind("cancel_label", &model.cancelLabel);
+
+                    c.BindEventCallback("login_ok_click",
+                        [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickOk(); });
+                    c.BindEventCallback("login_cancel_click",
+                        [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickCancel(); });
+                    c.BindEventCallback("login_toggle_remember_me",
+                        [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleRememberMe(); });
+                    c.BindEventCallback("login_toggle_save_password",
+                        [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleSavePassword(); });
+                });
+        }
+    }
 }
 
 void CLoginWin::PreRelease()
@@ -161,6 +220,21 @@ void CLoginWin::SetPosition(int x, int y)
 	m_aBtnSavePassword.SetPosition(x + 109, y + 176);
 	m_aBtn[LIW_OK].SetPosition(x + 150, y + 200);
 	m_aBtn[LIW_CANCEL].SetPosition(x + 211, y + 200);
+
+	// RmlUi panel overlay: positioned at the same real window-pixel origin CWin's own
+	// background sprite (m_psprBg) uses -- unlike the legacy g_pRenderText calls this replaces
+	// (which divided by g_fScreenRate_x/y to convert into the old 640x480 reference space),
+	// RmlUi's Context operates directly in real window pixels, so no scale conversion is
+	// needed here; the panel's children use fixed-pixel RCSS offsets relative to this container,
+	// matching "the login background is fixed artwork and does not scale" above.
+	if (m_pRmlDoc)
+	{
+		if (Rml::Element* panel = m_pRmlDoc->GetElementById("panel"))
+		{
+			panel->SetProperty("left", std::to_string(x) + "px");
+			panel->SetProperty("top", std::to_string(y) + "px");
+		}
+	}
 }
 
 void CLoginWin::Show(bool bShow)
@@ -180,6 +254,12 @@ void CLoginWin::Show(bool bShow)
     const int iState = bShow ? UISTATE_NORMAL : UISTATE_HIDE;
     if (m_pUsernameInputBox) m_pUsernameInputBox->SetState(iState);
     if (m_pPasswordInputBox) m_pPasswordInputBox->SetState(iState);
+
+    if (m_pRmlDoc)
+    {
+        if (bShow) { SyncRmlModel(); m_pRmlDoc->Show(); }
+        else       m_pRmlDoc->Hide();
+    }
 }
 
 bool CLoginWin::CursorInWin(int nArea)
@@ -204,15 +284,17 @@ void CLoginWin::UpdateWhileActive(double)
 	if (!g_MessageBox->IsEmpty())
 		return;
 
-	if (m_aBtn[LIW_OK].IsClick() || CInput::Instance().IsKeyDown(VK_RETURN))
+	if (m_aBtn[LIW_OK].IsClick() || m_bRmlOkClicked || CInput::Instance().IsKeyDown(VK_RETURN))
 	{
+		m_bRmlOkClicked = false;
 		PlayBuffer(SOUND_CLICK01);
 		RequestLogin();
 		return;
 	}
 
-	if (m_aBtn[LIW_CANCEL].IsClick() || CInput::Instance().IsKeyDown(VK_ESCAPE))
+	if (m_aBtn[LIW_CANCEL].IsClick() || m_bRmlCancelClicked || CInput::Instance().IsKeyDown(VK_ESCAPE))
 	{
+		m_bRmlCancelClicked = false;
 		PlayBuffer(SOUND_CLICK01);
 		CancelLogin();
 		CUIMng::Instance().SetSysMenuWinShow(false);
@@ -226,8 +308,9 @@ void CLoginWin::UpdateRememberCheckboxes()
 {
 	GameConfig& config = GameConfig::GetInstance();
 
-	if (m_aBtnRememberMe.IsClick())
+	if (m_aBtnRememberMe.IsClick() || m_bRmlRememberMeClicked)
 	{
+		m_bRmlRememberMeClicked = false;
 		m_RememberMe = m_aBtnRememberMe.IsCheck();
 		config.SetRememberMe(m_RememberMe != 0);
 
@@ -241,8 +324,9 @@ void CLoginWin::UpdateRememberCheckboxes()
 		}
 	}
 
-	if (!m_aBtnSavePassword.IsClick())
+	if (!m_aBtnSavePassword.IsClick() && !m_bRmlSavePasswordClicked)
 		return;
+	m_bRmlSavePasswordClicked = false;
 
 	if (!m_aBtnSavePassword.IsCheck())
 	{
@@ -329,36 +413,66 @@ void CLoginWin::RenderControls()
         FirstLoad = 0;
     }
 
-    CWin::RenderButtons();
+    // Legacy chrome removed here -- the background panel is still drawn by CWin::Render()'s
+    // m_psprBg (unchanged); checkboxes/OK-Cancel buttons/labels/trust-warning text now render
+    // via the RmlUi overlay instead (see this class's header comment and login.rml/.rcss).
+    // Input-box frame sprites and the actual CUITextInputBox text rendering are kept exactly as
+    // before -- text entry deliberately did not move to RmlUi.
     m_asprInputBox[LIW_ACCOUNT].Render();
     m_asprInputBox[LIW_PASSWORD].Render();
     m_pUsernameInputBox->Render();
     m_pPasswordInputBox->Render();
 
-    g_pRenderText->SetFont(g_hFixFont);
-    g_pRenderText->SetBgColor(0);
-    g_pRenderText->SetTextColor(CLRDW_WHITE);
+    SyncRmlModel();
+}
 
-    const int baseX = GetXPos();
-    const int baseY = GetYPos();
+void CLoginWin::SyncRmlModel()
+{
+    if (!m_pRmlDoc) return;
 
-    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 113) / g_fScreenRate_y), I18N::Game::Account);
-    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 139) / g_fScreenRate_y), I18N::Game::Password);
+    const bool rememberChecked = m_aBtnRememberMe.IsCheck();
+    if (m_RmlBinder.GetModel().rememberMeChecked != rememberChecked)
+    {
+        m_RmlBinder.GetModel().rememberMeChecked = rememberChecked;
+        m_RmlBinder.MarkDirty("remember_me_checked");
+    }
+
+    const bool saveChecked = m_aBtnSavePassword.IsCheck();
+    if (m_RmlBinder.GetModel().savePasswordChecked != saveChecked)
+    {
+        m_RmlBinder.GetModel().savePasswordChecked = saveChecked;
+        m_RmlBinder.MarkDirty("save_password_checked");
+    }
 
     wchar_t szServerName[MAX_TEXT_LENGTH] = {};
     const wchar_t* pServerStatus = g_ServerListManager->GetNonPVPInfo() ? I18N::Game::SDServer : I18N::Game::SDNonPvPServer;
     mu_swprintf(szServerName, pServerStatus, g_ServerListManager->GetSelectServerName(), g_ServerListManager->GetSelectServerIndex());
-    g_pRenderText->RenderText(int((baseX + 111) / g_fScreenRate_x), int((baseY + 80) / g_fScreenRate_y), szServerName);
+    const std::string serverNameUtf8 = WideToUtf8(szServerName);
+    if (m_RmlBinder.GetModel().serverName != serverNameUtf8)
+    {
+        m_RmlBinder.GetModel().serverName = serverNameUtf8;
+        m_RmlBinder.MarkDirty("server_name");
+    }
 
-    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 159) / g_fScreenRate_y), I18N::Game::LoginRememberUsername);
-    g_pRenderText->RenderText(int((baseX + 130) / g_fScreenRate_x), int((baseY + 179) / g_fScreenRate_y), I18N::Game::LoginRememberPassword);
-
-    // Trust warning rendered just below the login panel (the panel artwork is a
-    // fixed size, so there is no room for this long line inside it). Position is
-    // eyeballed against the background and may need tuning.
-    g_pRenderText->SetTextColor(255, 210, 60, 255);
-    g_pRenderText->RenderText(int((baseX + 30) / g_fScreenRate_x), int((baseY + 252) / g_fScreenRate_y), I18N::Game::LoginTrustWarning);
-    g_pRenderText->SetTextColor(CLRDW_WHITE);
+    // Static (per-locale) labels, synced from the same I18N::Game::* slots the legacy
+    // g_pRenderText calls used directly -- cheap to re-check every call via the string
+    // comparison; only actually dirties the model on an active locale change, which is rare.
+    auto syncLabel = [this](Rml::String LoginRmlModel::* field, const char* boundName, const wchar_t* text)
+    {
+        const std::string utf8 = WideToUtf8(text);
+        if (m_RmlBinder.GetModel().*field != utf8)
+        {
+            m_RmlBinder.GetModel().*field = utf8;
+            m_RmlBinder.MarkDirty(boundName);
+        }
+    };
+    syncLabel(&LoginRmlModel::accountLabel, "account_label", I18N::Game::Account);
+    syncLabel(&LoginRmlModel::passwordLabel, "password_label", I18N::Game::Password);
+    syncLabel(&LoginRmlModel::rememberMeLabel, "remember_me_label", I18N::Game::LoginRememberUsername);
+    syncLabel(&LoginRmlModel::savePasswordLabel, "save_password_label", I18N::Game::LoginRememberPassword);
+    syncLabel(&LoginRmlModel::trustWarning, "trust_warning", I18N::Game::LoginTrustWarning);
+    syncLabel(&LoginRmlModel::okLabel, "ok_label", I18N::Game::OK);
+    syncLabel(&LoginRmlModel::cancelLabel, "cancel_label", I18N::Game::Cancel);
 }
 
 void CLoginWin::RequestLogin()

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -36,9 +36,6 @@
 #include <RmlUi/Core/Element.h>
 #include <RmlUi/Core/Event.h>
 
-#define	LIW_ACCOUNT		0
-#define	LIW_PASSWORD	1
-
 #define LIW_OK			0
 #define LIW_CANCEL		1
 
@@ -96,15 +93,12 @@ void CLoginWin::Create()
     // The login background is fixed artwork and does not scale with the window
     // size, so keep the original height. The credential-consent controls fit on
     // the panel and the trust warning is drawn just below it (issue #462).
-    // Background sprite is theme-gated: the "modern" theme draws the whole panel look itself in
-    // RCSS (themes/modern/login.rcss's #panel), so it never creates one -- CWin::Create's own
-    // nTexID<=-2 sentinel (confirmed precedent: ServerSelWin.cpp's CWin::Create(0,0,-2)) leaves
-    // m_psprBg null, and CWin::Render()'s existing `if (m_psprBg)` guard then draws nothing.
-    const bool bUseLegacySprites = UI::RmlBridge::UsesLegacySpriteChrome(UI::RmlBridge::GetActiveThemeName());
-    CWin::Create(329, 245, bUseLegacySprites ? (BITMAP_LOG_IN + 7) : -2);
-
-    m_asprInputBox[LIW_ACCOUNT].Create(156, 23, BITMAP_LOG_IN + 8);
-    m_asprInputBox[LIW_PASSWORD].Create(156, 23, BITMAP_LOG_IN + 8);
+    // CWin never draws anything for this window -- every theme's #panel/.input-frame renders the
+    // background/input-box-frame artwork itself (see themes/legacy/login.rcss and
+    // themes/modern/login.rcss). CWin::Create's own nTexID<=-2 sentinel (confirmed precedent:
+    // ServerSelWin.cpp's CWin::Create(0,0,-2)) leaves m_psprBg null, and CWin::Render()'s existing
+    // `if (m_psprBg)` guard then draws nothing.
+    CWin::Create(329, 245, -2);
 
     for (int i = 0; i < 2; ++i)
     {
@@ -211,19 +205,9 @@ void CLoginWin::Create()
     }
 }
 
-void CLoginWin::PreRelease()
-{
-    for (int i = 0; i < 2; ++i)
-        m_asprInputBox[i].Release();
-}
-
 void CLoginWin::SetPosition(int x, int y)
 {
 	CWin::SetPosition(x, y);
-
-	const int boxOffsetX = x + 109;
-	m_asprInputBox[LIW_ACCOUNT].SetPosition(boxOffsetX, y + 106);
-	m_asprInputBox[LIW_PASSWORD].SetPosition(boxOffsetX, y + 131);
 
 	if (g_iChatInputType == 1)
 	{
@@ -261,10 +245,7 @@ void CLoginWin::Show(bool bShow)
     CWin::Show(bShow);
 
     for (int i = 0; i < 2; ++i)
-    {
-        m_asprInputBox[i].Show(bShow);
         m_aBtn[i].Show(bShow);
-    }
     m_aBtnRememberMe.Show(bShow);
     m_aBtnSavePassword.Show(bShow);
 
@@ -432,20 +413,11 @@ void CLoginWin::RenderControls()
         FirstLoad = 0;
     }
 
-    // Legacy chrome removed here -- the background panel is still drawn by CWin::Render()'s
-    // m_psprBg (unchanged); checkboxes/OK-Cancel buttons/labels/trust-warning text now render
-    // via the RmlUi overlay instead (see this class's header comment and login.rml/.rcss).
-    // Input-box frame sprites are theme-gated the same way the background sprite is (Create()'s
-    // comment) -- the modern theme draws its own .input-frame outline in RCSS instead
-    // (themes/modern/login.rcss), so rendering the legacy frame sprites there too would draw
-    // both on top of each other. The actual CUITextInputBox text is NOT rendered here -- see
-    // RenderTextOnTop()'s comment for why it moved to a separate, later call.
-    if (UI::RmlBridge::UsesLegacySpriteChrome(UI::RmlBridge::GetActiveThemeName()))
-    {
-        m_asprInputBox[LIW_ACCOUNT].Render();
-        m_asprInputBox[LIW_PASSWORD].Render();
-    }
-
+    // All panel chrome (background, input-box frames, checkboxes, OK/Cancel buttons, labels,
+    // trust-warning text) now renders via the RmlUi overlay -- see this class's header comment
+    // and login.rml/.rcss. Nothing legacy left to draw here. The actual CUITextInputBox text is
+    // NOT rendered here -- see RenderTextOnTop()'s comment for why it moved to a separate, later
+    // call.
     SyncRmlModel();
 }
 

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -98,6 +98,17 @@ void CLoginWin::Create()
     m_aBtnSavePassword.Create(16, 16, BITMAP_CHECK_BTN, 2, 0, 0, -1, 1, 1, 1);
     CWin::RegisterButton(&m_aBtnSavePassword);
 
+    // CButton::Update() auto-toggles m_bCheck on its own input polling whenever HasCheckVisuals()
+    // is true (both are 2-frame check-style art) -- independent of and in addition to
+    // RmlToggleRememberMe()/RmlToggleSavePassword()'s own SetCheck() flip below, since legacy
+    // input polling isn't gated by which UI tier's Context claimed the click. Left enabled, one
+    // click produces two flips (net no change). SetEnable(false) makes these pure state
+    // containers (SetCheck/IsCheck still work for every other call site); only the RmlUi handler
+    // drives them now. Plain action buttons (OK/Cancel) don't need this -- HasCheckVisuals() is
+    // false there, so redundant firing is harmless.
+    m_aBtnRememberMe.SetEnable(false);
+    m_aBtnSavePassword.SetEnable(false);
+
     SAFE_DELETE(m_pUsernameInputBox);
 
     m_pUsernameInputBox = new CUITextInputBox;
@@ -326,10 +337,10 @@ void CLoginWin::UpdateRememberCheckboxes()
 		return;
 	}
 
-	// Enabling requires confirmation. Revert the tick immediately; it is
-	// re-applied only if the dialog is accepted, so a cancel (however the dialog
-	// closes) always leaves the box unchecked.
-	m_aBtnSavePassword.SetCheck(false);
+	// Enabling requires confirmation, but the box stays ticked from the click that got us here --
+	// ApplyRememberPasswordChoice() already sets SetCheck(bAccepted) once the dialog resolves
+	// either way, so a Cancel still correctly unticks it. This just gives the click itself real
+	// visual feedback, matching Remember Me's own click.
 
 	// Storing the password implies remembering the account.
 	if (!m_RememberMe)

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -432,17 +432,21 @@ void CLoginWin::RenderControls()
     // Input-box frame sprites are theme-gated the same way the background sprite is (Create()'s
     // comment) -- the modern theme draws its own .input-frame outline in RCSS instead
     // (themes/modern/login.rcss), so rendering the legacy frame sprites there too would draw
-    // both on top of each other. The actual CUITextInputBox text rendering is never gated --
-    // text entry deliberately did not move to RmlUi in either theme.
+    // both on top of each other. The actual CUITextInputBox text is NOT rendered here -- see
+    // RenderTextOnTop()'s comment for why it moved to a separate, later call.
     if (UI::RmlBridge::UsesLegacySpriteChrome(UI::RmlBridge::GetActiveThemeName()))
     {
         m_asprInputBox[LIW_ACCOUNT].Render();
         m_asprInputBox[LIW_PASSWORD].Render();
     }
-    m_pUsernameInputBox->Render();
-    m_pPasswordInputBox->Render();
 
     SyncRmlModel();
+}
+
+void CLoginWin::RenderTextOnTop()
+{
+    m_pUsernameInputBox->Render();
+    m_pPasswordInputBox->Render();
 }
 
 void CLoginWin::SyncRmlModel()

--- a/src/source/UI/Windows/LoginWin.cpp
+++ b/src/source/UI/Windows/LoginWin.cpp
@@ -202,6 +202,12 @@ void CLoginWin::Create()
         // so this document resolves against the active theme's stylesheet -- see RmlTheme.h.
         if (modelCreated)
             m_pRmlDoc = UI::RmlBridge::LoadThemedDocument(RmlUiRuntime::Instance().GetContext(), "Data/Interface/RmlUi/login.rml");
+
+        // Deliberately NOT calling UI::RmlBridge::MakeDraggable() here -- the login screen is
+        // meant to stay static (see this class's CursorInWin(WA_MOVE) override, hardcoded false).
+        // MakeDraggable() itself was built and verified against this exact document during
+        // development (see docs/rmlui-ui-system/architecture.md) but isn't wired up for real use
+        // on this window.
     }
 }
 

--- a/src/source/UI/Windows/LoginWin.h
+++ b/src/source/UI/Windows/LoginWin.h
@@ -12,14 +12,16 @@ class CUITextInputBox;
 
 namespace Rml { class ElementDocument; }
 
-// RmlUi migration plan Phase 1 pilot (login dialog): the legacy CButton/CSprite objects below
-// remain the actual state-holders (IsCheck/SetCheck, position/size bookkeeping via CWin) --
-// nothing about their internal semantics changed. What changed is how they're driven: an RmlUi
-// document (Data/Interface/RmlUi/login.rml) now renders the checkboxes/buttons/labels/trust
-// warning as an overlay positioned on top of CWin::Render()'s existing background sprite
-// (m_psprBg, still drawn exactly as before -- not reproduced in RmlUi, to avoid re-authoring a
-// working panel graphic and to minimize regression risk with no compiler available to verify
-// against). Username/password text entry deliberately stays on the legacy CUITextInputBox
+// RmlUi migration plan Phase 1 pilot (login dialog): CWin no longer draws anything for this
+// window -- Create() always passes nTexID=-2, so m_psprBg is never created, and the input-box
+// frame sprites this class used to own (m_asprInputBox) are gone entirely. The RmlUi document
+// (Data/Interface/RmlUi/login.rml) renders the panel background, input-box frames, checkboxes,
+// buttons, labels, and trust warning as an overlay -- the "legacy" theme reproduces the original
+// look by pointing its RCSS decorators at the same art files (Interface/login_back.tga,
+// Interface/login_me.tga) the old CWin sprites drew, so this is a renderer swap, not a visual
+// change. The legacy CButton objects below remain the actual state-holders (IsCheck/SetCheck) for
+// the checkboxes/OK/Cancel buttons -- nothing about their internal semantics changed, only what
+// draws them. Username/password text entry deliberately stays on the legacy CUITextInputBox
 // objects (m_pUsernameInputBox/m_pPasswordInputBox) rather than moving to native RmlUi <input>
 // elements -- external code (WSclient.cpp, MsgWin.cpp) calls GetUsernameInputBox()/
 // GetPasswordInputBox()->GiveFocus() directly for error-recovery focus redirection, and
@@ -28,7 +30,6 @@ namespace Rml { class ElementDocument; }
 class CLoginWin : public CWin
 {
 protected:
-    CSprite		m_asprInputBox[2];
     CButton		m_aBtn[2];
     CButton     m_aBtnRememberMe;
     CButton     m_aBtnSavePassword;
@@ -111,7 +112,6 @@ private:
     void SyncRmlModel();
 
 protected:
-    void PreRelease();
     void UpdateWhileActive(double dDeltaTick);
     void UpdateWhileShow(double dDeltaTick);
     void RenderControls();

--- a/src/source/UI/Windows/LoginWin.h
+++ b/src/source/UI/Windows/LoginWin.h
@@ -46,7 +46,6 @@ public:
     void Create();
     void SetPosition(int nXCoord, int nYCoord);
     void Show(bool bShow);
-    bool CursorInWin(int nArea);
 
     void ConnectConnectionServer();
 
@@ -112,6 +111,7 @@ private:
     void SyncRmlModel();
 
 protected:
+    void PreRelease();
     void UpdateWhileActive(double dDeltaTick);
     void UpdateWhileShow(double dDeltaTick);
     void RenderControls();

--- a/src/source/UI/Windows/LoginWin.h
+++ b/src/source/UI/Windows/LoginWin.h
@@ -52,6 +52,15 @@ public:
     CUITextInputBox* GetUsernameInputBox() const { return m_pUsernameInputBox; }
     CUITextInputBox* GetPasswordInputBox() const { return m_pPasswordInputBox; }
 
+    // Draws the actual username/password text -- called explicitly by SceneManager.cpp AFTER
+    // RmlUiRuntime::Render(), not from RenderControls() (which still runs earlier, as part of
+    // CUIMng::Render()'s normal legacy pass). RmlUi always renders last in the frame, so any
+    // theme whose #panel has an opaque background (the "modern" theme; "legacy"'s is
+    // transparent, which is why this was never visibly broken before) would otherwise paint
+    // over this text -- confirmed against a real screenshot testing the modern theme, where the
+    // input text (and the cursor, fixed the same way) rendered invisibly underneath the panel.
+    void RenderTextOnTop();
+
     // Called from the RmlUi login document's data-event-click callbacks (see Create()'s
     // DataModelConstructor::BindEventCallback registrations). Polled-and-cleared exactly like
     // the legacy CButton::IsClick() edge triggers they supplement in UpdateWhileActive()/

--- a/src/source/UI/Windows/LoginWin.h
+++ b/src/source/UI/Windows/LoginWin.h
@@ -6,9 +6,25 @@
 #include "UI/Widgets/Win.h"
 
 #include "UI/Widgets/Button.h"
+#include "UI/RmlBridge/RmlModelBinder.h"
 
 class CUITextInputBox;
 
+namespace Rml { class ElementDocument; }
+
+// RmlUi migration plan Phase 1 pilot (login dialog): the legacy CButton/CSprite objects below
+// remain the actual state-holders (IsCheck/SetCheck, position/size bookkeeping via CWin) --
+// nothing about their internal semantics changed. What changed is how they're driven: an RmlUi
+// document (Data/Interface/RmlUi/login.rml) now renders the checkboxes/buttons/labels/trust
+// warning as an overlay positioned on top of CWin::Render()'s existing background sprite
+// (m_psprBg, still drawn exactly as before -- not reproduced in RmlUi, to avoid re-authoring a
+// working panel graphic and to minimize regression risk with no compiler available to verify
+// against). Username/password text entry deliberately stays on the legacy CUITextInputBox
+// objects (m_pUsernameInputBox/m_pPasswordInputBox) rather than moving to native RmlUi <input>
+// elements -- external code (WSclient.cpp, MsgWin.cpp) calls GetUsernameInputBox()/
+// GetPasswordInputBox()->GiveFocus() directly for error-recovery focus redirection, and
+// duplicating credential-entry/focus logic into a second, independent text-input system this
+// session can't test is a real regression risk not worth taking for this pass.
 class CLoginWin : public CWin
 {
 protected:
@@ -36,8 +52,54 @@ public:
     CUITextInputBox* GetUsernameInputBox() const { return m_pUsernameInputBox; }
     CUITextInputBox* GetPasswordInputBox() const { return m_pPasswordInputBox; }
 
+    // Called from the RmlUi login document's data-event-click callbacks (see Create()'s
+    // DataModelConstructor::BindEventCallback registrations). Polled-and-cleared exactly like
+    // the legacy CButton::IsClick() edge triggers they supplement in UpdateWhileActive()/
+    // UpdateRememberCheckboxes() -- kept as separate flags rather than faking IsClick() so the
+    // legacy CButton objects themselves (m_aBtn/m_aBtnRememberMe/m_aBtnSavePassword) are
+    // untouched and still own real check-state for every existing internal call site
+    // (RequestLogin, ApplyRememberPasswordChoice, etc).
+    void RmlClickOk() { m_bRmlOkClicked = true; }
+    void RmlClickCancel() { m_bRmlCancelClicked = true; }
+    void RmlToggleRememberMe()
+    {
+        m_aBtnRememberMe.SetCheck(!m_aBtnRememberMe.IsCheck());
+        m_bRmlRememberMeClicked = true;
+    }
+    void RmlToggleSavePassword()
+    {
+        m_aBtnSavePassword.SetCheck(!m_aBtnSavePassword.IsCheck());
+        m_bRmlSavePasswordClicked = true;
+    }
+
 private:
     int FirstLoad = 0;
+
+    bool m_bRmlOkClicked = false;
+    bool m_bRmlCancelClicked = false;
+    bool m_bRmlRememberMeClicked = false;
+    bool m_bRmlSavePasswordClicked = false;
+
+    struct LoginRmlModel
+    {
+        bool rememberMeChecked = false;
+        bool savePasswordChecked = false;
+        Rml::String serverName;
+        // Synced from the same I18N::Game::* slots RenderControls() used to feed directly into
+        // g_pRenderText -- keeps this migration localization-correct rather than hardcoding
+        // English strings into the RML/RCSS.
+        Rml::String accountLabel;
+        Rml::String passwordLabel;
+        Rml::String rememberMeLabel;
+        Rml::String savePasswordLabel;
+        Rml::String trustWarning;
+        Rml::String okLabel;
+        Rml::String cancelLabel;
+    };
+    RmlModelBinder<LoginRmlModel> m_RmlBinder;
+    Rml::ElementDocument* m_pRmlDoc = nullptr;
+
+    void SyncRmlModel();
 
 protected:
     void PreRelease();

--- a/src/source/UI/Windows/MsgWin.cpp
+++ b/src/source/UI/Windows/MsgWin.cpp
@@ -43,6 +43,7 @@ void CMsgWin::Create()
     CInput rInput = CInput::Instance();
 
     CWin::Create(rInput.GetScreenWidth(), rInput.GetScreenHeight());
+    SetMovable(false);
 
     m_sprBack.Create(352, 113, BITMAP_MESSAGE_WIN);
 
@@ -138,20 +139,6 @@ void CMsgWin::Show(bool bShow)
         m_aBtn[MW_CANCEL].Show(false);
         m_sprInput.Show(false);
     }
-}
-
-bool CMsgWin::CursorInWin(int nArea)
-{
-    if (!CWin::m_bShow)
-        return false;
-
-    switch (nArea)
-    {
-    case WA_MOVE:
-        return false;
-    }
-
-    return CWin::CursorInWin(nArea);
 }
 
 void CMsgWin::UpdateWhileActive(double dDeltaTick)

--- a/src/source/UI/Windows/MsgWin.h
+++ b/src/source/UI/Windows/MsgWin.h
@@ -37,7 +37,6 @@ public:
     void Create();
     void SetPosition(int nXCoord, int nYCoord);
     void Show(bool bShow);
-    bool CursorInWin(int nArea);
     void PopUp(int nMsgCode, wchar_t* pszMsg = nullptr);
 
 protected:

--- a/src/source/UI/Windows/OptionWin.cpp
+++ b/src/source/UI/Windows/OptionWin.cpp
@@ -71,6 +71,11 @@ void COptionWin::Create()
     {
         m_aBtn[i].Create(16, 16, BITMAP_CHECK_BTN, 2, 0, 0, -1, 1, 1, 1);
         CWin::RegisterButton(&m_aBtn[i]);
+
+        // Same double-toggle risk as CLoginWin's checkboxes (see LoginWin.cpp's SetEnable
+        // comment) -- these 3 are checkbox-style (HasCheckVisuals()) CButtons too, so their own
+        // input polling would fight RmlToggleAutoAttack/WhisperAlarm/SlideHelp's SetCheck() flip.
+        m_aBtn[i].SetEnable(false);
     }
 
     DWORD adwBtnClr[4] = { CLRDW_BR_GRAY, CLRDW_BR_GRAY, CLRDW_WHITE, 0 };

--- a/src/source/UI/Windows/OptionWin.cpp
+++ b/src/source/UI/Windows/OptionWin.cpp
@@ -17,8 +17,26 @@
 #include "UI/NewUI/NewUISystem.h"
 #include "I18N/All.h"
 
+#include "Render/RmlUi/RmlUiRuntime.h"
+#include "UI/RmlBridge/RmlTheme.h"
+#include "UI/RmlBridge/RmlDraggable.h"
+#include "Core/Utilities/StringUtils.h"
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/Event.h>
+#include <algorithm>
+#include <cmath>
+
 #define	OW_BTN_GAP		25
 #define	OW_SLD_GAP		48
+
+namespace
+{
+    // Matches the legacy CSlider art's real geometry (98px track - 13px thumb, see
+    // COptionWin::Create's iiThumb/iiBack) -- the travel distance a hand-rolled RmlUi thumb drags
+    // across.
+    constexpr float kSliderTravelPx = 85.0f;
+}
 
 
 
@@ -34,7 +52,9 @@ COptionWin::~COptionWin()
 void COptionWin::Create()
 {
     CInput rInput = CInput::Instance();
-    CWin::Create(rInput.GetScreenWidth(), rInput.GetScreenHeight());
+    // RmlUi migration, Batch 2: -2 (was the default -1) -- see this class's header comment.
+    CWin::Create(rInput.GetScreenWidth(), rInput.GetScreenHeight(), -2);
+    SetMovable(false);
 
     SImgInfo aiiBack[WE_BG_MAX] =
     {
@@ -69,6 +89,55 @@ void COptionWin::Create()
     m_aSlider[OW_SLD_EFFECT_VOL].SetSlideRange(9);
     m_aSlider[OW_SLD_RENDER_LV].SetSlideRange(4);
 
+    // RmlUi migration, Batch 2 -- see this class's header comment. Guarded the same way
+    // CLoginWin::Create() is (CUIMng::RepositionSceneUI() re-runs Create() on resolution change).
+    if (!m_pRmlDoc && RmlUiRuntime::Instance().IsCreated())
+    {
+        const bool modelCreated = m_RmlBinder.Create(RmlUiRuntime::Instance().GetContext(), "option",
+            [this](Rml::DataModelConstructor& c, OptionRmlModel& model)
+            {
+                c.Bind("auto_attack_checked", &model.autoAttackChecked);
+                c.Bind("whisper_alarm_checked", &model.whisperAlarmChecked);
+                c.Bind("slide_help_checked", &model.slideHelpChecked);
+                c.Bind("volume_thumb_left", &model.volumeThumbLeft);
+                c.Bind("render_thumb_left", &model.renderThumbLeft);
+                c.Bind("title_label", &model.titleLabel);
+                c.Bind("auto_attack_label", &model.autoAttackLabel);
+                c.Bind("whisper_alarm_label", &model.whisperAlarmLabel);
+                c.Bind("slide_help_label", &model.slideHelpLabel);
+                c.Bind("close_label", &model.closeLabel);
+                c.Bind("volume_label", &model.volumeLabel);
+                c.Bind("render_label", &model.renderLabel);
+                c.Bind("volume_value_text", &model.volumeValueText);
+                c.Bind("render_value_text", &model.renderValueText);
+
+                c.BindEventCallback("option_toggle_auto_attack",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleAutoAttack(); });
+                c.BindEventCallback("option_toggle_whisper_alarm",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleWhisperAlarm(); });
+                c.BindEventCallback("option_toggle_slide_help",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlToggleSlideHelp(); });
+                c.BindEventCallback("option_close_click",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickClose(); });
+            });
+
+        if (modelCreated)
+            m_pRmlDoc = UI::RmlBridge::LoadThemedDocument(RmlUiRuntime::Instance().GetContext(), "Data/Interface/RmlUi/option.rml");
+
+        // First production use of UI::RmlBridge::MakeDraggable -- previously built and unit-proven
+        // only against a throwaway handle (see its own header comment). Each thumb is its own
+        // handle and panel (there's nothing else to move); onMove clamps to the track's real
+        // travel distance and snaps to the slider's discrete step count, then pushes the
+        // resulting position straight to g_pOption the same way the legacy CSlider path does.
+        if (m_pRmlDoc)
+        {
+            if (Rml::Element* thumb = m_pRmlDoc->GetElementById("volume_thumb"))
+                UI::RmlBridge::MakeDraggable(thumb, thumb, [this](float newLeft, float) { OnSliderThumbDragged(OW_SLD_EFFECT_VOL, newLeft); });
+            if (Rml::Element* thumb = m_pRmlDoc->GetElementById("render_thumb"))
+                UI::RmlBridge::MakeDraggable(thumb, thumb, [this](float newLeft, float) { OnSliderThumbDragged(OW_SLD_RENDER_LV, newLeft); });
+        }
+    }
+
     SetPosition((rInput.GetScreenWidth() - m_winBack.GetWidth()) / 2,
         (rInput.GetScreenHeight() - m_winBack.GetHeight()) / 2);
 
@@ -80,6 +149,13 @@ void COptionWin::PreRelease()
     m_winBack.Release();
     for (int i = 0; i < OW_SLD_MAX; ++i)
         m_aSlider[i].Release();
+
+    // See CLoginMainWin::PreRelease()'s identical comment -- CUIMng::RemoveWinList() Release()s
+    // every window on every scene transition, and CWin's own Release() has no knowledge of
+    // m_pRmlDoc, so without this it can keep rendering into whatever scene comes next if this
+    // window happened to be open at the moment of transition.
+    if (m_pRmlDoc)
+        m_pRmlDoc->Hide();
 }
 
 void COptionWin::SetPosition(int nXCoord, int nYCoord)
@@ -101,6 +177,25 @@ void COptionWin::SetPosition(int nXCoord, int nYCoord)
         + m_aBtn[0].GetHeight() + OW_SLD_GAP;
     for (int i = 0; i < OW_SLD_MAX; ++i)
         m_aSlider[i].SetPosition(nBtnPosX, nSldPosBaseTop + i * nSldGap);
+
+    // RmlUi panel: positioned/sized to match m_winBack's real (screen-absolute) geometry, same
+    // idiom as CSysMenuWin::SetPosition. Every child below stays at a fixed RCSS offset relative
+    // to #panel (option.rcss) rather than being pushed from here -- unlike SysMenuWin's height,
+    // OptionWin's layout is never scene-conditional (m_winBack.SetLine(30) is the only value ever
+    // used), so there's nothing here that actually varies at runtime worth pushing per-child.
+    if (m_pRmlDoc)
+    {
+        if (Rml::Element* panel = m_pRmlDoc->GetElementById("panel"))
+        {
+            panel->SetProperty("left", std::to_string(nXCoord) + "px");
+            panel->SetProperty("top", std::to_string(nYCoord) + "px");
+            panel->SetProperty("width", std::to_string(m_winBack.GetWidth()) + "px");
+            panel->SetProperty("height", std::to_string(m_winBack.GetHeight()) + "px");
+        }
+
+        // #panel_middle's own inset/size is pure RCSS now -- see CSysMenuWin::SetPosition()'s
+        // identical comment for why the C++ push this replaced was unnecessary.
+    }
 }
 
 void COptionWin::Show(bool bShow)
@@ -112,20 +207,12 @@ void COptionWin::Show(bool bShow)
         m_aBtn[i].Show(bShow);
     for (int i = 0; i < OW_SLD_MAX; ++i)
         m_aSlider[i].Show(bShow);
-}
 
-bool COptionWin::CursorInWin(int nArea)
-{
-    if (!CWin::m_bShow)
-        return false;
-
-    switch (nArea)
+    if (m_pRmlDoc)
     {
-    case WA_MOVE:
-        return false;
+        if (bShow) { UpdateDisplay(); SyncRmlModel(); m_pRmlDoc->Show(); }
+        else       m_pRmlDoc->Hide();
     }
-
-    return CWin::CursorInWin(nArea);
 }
 
 void COptionWin::UpdateDisplay()
@@ -135,6 +222,18 @@ void COptionWin::UpdateDisplay()
     m_aBtn[OW_BTN_SLIDE_HELP].SetCheck(g_pOption->IsSlideHelp());
     m_aSlider[OW_SLD_EFFECT_VOL].SetSlidePos(g_pOption->GetVolumeLevel());
     m_aSlider[OW_SLD_RENDER_LV].SetSlidePos(g_pOption->GetRenderLevel());
+
+    // Mirror into the RmlUi model too -- this keeps the RmlUi thumbs/checkboxes correct even
+    // though nothing calls UpdateDisplay() outside Create()/Show() today (this window is
+    // currently unreachable, see this class's header comment); a future caller of UpdateDisplay()
+    // to reflect an external g_pOption change gets the RmlUi side updated for free.
+    if (m_pRmlDoc)
+    {
+        m_RmlBinder.GetModel().volumeThumbLeft = g_pOption->GetVolumeLevel() / 9.0f * kSliderTravelPx;
+        m_RmlBinder.MarkDirty("volume_thumb_left");
+        m_RmlBinder.GetModel().renderThumbLeft = g_pOption->GetRenderLevel() / 4.0f * kSliderTravelPx;
+        m_RmlBinder.MarkDirty("render_thumb_left");
+    }
 }
 
 void COptionWin::UpdateWhileActive(double dDeltaTick)
@@ -142,20 +241,27 @@ void COptionWin::UpdateWhileActive(double dDeltaTick)
     for (int i = 0; i < OW_SLD_MAX; ++i)
         m_aSlider[i].Update(dDeltaTick);
 
-    if (m_aBtn[OW_BTN_AUTO_ATTACK].IsClick())
+    if (m_aBtn[OW_BTN_AUTO_ATTACK].IsClick() || m_bRmlAutoAttackClicked)
     {
+        m_bRmlAutoAttackClicked = false;
         g_pOption->SetAutoAttack(m_aBtn[OW_BTN_AUTO_ATTACK].IsCheck());
+        SyncRmlModel();
     }
-    else if (m_aBtn[OW_BTN_WHISPER_ALARM].IsClick())
+    else if (m_aBtn[OW_BTN_WHISPER_ALARM].IsClick() || m_bRmlWhisperAlarmClicked)
     {
+        m_bRmlWhisperAlarmClicked = false;
         g_pOption->SetWhisperSound(m_aBtn[OW_BTN_WHISPER_ALARM].IsCheck());
+        SyncRmlModel();
     }
-    else if (m_aBtn[OW_BTN_SLIDE_HELP].IsClick())
+    else if (m_aBtn[OW_BTN_SLIDE_HELP].IsClick() || m_bRmlSlideHelpClicked)
     {
+        m_bRmlSlideHelpClicked = false;
         g_pOption->SetSlideHelp(m_aBtn[OW_BTN_SLIDE_HELP].IsCheck());
+        SyncRmlModel();
     }
-    else if (m_aBtn[OW_BTN_CLOSE].IsClick())
+    else if (m_aBtn[OW_BTN_CLOSE].IsClick() || m_bRmlCloseClicked)
     {
+        m_bRmlCloseClicked = false;
         CUIMng::Instance().HideWin(this);
         CUIMng::Instance().SetSysMenuWinShow(false);
     }
@@ -187,39 +293,114 @@ void COptionWin::UpdateWhileActive(double dDeltaTick)
 
 void COptionWin::RenderControls()
 {
-    m_winBack.Render();
+    // m_winBack/g_pRenderText/m_aSlider[i].Render() no longer draw -- RmlUi's #backdrop/#panel
+    // own 100% of this window's visuals (see this class's header comment). Legacy widgets stay
+    // registered/updated purely for redundant input detection, same as CSysMenuWin.
+    SyncRmlModel();
+}
 
-    g_pRenderText->SetFont(g_hFixFont);
-    g_pRenderText->SetTextColor(CLRDW_WHITE);
-    g_pRenderText->SetBgColor(0);
-    g_pRenderText->RenderText(int(m_winBack.GetXPos() / g_fScreenRate_x),
-        int((m_winBack.GetYPos() + 10) / g_fScreenRate_y),
-        I18N::Game::Option385, m_winBack.GetWidth() / g_fScreenRate_x, 0, RT3_SORT_CENTER);
+void COptionWin::SyncRmlModel()
+{
+    if (!m_pRmlDoc) return;
 
-    const wchar_t* apszBtnText[3] =
-    { I18N::Game::AutomaticAttack, I18N::Game::BeepSoundForWhispering, I18N::Game::SlideHelp };
-    for (int i = 0; i <= OW_BTN_SLIDE_HELP; ++i)
+    auto syncBool = [this](bool OptionRmlModel::* field, const char* boundName, bool value)
     {
-        g_pRenderText->RenderText(int((m_aBtn[i].GetXPos() + 24) / g_fScreenRate_x),
-            int((m_aBtn[i].GetYPos() + 4) / g_fScreenRate_y), apszBtnText[i]);
+        if (m_RmlBinder.GetModel().*field != value)
+        {
+            m_RmlBinder.GetModel().*field = value;
+            m_RmlBinder.MarkDirty(boundName);
+        }
+    };
+    syncBool(&OptionRmlModel::autoAttackChecked, "auto_attack_checked", m_aBtn[OW_BTN_AUTO_ATTACK].IsCheck());
+    syncBool(&OptionRmlModel::whisperAlarmChecked, "whisper_alarm_checked", m_aBtn[OW_BTN_WHISPER_ALARM].IsCheck());
+    syncBool(&OptionRmlModel::slideHelpChecked, "slide_help_checked", m_aBtn[OW_BTN_SLIDE_HELP].IsCheck());
+
+    auto syncLabel = [this](Rml::String OptionRmlModel::* field, const char* boundName, const wchar_t* text)
+    {
+        const std::string utf8 = StringUtils::WideToNarrow(text);
+        if (m_RmlBinder.GetModel().*field != utf8)
+        {
+            m_RmlBinder.GetModel().*field = utf8;
+            m_RmlBinder.MarkDirty(boundName);
+        }
+    };
+    syncLabel(&OptionRmlModel::titleLabel, "title_label", I18N::Game::Option385);
+    syncLabel(&OptionRmlModel::autoAttackLabel, "auto_attack_label", I18N::Game::AutomaticAttack);
+    syncLabel(&OptionRmlModel::whisperAlarmLabel, "whisper_alarm_label", I18N::Game::BeepSoundForWhispering);
+    syncLabel(&OptionRmlModel::slideHelpLabel, "slide_help_label", I18N::Game::SlideHelp);
+    syncLabel(&OptionRmlModel::closeLabel, "close_label", I18N::Game::Close388);
+    syncLabel(&OptionRmlModel::volumeLabel, "volume_label", I18N::Game::Volume);
+    syncLabel(&OptionRmlModel::renderLabel, "render_label", I18N::Game::EffectLimitation);
+
+    // Numeric display values -- render-level's is a display-only transform (raw levels 0-4 shown
+    // as 5,7,9,11,13), matching the legacy anVal[OW_SLD_RENDER_LV] computation exactly.
+    auto syncValueText = [this](Rml::String OptionRmlModel::* field, const char* boundName, int value)
+    {
+        wchar_t buf[8];
+        ::_itow(value, buf, 10);
+        const std::string utf8 = StringUtils::WideToNarrow(buf);
+        if (m_RmlBinder.GetModel().*field != utf8)
+        {
+            m_RmlBinder.GetModel().*field = utf8;
+            m_RmlBinder.MarkDirty(boundName);
+        }
+    };
+    syncValueText(&OptionRmlModel::volumeValueText, "volume_value_text", g_pOption->GetVolumeLevel());
+    syncValueText(&OptionRmlModel::renderValueText, "render_value_text", g_pOption->GetRenderLevel() * 2 + 5);
+}
+
+void COptionWin::OnSliderThumbDragged(int sliderIndex, float newLeftPx)
+{
+    const int steps = (sliderIndex == OW_SLD_EFFECT_VOL) ? 9 : 4;
+    const float clamped = std::clamp(newLeftPx, 0.0f, kSliderTravelPx);
+    const int pos = int(std::round(clamped / kSliderTravelPx * steps));
+    const float snappedPx = pos / float(steps) * kSliderTravelPx;
+
+    const char* thumbId = (sliderIndex == OW_SLD_EFFECT_VOL) ? "volume_thumb" : "render_thumb";
+    if (m_pRmlDoc)
+    {
+        if (Rml::Element* thumb = m_pRmlDoc->GetElementById(thumbId))
+        {
+            thumb->SetProperty("left", std::to_string(snappedPx) + "px");
+            // This is a horizontal-only track -- MakeDraggable tracks both axes (it has no
+            // knowledge this handle is constrained), so undo its vertical tracking every tick
+            // rather than letting the thumb drift with the cursor's Y movement.
+            thumb->SetProperty("top", "0px");
+        }
     }
 
-    int nTextPosY;
-    const wchar_t* apszSldText[OW_SLD_MAX] = { I18N::Game::Volume, I18N::Game::EffectLimitation };
-    int anVal[OW_SLD_MAX] = { g_pOption->GetVolumeLevel(), g_pOption->GetRenderLevel() * 2 + 5 };
+    m_aSlider[sliderIndex].SetSlidePos(pos);   // keep the legacy CSlider mirrored, same as CButton precedent
 
-    wchar_t szVal[3];
-
-    for (int i = 0; i < OW_SLD_MAX; ++i)
+    if (sliderIndex == OW_SLD_EFFECT_VOL)
     {
-        nTextPosY = int((m_aSlider[i].GetYPos() - 18) / g_fScreenRate_y);
-        g_pRenderText->RenderText(int(m_aSlider[i].GetXPos() / g_fScreenRate_x), nTextPosY, apszSldText[i]);
-
-        ::_itow(anVal[i], szVal, 10);
-        g_pRenderText->RenderText(int((m_aSlider[i].GetXPos() + 85) / g_fScreenRate_x), nTextPosY, szVal);
-
-        m_aSlider[i].Render();
+        if (g_pOption->GetVolumeLevel() != pos)
+        {
+            g_pOption->SetVolumeLevel(pos);
+            ::SetEffectVolumeLevel(g_pOption->GetVolumeLevel());
+        }
     }
+    else
+    {
+        if (g_pOption->GetRenderLevel() != pos)
+            g_pOption->SetRenderLevel(pos);
+    }
+    SyncRmlModel();
+}
 
-    CWin::RenderButtons();
+void COptionWin::RmlToggleAutoAttack()
+{
+    m_aBtn[OW_BTN_AUTO_ATTACK].SetCheck(!m_aBtn[OW_BTN_AUTO_ATTACK].IsCheck());
+    m_bRmlAutoAttackClicked = true;
+}
+
+void COptionWin::RmlToggleWhisperAlarm()
+{
+    m_aBtn[OW_BTN_WHISPER_ALARM].SetCheck(!m_aBtn[OW_BTN_WHISPER_ALARM].IsCheck());
+    m_bRmlWhisperAlarmClicked = true;
+}
+
+void COptionWin::RmlToggleSlideHelp()
+{
+    m_aBtn[OW_BTN_SLIDE_HELP].SetCheck(!m_aBtn[OW_BTN_SLIDE_HELP].IsCheck());
+    m_bRmlSlideHelpClicked = true;
 }

--- a/src/source/UI/Windows/OptionWin.h
+++ b/src/source/UI/Windows/OptionWin.h
@@ -6,6 +6,7 @@
 #include "UI/Widgets/WinEx.h"
 #include "UI/Widgets/Button.h"
 #include "UI/Widgets/Slider.h"
+#include "UI/RmlBridge/RmlModelBinder.h"
 
 #define	OW_BTN_AUTO_ATTACK		0
 #define	OW_BTN_WHISPER_ALARM	1
@@ -17,6 +18,18 @@
 #define OW_SLD_RENDER_LV		1
 #define OW_SLD_MAX				2
 
+namespace Rml { class ElementDocument; }
+
+// RmlUi migration, Batch 2. NOTE: this window is currently unreachable in live play -- SysMenuWin's
+// Option button opens a different, already-modern window (SEASON3B::CNewUIOptionWindow via
+// g_pNewUISystem->Show(INTERFACE_OPTION)) instead of this one, confirmed by exhaustive grep (see
+// the migration plan's "Key finding" section). This migration is deliberately faithful anyway
+// (the checkboxes/sliders genuinely work) but does NOT rewire that routing -- retiring one of the
+// two option-window implementations is a separate product decision left for later.
+//
+// CWin::Create() now passes nTexID=-2 (was the default -1) -- see CSysMenuWin's identical header
+// comment for the #backdrop/m_winBack-geometry-only rationale, which applies here unchanged.
+// The 2 sliders are UI::RmlBridge::MakeDraggable's first production use (see OptionWin.cpp).
 class COptionWin : public CWin
 {
 protected:
@@ -31,11 +44,47 @@ public:
     void Create();
     void SetPosition(int nXCoord, int nYCoord);
     void Show(bool bShow);
-    bool CursorInWin(int nArea);
     void UpdateDisplay();
+
+    void RmlToggleAutoAttack();
+    void RmlToggleWhisperAlarm();
+    void RmlToggleSlideHelp();
+    void RmlClickClose() { m_bRmlCloseClicked = true; }
 
 protected:
     void PreRelease();
     void UpdateWhileActive(double dDeltaTick);
     void RenderControls();
+
+private:
+    struct OptionRmlModel
+    {
+        bool autoAttackChecked = false;
+        bool whisperAlarmChecked = false;
+        bool slideHelpChecked = false;
+        float volumeThumbLeft = 0.0f;
+        float renderThumbLeft = 0.0f;
+        Rml::String titleLabel;
+        Rml::String autoAttackLabel;
+        Rml::String whisperAlarmLabel;
+        Rml::String slideHelpLabel;
+        Rml::String closeLabel;
+        Rml::String volumeLabel;
+        Rml::String renderLabel;
+        Rml::String volumeValueText;
+        Rml::String renderValueText;
+    };
+    RmlModelBinder<OptionRmlModel> m_RmlBinder;
+    Rml::ElementDocument* m_pRmlDoc = nullptr;
+    bool m_bRmlAutoAttackClicked = false;
+    bool m_bRmlWhisperAlarmClicked = false;
+    bool m_bRmlSlideHelpClicked = false;
+    bool m_bRmlCloseClicked = false;
+
+    void SyncRmlModel();
+    // Shared by both sliders' UI::RmlBridge::MakeDraggable onMove callback -- clamps to the
+    // track's real travel distance and snaps to the slider's discrete step count, mirroring
+    // CSlider::Update's own drag-to-discrete-position math (Slider.cpp) for a hand-rolled RmlUi
+    // element instead of the legacy widget.
+    void OnSliderThumbDragged(int sliderIndex, float newLeftPx);
 };

--- a/src/source/UI/Windows/RememberPasswordPrompt.cpp
+++ b/src/source/UI/Windows/RememberPasswordPrompt.cpp
@@ -2,58 +2,108 @@
 #include "UI/Windows/RememberPasswordPrompt.h"
 
 #include "Audio/DSPlaySound.h"
+#include "Core/Input/Input.h"
 #include "I18N/All.h"
-#include "UI/NewUI/Dialogs/NewUICommonMessageBox.h"
+#include "Render/RmlUi/RmlUiRuntime.h"
+#include "UI/RmlBridge/RmlModelBinder.h"
+#include "UI/RmlBridge/RmlTheme.h"
+#include "Core/Utilities/StringUtils.h"
 
+#include <RmlUi/Core/DataModelHandle.h>
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/Event.h>
+#include <RmlUi/Core/Property.h>
+
+// RmlUi migration, Batch 2: previously built on the shared SEASON3B::CNewUICommonMessageBox /
+// g_MessageBox engine (~80 other unrelated dialogs also ride that singleton stack -- confirmed by
+// exhaustive grep before this rewrite). Bypassing it here for this one dialog is safe (none of
+// the other consumers reference this dialog or its state) and removes two couplings: the login
+// scene no longer needs to hand-pump g_MessageBox (see LoginScene.cpp's render path, which
+// already drives RmlUiRuntime unconditionally every frame regardless of scene), and CLoginWin no
+// longer gates its own input on the *entire* shared message-box stack being empty, just on this
+// dialog's own Pending state.
 namespace
 {
-UI::Login::RememberPasswordChoice g_Choice = UI::Login::RememberPasswordChoice::None;
+    struct PromptModel
+    {
+        Rml::String titleText;
+        Rml::String bodyText;
+        Rml::String okLabel;
+        Rml::String cancelLabel;
+    };
 
-// Two-button confirmation, modelled on the game's other OK/Cancel dialogs (e.g.
-// the guild-request box). A bold yellow "WARNING!!!" header sits above the
-// orange message body.
-class CRememberPasswordMsgBoxLayout : public SEASON3B::TMsgBoxLayout<SEASON3B::CNewUICommonMessageBox>
-{
-public:
-    bool SetLayout() override;
-    static SEASON3B::CALLBACK_RESULT OnOk(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam);
-    static SEASON3B::CALLBACK_RESULT OnCancel(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf& xParam);
-};
+    RmlModelBinder<PromptModel> g_Binder;
+    Rml::ElementDocument* g_pDoc = nullptr;
+    UI::Login::RememberPasswordChoice g_Choice = UI::Login::RememberPasswordChoice::None;
 
-bool CRememberPasswordMsgBoxLayout::SetLayout()
-{
-    SEASON3B::CNewUICommonMessageBox* pMsgBox = GetMsgBox();
-    if (pMsgBox == nullptr)
-        return false;
+    void Resolve(UI::Login::RememberPasswordChoice choice)
+    {
+        g_Choice = choice;
+        PlayBuffer(SOUND_CLICK01);
+        if (g_pDoc)
+            g_pDoc->Hide();
+    }
 
-    if (!pMsgBox->Create(SEASON3B::MSGBOX_COMMON_TYPE_OKCANCEL))
-        return false;
+    // Document/model created once, guarded the same way CLoginWin::Create() is -- see that
+    // class's header comment. This module has no owning class/Create() entry point of its own
+    // (it's plain free functions), so the guard lives here instead, called lazily from
+    // OpenRememberPasswordPrompt().
+    void EnsureCreated()
+    {
+        if (g_pDoc || !RmlUiRuntime::Instance().IsCreated())
+            return;
 
-    pMsgBox->AddMsg(I18N::Game::LoginSavePasswordWarningTitle, CLRDW_YELLOW, SEASON3B::MSGBOX_FONT_BOLD);
-    pMsgBox->AddMsg(I18N::Game::LoginSavePasswordWarningBody, CLRDW_ORANGE);
+        const bool modelCreated = g_Binder.Create(RmlUiRuntime::Instance().GetContext(), "remember_password_prompt",
+            [](Rml::DataModelConstructor& c, PromptModel& model)
+            {
+                c.Bind("title_text", &model.titleText);
+                c.Bind("body_text", &model.bodyText);
+                c.Bind("ok_label", &model.okLabel);
+                c.Bind("cancel_label", &model.cancelLabel);
 
-    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_USER_COMMON_OK);
-    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_USER_COMMON_CANCEL);
-    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnOk, SEASON3B::MSGBOX_EVENT_PRESSKEY_RETURN);
-    pMsgBox->AddCallbackFunc(CRememberPasswordMsgBoxLayout::OnCancel, SEASON3B::MSGBOX_EVENT_PRESSKEY_ESC);
-    return true;
-}
+                c.BindEventCallback("prompt_ok_click",
+                    [](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { Resolve(UI::Login::RememberPasswordChoice::Ok); });
+                c.BindEventCallback("prompt_cancel_click",
+                    [](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { Resolve(UI::Login::RememberPasswordChoice::Cancel); });
+            });
 
-SEASON3B::CALLBACK_RESULT CRememberPasswordMsgBoxLayout::OnOk(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf&)
-{
-    g_Choice = UI::Login::RememberPasswordChoice::Ok;
-    PlayBuffer(SOUND_CLICK01);
-    g_MessageBox->SendEvent(pOwner, SEASON3B::MSGBOX_EVENT_DESTROY);
-    return SEASON3B::CALLBACK_BREAK;
-}
+        if (modelCreated)
+            g_pDoc = UI::RmlBridge::LoadThemedDocument(RmlUiRuntime::Instance().GetContext(), "Data/Interface/RmlUi/remember_password_prompt.rml");
 
-SEASON3B::CALLBACK_RESULT CRememberPasswordMsgBoxLayout::OnCancel(SEASON3B::CNewUIMessageBoxBase* pOwner, const leaf::xstreambuf&)
-{
-    g_Choice = UI::Login::RememberPasswordChoice::Cancel;
-    PlayBuffer(SOUND_CLICK01);
-    g_MessageBox->SendEvent(pOwner, SEASON3B::MSGBOX_EVENT_DESTROY);
-    return SEASON3B::CALLBACK_BREAK;
-}
+        if (g_pDoc)
+        {
+            // Centered once at creation -- this document has no CWin/resize hook (see the
+            // migration plan's known-gap note), so a live resolution change while it's open
+            // would leave it off-center until the next open. Accepted, not solved here.
+            if (Rml::Element* panel = g_pDoc->GetElementById("panel"))
+            {
+                const Rml::Property* widthProp = panel->GetProperty("width");
+                const Rml::Property* heightProp = panel->GetProperty("height");
+                const float panelWidth = widthProp ? widthProp->Get<float>() : 0.0f;
+                const float panelHeight = heightProp ? heightProp->Get<float>() : 0.0f;
+                panel->SetProperty("left", std::to_string((CInput::Instance().GetScreenWidth() - panelWidth) / 2) + "px");
+                panel->SetProperty("top", std::to_string((CInput::Instance().GetScreenHeight() - panelHeight) / 2) + "px");
+            }
+        }
+    }
+
+    void SyncLabels()
+    {
+        auto syncLabel = [](Rml::String PromptModel::* field, const char* boundName, const wchar_t* text)
+        {
+            const std::string utf8 = StringUtils::WideToNarrow(text);
+            if (g_Binder.GetModel().*field != utf8)
+            {
+                g_Binder.GetModel().*field = utf8;
+                g_Binder.MarkDirty(boundName);
+            }
+        };
+        syncLabel(&PromptModel::titleText, "title_text", I18N::Game::LoginSavePasswordWarningTitle);
+        syncLabel(&PromptModel::bodyText, "body_text", I18N::Game::LoginSavePasswordWarningBody);
+        syncLabel(&PromptModel::okLabel, "ok_label", I18N::Game::OK);
+        syncLabel(&PromptModel::cancelLabel, "cancel_label", I18N::Game::Cancel);
+    }
 } // namespace
 
 namespace UI::Login
@@ -61,7 +111,12 @@ namespace UI::Login
 void OpenRememberPasswordPrompt()
 {
     g_Choice = RememberPasswordChoice::Pending;
-    SEASON3B::CreateMessageBox(MSGBOX_LAYOUT_CLASS(CRememberPasswordMsgBoxLayout));
+    EnsureCreated();
+    if (g_pDoc)
+    {
+        SyncLabels();
+        g_pDoc->Show();
+    }
 }
 
 RememberPasswordChoice RememberPasswordChoiceState()
@@ -72,5 +127,16 @@ RememberPasswordChoice RememberPasswordChoiceState()
 void ClearRememberPasswordChoice()
 {
     g_Choice = RememberPasswordChoice::None;
+}
+
+void Tick()
+{
+    if (g_Choice != RememberPasswordChoice::Pending)
+        return;
+
+    if (CInput::Instance().IsKeyDown(VK_RETURN))
+        Resolve(RememberPasswordChoice::Ok);
+    else if (CInput::Instance().IsKeyDown(VK_ESCAPE))
+        Resolve(RememberPasswordChoice::Cancel);
 }
 } // namespace UI::Login

--- a/src/source/UI/Windows/RememberPasswordPrompt.cpp
+++ b/src/source/UI/Windows/RememberPasswordPrompt.cpp
@@ -115,7 +115,11 @@ void OpenRememberPasswordPrompt()
     if (g_pDoc)
     {
         SyncLabels();
-        g_pDoc->Show();
+        // Modal (not the ModalFlag::None default): without it, the login document underneath
+        // stays fully clickable, and RmlUi's focus-follows-click default can bring it back in
+        // front of this dialog. Context::GetElementAtPoint (Context.cpp) confirms modal
+        // hit-testing skips every element whose owner document isn't the focused/modal one.
+        g_pDoc->Show(Rml::ModalFlag::Modal, Rml::FocusFlag::Document);
     }
 }
 

--- a/src/source/UI/Windows/RememberPasswordPrompt.h
+++ b/src/source/UI/Windows/RememberPasswordPrompt.h
@@ -21,4 +21,12 @@ namespace UI::Login
     // The current answer. The caller applies it and then clears it.
     RememberPasswordChoice RememberPasswordChoiceState();
     void ClearRememberPasswordChoice();
+
+    // Polls Enter/Esc while the dialog is Pending, resolving it the same way its OK/Cancel
+    // buttons do. Call once per frame from a caller that's still ticking while the dialog owns
+    // input (CLoginWin::UpdateWhileShow() does this today) -- RmlUi's own Keydown routing to an
+    // unfocused document (this dialog has no naturally-focused element) is unverified in this
+    // engine's integration, so this reuses the polling idiom CLoginWin's own OK/Cancel already
+    // uses rather than introducing that as a new, unverified event path.
+    void Tick();
 }

--- a/src/source/UI/Windows/ServerSelWin.cpp
+++ b/src/source/UI/Windows/ServerSelWin.cpp
@@ -39,6 +39,7 @@ CServerSelWin::~CServerSelWin()
 void CServerSelWin::Create()
 {
     CWin::Create(0, 0, -2);
+    SetMovable(false);
 
     m_iSelectServerBtnIndex = -1;
 
@@ -383,20 +384,6 @@ void CServerSelWin::ShowServerBtns()
     }
 
     m_winDescription.Show(CWin::m_bShow);
-}
-
-bool CServerSelWin::CursorInWin(int nArea)
-{
-    if (!CWin::m_bShow)
-        return false;
-
-    switch (nArea)
-    {
-    case WA_MOVE:
-        return false;
-    }
-
-    return CWin::CursorInWin(nArea);
 }
 
 void CServerSelWin::UpdateWhileActive(double dDeltaTick)

--- a/src/source/UI/Windows/ServerSelWin.h
+++ b/src/source/UI/Windows/ServerSelWin.h
@@ -54,7 +54,6 @@ public:
     void SetPosition(int nXCoord, int nYCoord);
     void UpdateDisplay();
     void Show(bool bShow);
-    bool CursorInWin(int nArea);
 
 protected:
     void PreRelease();

--- a/src/source/UI/Windows/SysMenuWin.cpp
+++ b/src/source/UI/Windows/SysMenuWin.cpp
@@ -18,6 +18,13 @@
 #include "Core/Utilities/Log/ErrorReport.h"
 #include "Core/Utilities/Log/muConsoleDebug.h"
 
+#include "Render/RmlUi/RmlUiRuntime.h"
+#include "UI/RmlBridge/RmlTheme.h"
+#include "Core/Utilities/StringUtils.h"
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/Event.h>
+
 #define	SMW_BTN_GAP		4
 
 extern EGameScene  SceneFlag;
@@ -34,7 +41,9 @@ CSysMenuWin::~CSysMenuWin()
 void CSysMenuWin::Create()
 {
     CInput rInput = CInput::Instance();
-    CWin::Create(rInput.GetScreenWidth(), rInput.GetScreenHeight());
+    // RmlUi migration, Batch 2: -2 (was the default -1) -- see this class's header comment.
+    CWin::Create(rInput.GetScreenWidth(), rInput.GetScreenHeight(), -2);
+    SetMovable(false);
 
     SImgInfo aiiBack[WE_BG_MAX] =
     {
@@ -68,6 +77,34 @@ void CSysMenuWin::Create()
         m_winBack.SetLine(10);
         break;
     }
+    m_bSelectServerEnabled = (SceneFlag == CHARACTER_SCENE);
+
+    // RmlUi migration, Batch 2 -- see this class's header comment. Guarded the same way
+    // CLoginWin::Create() is (CUIMng::RepositionSceneUI() re-runs Create() on resolution change).
+    if (!m_pRmlDoc && RmlUiRuntime::Instance().IsCreated())
+    {
+        const bool modelCreated = m_RmlBinder.Create(RmlUiRuntime::Instance().GetContext(), "sys_menu",
+            [this](Rml::DataModelConstructor& c, SysMenuRmlModel& model)
+            {
+                c.Bind("select_server_hidden", &model.selectServerHidden);
+                c.Bind("exit_game_label", &model.exitGameLabel);
+                c.Bind("select_server_label", &model.selectServerLabel);
+                c.Bind("option_label", &model.optionLabel);
+                c.Bind("close_label", &model.closeLabel);
+
+                c.BindEventCallback("sysmenu_exit_game_click",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickExitGame(); });
+                c.BindEventCallback("sysmenu_select_server_click",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickSelectServer(); });
+                c.BindEventCallback("sysmenu_option_click",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickOption(); });
+                c.BindEventCallback("sysmenu_close_click",
+                    [this](Rml::DataModelHandle, Rml::Event&, const Rml::VariantList&) { RmlClickClose(); });
+            });
+
+        if (modelCreated)
+            m_pRmlDoc = UI::RmlBridge::LoadThemedDocument(RmlUiRuntime::Instance().GetContext(), "Data/Interface/RmlUi/sys_menu.rml");
+    }
 
     SetPosition((rInput.GetScreenWidth() - m_winBack.GetWidth()) / 2,
         (rInput.GetScreenHeight() - m_winBack.GetHeight()) / 2);
@@ -76,6 +113,13 @@ void CSysMenuWin::Create()
 void CSysMenuWin::PreRelease()
 {
     m_winBack.Release();
+
+    // See CLoginMainWin::PreRelease()'s identical comment -- CUIMng::RemoveWinList() Release()s
+    // every window on every scene transition, and CWin's own Release() has no knowledge of
+    // m_pRmlDoc, so without this it can keep rendering into whatever scene comes next if this
+    // window happened to be open at the moment of transition.
+    if (m_pRmlDoc)
+        m_pRmlDoc->Hide();
 }
 
 void CSysMenuWin::SetPosition(int nXCoord, int nYCoord)
@@ -91,6 +135,54 @@ void CSysMenuWin::SetPosition(int nXCoord, int nYCoord)
     int nCloseBtnPosY = m_winBack.GetYPos() + m_winBack.GetHeight() - 52;
     m_aBtn[SMW_BTN_CLOSE].SetPosition(nBtnPosX, nCloseBtnPosY);
     m_aBtn[SMW_BTN_OPTION].SetPosition(nBtnPosX, nCloseBtnPosY - nBtnGap);
+
+    // RmlUi panel: positioned/sized to match m_winBack's real (screen-absolute, quantized-height)
+    // geometry, same idiom as CLoginWin::SetPosition. Buttons below are positioned panel-relative
+    // (not screen-absolute like the legacy CButtons above) -- their offsets only depend on
+    // m_winBack's width/height, not its screen position, so this is the same math as above minus
+    // m_winBack.GetXPos()/GetYPos().
+    if (m_pRmlDoc)
+    {
+        if (Rml::Element* panel = m_pRmlDoc->GetElementById("panel"))
+        {
+            panel->SetProperty("left", std::to_string(nXCoord) + "px");
+            panel->SetProperty("top", std::to_string(nYCoord) + "px");
+            panel->SetProperty("width", std::to_string(m_winBack.GetWidth()) + "px");
+            panel->SetProperty("height", std::to_string(m_winBack.GetHeight()) + "px");
+        }
+
+        // #panel_middle's own inset/size is pure RCSS now (base.rcss's .panel-middle rule,
+        // left/top/right/bottom) -- no C++ push needed, since RmlUi's layout engine correctly
+        // derives width/height from opposing edges on a position:absolute element (confirmed by
+        // reading LayoutDetails::BuildBoxWidth/BuildBoxHeight directly). An earlier version of
+        // this method pushed it explicitly out of unconfirmed caution about that; removed once
+        // actually confirmed unnecessary, since a theme-specific geometry value living in C++
+        // would mean any future theme needing a different inset couldn't express that without an
+        // engine change -- this project's stated goal is that themes need zero C++/recompilation.
+
+        const int nRelBtnPosX = (m_winBack.GetWidth() - m_aBtn[0].GetWidth()) / 2;
+        const int nRelBtnPosBaseTop = 33;
+        const char* aBtnIds[SMW_BTN_MAX] = { "btn_exit_game", "btn_select_server", "btn_option", "btn_close" };
+        for (int i = 0; i < SMW_BTN_OPTION; ++i)
+        {
+            if (Rml::Element* btn = m_pRmlDoc->GetElementById(aBtnIds[i]))
+            {
+                btn->SetProperty("left", std::to_string(nRelBtnPosX) + "px");
+                btn->SetProperty("top", std::to_string(nRelBtnPosBaseTop + i * nBtnGap) + "px");
+            }
+        }
+        const int nRelCloseBtnPosY = m_winBack.GetHeight() - 52;
+        if (Rml::Element* btn = m_pRmlDoc->GetElementById("btn_close"))
+        {
+            btn->SetProperty("left", std::to_string(nRelBtnPosX) + "px");
+            btn->SetProperty("top", std::to_string(nRelCloseBtnPosY) + "px");
+        }
+        if (Rml::Element* btn = m_pRmlDoc->GetElementById("btn_option"))
+        {
+            btn->SetProperty("left", std::to_string(nRelBtnPosX) + "px");
+            btn->SetProperty("top", std::to_string(nRelCloseBtnPosY - nBtnGap) + "px");
+        }
+    }
 }
 void CSysMenuWin::Show(bool bShow)
 {
@@ -99,30 +191,24 @@ void CSysMenuWin::Show(bool bShow)
     m_winBack.Show(bShow);
     for (int i = 0; i < SMW_BTN_MAX; ++i)
         m_aBtn[i].Show(bShow);
-}
 
-bool CSysMenuWin::CursorInWin(int nArea)
-{
-    if (!CWin::m_bShow)
-        return false;
-
-    switch (nArea)
+    if (m_pRmlDoc)
     {
-    case WA_MOVE:
-        return false;
+        if (bShow) { SyncRmlModel(); m_pRmlDoc->Show(); }
+        else       m_pRmlDoc->Hide();
     }
-
-    return CWin::CursorInWin(nArea);
 }
 
 void CSysMenuWin::UpdateWhileActive(double dDeltaTick)
 {
-    if (m_aBtn[SMW_BTN_GAME_END].IsClick())
+    if (m_aBtn[SMW_BTN_GAME_END].IsClick() || m_bRmlExitGameClicked)
     {
+        m_bRmlExitGameClicked = false;
         CUIMng::Instance().PopUpMsgWin(MESSAGE_GAME_END_COUNTDOWN);
     }
-    else if (m_aBtn[SMW_BTN_SERVER_SEL].IsClick())
+    else if ((m_aBtn[SMW_BTN_SERVER_SEL].IsClick() || m_bRmlSelectServerClicked) && m_bSelectServerEnabled)
     {
+        m_bRmlSelectServerClicked = false;
         g_ErrorReport.Write(L"> Menu - Join another server.");
         g_ErrorReport.WriteCurrentTime();
         LogOut = true;
@@ -133,14 +219,16 @@ void CSysMenuWin::UpdateWhileActive(double dDeltaTick)
         rUIMng.HideWin(this);
         rUIMng.HideWin(&rUIMng.m_CharSelMainWin);
     }
-    else if (m_aBtn[SMW_BTN_OPTION].IsClick())
+    else if (m_aBtn[SMW_BTN_OPTION].IsClick() || m_bRmlOptionClicked)
     {
+        m_bRmlOptionClicked = false;
         CUIMng& rUIMng = CUIMng::Instance();
         rUIMng.HideWin(this);
         g_pNewUISystem->Show(SEASON3B::INTERFACE_OPTION);
     }
-    else if (m_aBtn[SMW_BTN_CLOSE].IsClick())
+    else if (m_aBtn[SMW_BTN_CLOSE].IsClick() || m_bRmlCloseClicked)
     {
+        m_bRmlCloseClicked = false;
         CUIMng::Instance().HideWin(this);
     }
     else if (CInput::Instance().IsKeyDown(VK_ESCAPE))
@@ -152,6 +240,34 @@ void CSysMenuWin::UpdateWhileActive(double dDeltaTick)
 
 void CSysMenuWin::RenderControls()
 {
-    m_winBack.Render();
-    CWin::RenderButtons();
+    // m_winBack no longer renders -- RmlUi's #backdrop/#panel own 100% of this window's visuals
+    // (see this class's header comment). CWin::RenderButtons() also draws nothing visible since
+    // the legacy CButtons are unregistered from any bitmap/text draw path once RmlUi renders
+    // their labels; kept registered purely for redundant click detection like CLoginWin's.
+    SyncRmlModel();
+}
+
+void CSysMenuWin::SyncRmlModel()
+{
+    if (!m_pRmlDoc) return;
+
+    if (m_RmlBinder.GetModel().selectServerHidden != !m_bSelectServerEnabled)
+    {
+        m_RmlBinder.GetModel().selectServerHidden = !m_bSelectServerEnabled;
+        m_RmlBinder.MarkDirty("select_server_hidden");
+    }
+
+    auto syncLabel = [this](Rml::String SysMenuRmlModel::* field, const char* boundName, const wchar_t* text)
+    {
+        const std::string utf8 = StringUtils::WideToNarrow(text);
+        if (m_RmlBinder.GetModel().*field != utf8)
+        {
+            m_RmlBinder.GetModel().*field = utf8;
+            m_RmlBinder.MarkDirty(boundName);
+        }
+    };
+    syncLabel(&SysMenuRmlModel::exitGameLabel, "exit_game_label", I18N::Game::ExitGame);
+    syncLabel(&SysMenuRmlModel::selectServerLabel, "select_server_label", I18N::Game::SelectServer);
+    syncLabel(&SysMenuRmlModel::optionLabel, "option_label", I18N::Game::Option385);
+    syncLabel(&SysMenuRmlModel::closeLabel, "close_label", I18N::Game::Close388);
 }

--- a/src/source/UI/Windows/SysMenuWin.h
+++ b/src/source/UI/Windows/SysMenuWin.h
@@ -2,6 +2,7 @@
 
 #include "UI/Widgets/WinEx.h"
 #include "UI/Widgets/Button.h"
+#include "UI/RmlBridge/RmlModelBinder.h"
 
 #define	SMW_BTN_GAME_END	0
 #define	SMW_BTN_SERVER_SEL	1
@@ -9,6 +10,14 @@
 #define	SMW_BTN_CLOSE		3
 #define	SMW_BTN_MAX			4
 
+namespace Rml { class ElementDocument; }
+
+// RmlUi migration, Batch 2: CWin::Create() now passes nTexID=-2 (was the default -1, a real
+// full-screen alpha=128 black CWin::m_psprBg) -- the dim backdrop moves to RmlUi (#backdrop in
+// base.rcss), and m_winBack stays alive purely for its quantized-height geometry math
+// (Create()/SetLine()/GetWidth()/GetHeight()), never rendered. RmlUi renders 100% of this
+// window's visuals in every theme; the legacy CButtons stay registered (redundant, harmless
+// detection path) alongside Rml*Click*() methods mirroring CLoginWin's pattern.
 class CSysMenuWin : public CWin
 {
 protected:
@@ -22,10 +31,38 @@ public:
     void Create();
     void SetPosition(int nXCoord, int nYCoord);
     void Show(bool bShow);
-    bool CursorInWin(int nArea);
+
+    void RmlClickExitGame() { m_bRmlExitGameClicked = true; }
+    void RmlClickSelectServer() { if (m_bSelectServerEnabled) m_bRmlSelectServerClicked = true; }
+    void RmlClickOption() { m_bRmlOptionClicked = true; }
+    void RmlClickClose() { m_bRmlCloseClicked = true; }
 
 protected:
     void PreRelease();
     void UpdateWhileActive(double dDeltaTick);
     void RenderControls();
+
+private:
+    struct SysMenuRmlModel
+    {
+        // Login scene: Select Server is fully hidden, not just disabled -- CWinEx's shorter
+        // login-scene panel (SetLine(6)) leaves no real room for a 4th button slot, so a
+        // disabled-but-still-drawn button visibly collided with Option (see .hidden's comment in
+        // base.rcss). Character scene: shown normally.
+        bool selectServerHidden = false;
+        Rml::String exitGameLabel;
+        Rml::String selectServerLabel;
+        Rml::String optionLabel;
+        Rml::String closeLabel;
+    };
+    RmlModelBinder<SysMenuRmlModel> m_RmlBinder;
+    Rml::ElementDocument* m_pRmlDoc = nullptr;
+    bool m_bSelectServerEnabled = false;
+
+    bool m_bRmlExitGameClicked = false;
+    bool m_bRmlSelectServerClicked = false;
+    bool m_bRmlOptionClicked = false;
+    bool m_bRmlCloseClicked = false;
+
+    void SyncRmlModel();
 };


### PR DESCRIPTION
## Summary

Migrates the client's UI toward [RmlUi](https://github.com/mikke89/RmlUi) (HTML/CSS-driven UI middleware), coexisting with the three legacy UI frameworks rather than replacing them in one shot. Nothing from this line of work has merged to `main` yet — this PR is still entirely **Phase 0 (groundwork) through the Phase 1 pilot**, per the tracked migration plan; no later phase has been started.

Highlights:
- Custom `Rml::RenderInterface`/`SystemInterface` implementation targeting this engine's own `RHI::`/`GlobalUBO`, not RmlUi's bundled backends. Scissor support (`RHI::SetScissorEnabled`/`SetScissorRect`) is implemented for the GL backend, matching what's actually active on `main` today.
- Event-driven SDL input arbitration between RmlUi and the two legacy UI tiers.
- A data-driven, modder-pluggable theme system (`Data/Interface/RmlUi/themes/<name>/`, `config.ini`'s `[UI] RmlTheme`) — new themes need zero source changes for the common (sprite-free) case, and custom-image themes already work too (documented, including the real OZT/OZJ format constraint modders will hit).
- Two real themes for the login screen: `legacy` (original sprite/texture look) and `modern` (fully programmatic RCSS, no sprite dependency), proving the theme-switch mechanism itself. The login panel's background/frame chrome is now rendered entirely by RmlUi in both themes — an earlier per-theme flag that let `CWin` keep drawing part of it underneath was found to work against the migration's own goal and was removed.
- `UI::RmlBridge::MakeDraggable` — a reusable drag-to-move helper built on RmlUi's own native drag events, establishing the pattern that cross-window interaction behavior belongs in `UI::RmlBridge` as a shared primitive, not reimplemented per window.
- A dozen-plus real bugs found and fixed along the way (macro collisions, GL state leaks, input-arbitration side effects, an RCSS `pointer-events` inheritance trap, an unsupported `box-shadow` blur path, a render-ordering bug) — all cataloged in `docs/rmlui-ui-system/gotchas-and-patterns.md` for whoever migrates the next window.
- New documentation set: `docs/rmlui-ui-system/` (architecture, theming & modding, gotchas), linked from the top-level README.

Not yet done: a live in-game theme hot-swap (currently config.ini + relaunch), box-shadow support (needs RmlUi layer/filter compositing, deliberately out of scope for this MVP render interface), and a plain-PNG/JPG fallback for custom theme images (currently OZT/OZJ-only, matching the rest of the game's asset pipeline).

## Rollout Plan

Full detail in the tracked migration plan; status reflects this PR plus what's still ahead.

**Done (this PR):**
- [x] Phase 0 — groundwork: RHI scissor support (GL), vertex format conversion, render/system interface, build system, model/binder layer, adapter pattern convention, namespace convention.
- [x] Phase 0.8 — event-driven SDL input arbitration between RmlUi and the two legacy UI tiers.
- [x] Phase 1 pilot — loading screen (RmlUi-rendered) + login/character-select dialog (`CLoginWin`, hybrid legacy/RmlUi), with its chrome fully RmlUi-rendered in both themes.
- [x] Theming framework — pluggable theme folders, two real themes (`legacy`, `modern`) for the login screen, custom-sprite-theme workflow documented.
- [x] `UI::RmlBridge::MakeDraggable` — reusable drag-to-move interaction helper.
- [x] Documentation — architecture, theming/modding guide, bug catalog.

**Pending / follow-up (not in this PR):**
- [ ] Live in-game theme hot-swap (no relaunch) — needs `Context::RemoveDataModel`/`CSprite` teardown-and-rebuild lifecycle verified safe first.
- [ ] `box-shadow`/layer-filter compositing support in `RmlUiRenderInterface` (currently unimplemented; documented workaround in place).
- [ ] Plain PNG/JPG/BMP support for custom theme images — vendor `stb_image.h` as a fallback in `LoadTexture` when the OZT/OZJ lookup fails, specific to RmlUi-referenced assets.
- [ ] Phase 2 — generic message-box engine (`NewUICustomMessageBox`/`NewUICommonMessageBox`) + a first HUD slice (health/mana bars) to validate the binding layer against hot-path data.
- [ ] Phase 3 — full HUD migration (hotkeys, buffs, quick-command window).
- [ ] Phase 4 — 3D-in-UI render-to-texture bridge (item/character preview panels), a prerequisite for character info and inventory item-hover.
- [ ] Phase 5 — shared inventory/drag-drop controller (inventory, storage, shop, trade).
- [ ] A `themes/<name>/` folder + per-window RCSS for every future migrated window that wants theming (the mechanism is generic; only the login screen uses it today).

## Related issues

No linked issue — this is proactive infrastructure work for the ongoing RmlUi UI migration (see the plan and docs added in this PR for the full rationale).

## Checklist

- [x] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [x] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)) — every code commit in this branch was verified against a real `cmake --build` before committing.
- [ ] Changes are focused on one concern; the diff is as small as it reasonably can be. — Each individual commit is scoped to one concern (see commit log), but this PR bundles a full migration phase (20 commits: groundwork → pilot → theming → interaction helper → docs) rather than splitting into multiple PRs. Happy to split if you'd prefer smaller review units.
