### PR TITLE
Fix the crossbow visual desync: bow play speed and mid-walk position snap

### DIFF
--- a/docs/character-movement.md
+++ b/docs/character-movement.md
@@ -1,0 +1,71 @@
+# Character movement and animation timing
+
+How the client decides *where* a character is drawn and *how fast* its equipment
+animates. Both are easy to get subtly wrong, and both show up as the same
+symptom: a character that stutters, slides or teleports while it attacks.
+
+## Tile, destination and rendered position
+
+Every character carries three related but distinct notions of "where it is":
+
+| State | Meaning |
+| --- | --- |
+| `PositionX` / `PositionY` | The **logical map tile** the character occupies. Whole-tile integers. |
+| `TargetX` / `TargetY` | The **destination tile** of the last move packet. Can be a whole path away. |
+| `Object.Position[0/1]` | The **rendered world position**, smoothly interpolated between tile centres. |
+
+`MovePath` walks a character along its path one segment at a time. At the start
+of each segment it advances `PositionX/PositionY` to the *next* path tile, while
+`Object.Position` is still travelling toward it. So during a walk the logical
+tile is up to one tile ahead of the model, and the two only coincide for the
+single frame in which a segment completes.
+
+`TargetX/TargetY` is not a position at all — it is where the character has been
+told to go. Outside of an active walk it happens to equal `PositionX/PositionY`,
+because every packet that places a character sets both together.
+
+### Rule: never place a model from `TargetX/TargetY`
+
+When something has to put a model on a tile centre — an action packet, a stop, a
+teleport — it uses `PositionX/PositionY`:
+
+```cpp
+c->Object.Position[0] = ((c->PositionX) + 0.5f) * TERRAIN_SCALE;
+c->Object.Position[1] = ((c->PositionY) + 0.5f) * TERRAIN_SCALE;
+```
+
+The original S6 client's action handler used `TargetX/TargetY` here. When an
+action arrived mid-walk that flung the model to the far end of the path, and the
+next movement tick — which re-paths from `PositionX/PositionY` — dragged it back
+again. The result is the classic jump-then-slide: worst on ranged attacks, which
+fire between tiles far more often than melee swings do, and worst of all on a
+crossbow, whose longer draw makes the correction easy to see.
+
+Placing from `PositionX/PositionY` bounds the correction to at most one tile and
+keeps the rendered model, the logical tile and the path in agreement. It does not
+change any logical state, so the character still walks on to its destination if
+the server told it to.
+
+## Weapon animation follows the character's action
+
+A bow or crossbow is a separate model with its own animation, and its draw has to
+stay in step with the character's shot. `RenderCharacter` therefore copies the
+playback speed of the **action the character is currently playing** onto the
+weapon part:
+
+```cpp
+w->PlaySpeed = Models[MODEL_PLAYER].Actions[o->CurrentAction].PlaySpeed;
+```
+
+Elves fire from four different poses — on foot, on wings, on a Uniria/Dinorant
+mount and on a Fenrir — and each pose has a separate animation track per weapon
+type, plus a raised-shot ("_UP") variant of all of them. `IsBowAttackAction` and
+`IsRaisedBowAttackAction` in `Engine/Object/PlayerActionState.h` enumerate the
+full set; anything that special-cases bow fire should use them rather than
+spelling out action constants.
+
+The original S6 client hardcoded `PLAYER_ATTACK_BOW` as the playback-speed source
+for every bow action, and only recognised the on-foot and winged poses at all.
+That works only for as long as every bow action shares a play speed, and it left
+mounted, Fenrir and raised shots falling through to the catch-all branch, which
+pins the weapon at `PlaySpeed = 0` — a bow frozen mid-draw for the whole shot.

--- a/src/source/Engine/Object/PlayerActionState.h
+++ b/src/source/Engine/Object/PlayerActionState.h
@@ -15,6 +15,36 @@ namespace Engine::Object
         return currentAction >= PLAYER_ATTACK_FIST && currentAction <= PLAYER_RIDE_SKILL;
     }
 
+    // True while a player is firing an equipped bow or crossbow. Elves shoot from
+    // four different poses - on foot, on wings, on a Uniria/Dinorant mount and on a
+    // Fenrir - and each pose has a separate animation track per weapon type (see
+    // SetPlayerBow in WSclient.cpp), so the set is not contiguous in the enum.
+    inline bool IsBowAttackAction(int currentAction)
+    {
+        switch (currentAction)
+        {
+        case PLAYER_ATTACK_BOW:
+        case PLAYER_ATTACK_CROSSBOW:
+        case PLAYER_ATTACK_FLY_BOW:
+        case PLAYER_ATTACK_FLY_CROSSBOW:
+        case PLAYER_ATTACK_RIDE_BOW:
+        case PLAYER_ATTACK_RIDE_CROSSBOW:
+        case PLAYER_FENRIR_ATTACK_BOW:
+        case PLAYER_FENRIR_ATTACK_CROSSBOW:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    // True while a player is firing an equipped bow or crossbow in the raised-shot
+    // pose (see SetPlayerHighBow in WSclient.cpp). Same four poses as
+    // IsBowAttackAction, on the contiguous "_UP" animation tracks.
+    inline bool IsRaisedBowAttackAction(int currentAction)
+    {
+        return currentAction >= PLAYER_ATTACK_BOW_UP && currentAction <= PLAYER_ATTACK_RIDE_CROSSBOW_UP;
+    }
+
     // True while a player is sitting or holding a pose (PLAYER_SIT1 ..
     // PLAYER_POSE_FEMALE1). Used to keep these animations from being reset to the
     // stand pose when equipment or class changes.

--- a/src/source/Engine/Object/ZzzCharacter.cpp
+++ b/src/source/Engine/Object/ZzzCharacter.cpp
@@ -4816,13 +4816,8 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
                 || c->Skill == AT_SKILL_TRIPLE_SHOT_STR
                 || c->Skill == AT_SKILL_TRIPLE_SHOT_MASTERY)
                 Skill = 1;
-            if ((o->Type == MODEL_PLAYER &&
-                (o->CurrentAction == PLAYER_ATTACK_BOW || o->CurrentAction == PLAYER_ATTACK_CROSSBOW ||
-                    o->CurrentAction == PLAYER_ATTACK_FLY_BOW || o->CurrentAction == PLAYER_ATTACK_FLY_CROSSBOW ||
-                    o->CurrentAction == PLAYER_FENRIR_ATTACK_BOW || o->CurrentAction == PLAYER_FENRIR_ATTACK_CROSSBOW ||
-                    o->CurrentAction == PLAYER_ATTACK_RIDE_BOW || o->CurrentAction == PLAYER_ATTACK_RIDE_CROSSBOW)) ||
-                o->Type != MODEL_PLAYER && o->Kind == KIND_PLAYER
-                )
+            if ((o->Type == MODEL_PLAYER && Engine::Object::IsBowAttackAction(o->CurrentAction))
+                || (o->Type != MODEL_PLAYER && o->Kind == KIND_PLAYER))
             {
                 if (AT_SKILL_MULTI_SHOT != (c->Skill))
                     CreateArrows(c, o, NULL, FindHotKey((c->Skill)), Skill, (c->Skill));
@@ -4838,12 +4833,7 @@ void MoveCharacter(CHARACTER* c, OBJECT* o)
         {
             CHARACTER* tc = &CharactersClient[c->TargetCharacter];
             OBJECT* to = &tc->Object;
-            if (o->Type == MODEL_PLAYER &&
-                (o->CurrentAction == PLAYER_ATTACK_BOW || o->CurrentAction == PLAYER_ATTACK_CROSSBOW ||
-                    o->CurrentAction == PLAYER_ATTACK_FLY_BOW || o->CurrentAction == PLAYER_ATTACK_FLY_CROSSBOW ||
-                    o->CurrentAction == PLAYER_ATTACK_RIDE_BOW || o->CurrentAction == PLAYER_ATTACK_RIDE_CROSSBOW
-                    || o->CurrentAction == PLAYER_FENRIR_ATTACK_BOW || o->CurrentAction == PLAYER_FENRIR_ATTACK_CROSSBOW	//^ 펜릴 스킬 관련(요정 화살 나가게 하는 것)
-                    ))
+            if (o->Type == MODEL_PLAYER && Engine::Object::IsBowAttackAction(o->CurrentAction))
             {
                 if (AT_SKILL_MULTI_SHOT != (c->Skill))
                     CreateArrows(c, o, to, FindHotKey((c->Skill)), 0, (c->Skill));
@@ -10092,7 +10082,7 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
             PART_t* w = &c->Weapon[i];
             if (w->Type != -1 && w->Type != MODEL_BOLT && w->Type != MODEL_ARROWS && w->Type != MODEL_DARK_RAVEN_ITEM)
             {
-                if (o->CurrentAction == PLAYER_ATTACK_BOW || o->CurrentAction == PLAYER_ATTACK_CROSSBOW || o->CurrentAction == PLAYER_ATTACK_FLY_BOW || o->CurrentAction == PLAYER_ATTACK_FLY_CROSSBOW)
+                if (Engine::Object::IsBowAttackAction(o->CurrentAction) || Engine::Object::IsRaisedBowAttackAction(o->CurrentAction))
                 {
                     if (w->Type == MODEL_STINGER_BOW)
                     {
@@ -10102,7 +10092,13 @@ void RenderCharacter(CHARACTER* c, OBJECT* o, int Select)
                     {
                         w->CurrentAction = 0;
                     }
-                    w->PlaySpeed = Models[MODEL_PLAYER].Actions[PLAYER_ATTACK_BOW].PlaySpeed;
+                    // The weapon draws in step with the character, so it has to follow the
+                    // playback speed of the action the character is actually playing. Reading
+                    // PLAYER_ATTACK_BOW instead only happens to match while every bow action
+                    // shares a play speed, and the mounted, Fenrir and raised-shot actions used
+                    // to miss this branch entirely and fall through to the catch-all below,
+                    // which freezes the weapon at PlaySpeed 0 for the whole shot.
+                    w->PlaySpeed = Models[MODEL_PLAYER].Actions[o->CurrentAction].PlaySpeed;
                 }
                 else if (w->Type == MODEL_FLAIL)
                 {

--- a/src/source/Network/Server/WSclient.cpp
+++ b/src/source/Network/Server/WSclient.cpp
@@ -3499,8 +3499,15 @@ void ReceiveAction(const BYTE* ReceiveBuffer, int Size)
     c->Object.Angle[2] = ((float)(Data->Angle) - 1.f) * 45.f;
     c->Movement = false;
 
-    c->Object.Position[0] = c->TargetX * TERRAIN_SCALE + TERRAIN_SCALE * 0.5f;
-    c->Object.Position[1] = c->TargetY * TERRAIN_SCALE + TERRAIN_SCALE * 0.5f;
+    // Park the model on the tile the character occupies right now, not on the far end of
+    // the walk this action interrupted. c->TargetX/Y is the destination of the last move
+    // packet and can be a whole path away, while MovePath keeps c->PositionX/Y on the
+    // current path tile. Snapping to the destination teleported the model forward, and the
+    // next MoveMonsterClient tick - which re-paths from c->PositionX/Y - dragged it back,
+    // which is the jump-then-slide seen when an action lands mid-step. Ranged attacks hit
+    // this most often because they fire between tiles far more than melee swings do.
+    c->Object.Position[0] = ((c->PositionX) + 0.5f) * TERRAIN_SCALE;
+    c->Object.Position[1] = ((c->PositionY) + 0.5f) * TERRAIN_SCALE;
     switch (Data->Action)
     {
     case AT_STAND1:


### PR DESCRIPTION
## Summary

A [RaGEZONE thread](https://forum.ragezone.com/threads/crossbow-visual-desync-bug-s5-2-main-source.1270605/) describes an Elf stuttering/jumping when it starts a normal ranged attack while walking, most visible with a crossbow. Both defects it traces the symptom to are present verbatim in this source. This fixes both.

### 1. A fired bow ignored the action it was fired from

`RenderCharacter` copied `PLAYER_ATTACK_BOW`'s playback speed onto the weapon part for every bow action:

```cpp
if (o->CurrentAction == PLAYER_ATTACK_BOW || o->CurrentAction == PLAYER_ATTACK_CROSSBOW || o->CurrentAction == PLAYER_ATTACK_FLY_BOW || o->CurrentAction == PLAYER_ATTACK_FLY_CROSSBOW)
{
    ...
    w->PlaySpeed = Models[MODEL_PLAYER].Actions[PLAYER_ATTACK_BOW].PlaySpeed;
}
```

Two problems:

- The hardcoded source action only matches while every bow action happens to share a play speed. Today `SetPlayerAttackSpeed` gives all four the same value, so this is latent rather than visible — but it breaks the moment one of them is tuned separately.
- The condition only covers the on-foot and winged poses. `SetPlayerBow` and `SetPlayerHighBow` also produce the mounted (`PLAYER_ATTACK_RIDE_*`), Fenrir (`PLAYER_FENRIR_ATTACK_*`) and raised-shot (`*_UP`) bow actions. Those fell through to the catch-all branch at the end of the chain, which sets `w->PlaySpeed = 0` and `w->AnimationFrame = 0.001f` — the bow is frozen mid-draw for the entire shot. That one is visible today.

The play speed now comes from `o->CurrentAction`, and the branch is gated on the full set of bow-fire actions. `IsBowAttackAction` / `IsRaisedBowAttackAction` in `Engine/Object/PlayerActionState.h` hold that set; the two arrow-spawn conditions in `MoveCharacter` spelled the same eight constants out by hand and now use the predicate.

### 2. An action packet placed the model at the end of its walk

`ReceiveAction` placed the model at `TargetX/TargetY`:

```cpp
c->Movement = false;
c->Object.Position[0] = c->TargetX * TERRAIN_SCALE + TERRAIN_SCALE * 0.5f;
c->Object.Position[1] = c->TargetY * TERRAIN_SCALE + TERRAIN_SCALE * 0.5f;
```

`TargetX/TargetY` is the *destination* of the last move packet (`ReceiveCharacterMove`), which can be a whole path away — it is not the character's position. `MovePath` keeps the current tile in `PositionX/PositionY`. So an action landing mid-walk flung the model to the far end of the path, and the next `MoveMonsterClient` tick — which re-paths from `PositionX/PositionY` — dragged it back. That is the jump-then-slide.

It now places from `PositionX/PositionY`, which is what every other placement in `WSclient.cpp` already uses (lines 2100, 2580, 2740, 7965 …). The correction is bounded to at most one tile, and no logical state changes, so a character still walks on to its destination if the server told it to.

Ranged attacks hit this far more than melee swings because they fire between tiles more often, and a crossbow's longer draw makes the correction easy to see — which is why the thread found it with a crossbow.

### Deliberately not included

The thread goes on to a deferred-attack queue that holds the shot until the model reaches a tile boundary. That changes local input timing, needs cancellation handling for a target that dies/leaves range/is re-commanded, and its author reported it still only working ~90% of the time and introducing bow-attack teleports. It is a gameplay-timing change rather than a bug fix, so it is out of scope here.

### Testing

Both changed translation units compile clean (Linux, `-DENABLE_EDITOR=OFF`). The behaviour itself is visual and needs a running client with an Elf: walking normal attacks with a bow vs. a crossbow, then repeated with wings, a Uniria/Dinorant and a Fenrir, watched both locally and from a second client.

## Related issues

None.

## Checklist

- [x] I have read and followed [`docs/CODING_RULES.md`](docs/CODING_RULES.md).
- [x] I have built the project locally (see [`docs/build/README.md`](docs/build/README.md)).
- [x] Changes are focused on one concern; the diff is as small as it reasonably can be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqhNAaXndVGKwLubUXh68q

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqhNAaXndVGKwLubUXh68q)_