### PR TITLE
Fix invisible UI on character creation screen

### DIFF
--- a/src/source/Character/CharMakeWin.cpp
+++ b/src/source/Character/CharMakeWin.cpp
@@ -390,6 +390,7 @@ void CCharMakeWin::RequestCreateCharacter()
 void CCharMakeWin::RenderControls()
 {
     RenderCreateCharacter();
+    BeginBitmap();
     ::EnableAlphaTest();
 
     for (auto& sprite : m_asprBack)


### PR DESCRIPTION
## Summary

The character creation screen rendered the 3D character preview, but its panels, buttons, and text were invisible.

## Root cause

`RenderCreateCharacter()` switches to the 3D viewport and projection. `EndOpengl()` is empty, so that 3D projection remained active while the creation controls were rendered.

## Fix

Add one `BeginBitmap()` call immediately after `RenderCreateCharacter()` in `CCharMakeWin::RenderControls()` to restore the 2D viewport and projection before drawing the UI.

- File: `src/source/Character/CharMakeWin.cpp:393`
- Tested in the Season 6 client.