### PR TITLE
Android renderer baseline and backend seam (AH-1307)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ _deps
 /build/
 build-mingw/
 build-linux/
+/build-android/
+/build-x64/
 /cmake-build-debug/
 /cmake-build-release/
 /CMakeFiles/

--- a/ClientLibrary/MUnique.Client.Library.csproj
+++ b/ClientLibrary/MUnique.Client.Library.csproj
@@ -34,6 +34,16 @@
     <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
   </ItemGroup>
 
+  <!-- Spike AH-1118: linux-bionic (Android) is not a bundled AOT RID. Teach the SDK
+       that a NativeAOT runtime pack exists for it (nuget.org ships
+       Microsoft.NETCore.App.Runtime.NativeAOT.linux-bionic-arm64) and publish with
+       -p:PublishAotUsingRuntimePack=true. -->
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux-bionic'))">
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="10.0.11" />
+    <KnownRuntimePack Update="Microsoft.NETCore.App"
+                      RuntimePackRuntimeIdentifiers="linux-bionic-arm64;linux-bionic-arm;linux-bionic-x64;%(RuntimePackRuntimeIdentifiers)" />
+  </ItemGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
     <None Include="..\.editorconfig" Link=".editorconfig" />

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,88 @@
+plugins {
+    id "com.android.application"
+}
+
+def defaultNativeDir = new File(rootProject.projectDir, "../out/android/native")
+def nativeLibDir = providers.gradleProperty("muNativeLibDir")
+        .map { file(it) }
+        .getOrElse(defaultNativeDir)
+
+android {
+    namespace "com.alin.mumain"
+    compileSdk 36
+
+    defaultConfig {
+        applicationId "com.alin.mumain"
+        minSdk 28
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        ndk {
+            abiFilters "arm64-v8a", "x86_64"
+        }
+    }
+
+    buildTypes {
+        debug {
+            debuggable true
+        }
+        release {
+            minifyEnabled false
+            signingConfig signingConfigs.debug
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    sourceSets {
+        main {
+            java.srcDir "src/main/java"
+            java.srcDir "../../src/ThirdParty/SDL/android-project/app/src/main/java"
+            jniLibs.srcDir nativeLibDir
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging true
+        }
+    }
+}
+
+tasks.register("verifyNativeLibraries") {
+    doLast {
+        def supportedAbis = ["arm64-v8a", "x86_64"]
+        def requiredLibraries = [
+                "libmain.so",
+                "libGL.so",
+                "libcurl.so",
+                "libturbojpeg.so",
+                "libMUniqueClient.so"
+        ]
+        def foundAbi = false
+
+        supportedAbis.each { abi ->
+            def abiDir = new File(nativeLibDir, abi)
+            if (abiDir.isDirectory()) {
+                foundAbi = true
+                requiredLibraries.each { library ->
+                    if (!new File(abiDir, library).isFile()) {
+                        throw new GradleException("Missing ${abi}/${library} in ${nativeLibDir}")
+                    }
+                }
+            }
+        }
+
+        if (!foundAbi) {
+            throw new GradleException("No Android native libraries found in ${nativeLibDir}")
+        }
+    }
+}
+
+tasks.named("preBuild").configure {
+    dependsOn tasks.named("verifyNativeLibraries")
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:glEsVersion="0x00030000"
+        android:required="true" />
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+
+    <application
+        android:allowBackup="false"
+        android:hardwareAccelerated="true"
+        android:label="MuMain"
+        android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+
+        <activity
+            android:name=".LoadingActivity"
+            android:exported="true"
+            android:label="MuMain"
+            android:screenOrientation="landscape">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".MuMainActivity"
+            android:alwaysRetainTaskState="true"
+            android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
+            android:exported="false"
+            android:label="MuMain"
+            android:launchMode="singleInstance"
+            android:preferMinimalPostProcessing="true"
+            android:screenOrientation="landscape"
+            android:windowSoftInputMode="adjustPan" />
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/alin/mumain/LoadingActivity.java
+++ b/android/app/src/main/java/com/alin/mumain/LoadingActivity.java
@@ -1,0 +1,140 @@
+package com.alin.mumain;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.Gravity;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+
+/** Shows loading feedback while libmain's global constructors read game data. */
+public final class LoadingActivity extends Activity {
+    private static final long UPDATE_INTERVAL_MS = 500;
+    private static final int COPY_BUFFER_SIZE = 8192;
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private TextView status;
+    private long startMs;
+    private volatile boolean libraryLoaded;
+    private volatile String libraryError;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        startMs = System.currentTimeMillis();
+        setContentView(createLoadingView());
+
+        Thread loader = new Thread(this::loadEngine, "libmain-loader");
+        loader.start();
+        handler.postDelayed(this::updateStatus, UPDATE_INTERVAL_MS);
+    }
+
+    private LinearLayout createLoadingView() {
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setGravity(Gravity.CENTER);
+        root.setBackgroundColor(Color.rgb(8, 10, 20));
+
+        TextView title = new TextView(this);
+        title.setText("MU Online");
+        title.setTextColor(Color.rgb(224, 186, 92));
+        title.setTextSize(32);
+        title.setGravity(Gravity.CENTER);
+        root.addView(title);
+
+        ProgressBar spinner = new ProgressBar(this);
+        LinearLayout.LayoutParams spinnerParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        spinnerParams.topMargin = 48;
+        spinnerParams.gravity = Gravity.CENTER_HORIZONTAL;
+        root.addView(spinner, spinnerParams);
+
+        status = new TextView(this);
+        status.setText("Loading engine and game data…");
+        status.setTextColor(Color.WHITE);
+        status.setTextSize(14);
+        status.setGravity(Gravity.CENTER);
+        LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        statusParams.topMargin = 36;
+        root.addView(status, statusParams);
+        return root;
+    }
+
+    private void loadEngine() {
+        try {
+            prepareData();
+            System.loadLibrary("main");
+            libraryLoaded = true;
+        } catch (Throwable error) {
+            libraryError = error.getMessage();
+        }
+    }
+
+    private void updateStatus() {
+        long seconds = (System.currentTimeMillis() - startMs) / 1000;
+        if (libraryError != null) {
+            status.setText("Engine failed to load:\n" + libraryError);
+            return;
+        }
+        if (libraryLoaded) {
+            startActivity(new Intent(this, MuMainActivity.class));
+            finish();
+            return;
+        }
+
+        status.setText("Loading engine and game data… " + seconds + "s\n"
+                + "(first boot takes a minute or two)");
+        handler.postDelayed(this::updateStatus, UPDATE_INTERVAL_MS);
+    }
+
+    private void prepareData() {
+        try {
+            File filesDirectory = getFilesDir();
+            linkSharedDataWhenNeeded(filesDirectory);
+            copySharedConfigurationWhenNewer(filesDirectory);
+        } catch (Exception ignored) {
+            // MuMain reports missing data through MuError.log and its loading UI.
+        }
+    }
+
+    private void linkSharedDataWhenNeeded(File filesDirectory) throws Exception {
+        File internalData = new File(filesDirectory, "Data");
+        File sharedData = new File("/sdcard/mumain/Data");
+        if (!internalData.exists() && sharedData.exists()) {
+            android.system.Os.symlink(sharedData.getAbsolutePath(), internalData.getAbsolutePath());
+        }
+    }
+
+    private void copySharedConfigurationWhenNewer(File filesDirectory) throws Exception {
+        File sharedConfiguration = new File("/sdcard/mumain/config.ini");
+        File internalConfiguration = new File(filesDirectory, "config.ini");
+        if (!sharedConfiguration.exists()
+                || (internalConfiguration.exists()
+                && sharedConfiguration.lastModified() <= internalConfiguration.lastModified())) {
+            return;
+        }
+
+        try (FileInputStream input = new FileInputStream(sharedConfiguration);
+             FileOutputStream output = new FileOutputStream(internalConfiguration)) {
+            byte[] buffer = new byte[COPY_BUFFER_SIZE];
+            int bytesRead;
+            while ((bytesRead = input.read(buffer)) > 0) {
+                output.write(buffer, 0, bytesRead);
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/alin/mumain/MuMainActivity.java
+++ b/android/app/src/main/java/com/alin/mumain/MuMainActivity.java
@@ -1,0 +1,177 @@
+package com.alin.mumain;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.Gravity;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import org.libsdl.app.SDLActivity;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.RandomAccessFile;
+
+/** SDL activity for the MuMain Android client. */
+public final class MuMainActivity extends SDLActivity {
+    private static final long UPDATE_INTERVAL_MS = 500;
+    private static final int MAX_LOG_BYTES = 65_536;
+    private static final int MIN_RENDER_WIDTH = 640;
+    private static final int MIN_RENDER_HEIGHT = 360;
+    private static final float NATIVE_RENDER_SCALE = 1.0f;
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private LinearLayout overlay;
+    private TextView status;
+    private long startMs;
+    private long logBaseOffset;
+
+    @Override
+    protected String[] getLibraries() {
+        return new String[] {"main"};
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        applyRenderScale();
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
+        startMs = System.currentTimeMillis();
+        File log = new File(getFilesDir(), "MuError.log");
+        logBaseOffset = log.exists() ? log.length() : 0;
+        createLoadingOverlay();
+        handler.postDelayed(this::pollBootLog, UPDATE_INTERVAL_MS);
+    }
+
+    private void applyRenderScale() {
+        float scale = readRenderScale();
+        if (scale <= 0.05f || scale >= 0.999f || mSurface == null) {
+            return;
+        }
+
+        android.util.DisplayMetrics metrics = new android.util.DisplayMetrics();
+        getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
+        int width = Math.max(MIN_RENDER_WIDTH, (int) (metrics.widthPixels * scale));
+        int height = Math.max(MIN_RENDER_HEIGHT, (int) (metrics.heightPixels * scale));
+        mSurface.getHolder().setFixedSize(width, height);
+        android.util.Log.i("MuMainGL", "render scale " + scale + " -> " + width + "x" + height
+                + " (native " + metrics.widthPixels + "x" + metrics.heightPixels + ")");
+    }
+
+    private float readRenderScale() {
+        File scaleFile = new File(getFilesDir(), "render_scale.txt");
+        if (!scaleFile.exists()) {
+            return NATIVE_RENDER_SCALE;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(scaleFile))) {
+            String value = reader.readLine();
+            return value == null || value.trim().isEmpty()
+                    ? NATIVE_RENDER_SCALE
+                    : Float.parseFloat(value.trim());
+        } catch (Exception ignored) {
+            return NATIVE_RENDER_SCALE;
+        }
+    }
+
+    private void createLoadingOverlay() {
+        overlay = new LinearLayout(this);
+        overlay.setOrientation(LinearLayout.VERTICAL);
+        overlay.setGravity(Gravity.CENTER);
+        overlay.setBackgroundColor(Color.argb(230, 8, 10, 20));
+        overlay.setOnClickListener(view -> removeOverlay());
+
+        TextView title = new TextView(this);
+        title.setText("MU Online");
+        title.setTextColor(Color.rgb(224, 186, 92));
+        title.setTextSize(30);
+        title.setGravity(Gravity.CENTER);
+        overlay.addView(title);
+
+        ProgressBar spinner = new ProgressBar(this);
+        LinearLayout.LayoutParams spinnerParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        spinnerParams.topMargin = 48;
+        spinnerParams.gravity = Gravity.CENTER_HORIZONTAL;
+        overlay.addView(spinner, spinnerParams);
+
+        status = new TextView(this);
+        status.setText("Starting engine…");
+        status.setTextColor(Color.WHITE);
+        status.setTextSize(14);
+        status.setGravity(Gravity.CENTER);
+        LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        statusParams.topMargin = 36;
+        overlay.addView(status, statusParams);
+
+        addContentView(overlay, new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT));
+    }
+
+    private void pollBootLog() {
+        if (overlay == null) {
+            return;
+        }
+
+        String line = lastLogLineThisRun();
+        long seconds = (System.currentTimeMillis() - startMs) / 1000;
+        if (line != null && line.contains("Login Scene init success")) {
+            removeOverlay();
+            return;
+        }
+
+        String shown = line == null || line.isEmpty() ? "Loading game data…" : line;
+        if (shown.length() > 64) {
+            shown = shown.substring(0, 64);
+        }
+        status.setText("Loading — " + seconds + "s\n" + shown);
+        handler.postDelayed(this::pollBootLog, UPDATE_INTERVAL_MS);
+    }
+
+    private void removeOverlay() {
+        if (overlay != null && overlay.getParent() instanceof ViewGroup) {
+            ((ViewGroup) overlay.getParent()).removeView(overlay);
+        }
+        overlay = null;
+    }
+
+    private String lastLogLineThisRun() {
+        File log = new File(getFilesDir(), "MuError.log");
+        if (!log.exists()) {
+            return null;
+        }
+
+        try (RandomAccessFile reader = new RandomAccessFile(log, "r")) {
+            long length = reader.length();
+            if (length <= logBaseOffset) {
+                return null;
+            }
+
+            reader.seek(logBaseOffset);
+            int size = (int) Math.min(length - logBaseOffset, MAX_LOG_BYTES);
+            byte[] buffer = new byte[size];
+            reader.readFully(buffer);
+            String[] lines = new String(buffer, "UTF-8").split("\r?\n");
+            for (int index = lines.length - 1; index >= 0; index--) {
+                String candidate = lines[index].trim();
+                if (!candidate.isEmpty()) {
+                    return candidate;
+                }
+            }
+        } catch (Exception ignored) {
+            // The next polling interval retries while the engine writes the log.
+        }
+        return null;
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.application" version "8.7.3" apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=false
+android.nonTransitiveRClass=true
+android.suppressUnsupportedCompileSdk=36

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MuMainAndroid"
+include ":app"

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -17,6 +17,15 @@ A native Linux build produces a real, playable client: the engine plus the
 | Rider | [linux/rider.md](linux/rider.md) |
 | VS Code | [linux/vscode.md](linux/vscode.md) |
 
+### Android
+
+The Android port builds the native client in Linux/WSL and packages it with the
+Android SDK on Windows.
+
+| Setup | Guide |
+|-------|-------|
+| Command line | [android/console.md](android/console.md) |
+
 ### Windows
 
 The Windows client can be built natively on Windows, or cross-compiled from
@@ -33,8 +42,7 @@ Linux/WSL with MinGW-w64.
 
 ### Planned
 
-`android/` and `iOS/` are placeholders for future ports; the engine is not yet
-buildable for them. See the per-platform notes when that work lands.
+`iOS/` is a placeholder for a future port.
 
 ## Supported targets
 
@@ -43,6 +51,7 @@ buildable for them. See the per-platform notes when that work lands.
 | Linux | x64 | on / off | `MUnique.Client.Library.so` (linux-x64 AOT) | Full client |
 | Windows | x64 | on / off | `MUnique.Client.Library.dll` (win-x64 AOT) | Full client |
 | Windows | x86 | on / off | `MUnique.Client.Library.dll` (win-x86 AOT) | Full client |
+| Android | arm64 / x64 | off | `MUnique.Client.Library.so` (linux-bionic AOT) | Experimental client |
 | Linux | x86 | - | none | Not supported (see below) |
 
 CI builds every supported row: see [windows-build.yml](../../.github/workflows/windows-build.yml)

--- a/docs/build/android/console.md
+++ b/docs/build/android/console.md
@@ -1,0 +1,85 @@
+# Android command-line build
+
+The Android client is an arm64/x86_64 SDL application. The current baseline
+uses MuMain's OpenGL renderer through GL4ES; the tracked renderer selector keeps
+that choice explicit while the SDL_GPU/Vulkan backend is developed.
+
+## Requirements
+
+- Linux or WSL with CMake 3.25+, Ninja, Git, `patchelf`, and .NET SDK 10 with
+  Native AOT support.
+- Android NDK r28 or newer.
+- Windows Android SDK platform 36, Android Studio's JBR, and PowerShell for APK
+  packaging. The Gradle wrapper is supplied by the SDL submodule.
+- Repository submodules initialized with `git submodule update --init --recursive`.
+
+## Build native libraries
+
+From Linux/WSL:
+
+```bash
+export ANDROID_NDK_ROOT=/path/to/android-ndk-r28b
+tools/android/build-native.sh
+```
+
+The script checks out pinned gl4es, curl, and libjpeg-turbo revisions under
+`out/android/dependencies`, builds them for `arm64-v8a`, builds MuMain and the
+`linux-bionic-arm64` NativeAOT network library, strips the package copies, and
+writes them to `out/android/native/arm64-v8a`.
+
+To build the emulator ABI as well:
+
+```bash
+MU_ANDROID_ABI=x86_64 tools/android/build-native.sh
+```
+
+Generated dependencies, build trees, and binaries stay under `out/android` and
+are not committed.
+
+## Package and install
+
+From Windows PowerShell in the same checkout:
+
+```powershell
+tools\android\package-apk.ps1
+adb install -r out\android\MuMain-debug.apk
+```
+
+`adb install -r` is important during development because it preserves the
+existing account configuration and the large game-data directory. A first-time
+debug install needs `Data/` and `config.ini` copied into the application's
+internal `files` directory before launch:
+
+```bash
+tar -C src/bin -cf - Data config.ini | \
+  adb shell run-as com.alin.mumain sh -c 'cd files && tar -xf -'
+```
+
+The APK logs `Renderer backend = OpenGL` to `MuError.log`. Android logcat also
+identifies GL4ES and the physical GPU. Desktop and Linux builds continue to use
+OpenGL.
+
+## Fold4 performance baseline
+
+Use the Galaxy Z Fold4 unfolded in landscape at native render scale `1.0`.
+Select production character `alin1033` (Dark Wizard, level 215), connect at the
+saved Lorencia location `(187, 124)`, and leave the camera and character
+untouched after the map settles. Start a 120-second capture from Windows:
+
+```powershell
+tools\android\capture-performance.ps1 -DurationSeconds 120
+```
+
+The 2026-08-25 GL4ES baseline in this scene sustained about 1.3 FPS with
+752-803 ms frames. `RenderJoints` alone measured 392-446 ms. A diagnostic build
+with joints disabled averaged 7.7 FPS and 127 ms frames, which proved that the
+joint/tail path is dominant but also that removing one pass cannot reach the
+16.7 ms target. A clean-build recapture on the same date successfully traversed
+login, character select, and the production connection; ten settled in-game
+samples averaged 1.93 FPS (1.2-2.5 FPS) with 419-474 ms average render sections.
+
+Every renderer comparison must record the APK hash, backend, render scale,
+device orientation, per-pass CPU time, draw count, uploaded bytes, total frame
+time, and the first 120 seconds after warm-up. The Vulkan release gate is
+sustained 60 FPS with p95 frame time at or below 16.7 ms; loading and network
+transitions are excluded.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,23 @@ endif()
 # Editor mode option (for admin builds)
 option(ENABLE_EDITOR "Enable editor features for admin builds" OFF)
 
+# Renderer selection is explicit even while OpenGL is the only completed
+# backend. AH-1308 replaces the guarded SDL_GPU branch with the first Vulkan
+# implementation; keeping the choice in CMake now prevents platform bootstrap
+# code from silently deciding which renderer is active.
+set(MU_RENDER_BACKEND "OpenGL" CACHE STRING "Renderer backend (OpenGL or SDL_GPU)")
+set_property(CACHE MU_RENDER_BACKEND PROPERTY STRINGS OpenGL SDL_GPU)
+if(NOT MU_RENDER_BACKEND STREQUAL "OpenGL" AND
+   NOT MU_RENDER_BACKEND STREQUAL "SDL_GPU")
+  message(FATAL_ERROR "Unknown MU_RENDER_BACKEND='${MU_RENDER_BACKEND}'. "
+    "Choose OpenGL or SDL_GPU.")
+endif()
+if(MU_RENDER_BACKEND STREQUAL "SDL_GPU")
+  message(FATAL_ERROR "MU_RENDER_BACKEND=SDL_GPU is reserved for the Vulkan "
+    "backend landing in AH-1308; use OpenGL for the reproducible baseline.")
+endif()
+message(STATUS "MuMain renderer backend: ${MU_RENDER_BACKEND}")
+
 # ---------------------------------------------------------------------------
 # Engine/game code -> static library (libMuClient); MuMain -> thin executable.
 #
@@ -171,6 +188,7 @@ endif()
 # links MuClient inherit them automatically.
 add_library(MuClient STATIC ${MU_CLIENT_SOURCES})
 target_compile_features(MuClient PUBLIC cxx_std_20)
+target_compile_definitions(MuClient PUBLIC MU_RENDER_BACKEND_OPENGL=1)
 
 # The in-game shop downloader uses libcurl off Windows (issue #462); on Windows
 # it uses the OS WinINet/urlmon stack and needs no extra dependency here.
@@ -326,6 +344,36 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     OpenGL::GL
     OpenGL::GLU
     ${GLEW_LIBRARY}
+    ${TURBOJPEG_LIBRARY}
+  )
+endif()
+
+if(ANDROID)
+  # Android baseline dependencies are built by tools/android/build-native.sh.
+  # Keep their locations as cache inputs instead of smuggling absolute paths
+  # through CMAKE_CXX_FLAGS/CMAKE_*_LINKER_FLAGS as the original spike did.
+  set(MU_ANDROID_GL4ES_ROOT "" CACHE PATH
+      "gl4es source root containing include/ for the Android OpenGL baseline")
+  set(MU_ANDROID_GL4ES_LIBRARY "" CACHE FILEPATH
+      "Android libGL.so produced by gl4es (SONAME must be libGL.so)")
+
+  if(NOT MU_ANDROID_GL4ES_ROOT OR
+     NOT EXISTS "${MU_ANDROID_GL4ES_ROOT}/include/GL/gl.h")
+    message(FATAL_ERROR "Set MU_ANDROID_GL4ES_ROOT to the gl4es source root. "
+      "tools/android/build-native.sh configures this automatically.")
+  endif()
+  if(NOT MU_ANDROID_GL4ES_LIBRARY OR
+     NOT EXISTS "${MU_ANDROID_GL4ES_LIBRARY}")
+    message(FATAL_ERROR "Set MU_ANDROID_GL4ES_LIBRARY to the staged libGL.so. "
+      "tools/android/build-native.sh configures this automatically.")
+  endif()
+
+  find_library(TURBOJPEG_LIBRARY NAMES turbojpeg REQUIRED)
+  target_include_directories(MuClient PUBLIC "${MU_ANDROID_GL4ES_ROOT}/include")
+  target_compile_definitions(MuClient PUBLIC GLEW_NO_GLU)
+  target_compile_options(MuClient PUBLIC -Wno-c++11-narrowing)
+  target_link_libraries(MuClient PUBLIC
+    ${MU_ANDROID_GL4ES_LIBRARY}
     ${TURBOJPEG_LIBRARY}
   )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -213,10 +213,11 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "iOS")
 elseif (APPLE)
   set(MU_APP_ENTRY "source/App/Platform/macOS/main.mm")
 elseif (ANDROID)
-  message(FATAL_ERROR "Android is not a supported build target yet: it needs "
-    "an OpenGL ES renderer port, and its entry point is android_main via "
-    "native_app_glue built as a shared library, not an executable. When that "
-    "work starts, add source/App/Platform/Android/ and replace this branch.")
+  # AH-1118 spike: Android entry (SDL3 SDL_main glue + gl4es env + chdir to the
+  # app's internal storage) plus the shared bootstrap from Winmain.cpp.
+  set(MU_APP_ENTRY
+    "source/App/Platform/Android/main.cpp"
+    "source/App/Platform/Windows/Winmain.cpp")
 elseif (UNIX)
   # Linux entry (main.cpp) plus the shared bootstrap/game-loop from Winmain.cpp,
   # which now compiles off Windows (issue #462). main() calls into it.
@@ -229,9 +230,18 @@ else()
     "and a branch above.")
 endif()
 
+if (ANDROID)
+  # AH-1118 spike: Android apps are a shared library loaded by SDLActivity, not
+  # an executable. Undefined symbols stay permitted at link (curl is stubbed at
+  # packaging time).
+  list(TRANSFORM MU_APP_ENTRY PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+  add_library(Main SHARED ${MU_APP_ENTRY})
+  set_target_properties(Main PROPERTIES OUTPUT_NAME main PREFIX "lib")
+else()
 add_executable(Main
   "${CMAKE_CURRENT_SOURCE_DIR}/${MU_APP_ENTRY}"
 )
+endif()
 target_compile_features(Main PUBLIC cxx_std_20)
 target_link_libraries(Main PRIVATE MuClient::MuClient)
 
@@ -327,7 +337,9 @@ endif()
 # linux-x64 .so (a Windows dotnet.exe cannot cross-OS AOT). Everything else
 # (Windows/MinGW targets, including from WSL) prefers dotnet.exe so the win-*
 # AOT build works. Pick accordingly.
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR ANDROID)
+  # AH-1118 spike: Android cross-builds run on a Linux host; the host dotnet
+  # drives both the ResxGen host tool and the linux-bionic AOT publish.
   find_program(DOTNET_EXECUTABLE dotnet)
   if (NOT DOTNET_EXECUTABLE)
     find_program(DOTNET_EXECUTABLE dotnet.exe)
@@ -542,7 +554,7 @@ if (DOTNET_EXECUTABLE)
   # 1. Define the output path. Native AOT emits a platform-native shared
   # library: .dll on Windows, .so on Linux (the runtime client dlopen's it by
   # this name).
-  if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR ANDROID)
     set(DOTNET_LIB_NAME "MUnique.Client.Library.so")
   else()
     set(DOTNET_LIB_NAME "MUnique.Client.Library.dll")
@@ -582,7 +594,27 @@ if (DOTNET_EXECUTABLE)
   # Override environment variables to avoid issues with umlauts in Windows username
   # Determine the runtime identifier from the target OS and pointer width. Native
   # AOT has no linux-x86 target, so 32-bit is Windows-only.
-  if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  if (ANDROID)
+    # AH-1118 spike: Native AOT for Android via the linux-bionic RIDs, driven by
+    # the NDK toolchain (proven standalone; see task notes). ANDROID_NDK is set
+    # by the NDK's CMake toolchain file.
+    if (ANDROID_ABI STREQUAL "x86_64")
+      set(DOTNET_RID "linux-bionic-x64")
+      set(_NDK_CLANG "x86_64-linux-android28-clang")
+    else()
+      set(DOTNET_RID "linux-bionic-arm64")
+      set(_NDK_CLANG "aarch64-linux-android29-clang")
+    endif()
+    set(DOTNET_PLATFORM "AnyCPU")
+    set(_NDK_LLVM "${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/bin")
+    set(DOTNET_EXTRA_ARGS
+        "-p:ci=true"
+        "-p:PublishAotUsingRuntimePack=true"
+        "-p:CppCompilerAndLinker=${_NDK_LLVM}/${_NDK_CLANG}"
+        "-p:LinkerFlavor=lld"
+        "-p:ObjCopyName=${_NDK_LLVM}/llvm-objcopy")
+    message(STATUS ".NET Client Library will build for ${DOTNET_RID} (Android ${ANDROID_ABI})")
+  elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(DOTNET_RID "linux-x64")
     set(DOTNET_PLATFORM "x64")
     # The PreBuild XSLT step regenerates files using Windows-style backslash

--- a/src/source/App/Platform/Android/main.cpp
+++ b/src/source/App/Platform/Android/main.cpp
@@ -34,6 +34,7 @@ int main(int /*argc*/, char* /*argv*/[])
     setenv("LIBGL_LOGSHADERERROR", "1", 1);
     setenv("LIBGL_DBGSHADERCONV", "1", 1);
 
+
     // The engine's font discovery probes desktop Linux paths; point it at the
     // Android system font so UI text renders.
     setenv("MU_FONT", "/system/fonts/Roboto-Regular.ttf", 0);

--- a/src/source/App/Platform/Android/main.cpp
+++ b/src/source/App/Platform/Android/main.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdlib>
 #include <unistd.h>
+#include <sys/system_properties.h>
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
@@ -26,6 +27,17 @@ extern "C" __attribute__((constructor(101))) void mu_android_early_chdir(void)
 
 int main(int /*argc*/, char* /*argv*/[])
 {
+    // Inside an emulator, GL calls cross a per-call transport whose round trips
+    // dominate; the mapped streaming writes trade one call for two there, so
+    // keep the plain SubData path. Real devices keep the stall-free mapping.
+    {
+        char qemu[PROP_VALUE_MAX] = {0};
+        __system_property_get("ro.kernel.qemu", qemu);
+        if (qemu[0] == '1')
+        {
+            setenv("MU_STREAM_MAP", "0", 1);
+        }
+    }
     // gl4es: back the desktop-GL API with an ES2 context it finds itself.
     setenv("LIBGL_ES", "2", 1);
     setenv("LIBGL_GL", "21", 1);
@@ -39,6 +51,7 @@ int main(int /*argc*/, char* /*argv*/[])
     // Android system font so UI text renders.
     setenv("MU_FONT", "/system/fonts/Roboto-Regular.ttf", 0);
 
+
     // The engine loads Data/ and config.ini relative to the working directory;
     // point it at the app's internal storage, where the data was pushed.
     const char* internal = SDL_GetAndroidInternalStoragePath();
@@ -46,6 +59,12 @@ int main(int /*argc*/, char* /*argv*/[])
     {
         chdir(internal);
     }
+
+    // Without the trap, Android's back gesture minimizes the game mid-session;
+    // trapped, it arrives as SDL_SCANCODE_AC_BACK for the engine to handle.
+    // (SDL_SetHint, not setenv: SDLActivity queries this through the hint
+    // table, which the environment does not reach here.)
+    SDL_SetHint(SDL_HINT_ANDROID_TRAP_BACK_BUTTON, "1");
 
     return WinMain(nullptr, nullptr, nullptr, SW_SHOW);
 }

--- a/src/source/App/Platform/Android/main.cpp
+++ b/src/source/App/Platform/Android/main.cpp
@@ -1,0 +1,50 @@
+// Android entry point (AH-1118 spike).
+//
+// Mirrors the Linux entry: the portable bootstrap lives in Winmain.cpp and its
+// WinMain is a plain function off Windows. SDL3's SDL_main glue provides the
+// JNI bridge from SDLActivity; gl4es supplies desktop GL over the ES context.
+#include "Core/Platform/WinCompat.h"
+
+#include <cstdlib>
+#include <unistd.h>
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+#include <SDL3/SDL_system.h>
+
+int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nCmdShow);
+
+// The engine's global constructors (e.g. CMixRecipeMgr) read game data relative
+// to the working directory, and they run while libmain.so is still being
+// dlopen'd -- before main() and before any Java-side hook can act. An explicit
+// low-numbered constructor priority runs before every default-priority C++
+// global initializer in this library, so the chdir happens first.
+extern "C" __attribute__((constructor(101))) void mu_android_early_chdir(void)
+{
+    chdir("/data/data/com.alin.mumain/files");
+}
+
+int main(int /*argc*/, char* /*argv*/[])
+{
+    // gl4es: back the desktop-GL API with an ES2 context it finds itself.
+    setenv("LIBGL_ES", "2", 1);
+    setenv("LIBGL_GL", "21", 1);
+    // Diagnostics for the rendering-compat pass: surface shader conversion
+    // failures and GL errors in logcat.
+    setenv("LIBGL_LOGSHADERERROR", "1", 1);
+    setenv("LIBGL_DBGSHADERCONV", "1", 1);
+
+    // The engine's font discovery probes desktop Linux paths; point it at the
+    // Android system font so UI text renders.
+    setenv("MU_FONT", "/system/fonts/Roboto-Regular.ttf", 0);
+
+    // The engine loads Data/ and config.ini relative to the working directory;
+    // point it at the app's internal storage, where the data was pushed.
+    const char* internal = SDL_GetAndroidInternalStoragePath();
+    if (internal != nullptr)
+    {
+        chdir(internal);
+    }
+
+    return WinMain(nullptr, nullptr, nullptr, SW_SHOW);
+}

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -1743,6 +1743,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
     // Fullscreen is requested via an SDL window flag below; SDL handles the
     // display-mode change and restores it on teardown.
     g_ErrorReport.Write(L"> Screen size = %d x %d.\r\n", WindowWidth, WindowHeight);
+    g_ErrorReport.Write(L"> Renderer backend = %hs.\r\n", RHI::GetConfiguredBackendName());
 
     g_hInst = hInstance;
 

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -242,10 +242,34 @@ static void MaybeCaptureFrame()
 // SDL_GL_SwapWindow instead of the Win32 ::SwapBuffers (issue #442). This is the one place all
 // of this file's/LoadingScene.cpp's/SceneManager.cpp's/UIMng.cpp's present call sites funnel
 // through, so branching here (rather than at each call site) covers all of them uniformly.
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
+
 void PlatformSwapBuffers()
 {
     if (g_sdlWindow)
     {
+#ifdef __ANDROID__
+        // AH-1118: coarse frame-rate meter for the rendering-perf pass.
+        {
+            static Uint64 s_windowStart = 0;
+            static int s_frames = 0;
+            ++s_frames;
+            const Uint64 now = SDL_GetTicks();
+            if (s_windowStart == 0)
+            {
+                s_windowStart = now;
+            }
+            else if (now - s_windowStart >= 5000)
+            {
+                __android_log_print(ANDROID_LOG_INFO, "MuMainFPS", "fps=%.1f",
+                    s_frames * 1000.0 / static_cast<double>(now - s_windowStart));
+                s_windowStart = now;
+                s_frames = 0;
+            }
+        }
+#endif
         // GLP-19: IR defers its draw until the next incompatible Begin() or an explicit flush, so
         // the frame's last batch would otherwise sit unsubmitted until some later frame. Every
         // swap path in the tree funnels through here (SceneManager, LoadingScene, UIMng), which
@@ -1713,7 +1737,16 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
     // every map/panel; compatibility (CoreProfile=0) remains available as a rollback.
     // Core additionally needs an explicit version request (compatibility takes the
     // driver's highest, and must keep doing so -- see the else branch below).
+#ifdef __ANDROID__
+    // AH-1118: run the modern core-profile engine path on a native OpenGL ES 3
+    // context; shader sources are transposed to `#version 300 es` at compile
+    // time (EsShaderShim.h). gl4es stays linked only to satisfy legacy GL
+    // symbols on code paths the core pipeline never executes.
+    g_CoreProfile = TRUE;
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+#else
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, g_CoreProfile ? SDL_GL_CONTEXT_PROFILE_CORE : SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
+#endif
 #if defined(_DEBUG) && ENABLE_GL_KHR_DEBUG_CALLBACK
     // KHR_debug callback (registered below, after context creation) needs the context
     // created with the debug flag to get synchronous, precisely-attributed messages.
@@ -1734,7 +1767,12 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
         // Descend only on failure; the {3,3} rung is byte-identical to the pre-GLP-08 fixed
         // request, so a machine where the whole loop somehow misbehaves still ends up exactly
         // where it was before this change.
+#ifdef __ANDROID__
+        // OpenGL ES rungs; ES 3.0 is the floor the transposed shaders need.
+        static constexpr struct { int major, minor; } kCoreVersionAttempts[] = { {3, 2}, {3, 1}, {3, 0} };
+#else
         static constexpr struct { int major, minor; } kCoreVersionAttempts[] = { {4, 5}, {4, 3}, {3, 3} };
+#endif
         constexpr int kAttemptCount = sizeof(kCoreVersionAttempts) / sizeof(kCoreVersionAttempts[0]);
 
         // config.ini [Render] MaxGLVersion caps which rung the loop starts at -- rollback path
@@ -1811,6 +1849,25 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
     }
 
     SDL_GL_MakeCurrent(g_sdlWindow, g_sdlGLContext);
+
+#ifdef __ANDROID__
+    // AH-1118: Android ignores the requested window size and hands back the
+    // native fullscreen surface; adopt its real pixel size so the viewport and
+    // UI cover the whole display instead of a 1024x768 corner.
+    {
+        int drawW = 0;
+        int drawH = 0;
+        SDL_GetWindowSizeInPixels(g_sdlWindow, &drawW, &drawH);
+        if (drawW > 0 && drawH > 0)
+        {
+            WindowWidth = static_cast<unsigned int>(drawW);
+            WindowHeight = static_cast<unsigned int>(drawH);
+            OpenglWindowWidth = WindowWidth;
+            OpenglWindowHeight = WindowHeight;
+        }
+    }
+#endif
+
     RHI::Init(nullptr, static_cast<int>(WindowWidth), static_cast<int>(WindowHeight));
 
 #if defined(_DEBUG) && ENABLE_GL_KHR_DEBUG_CALLBACK

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -244,6 +244,7 @@ static void MaybeCaptureFrame()
 // through, so branching here (rather than at each call site) covers all of them uniformly.
 #ifdef __ANDROID__
 #include <android/log.h>
+#include "Core/Utilities/FrameProfiler.h"
 #endif
 
 void PlatformSwapBuffers()

--- a/src/source/App/Platform/Windows/Winmain.cpp
+++ b/src/source/App/Platform/Windows/Winmain.cpp
@@ -276,6 +276,21 @@ void PlatformSwapBuffers()
         // swap path in the tree funnels through here (SceneManager, LoadingScene, UIMng), which
         // makes this the one place that cannot be missed.
         IR::Flush();
+#ifdef __ANDROID__
+        // AH-1118: alarm on pathological presents -- measures the SwapWindow
+        // block that the off-CPU profile could not attribute.
+        {
+            const Uint64 t0 = SDL_GetTicksNS();
+            SDL_GL_SwapWindow(g_sdlWindow);
+            const Uint64 dtMs = (SDL_GetTicksNS() - t0) / 1000000ull;
+            if (dtMs >= 100)
+            {
+                __android_log_print(ANDROID_LOG_WARN, "MuMainPace",
+                    "SwapWindow blocked %llu ms", (unsigned long long)dtMs);
+            }
+            return;
+        }
+#endif
 #ifndef _WIN32
         MaybeCaptureFrame();
 #endif
@@ -1251,6 +1266,13 @@ MSG MainLoop()
                 else
                     SDL_StopTextInput(g_sdlWindow);
                 s_textInputActive = wantTextInput;
+#ifdef __ANDROID__
+                __android_log_print(ANDROID_LOG_INFO, "MuMainInput",
+                    "text input %s (focused=%p, started=%d, kbdShown=%d)",
+                    wantTextInput ? "START" : "STOP", (void*)focusedField,
+                    (int)SDL_TextInputActive(g_sdlWindow),
+                    (int)SDL_ScreenKeyboardShown(g_sdlWindow));
+#endif
             }
 
             // Anchor the IME candidate window at the caret (reference px -> window
@@ -1972,6 +1994,21 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
     g_ErrorReport.AddSeparator();
 
     InitVSync();
+#ifdef __ANDROID__
+    // AH-1118 pacing experiment: the on-device profile shows the frame loop
+    // SLEEPING at ~0.7 FPS (CpuUsage/sleep_for dominate an otherwise idle CPU),
+    // so the pacing path is suspect. Force uncapped + vsync off and log every
+    // input to the decision so the real numbers are on record.
+    {
+        const bool vsAvail = IsVSyncAvailable();
+        const int fpsLimit = GetFPSLimit();
+        DisableVSync();
+        SetTargetFps(-1);
+        __android_log_print(ANDROID_LOG_INFO, "MuMainPace",
+            "vsyncAvailable=%d fpsLimit=%d forced=uncapped targetFps=%.2f",
+            vsAvail ? 1 : 0, fpsLimit, GetTargetFps());
+    }
+#else
     if (IsVSyncAvailable())
     {
         if (EnableVSync())
@@ -1983,6 +2020,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nC
     {
         SetTargetFps(GetFPSLimit());
     }
+#endif
 
     // Make the bundled ./fonts faces resolvable by GDI before the first CreateFont,
     // so a chosen curated font works even without a system-wide install.

--- a/src/source/App/stdafx.h
+++ b/src/source/App/stdafx.h
@@ -160,8 +160,30 @@
 #endif
 
 //opengl
+#ifdef __ANDROID__
+// AH-1118 spike: GL4ES supplies the desktop GL API on top of GLES2. Its headers
+// declare everything as real functions exported by its libGL, so GLEW (which is
+// only a compile-time dependency here; glewInit is never called) drops out.
+// gl4es's glext.h is GL-2.1-era: rename its glShaderSource pointer typedef out
+// of the way of the engine's own (const-correct) declarations, and supply the
+// few modern enums the renderer references.
+#define PFNGLSHADERSOURCEPROC PFNGLSHADERSOURCEPROC_gl4es
+#include <GL/gl.h>
+#include <GL/glext.h>
+#undef PFNGLSHADERSOURCEPROC
+#ifndef GL_MAP_PERSISTENT_BIT
+#define GL_MAP_PERSISTENT_BIT 0x0040
+#endif
+#ifndef GL_MAP_COHERENT_BIT
+#define GL_MAP_COHERENT_BIT 0x0080
+#endif
+#ifndef GL_DEBUG_SOURCE_APPLICATION
+#define GL_DEBUG_SOURCE_APPLICATION 0x824A
+#endif
+#else
 #include <gl/glew.h>
 #include <gl/GL.h>
+#endif
 
 // DXP-08a Category 1: intercepts glColor3f/3fv/3ub/4f/4ub project-wide so every call site
 // keeps working under both GL profiles without a per-site rewrite -- see GLColorIntercept.h.

--- a/src/source/Camera/CameraProjection.cpp
+++ b/src/source/Camera/CameraProjection.cpp
@@ -103,6 +103,16 @@ void CameraProjection::TransformPosition(const CameraState& state, const vec3_t 
 
 bool CameraProjection::TestDepthBuffer(const CameraState& state, const vec3_t position)
 {
+#ifdef __ANDROID__
+    // AH-1118: this single 1-pixel depth readback (sun lens-flare visibility)
+    // drains the whole GPU pipeline once per frame -- measured at 1-3 FPS on
+    // both Adreno and the emulator -- and GL_DEPTH_COMPONENT reads are not
+    // legal in OpenGL ES to begin with. Report "occluded" (no flare) until an
+    // async occlusion query replaces this.
+    (void)state;
+    (void)position;
+    return false;
+#else
     vec3_t worldPosition;
     int x, y;
     TransformPosition(state, position, worldPosition, &x, &y);
@@ -130,6 +140,7 @@ bool CameraProjection::TestDepthBuffer(const CameraState& state, const vec3_t po
     const float expected = (f / (f - n)) * (1.0f + n / z_eye);
 
     return (depth >= expected);
+#endif
 }
 
 void CameraProjection::GetOpenGLMatrix(float outMatrix[3][4])

--- a/src/source/Core/Platform/WinApiShims.h
+++ b/src/source/Core/Platform/WinApiShims.h
@@ -133,7 +133,10 @@ inline DWORD GetCurrentThreadId()
 {
     // pthread_t is 8 bytes on LP64; fold the high half into the low half before
     // truncating so two threads are less likely to collide on the low 32 bits.
-    const std::uint64_t id = reinterpret_cast<std::uintptr_t>(pthread_self());
+    // static_cast, not reinterpret_cast: glibc's pthread_t (unsigned long) made
+    // the reinterpret_cast a same-type no-op, but bionic's is signed long, and
+    // reinterpret_cast between distinct integral types is ill-formed.
+    const std::uint64_t id = static_cast<std::uint64_t>(pthread_self());
     return static_cast<DWORD>(id ^ (id >> 32));
 }
 

--- a/src/source/Core/Utilities/FrameProfiler.h
+++ b/src/source/Core/Utilities/FrameProfiler.h
@@ -306,6 +306,15 @@ namespace FrameProfiler
         {
             GpuQueryFns& fns = QueryFns();
             if (fns.loaded) return true;
+            // AH-1118: latch on ATTEMPT, not on success. GL_TIMESTAMP queries are
+            // desktop-GL/EXT_disjoint_timer_query only, so on plain OpenGL ES
+            // QueryCounter never resolves and a success-only latch re-ran all four
+            // lookups from every GpuTimerBegin -- roughly ten times a frame, each a
+            // full dynamic-linker symbol search. Measured at ~11% of the render
+            // thread on Adreno 730: the instrumentation was distorting what it measured.
+            static bool s_attempted = false;
+            if (s_attempted) return fns.loaded;
+            s_attempted = true;
             fns.GenQueries          = (PFNGLGENQUERIESPROC)SDL_GL_GetProcAddress("glGenQueries");
             fns.QueryCounter        = (PFNGLQUERYCOUNTERPROC)SDL_GL_GetProcAddress("glQueryCounter");
             fns.GetQueryObjectiv    = (PFNGLGETQUERYOBJECTIVPROC)SDL_GL_GetProcAddress("glGetQueryObjectiv");

--- a/src/source/Core/Utilities/FrameProfiler.h
+++ b/src/source/Core/Utilities/FrameProfiler.h
@@ -52,12 +52,21 @@ namespace FrameProfiler
         Overlay,   // $details/$glstats/FPS-counter self-cost. These render text as roughly one IR
                    // quad per glyph and used to be tagged Other, contaminating the exact bucket
                    // under investigation -- an observer effect large enough to mislead.
+        // AH-1118: split out of Other -- with the big buckets fixed, Other's ~250
+        // buffer appends per frame were the largest remaining unattributed cost
+        // on Android, and none of its constituents were separable.
+        Leaves,     // RenderLeaves() -- weather sprites (both call sites)
+        Points,     // RenderPoints() -- light glow points
+        EffShadows, // RenderEffectShadows()
+        Boids,      // RenderBoids()/RenderFishs() -- ambient critters
+        AfterFx,    // RenderAfterEffects()
         Count_
     };
 
     inline constexpr const char* kPassNames[(int)Pass::Count_] = {
         "Terrain", "Objects", "Chars", "Items", "Effects", "Other", "CharWait", "MoveFx", "MovePart",
-        "Skinning", "UI", "Present", "Sprites", "Particles", "Joints", "Overlay"
+        "Skinning", "UI", "Present", "Sprites", "Particles", "Joints", "Overlay",
+        "Leaves", "Points", "EffShadows", "Boids", "AfterFx"
     };
 
     inline float& AccumulatorMs(Pass p)

--- a/src/source/Data/GameConfig/GameConfig.cpp
+++ b/src/source/Data/GameConfig/GameConfig.cpp
@@ -45,6 +45,15 @@ GameConfig::GameConfig()
     m_configPath = exePath;
     m_configPath += L"config.ini";
 
+#ifdef __ANDROID__
+    // AH-1118 spike: on Android the "module path" resolves into the read-only
+    // system/APK area, so the file above is silently never found and every
+    // setting falls back to its default (including ServerIP=127.127.127.127).
+    // The app's working directory is set to its internal files dir before any
+    // initializer runs; the pushed config.ini lives there.
+    m_configPath = L"config.ini";
+#endif
+
     Load();
 }
 

--- a/src/source/Dotnet/Connection.cpp
+++ b/src/source/Dotnet/Connection.cpp
@@ -1,5 +1,8 @@
 #include "stdafx.h"
 #include <map>
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
 
 #include "Connection.h"
 
@@ -102,6 +105,16 @@ Connection::Connection(const wchar_t* host, int32_t port, bool isEncrypted, void
     }
 
     this->_handle = dotnet_connect(host, port, isEncrypted ? 1 : 0, &OnPacketReceivedS, &OnDisconnectedS);
+#ifdef __ANDROID__
+    // AH-1118 spike diagnostics: surface the managed connect result in logcat.
+    {
+        char hostNarrow[128] = {0};
+        for (int i = 0; i < 127 && host[i]; ++i) hostNarrow[i] = static_cast<char>(host[i]);
+        __android_log_print(ANDROID_LOG_INFO, "MuMainNet",
+            "connect host=%s port=%d enc=%d -> handle=%d",
+            hostNarrow, port, isEncrypted ? 1 : 0, this->_handle);
+    }
+#endif
 
     if (IsConnected())
     {

--- a/src/source/Dotnet/Connection.h
+++ b/src/source/Dotnet/Connection.h
@@ -56,7 +56,14 @@ inline void* get_munique_client_library_handle()
                     return h;
             }
         }
+#ifdef __ANDROID__
+        // AH-1118 spike: on Android the library ships in the APK's jniLibs,
+        // which requires the lib*.so naming; the system linker finds it in the
+        // app's native library directory by plain name.
+        return dlopen("libMUniqueClient.so", RTLD_LAZY);
+#else
         return dlopen("MUnique.Client.Library.so", RTLD_LAZY);
+#endif
     }();
     return handle;
 }

--- a/src/source/Guild/NewUIGuildInfoWindow.cpp
+++ b/src/source/Guild/NewUIGuildInfoWindow.cpp
@@ -618,16 +618,13 @@ void SEASON3B::CNewUIGuildInfoWindow::Render_Text()
 
 void SEASON3B::CNewUIGuildInfoWindow::Render_Guild_History()
 {
-    for (int x = m_Pos.x + 73; x < m_Pos.x + 73 + 42; x++)
-    {
-        RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, x, m_Pos.y + 104, 1, 14);
-        RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, x, m_Pos.y + 104 + 34, 1, 14);
-    }
-    for (int y = m_Pos.y + 104; y < m_Pos.y + 104 + 42; y++)
-    {
-        RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 70, y, 14, 1);
-        RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 105, y, 14, 1);
-    }
+    // AH-1118: stretched quads instead of per-pixel strip loops -- identical
+    // texels for 1px strips, two draws instead of two texture rebinds per pixel
+    // (see NewUIInventoryCtrl.cpp's border rendering for the measurement).
+    RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, m_Pos.x + 73, m_Pos.y + 104, 42, 14);
+    RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, m_Pos.x + 73, m_Pos.y + 104 + 34, 42, 14);
+    RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 70, m_Pos.y + 104, 14, 42);
+    RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 105, m_Pos.y + 104, 14, 42);
 
     RenderImage(IMAGE_GUILDINFO_TOP_LEFT, m_Pos.x + 70, m_Pos.y + 104, 14, 14);
     RenderImage(IMAGE_GUILDINFO_TOP_RIGHT, m_Pos.x + 105, m_Pos.y + 104, 14, 14);
@@ -637,17 +634,10 @@ void SEASON3B::CNewUIGuildInfoWindow::Render_Guild_History()
     CreateGuildMark(Hero->GuildMarkIndex);
     RenderBitmap(BITMAP_GUILD, m_Pos.x + 74, m_Pos.y + 106, 39, 39);
 
-    for (int x = m_Pos.x + 12; x < m_Pos.x + 12 + 166; x++)
-    {
-        RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, x, m_Pos.y + 159, 1, 14);
-        RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, x, m_Pos.y + 159 + 56, 1, 14);
-    }
-
-    for (int y = m_Pos.y + 159; y < m_Pos.y + 159 + 65; y++)
-    {
-        RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 10, y, 14, 1);
-        RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 167, y, 14, 1);
-    }
+    RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, m_Pos.x + 12, m_Pos.y + 159, 166, 14);
+    RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, m_Pos.x + 12, m_Pos.y + 159 + 56, 166, 14);
+    RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 10, m_Pos.y + 159, 14, 65);
+    RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 167, m_Pos.y + 159, 14, 65);
 
     RenderImage(IMAGE_GUILDINFO_TOP_LEFT, m_Pos.x + 10, m_Pos.y + 159, 14, 14);
     RenderImage(IMAGE_GUILDINFO_TOP_RIGHT, m_Pos.x + 167, m_Pos.y + 159, 14, 14);
@@ -658,18 +648,12 @@ void SEASON3B::CNewUIGuildInfoWindow::Render_Guild_History()
     RenderColor(m_Pos.x + 11, m_Pos.y + 260, 165, 84);
     EndRenderColor();
 
-    for (int x = m_Pos.x + 12; x < m_Pos.x + 12 + 165; x++)
-    {
-        if (x > 73)
-            RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, x, m_Pos.y + 260, 1, 14);
-        RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, x, m_Pos.y + 260 + 74, 1, 14);
-    }
-
-    for (int y = m_Pos.y + 260; y < m_Pos.y + 260 + 82; y++)
-    {
-        RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 10, y, 14, 1);
-        RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 167, y, 14, 1);
-    }
+    // The original guarded the top strip on `x > 73` in SCREEN pixels -- always
+    // true for any on-screen window position, so the full span is equivalent.
+    RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, m_Pos.x + 12, m_Pos.y + 260, 165, 14);
+    RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, m_Pos.x + 12, m_Pos.y + 260 + 74, 165, 14);
+    RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 10, m_Pos.y + 260, 14, 82);
+    RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 167, m_Pos.y + 260, 14, 82);
     RenderImage(IMAGE_GUILDINFO_TOP_RIGHT, m_Pos.x + 167, m_Pos.y + 260, 14, 14);
     RenderImage(IMAGE_GUILDINFO_BOTTOM_LEFT, m_Pos.x + 10, m_Pos.y + 334, 14, 14);
     RenderImage(IMAGE_GUILDINFO_BOTTOM_RIGHT, m_Pos.x + 167, m_Pos.y + 334, 14, 14);
@@ -804,16 +788,10 @@ void SEASON3B::CNewUIGuildInfoWindow::Render_Guild_Info()
         RenderColor(m_Pos.x + 12, m_Pos.y + 12 + 98, 165, 15);
         EndRenderColor();
 
-        for (int x = m_Pos.x + 12; x < m_Pos.x + 12 + 166; x++)
-        {
-            RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, x, m_Pos.y + 109, 1, 14);
-            RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, x, m_Pos.y + 109 + 92, 1, 14);
-        }
-        for (int y = m_Pos.y + 109; y < m_Pos.y + 109 + 100; y++)
-        {
-            RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 10, y, 14, 1);
-            RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 167, y, 14, 1);
-        }
+        RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, m_Pos.x + 12, m_Pos.y + 109, 166, 14);
+        RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, m_Pos.x + 12, m_Pos.y + 109 + 92, 166, 14);
+        RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 10, m_Pos.y + 109, 14, 100);
+        RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 167, m_Pos.y + 109, 14, 100);
 
         RenderImage(IMAGE_GUILDINFO_TOP_LEFT, m_Pos.x + 10, m_Pos.y + 109, 14, 14);
         RenderImage(IMAGE_GUILDINFO_TOP_RIGHT, m_Pos.x + 167, m_Pos.y + 109, 14, 14);
@@ -841,16 +819,10 @@ void SEASON3B::CNewUIGuildInfoWindow::Render_Guild_Enum()
     RenderColor(m_Pos.x + 12, m_Pos.y + 12 + 93, 165, 20);
     EndRenderColor();
 
-    for (int x = m_Pos.x + 12; x < m_Pos.x + 177; x++)
-    {
-        RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, x, m_Pos.y + 93 + 12, 1, 14);
-        RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, x, m_Pos.y + 3 + 344, 1, 14);
-    }
-    for (int y = m_Pos.y + 12 + 93; y < m_Pos.y + 12 + 344; y++)
-    {
-        RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 8, y, 14, 1);
-        RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 168, y, 14, 1);
-    }
+    RenderImage(IMAGE_GUILDINFO_TOP_PIXEL, m_Pos.x + 12, m_Pos.y + 93 + 12, 165, 14);
+    RenderImage(IMAGE_GUILDINFO_BOTTOM_PIXEL, m_Pos.x + 12, m_Pos.y + 3 + 344, 165, 14);
+    RenderImage(IMAGE_GUILDINFO_LEFT_PIXEL, m_Pos.x + 8, m_Pos.y + 12 + 93, 14, 251);
+    RenderImage(IMAGE_GUILDINFO_RIGHT_PIXEL, m_Pos.x + 168, m_Pos.y + 12 + 93, 14, 251);
 
     RenderImage(IMAGE_GUILDINFO_TOP_LEFT, m_Pos.x + 8, m_Pos.y + 105, 14, 14);
     RenderImage(IMAGE_GUILDINFO_TOP_RIGHT, m_Pos.x + 168, m_Pos.y + 105, 14, 14);

--- a/src/source/Render/Core/BindState.cpp
+++ b/src/source/Render/Core/BindState.cpp
@@ -22,7 +22,14 @@ static PFNGLACTIVETEXTUREPROC   fn_glActiveTexture   = nullptr;
 static bool LoadBindStateFunctions()
 {
     static bool loaded = false;
-    if (loaded) return true;
+    // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+    // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+    // driver without KHR_debug), a success-only latch re-runs every lookup on
+    // every call forever -- measured at ~10% of the render thread in the dynamic
+    // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+    static bool attempted = false;
+    if (attempted) return loaded;
+    attempted = true;
 
     fn_glUseProgram      = (PFNGLUSEPROGRAMPROC)SDL_GL_GetProcAddress("glUseProgram");
     fn_glBindVertexArray = (PFNGLBINDVERTEXARRAYPROC)SDL_GL_GetProcAddress("glBindVertexArray");

--- a/src/source/Render/Effects/ZzzEffectFireLeave.cpp
+++ b/src/source/Render/Effects/ZzzEffectFireLeave.cpp
@@ -547,6 +547,22 @@ void RenderLeaves()
     }
 
     glColor3f(1.f, 1.f, 1.f);
+
+    // AH-1118: one identity model matrix for the whole loop; each plane's
+    // world position is folded into its CPU-side corner transform
+    // (RenderPlane3DAt). The old per-leaf PushModel/SetModel/PopModel cost
+    // 3 UBO buffer writes per leaf per frame -- measured at 240 buffer
+    // updates and 73 ms/frame for 80 leaves on Adreno 730 -- and broke the
+    // IR batch on every leaf. Now all same-texture leaves merge into one
+    // draw under one model update.
+    const bool spriteMap = (gMapManager.WorldActive == WD_2DEVIAS || IsIceCity() || IsSantaTown());
+    if (!spriteMap)
+    {
+        GlobalUBO::Instance().PushModel();
+        vec3_t vOrigin = { 0.f, 0.f, 0.f };
+        GlobalUBO::Instance().SetModel(vOrigin, 1.0f);
+    }
+
 #ifdef DEVIAS_XMAS_EVENT
     int iMaxLeaves;
     if (World == WD_2DEVIAS)
@@ -565,20 +581,17 @@ void RenderLeaves()
             )
         {
             BindTexture(o->Type);
-            if (gMapManager.WorldActive == WD_2DEVIAS || IsIceCity() || IsSantaTown())
+            if (spriteMap)
             {
                 RenderSprite(o->Type, o->Position, o->Scale, o->Scale, o->Light);
             }
             else
             {
-                GlobalUBO::Instance().PushModel();
-                GlobalUBO::Instance().SetModel(o->Position, 1.0f);
-
                 float Matrix[3][4];
                 AngleMatrix(o->Angle, Matrix);
 
                 if (gMapManager.InChaosCastle() == true)
-                    RenderPlane3D(o->TurningForce[0], o->TurningForce[1], Matrix);
+                    RenderPlane3DAt(o->TurningForce[0], o->TurningForce[1], Matrix, o->Position);
                 else
                 {
                     if (o->Type == BITMAP_RAIN)
@@ -586,21 +599,25 @@ void RenderLeaves()
                         if (gMapManager.WorldActive == WD_34CRYWOLF_1ST)
                         {
                             if (weather == 1)
-                                RenderPlane3D(1.f, 20.f, Matrix);
+                                RenderPlane3DAt(1.f, 20.f, Matrix, o->Position);
                         }
                         else
-                            RenderPlane3D(1.f, 20.f, Matrix);
+                            RenderPlane3DAt(1.f, 20.f, Matrix, o->Position);
                     }
                     else if (o->Type == BITMAP_FIRE_SNUFF)
-                        RenderPlane3D(o->Scale * 2.f, o->Scale * 4.f, Matrix);
+                        RenderPlane3DAt(o->Scale * 2.f, o->Scale * 4.f, Matrix, o->Position);
                     else
                     {
-                        RenderPlane3D(3.f, 3.f, Matrix);
+                        RenderPlane3DAt(3.f, 3.f, Matrix, o->Position);
                     }
                 }
-
-                GlobalUBO::Instance().PopModel();
             }
         }
+
+    }
+
+    if (!spriteMap)
+    {
+        GlobalUBO::Instance().PopModel();
     }
 }

--- a/src/source/Render/Effects/ZzzEffectParticle.cpp
+++ b/src/source/Render/Effects/ZzzEffectParticle.cpp
@@ -2,6 +2,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include <algorithm>
 #include "Render/Models/BoneManager.h"
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Engine/Object/ZzzInfomation.h"
@@ -8905,8 +8906,26 @@ void RenderParticles(BYTE byRenderOneMore)
         return;
     }
 
-    for (int i = 0; i < MAX_PARTICLES; i++)
+    // AH-1118: draw particles grouped by texture (stable within a texture, so
+    // per-type animation stays deterministic). The natural array order
+    // interleaves TexTypes, and every texture change breaks an IR batch --
+    // measured at ~700 breaks per login-scene frame, each one a streaming
+    // buffer append whose driver-side cost dominates the frame on mobile GPUs.
+    static int s_renderOrder[MAX_PARTICLES];
+    int liveCount = 0;
+    for (int idx = 0; idx < MAX_PARTICLES; idx++)
     {
+        if (Particles[idx].Live)
+        {
+            s_renderOrder[liveCount++] = idx;
+        }
+    }
+    std::stable_sort(s_renderOrder, s_renderOrder + liveCount,
+        [](int a, int b) { return Particles[a].TexType < Particles[b].TexType; });
+
+    for (int k = 0; k < liveCount; k++)
+    {
+        const int i = s_renderOrder[k];
         PARTICLE* o = &Particles[i];
         if (o->Live)
         {

--- a/src/source/Render/Effects/ZzzEffectParticle.cpp
+++ b/src/source/Render/Effects/ZzzEffectParticle.cpp
@@ -8920,8 +8920,26 @@ void RenderParticles(BYTE byRenderOneMore)
             s_renderOrder[liveCount++] = idx;
         }
     }
+    // Sort key includes SubType: the switch below picks the blend mode from
+    // (TexType, SubType), so grouping by both lets one blend state serve a
+    // whole run instead of flushing the batch on nearly every particle.
     std::stable_sort(s_renderOrder, s_renderOrder + liveCount,
-        [](int a, int b) { return Particles[a].TexType < Particles[b].TexType; });
+        [](int a, int b)
+        {
+            if (Particles[a].TexType != Particles[b].TexType)
+                return Particles[a].TexType < Particles[b].TexType;
+            if (Particles[a].Type != Particles[b].Type)
+                return Particles[a].Type < Particles[b].Type;
+            return Particles[a].SubType < Particles[b].SubType;
+        });
+
+    // The default blend below used to run per particle, resetting state that the
+    // per-type case then overrode -- an X->Y toggle on every particle that broke
+    // the IR batch even in sorted order. Apply it once per (TexType, SubType) run;
+    // within a run the case's own blend call is cached and free.
+    int lastRunTexType = -0x7FFFFFFF;
+    int lastRunSubType = -0x7FFFFFFF;
+    int lastRunParticleType = -0x7FFFFFFF;
 
     for (int k = 0; k < liveCount; k++)
     {
@@ -8941,7 +8959,17 @@ void RenderParticles(BYTE byRenderOneMore)
             BITMAP_t* pBitmap = Bitmaps.GetTexture(o->TexType);
             float Width = pBitmap->Width * o->Scale;
             float Height = pBitmap->Height * o->Scale;
-            if (pBitmap->Components == 3)
+            const bool newBlendRun = (o->TexType != lastRunTexType || o->SubType != lastRunSubType ||
+                                      o->Type != lastRunParticleType);
+            lastRunTexType = o->TexType;
+            lastRunSubType = o->SubType;
+            lastRunParticleType = o->Type;
+            if (!newBlendRun)
+            {
+                // Same (TexType, SubType) run: blend state from the previous
+                // particle's case still stands -- skip the default reset.
+            }
+            else if (pBitmap->Components == 3)
             {
                 EnableAlphaBlend();
             }

--- a/src/source/Render/Models/ZzzBMD.cpp
+++ b/src/source/Render/Models/ZzzBMD.cpp
@@ -66,7 +66,14 @@ static PFNGLVERTEXATTRIBIPOINTERPROC     fn_glVertexAttribIPointer     = nullptr
 static bool LoadBMDGLFunctions()
 {
     static bool loaded = false;
-    if (loaded) return true;
+    // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+    // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+    // driver without KHR_debug), a success-only latch re-runs every lookup on
+    // every call forever -- measured at ~10% of the render thread in the dynamic
+    // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+    static bool attempted = false;
+    if (attempted) return loaded;
+    attempted = true;
 
     fn_glGenVertexArrays          = (PFNGLGENVERTEXARRAYSPROC)SDL_GL_GetProcAddress("glGenVertexArrays");
     fn_glDeleteVertexArrays       = (PFNGLDELETEVERTEXARRAYSPROC)SDL_GL_GetProcAddress("glDeleteVertexArrays");

--- a/src/source/Render/Models/ZzzBMD.cpp
+++ b/src/source/Render/Models/ZzzBMD.cpp
@@ -2369,6 +2369,9 @@ void BMD::AddClothesShadowTriangles(void* pClothes, const int clothesCount, cons
     {
         CPlanarShadowShader::Instance().Draw(reinterpret_cast<const float*>(vertices), target_vertex_index + 1);
     }
+#ifndef __ANDROID__
+    // Client-array submission does not exist in the ES context; with the shadow
+    // shader unavailable, dropping the shadow beats dereferencing a NULL entry.
     else
     {
         glEnableClientState(GL_VERTEX_ARRAY);
@@ -2377,6 +2380,7 @@ void BMD::AddClothesShadowTriangles(void* pClothes, const int clothesCount, cons
         FrameProfiler::CountGLCall(FrameProfiler::Counter::DrawCalls);
         glDisableClientState(GL_TEXTURE_COORD_ARRAY);
     }
+#endif
 }
 
 void BMD::AddMeshShadowTriangles(const int blendMesh, const int hiddenMesh, const int startMesh, const int endMesh, const float sx, const float sy) const
@@ -2457,6 +2461,8 @@ void BMD::AddMeshShadowTriangles(const int blendMesh, const int hiddenMesh, cons
     {
         CPlanarShadowShader::Instance().Draw(reinterpret_cast<const float*>(vertices), target_vertex_index + 1);
     }
+#ifndef __ANDROID__
+    // See AddClothesShadowTriangles(): no client arrays in the ES context.
     else
     {
         glEnableClientState(GL_VERTEX_ARRAY);
@@ -2465,6 +2471,7 @@ void BMD::AddMeshShadowTriangles(const int blendMesh, const int hiddenMesh, cons
         FrameProfiler::CountGLCall(FrameProfiler::Counter::DrawCalls);
         glDisableClientState(GL_TEXTURE_COORD_ARRAY);
     }
+#endif
 }
 
 void BMD::RenderBodyShadow(const int blendMesh, const int hiddenMesh, const int startMeshNumber, const int endMeshNumber, void* pClothes, const int clothesCount)

--- a/src/source/Render/RHI/RHI.cpp
+++ b/src/source/Render/RHI/RHI.cpp
@@ -51,6 +51,28 @@ namespace RHI_GL_Impl {
 
 namespace RHI {
 
+Backend GetConfiguredBackend()
+{
+#if defined(MU_RENDER_BACKEND_OPENGL)
+    return Backend::OpenGL;
+#else
+#error "No MuMain renderer backend was selected by CMake."
+#endif
+}
+
+const char* GetConfiguredBackendName()
+{
+    switch (GetConfiguredBackend())
+    {
+    case Backend::OpenGL:
+        return "OpenGL";
+    case Backend::SdlGpu:
+        return "SDL_GPU";
+    }
+
+    return "Unknown";
+}
+
 const Caps& GetCaps()
 {
     return RHI_GL_Impl::GetCaps();

--- a/src/source/Render/RHI/RHI.h
+++ b/src/source/Render/RHI/RHI.h
@@ -15,6 +15,14 @@
 
 namespace RHI {
 
+enum class Backend {
+    OpenGL,
+    SdlGpu,
+};
+
+Backend GetConfiguredBackend();
+const char* GetConfiguredBackendName();
+
 // Opaque, backend-owned handles. Strongly typed so a BufferHandle can't be
 // passed where a TextureHandle is expected -- catches backend-swap mistakes
 // at compile time, not runtime.

--- a/src/source/Render/RHI/RHI_GL.cpp
+++ b/src/source/Render/RHI/RHI_GL.cpp
@@ -79,7 +79,22 @@ namespace {
 
         const char* versionStr = (const char*)glGetString(GL_VERSION);
         int major = 0, minor = 0;
-        if (versionStr) sscanf(versionStr, "%d.%d", &major, &minor);
+        bool isES = false;
+        if (versionStr)
+        {
+            // OpenGL ES reports "OpenGL ES M.m ..."; a plain "%d.%d" scan of that
+            // string parses the word "OpenGL" and yields 0.0, silently failing every
+            // version-gated capability below (observed as "GL context 0.0" in the
+            // error report on Android).
+            if (sscanf(versionStr, "OpenGL ES %d.%d", &major, &minor) == 2)
+            {
+                isES = true;
+            }
+            else
+            {
+                sscanf(versionStr, "%d.%d", &major, &minor);
+            }
+        }
         g_Caps.glMajor = major;
         g_Caps.glMinor = minor;
 
@@ -87,16 +102,21 @@ namespace {
         GLint numExtensions = 0;
         glGetIntegerv(GL_NUM_EXTENSIONS, &numExtensions);
 
+        // ES exposes several of these features under EXT names or as core at
+        // different version thresholds than desktop GL; probe accordingly.
         g_Caps.bufferStorage = ProbeOneCap(L"bufferStorage",
-            AtLeastGLVersion(major, minor, 4, 4) || HasGLExtension("GL_ARB_buffer_storage", fn_glGetStringi, numExtensions),
-            "glBufferStorage");
+            isES ? HasGLExtension("GL_EXT_buffer_storage", fn_glGetStringi, numExtensions)
+                 : (AtLeastGLVersion(major, minor, 4, 4) || HasGLExtension("GL_ARB_buffer_storage", fn_glGetStringi, numExtensions)),
+            isES ? "glBufferStorageEXT" : "glBufferStorage");
 
         g_Caps.vertexAttribBinding = ProbeOneCap(L"vertexAttribBinding",
-            AtLeastGLVersion(major, minor, 4, 3) || HasGLExtension("GL_ARB_vertex_attrib_binding", fn_glGetStringi, numExtensions),
+            isES ? AtLeastGLVersion(major, minor, 3, 1)
+                 : (AtLeastGLVersion(major, minor, 4, 3) || HasGLExtension("GL_ARB_vertex_attrib_binding", fn_glGetStringi, numExtensions)),
             "glBindVertexBuffer", "glVertexAttribFormat");
 
         g_Caps.programBinary = ProbeOneCap(L"programBinary",
-            AtLeastGLVersion(major, minor, 4, 1) || HasGLExtension("GL_ARB_get_program_binary", fn_glGetStringi, numExtensions),
+            isES ? AtLeastGLVersion(major, minor, 3, 0)
+                 : (AtLeastGLVersion(major, minor, 4, 1) || HasGLExtension("GL_ARB_get_program_binary", fn_glGetStringi, numExtensions)),
             "glGetProgramBinary", "glProgramBinary");
 
         g_Caps.timerQuery = ProbeOneCap(L"timerQuery",
@@ -287,6 +307,46 @@ namespace {
         g_BufferCapacity[id] = (GLsizeiptr)sizeBytes;
         return BufferHandle{ id };
     }
+
+    // Write into a possibly in-flight streaming buffer without the implicit
+    // synchronization glBufferSubData can incur (a hard stall on tiled/mobile
+    // GPUs) -- the same UNSYNCHRONIZED | INVALIDATE_RANGE contract the GLP-09
+    // UBO ring's fallback rung already uses. Ring discipline guarantees the
+    // written range is not one an in-flight draw reads. Returns false where
+    // mapping is unavailable or fails, so callers can fall back to SubData.
+    bool MappedRangeWrite(GLenum target, GLintptr offset, GLsizeiptr size, const void* data)
+    {
+        // MU_STREAM_MAP=0 opts out (the Android entry point sets it inside
+        // emulators, whose per-GL-call transport cost makes map+unmap more
+        // expensive than the single SubData it replaces; on real mobile GPUs
+        // the stall avoidance is what matters).
+        static const bool s_enabled = []() {
+            const char* v = std::getenv("MU_STREAM_MAP");
+            return v == nullptr || v[0] != '0';
+        }();
+        if (!s_enabled)
+        {
+            return false;
+        }
+        typedef void*     (APIENTRY* PFNMAPRANGELOCAL)(GLenum, GLintptr, GLsizeiptr, GLbitfield);
+        typedef GLboolean (APIENTRY* PFNUNMAPLOCAL)(GLenum);
+        static PFNMAPRANGELOCAL s_map =
+            (PFNMAPRANGELOCAL)SDL_GL_GetProcAddress("glMapBufferRange");
+        static PFNUNMAPLOCAL s_unmap =
+            (PFNUNMAPLOCAL)SDL_GL_GetProcAddress("glUnmapBuffer");
+        if (s_map == nullptr || s_unmap == nullptr)
+        {
+            return false;
+        }
+        void* dst = s_map(target, offset, size,
+            GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_RANGE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
+        if (dst == nullptr)
+        {
+            return false;
+        }
+        memcpy(dst, data, (size_t)size);
+        return s_unmap(target) == GL_TRUE;
+    }
 }
 
 BufferHandle CreateVertexBuffer(const void* initialData, size_t sizeBytes, BufferUsage usage)
@@ -315,7 +375,10 @@ void UpdateBuffer(BufferHandle handle, const void* data, size_t sizeBytes)
         FrameProfiler::CountGLCall(FrameProfiler::Counter::BufferUpdates);
         FrameProfiler::TagBufferOrphan();
     }
-    fn_glBufferSubData(GL_ARRAY_BUFFER, 0, (GLsizeiptr)sizeBytes, data);
+    if (!MappedRangeWrite(GL_ARRAY_BUFFER, 0, (GLsizeiptr)sizeBytes, data))
+    {
+        fn_glBufferSubData(GL_ARRAY_BUFFER, 0, (GLsizeiptr)sizeBytes, data);
+    }
     FrameProfiler::CountGLCall(FrameProfiler::Counter::BufferUpdates);
     fn_glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
@@ -374,7 +437,10 @@ size_t AppendBuffer(BufferHandle handle, const void* data, size_t sizeBytes)
         writeOffset = 0;
     }
 
-    fn_glBufferSubData(GL_ARRAY_BUFFER, writeOffset, neededSize, data);
+    if (!MappedRangeWrite(GL_ARRAY_BUFFER, writeOffset, neededSize, data))
+    {
+        fn_glBufferSubData(GL_ARRAY_BUFFER, writeOffset, neededSize, data);
+    }
     FrameProfiler::CountGLCall(FrameProfiler::Counter::BufferUpdates);
     fn_glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -447,6 +513,11 @@ namespace {
         static bool loaded = false;
         if (loaded) return true;
         fn_glBufferStorage = (PFNGLBUFFERSTORAGEPROC)SDL_GL_GetProcAddress("glBufferStorage");
+        if (fn_glBufferStorage == nullptr)
+        {
+            // OpenGL ES ships this as GL_EXT_buffer_storage; same signature.
+            fn_glBufferStorage = (PFNGLBUFFERSTORAGEPROC)SDL_GL_GetProcAddress("glBufferStorageEXT");
+        }
         loaded = (fn_glBufferStorage != nullptr);
         return loaded;
     }

--- a/src/source/Render/RHI/RHI_GL.cpp
+++ b/src/source/Render/RHI/RHI_GL.cpp
@@ -257,7 +257,14 @@ namespace {
     bool LoadBufferGLFunctions()
     {
         static bool loaded = false;
-        if (loaded) return true;
+        // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+        // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+        // driver without KHR_debug), a success-only latch re-runs every lookup on
+        // every call forever -- measured at ~10% of the render thread in the dynamic
+        // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+        static bool attempted = false;
+        if (attempted) return loaded;
+        attempted = true;
         fn_glGenBuffers     = (PFNGLGENBUFFERSPROC)SDL_GL_GetProcAddress("glGenBuffers");
         fn_glBindBuffer     = (PFNGLBINDBUFFERPROC)SDL_GL_GetProcAddress("glBindBuffer");
         fn_glBufferData     = (PFNGLBUFFERDATAPROC)SDL_GL_GetProcAddress("glBufferData");
@@ -492,7 +499,14 @@ namespace {
     bool LoadUboRingSyncFunctions()
     {
         static bool loaded = false;
-        if (loaded) return true;
+        // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+        // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+        // driver without KHR_debug), a success-only latch re-runs every lookup on
+        // every call forever -- measured at ~10% of the render thread in the dynamic
+        // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+        static bool attempted = false;
+        if (attempted) return loaded;
+        attempted = true;
         fn_glFenceSync       = (PFNGLFENCESYNCPROC)SDL_GL_GetProcAddress("glFenceSync");
         fn_glClientWaitSync  = (PFNGLCLIENTWAITSYNCPROC)SDL_GL_GetProcAddress("glClientWaitSync");
         fn_glDeleteSync      = (PFNGLDELETESYNCPROC)SDL_GL_GetProcAddress("glDeleteSync");
@@ -511,7 +525,14 @@ namespace {
     bool LoadBufferStorageFunction()
     {
         static bool loaded = false;
-        if (loaded) return true;
+        // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+        // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+        // driver without KHR_debug), a success-only latch re-runs every lookup on
+        // every call forever -- measured at ~10% of the render thread in the dynamic
+        // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+        static bool attempted = false;
+        if (attempted) return loaded;
+        attempted = true;
         fn_glBufferStorage = (PFNGLBUFFERSTORAGEPROC)SDL_GL_GetProcAddress("glBufferStorage");
         if (fn_glBufferStorage == nullptr)
         {
@@ -964,7 +985,14 @@ namespace {
     bool LoadVertexLayoutGLFunctions()
     {
         static bool loaded = false;
-        if (loaded) return true;
+        // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+        // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+        // driver without KHR_debug), a success-only latch re-runs every lookup on
+        // every call forever -- measured at ~10% of the render thread in the dynamic
+        // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+        static bool attempted = false;
+        if (attempted) return loaded;
+        attempted = true;
         fn_glGenVertexArrays         = (PFNGLGENVERTEXARRAYSPROC)SDL_GL_GetProcAddress("glGenVertexArrays");
         fn_glDeleteVertexArrays      = (PFNGLDELETEVERTEXARRAYSPROC)SDL_GL_GetProcAddress("glDeleteVertexArrays");
         fn_glVertexAttribPointer     = (PFNGLVERTEXATTRIBPOINTERPROC)SDL_GL_GetProcAddress("glVertexAttribPointer");

--- a/src/source/Render/Shaders/BMDMeshShader.cpp
+++ b/src/source/Render/Shaders/BMDMeshShader.cpp
@@ -61,7 +61,14 @@ static PFNGLUNIFORMMATRIX4FVPROC   fn_glUniformMatrix4fv    = nullptr;
 static bool LoadGLShaderFunctions()
 {
     static bool loaded = false;
-    if (loaded) return true;
+    // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+    // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+    // driver without KHR_debug), a success-only latch re-runs every lookup on
+    // every call forever -- measured at ~10% of the render thread in the dynamic
+    // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+    static bool attempted = false;
+    if (attempted) return loaded;
+    attempted = true;
 
     fn_glCreateShader       = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress("glCreateShader");
     fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)MU_GLSHADERSOURCE_PROC;

--- a/src/source/Render/Shaders/BMDMeshShader.cpp
+++ b/src/source/Render/Shaders/BMDMeshShader.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "Render/Shaders/EsShaderShim.h"
 #include "BMDMeshShader.h"
 #include "Render/Core/RenderConfig.h"
 #include "Render/Core/GlobalUBO.h"
@@ -63,7 +64,7 @@ static bool LoadGLShaderFunctions()
     if (loaded) return true;
 
     fn_glCreateShader       = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress("glCreateShader");
-    fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)SDL_GL_GetProcAddress("glShaderSource");
+    fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)MU_GLSHADERSOURCE_PROC;
     fn_glCompileShader       = (PFNGLCOMPILESHADERPROC)SDL_GL_GetProcAddress("glCompileShader");
     fn_glGetShaderiv         = (PFNGLGETSHADERIVPROC)SDL_GL_GetProcAddress("glGetShaderiv");
     fn_glGetShaderInfoLog    = (PFNGLGETSHADERINFOLOGPROC)SDL_GL_GetProcAddress("glGetShaderInfoLog");

--- a/src/source/Render/Shaders/EsShaderShim.h
+++ b/src/source/Render/Shaders/EsShaderShim.h
@@ -1,0 +1,60 @@
+#pragma once
+// AH-1118: on Android the engine's `#version 330 core` shaders are transposed
+// to GLSL ES (`#version 300 es`, with explicit default precision) at
+// glShaderSource time, so the modern core-profile pipeline runs on a native
+// OpenGL ES 3 context. Desktop builds resolve the real driver entry unchanged.
+#ifdef __ANDROID__
+#include <SDL3/SDL.h>
+#include <cstring>
+#include <string>
+
+typedef void (*MU_PFNGLSHADERSOURCE)(unsigned int, int, const char* const*, const int*);
+
+inline void MU_EsShaderSource(unsigned int shader, int count, const char* const* strings, const int* lengths)
+{
+    static MU_PFNGLSHADERSOURCE real =
+        (MU_PFNGLSHADERSOURCE)SDL_GL_GetProcAddress("glShaderSource");
+
+    std::string src;
+    for (int i = 0; i < count; ++i)
+    {
+        if (strings[i] == nullptr)
+        {
+            continue;
+        }
+        if (lengths != nullptr && lengths[i] >= 0)
+        {
+            src.append(strings[i], static_cast<size_t>(lengths[i]));
+        }
+        else
+        {
+            src.append(strings[i]);
+        }
+    }
+
+    // ES compilers require #version on the very first line; the engine's raw
+    // string literals open with a newline that desktop drivers tolerated.
+    const size_t firstContent = src.find_first_not_of(" \t\r\n");
+    if (firstContent != std::string::npos && firstContent > 0)
+    {
+        src.erase(0, firstContent);
+    }
+
+    static const char kDesktop[] = "#version 330 core";
+    const size_t pos = src.find(kDesktop);
+    if (pos != std::string::npos)
+    {
+        src.replace(pos, sizeof(kDesktop) - 1,
+                    "#version 300 es\n"
+                    "precision highp float;\n"
+                    "precision highp int;\n");
+    }
+
+    const char* one = src.c_str();
+    real(shader, 1, &one, nullptr);
+}
+
+#define MU_GLSHADERSOURCE_PROC ((void*)&MU_EsShaderSource)
+#else
+#define MU_GLSHADERSOURCE_PROC SDL_GL_GetProcAddress("glShaderSource")
+#endif

--- a/src/source/Render/Shaders/PassthroughShader.cpp
+++ b/src/source/Render/Shaders/PassthroughShader.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "Render/Shaders/EsShaderShim.h"
 #include "PassthroughShader.h"
 #include "Render/Core/RenderConfig.h"
 #include "Render/Core/BindState.h"
@@ -59,7 +60,7 @@ static bool LoadGLShaderFunctions()
     if (loaded) return true;
 
     fn_glCreateShader       = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress("glCreateShader");
-    fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)SDL_GL_GetProcAddress("glShaderSource");
+    fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)MU_GLSHADERSOURCE_PROC;
     fn_glCompileShader       = (PFNGLCOMPILESHADERPROC)SDL_GL_GetProcAddress("glCompileShader");
     fn_glGetShaderiv         = (PFNGLGETSHADERIVPROC)SDL_GL_GetProcAddress("glGetShaderiv");
     fn_glGetShaderInfoLog    = (PFNGLGETSHADERINFOLOGPROC)SDL_GL_GetProcAddress("glGetShaderInfoLog");

--- a/src/source/Render/Shaders/PassthroughShader.cpp
+++ b/src/source/Render/Shaders/PassthroughShader.cpp
@@ -57,7 +57,14 @@ static PFNGLACTIVETEXTUREPROC      fn_glActiveTexture       = nullptr;
 static bool LoadGLShaderFunctions()
 {
     static bool loaded = false;
-    if (loaded) return true;
+    // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+    // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+    // driver without KHR_debug), a success-only latch re-runs every lookup on
+    // every call forever -- measured at ~10% of the render thread in the dynamic
+    // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+    static bool attempted = false;
+    if (attempted) return loaded;
+    attempted = true;
 
     fn_glCreateShader       = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress("glCreateShader");
     fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)MU_GLSHADERSOURCE_PROC;

--- a/src/source/Render/Shaders/PlanarShadowShader.cpp
+++ b/src/source/Render/Shaders/PlanarShadowShader.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "Render/Shaders/EsShaderShim.h"
 #include "Render/Shaders/PlanarShadowShader.h"
 #include "Render/Core/BindState.h"
 #include "Render/Core/RenderConfig.h"

--- a/src/source/Render/Shaders/PlanarShadowShader.cpp
+++ b/src/source/Render/Shaders/PlanarShadowShader.cpp
@@ -156,7 +156,7 @@ CPlanarShadowShader::~CPlanarShadowShader() { Shutdown(); }
 bool CPlanarShadowShader::LoadGLFunctions()
 {
     fn_glCreateShader       = (PFNGLCREATESHADERPROC)      SDL_GL_GetProcAddress("glCreateShader");
-    fn_glShaderSource       = (PFNGLSHADERSOURCEPROC)      SDL_GL_GetProcAddress("glShaderSource");
+    fn_glShaderSource       = (PFNGLSHADERSOURCEPROC)      MU_GLSHADERSOURCE_PROC;
     fn_glCompileShader      = (PFNGLCOMPILESHADERPROC)     SDL_GL_GetProcAddress("glCompileShader");
     fn_glGetShaderiv        = (PFNGLGETSHADERIVPROC)       SDL_GL_GetProcAddress("glGetShaderiv");
     fn_glCreateProgram      = (PFNGLCREATEPROGRAMPROC)     SDL_GL_GetProcAddress("glCreateProgram");

--- a/src/source/Render/Shaders/TerrainShader.cpp
+++ b/src/source/Render/Shaders/TerrainShader.cpp
@@ -56,7 +56,14 @@ static PFNGLACTIVETEXTUREPROC      fn_glActiveTexture       = nullptr;
 static bool LoadGLShaderFunctions()
 {
     static bool loaded = false;
-    if (loaded) return true;
+    // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+    // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+    // driver without KHR_debug), a success-only latch re-runs every lookup on
+    // every call forever -- measured at ~10% of the render thread in the dynamic
+    // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+    static bool attempted = false;
+    if (attempted) return loaded;
+    attempted = true;
 
     fn_glCreateShader       = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress("glCreateShader");
     fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)MU_GLSHADERSOURCE_PROC;

--- a/src/source/Render/Shaders/TerrainShader.cpp
+++ b/src/source/Render/Shaders/TerrainShader.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "Render/Shaders/EsShaderShim.h"
 #include "TerrainShader.h"
 #include "Render/Core/RenderConfig.h"
 #include "Render/Core/BindState.h"
@@ -58,7 +59,7 @@ static bool LoadGLShaderFunctions()
     if (loaded) return true;
 
     fn_glCreateShader       = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress("glCreateShader");
-    fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)SDL_GL_GetProcAddress("glShaderSource");
+    fn_glShaderSource        = (PFNGLSHADERSOURCEPROC)MU_GLSHADERSOURCE_PROC;
     fn_glCompileShader       = (PFNGLCOMPILESHADERPROC)SDL_GL_GetProcAddress("glCompileShader");
     fn_glGetShaderiv         = (PFNGLGETSHADERIVPROC)SDL_GL_GetProcAddress("glGetShaderiv");
     fn_glGetShaderInfoLog    = (PFNGLGETSHADERINFOLOGPROC)SDL_GL_GetProcAddress("glGetShaderInfoLog");

--- a/src/source/Render/Terrain/ZzzLodTerrain.cpp
+++ b/src/source/Render/Terrain/ZzzLodTerrain.cpp
@@ -3,8 +3,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#include <GL/gl.h>
-#include <GL/glu.h>
 #include <math.h>
 #include <iterator>
 #include "Render/Textures/ZzzOpenglUtil.h"

--- a/src/source/Render/Terrain/ZzzLodTerrain.cpp
+++ b/src/source/Render/Terrain/ZzzLodTerrain.cpp
@@ -5,6 +5,9 @@
 #include "stdafx.h"
 #include <math.h>
 #include <iterator>
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
 #include "Render/Textures/ZzzOpenglUtil.h"
 #include "Render/Core/BindState.h"
 #include "Core/Utilities/FrameProfiler.h"
@@ -1084,7 +1087,14 @@ static PFNGLPOPDEBUGGROUPPROC          fn_glPopDebugGroup          = nullptr;
 static bool LoadTerrainGLFunctions()
 {
     static bool loaded = false;
-    if (loaded) return true;
+    // AH-1118: latch on ATTEMPT, not on success. These loaders are called from
+    // per-draw paths; if any symbol fails to resolve (e.g. glPushDebugGroup on a
+    // driver without KHR_debug), a success-only latch re-runs every lookup on
+    // every call forever -- measured at ~10% of the render thread in the dynamic
+    // linker on Adreno 730, since eglGetProcAddress is a full symbol search.
+    static bool attempted = false;
+    if (attempted) return loaded;
+    attempted = true;
 
     fn_glGenBuffers              = (PFNGLGENBUFFERSPROC)SDL_GL_GetProcAddress("glGenBuffers");
     fn_glDeleteBuffers           = (PFNGLDELETEBUFFERSPROC)SDL_GL_GetProcAddress("glDeleteBuffers");
@@ -1098,6 +1108,15 @@ static bool LoadTerrainGLFunctions()
     fn_glPopDebugGroup           = (PFNGLPOPDEBUGGROUPPROC)SDL_GL_GetProcAddress("glPopDebugGroup");
 
     loaded = (fn_glGenBuffers && fn_glBindBuffer && fn_glBufferData && fn_glGenVertexArrays);
+#ifdef __ANDROID__
+    // A null pointer here is a silently disabled feature, not just a slow path --
+    // name the misses once so they can't hide behind the attempt-latch above.
+    __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
+        "terrain GL procs: genBuf=%d bindBuf=%d bufData=%d genVAO=%d attrPtr=%d dbgGroup=%d",
+        fn_glGenBuffers != nullptr, fn_glBindBuffer != nullptr, fn_glBufferData != nullptr,
+        fn_glGenVertexArrays != nullptr, fn_glVertexAttribPointer != nullptr,
+        fn_glPushDebugGroup != nullptr);
+#endif
     return loaded;
 }
 

--- a/src/source/Render/Textures/ZzzOpenglUtil.cpp
+++ b/src/source/Render/Textures/ZzzOpenglUtil.cpp
@@ -3,6 +3,9 @@
 
 #include "stdafx.h"
 #include "ZzzOpenglUtil.h"
+#ifdef __ANDROID__
+#include <unordered_map>
+#endif
 #include "ZzzTexture.h"
 #include "Render/Models/ZzzBMD.h"
 #include "Engine/Object/ZzzInfomation.h"
@@ -183,6 +186,12 @@ GLRenderStateSnapshot GetRenderStateSnapshot()
     };
 }
 
+#ifdef __ANDROID__
+// AH-1118 diagnostics: which bitmap indices churn the texture binding (each
+// change breaks the IR batch). Read+cleared by the SceneManager 5s stats dump.
+std::unordered_map<int, unsigned int> g_muBindHisto;
+#endif
+
 void BindTexture(int tex)
 {
     if (CachTexture != tex)
@@ -195,6 +204,9 @@ void BindTexture(int tex)
         const uint32_t textureID = (tex >= 0) ? static_cast<uint32_t>(Bitmaps[tex].TextureNumber)
                                                : static_cast<uint32_t>(-1 * tex);
         BindTexture2D(0, textureID);
+#ifdef __ANDROID__
+        ++g_muBindHisto[tex];
+#endif
     }
 }
 

--- a/src/source/Render/Textures/ZzzOpenglUtil.cpp
+++ b/src/source/Render/Textures/ZzzOpenglUtil.cpp
@@ -1091,6 +1091,31 @@ void RenderPlane3D(float Width, float Height, float Matrix[3][4])
     IR::End();
 }
 
+void RenderPlane3DAt(float Width, float Height, float Matrix[3][4], const vec3_t Position)
+{
+    vec3_t BoundingVertices[4];
+    Vector(-Width, -Width, Height, BoundingVertices[3]);
+    Vector(Width, Width, Height, BoundingVertices[2]);
+    Vector(Width, Width, -Height, BoundingVertices[1]);
+    Vector(-Width, -Width, -Height, BoundingVertices[0]);
+
+    vec3_t TransformVertices[4];
+    for (int j = 0; j < 4; j++)
+    {
+        VectorTransform(BoundingVertices[j], Matrix, TransformVertices[j]);
+        VectorAdd(TransformVertices[j], Position, TransformVertices[j]);
+    }
+
+    IR::Begin(GL_QUADS);
+    PassthroughShader::Instance().SetUseTexture(true);
+    IR::Color3f(1.f, 1.f, 1.f);
+    IR::TexCoord2f(0.f, 1.f); IR::Vertex3fv(TransformVertices[0]);
+    IR::TexCoord2f(1.f, 1.f); IR::Vertex3fv(TransformVertices[1]);
+    IR::TexCoord2f(1.f, 0.f); IR::Vertex3fv(TransformVertices[2]);
+    IR::TexCoord2f(0.f, 0.f); IR::Vertex3fv(TransformVertices[3]);
+    IR::End();
+}
+
 void BeginSprite()
 {
     // Sprites pre-transform their position into view space on the CPU (VectorTransform

--- a/src/source/Render/Textures/ZzzOpenglUtil.h
+++ b/src/source/Render/Textures/ZzzOpenglUtil.h
@@ -133,6 +133,11 @@ struct GLRenderStateSnapshot
 GLRenderStateSnapshot GetRenderStateSnapshot();
 
 void RenderPlane3D(float Width, float Height, float Matrix[3][4]);
+// AH-1118: RenderPlane3D with the world position folded into the CPU-side
+// corner transform, so callers can batch many planes under one identity model
+// matrix instead of a UBO model update per plane (RenderLeaves measured 3
+// buffer writes per leaf per frame through the SetModel path).
+void RenderPlane3DAt(float Width, float Height, float Matrix[3][4], const vec3_t Position);
 void RenderSprite(int Texture, vec3_t Position, float Width, float Height, vec3_t Light, float Angle = 0.f, float u = 0.f, float v = 0.f, float uWidth = 1.f, float vHeight = 1.f);
 void RenderSpriteUV(int Texture, vec3_t Position, float Width, float Height, float(*UV)[2], vec3_t Light[4], float Alpha = 1.f);
 void RenderNumber(vec3_t Position, int Num, vec3_t Color, float Alpha = 1.f, float Scale = 15.f);

--- a/src/source/Scenes/MainScene.cpp
+++ b/src/source/Scenes/MainScene.cpp
@@ -475,8 +475,8 @@ static void RenderGameWorld(BYTE& byWaterMap, int width, int height)
 
     if (renderEffects)
     {
-        RenderEffectShadows();
-        RenderBoids();
+        { FRAME_PROFILE(EffShadows); RenderEffectShadows(); }
+        { FRAME_PROFILE(Boids); RenderBoids(); }
     }
 
     { FRAME_PROFILE(Characters); RenderCharactersClient(); }
@@ -491,17 +491,17 @@ static void RenderGameWorld(BYTE& byWaterMap, int width, int height)
     if (!g_Camera.TopViewEnable && renderDroppedItems)
         { FRAME_PROFILE(Items); RenderItems(); }
 
-    RenderFishs();
+    { FRAME_PROFILE(Boids); RenderFishs(); }
     RenderMount();
 
     if (renderWeatherEffects)
-        RenderLeaves();
+        { FRAME_PROFILE(Leaves); RenderLeaves(); }
 
     if (!gMapManager.InChaosCastle())
         ThePetProcess().RenderPets();
 
     if (renderEffects)
-        RenderBoids(true);
+        { FRAME_PROFILE(Boids); RenderBoids(true); }
 
     if (renderStatic)
         { FRAME_PROFILE(Objects); RenderObjects_AfterCharacter(); }
@@ -519,7 +519,7 @@ static void RenderGameWorld(BYTE& byWaterMap, int width, int height)
 
     if (ShouldRenderLeaves())
     {
-        RenderLeaves();
+        FRAME_PROFILE(Leaves); RenderLeaves();
     }
 
     // GLP-24: these two were the frame's largest GL producers and fell outside every FRAME_PROFILE
@@ -530,12 +530,12 @@ static void RenderGameWorld(BYTE& byWaterMap, int width, int height)
 
     if (IsWaterTerrain() == false)
     {
-        RenderPoints(byWaterMap);
+        FRAME_PROFILE(Points); RenderPoints(byWaterMap);
     }
 
     EndSprite();
 
-    RenderAfterEffects();
+    { FRAME_PROFILE(AfterFx); RenderAfterEffects(); }
 
     if (IsWaterTerrain() == true)
     {
@@ -553,11 +553,11 @@ static void RenderGameWorld(BYTE& byWaterMap, int width, int height)
         BeginSprite();
 
         if (gMapManager.WorldActive == WD_2DEVIAS && HeroTile != 3 && HeroTile < 10)
-            RenderLeaves();
+            { FRAME_PROFILE(Leaves); RenderLeaves(); }
 
         { FRAME_PROFILE(Sprites); RenderSprites(byWaterMap); }
         { FRAME_PROFILE(Particles); RenderParticles(byWaterMap); }
-        RenderPoints(byWaterMap);
+        { FRAME_PROFILE(Points); RenderPoints(byWaterMap); }
 
         EndSprite();
         EndOpengl();

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -9,6 +9,10 @@
 #include <numeric>
 #include "SceneManager.h"
 #include "Core/Utilities/FrameProfiler.h"
+#ifdef __ANDROID__
+#include <android/log.h>
+#include <chrono>
+#endif
 #include "Core/Utilities/PlatformInfo.h"
 #include "Render/Core/ImmediateRenderer.h"
 #include "Render/Shaders/PassthroughShader.h"
@@ -1209,6 +1213,49 @@ void MainScene(HDC hDC)
             // for why this can't live inside either overlay function. AdvanceGpuTimers() must run
             // after this frame's Terrain/Objects/Characters/Items/Effects/UI passes have all
             // issued their GpuTimerBegin/End calls, which RenderCurrentScene() above guarantees.
+#ifdef __ANDROID__
+            // AH-1118 batching pass: dump the frame's GL statistics to logcat
+            // every ~5s, before the reset below wipes them.
+            {
+                FrameProfiler::g_CountersEnabled = true;
+                using clock = std::chrono::steady_clock;
+                static clock::time_point s_lastDump{};
+                const clock::time_point nowT = clock::now();
+                if (nowT - s_lastDump >= std::chrono::seconds(5))
+                {
+                    s_lastDump = nowT;
+                    using FrameProfiler::Counter;
+                    using FrameProfiler::CounterValue;
+                    using FrameProfiler::Pass;
+                    __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
+                        "tot gl=%u draw=%u bufUp=%u orphan=%u prog=%u tex=%u uni=%u",
+                        CounterValue(Counter::GLCalls), CounterValue(Counter::DrawCalls),
+                        CounterValue(Counter::BufferUpdates), CounterValue(Counter::BufferOrphans),
+                        CounterValue(Counter::ProgramBinds), CounterValue(Counter::TextureBinds),
+                        CounterValue(Counter::UniformWrites));
+                    for (int p = 0; p < static_cast<int>(Pass::Count_); ++p)
+                    {
+                        const uint32_t gl = CounterValue(static_cast<Pass>(p), Counter::GLCalls);
+                        if (gl >= 200)
+                        {
+                            __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
+                                "pass %s gl=%u draw=%u tex=%u buf=%u",
+                                FrameProfiler::kPassNames[p], gl,
+                                CounterValue(static_cast<Pass>(p), Counter::DrawCalls),
+                                CounterValue(static_cast<Pass>(p), Counter::TextureBinds),
+                                CounterValue(static_cast<Pass>(p), Counter::BufferUpdates));
+                        }
+                    }
+                    __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
+                        "IR draws=%u verts=%u brk tex=%u blend=%u depth=%u prog=%u uni=%u mtx=%u draw=%u oth=%u",
+                        CounterValue(Counter::IRDraws), CounterValue(Counter::IRVertices),
+                        CounterValue(Counter::IRBreakTexture), CounterValue(Counter::IRBreakBlend),
+                        CounterValue(Counter::IRBreakDepth), CounterValue(Counter::IRBreakProgram),
+                        CounterValue(Counter::IRBreakUniform), CounterValue(Counter::IRBreakMatrix),
+                        CounterValue(Counter::IRBreakDraw), CounterValue(Counter::IRBreakOther));
+                }
+            }
+#endif
             FrameProfiler::ResetFrame();
             FrameProfiler::ResetCounters();
             FrameProfiler::AdvanceGpuTimers();

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -12,6 +12,7 @@
 #ifdef __ANDROID__
 #include <android/log.h>
 #include <chrono>
+#include <unordered_map>
 #endif
 #include "Core/Utilities/PlatformInfo.h"
 #include "Render/Core/ImmediateRenderer.h"
@@ -1317,6 +1318,37 @@ void MainScene(HDC hDC)
                             g_muTextCacheHits, g_muTextCacheMisses);
                         g_muTextCacheHits = 0;
                         g_muTextCacheMisses = 0;
+                    }
+                    {
+                        // Top texture-bind churners since the last dump. Bitmap index
+                        // -> bind count; negative indices are raw GL texture ids
+                        // (the string cache draws with those).
+                        extern std::unordered_map<int, unsigned int> g_muBindHisto;
+                        std::vector<std::pair<int, unsigned int>> top(g_muBindHisto.begin(), g_muBindHisto.end());
+                        std::sort(top.begin(), top.end(),
+                                  [](const auto& a, const auto& b) { return a.second > b.second; });
+                        char histLine[256];
+                        int off = 0;
+                        unsigned int negatives = 0;
+                        for (const auto& kv : top) if (kv.first < 0) negatives += kv.second;
+                        for (size_t t = 0; t < top.size() && t < 8 && off < 200; ++t)
+                        {
+                            if (top[t].first < 0) continue;
+                            off += snprintf(histLine + off, sizeof(histLine) - off, "%d:%u ",
+                                            top[t].first, top[t].second);
+                        }
+                        __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
+                            "bindhisto raw=%u %s", negatives, histLine);
+                        // Dynamic-range slots carry their source filename -- log it so the
+                        // histogram is actionable without an enum lookup.
+                        for (size_t t = 0; t < top.size() && t < 6; ++t)
+                        {
+                            if (top[t].first < (int)BITMAP_NONAMED_TEXTURES_BEGIN) continue;
+                            __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
+                                "bindname %d:%u %ls", top[t].first, top[t].second,
+                                Bitmaps[top[t].first].FileName);
+                        }
+                        g_muBindHisto.clear();
                     }
                     if (g_muSplitFrames > 0)
                     {

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -663,6 +663,11 @@ static void RenderGLStats()
 {
     if (!FrameProfiler::g_CountersEnabled)
         return;
+#ifdef __ANDROID__
+    // Counters stay on for the periodic logcat dump, but the on-screen HUD's
+    // per-line text rendering is too expensive on mobile GL to pay every frame.
+    return;
+#endif
 
     BeginBitmap();
 
@@ -1227,6 +1232,22 @@ void MainScene(HDC hDC)
                     using FrameProfiler::Counter;
                     using FrameProfiler::CounterValue;
                     using FrameProfiler::Pass;
+                    // Per-pass CPU milliseconds for the frame in flight -- the
+                    // decisive "where do 900 ms go" breakdown.
+                    {
+                        char msLine[256];
+                        int off = 0;
+                        for (int p = 0; p < static_cast<int>(Pass::Count_) && off < 200; ++p)
+                        {
+                            const float ms = FrameProfiler::AccumulatorMs(static_cast<Pass>(p));
+                            if (ms >= 1.0f)
+                            {
+                                off += snprintf(msLine + off, sizeof(msLine) - off, "%s=%.0f ",
+                                                FrameProfiler::kPassNames[p], ms);
+                            }
+                        }
+                        __android_log_print(ANDROID_LOG_INFO, "MuMainGL", "ms %s", msLine);
+                    }
                     __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
                         "tot gl=%u draw=%u bufUp=%u orphan=%u prog=%u tex=%u uni=%u",
                         CounterValue(Counter::GLCalls), CounterValue(Counter::DrawCalls),

--- a/src/source/Scenes/SceneManager.cpp
+++ b/src/source/Scenes/SceneManager.cpp
@@ -1181,8 +1181,39 @@ static void ManageMainSceneAudio()
  *
  * @param hDC Device context for rendering
  */
+#ifdef __ANDROID__
+// AH-1118: wall-clock split of the frame -- time inside MainScene vs the gap
+// between MainScene calls (game update, input pump, swap, everything else).
+// Accumulated per frame, averaged into the 5s MuMainGL dump.
+static double g_muInsideMsAccum = 0.0;
+static double g_muOutsideMsAccum = 0.0;
+static int    g_muSplitFrames = 0;
+static std::chrono::steady_clock::time_point g_muLastExit{};
+#endif
+
 void MainScene(HDC hDC)
 {
+#ifdef __ANDROID__
+    struct MuSplitScope
+    {
+        std::chrono::steady_clock::time_point entry;
+        MuSplitScope()
+        {
+            entry = std::chrono::steady_clock::now();
+            if (g_muLastExit.time_since_epoch().count() != 0)
+            {
+                g_muOutsideMsAccum += std::chrono::duration<double, std::milli>(entry - g_muLastExit).count();
+            }
+        }
+        ~MuSplitScope()
+        {
+            const auto exitT = std::chrono::steady_clock::now();
+            g_muInsideMsAccum += std::chrono::duration<double, std::milli>(exitT - entry).count();
+            g_muLastExit = exitT;
+            ++g_muSplitFrames;
+        }
+    } muSplitScope;
+#endif
     if (SceneFlag == LOG_IN_SCENE || SceneFlag == CHARACTER_SCENE)
     {
         UpdateLoginAndCharacterScenes();
@@ -1195,14 +1226,27 @@ void MainScene(HDC hDC)
         return;
     }
 
+#ifdef __ANDROID__
+    // AH-1118: bisect the inside-MainScene time -- update phase vs render phase.
+    static double s_muUpdateMs = 0.0, s_muRenderMs = 0.0;
+    const auto muT0 = std::chrono::steady_clock::now();
+#endif
     UpdateCoreSystems();
     SetWorldClearColor();
+#ifdef __ANDROID__
+    const auto muT1 = std::chrono::steady_clock::now();
+    s_muUpdateMs += std::chrono::duration<double, std::milli>(muT1 - muT0).count();
+#endif
 
     bool Success = false;
 
     try
     {
         Success = RenderCurrentScene(hDC);
+#ifdef __ANDROID__
+        s_muRenderMs += std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - muT1).count();
+#endif
         {
             // GLP-24: tagged Overlay, not Other. These three render text as roughly one IR quad per
             // glyph, so with $glstats on they were adding hundreds of draw calls to the very bucket
@@ -1247,6 +1291,47 @@ void MainScene(HDC hDC)
                             }
                         }
                         __android_log_print(ANDROID_LOG_INFO, "MuMainGL", "ms %s", msLine);
+                    }
+                    {
+                        char gpuLine[256];
+                        int off = 0;
+                        for (int gi = 0; gi < FrameProfiler::kGpuTimedPassCount && off < 200; ++gi)
+                        {
+                            const Pass p = FrameProfiler::kGpuTimedPasses[gi];
+                            const float ms = FrameProfiler::GpuMs(p);
+                            if (ms >= 1.0f)
+                            {
+                                off += snprintf(gpuLine + off, sizeof(gpuLine) - off, "%s=%.0f ",
+                                                FrameProfiler::kPassNames[(int)p], ms);
+                            }
+                        }
+                        if (off > 0)
+                        {
+                            __android_log_print(ANDROID_LOG_INFO, "MuMainGL", "gpu %s", gpuLine);
+                        }
+                    }
+                    {
+                        extern unsigned int g_muTextCacheHits, g_muTextCacheMisses;
+                        __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
+                            "textcache hits=%u misses=%u (since last dump)",
+                            g_muTextCacheHits, g_muTextCacheMisses);
+                        g_muTextCacheHits = 0;
+                        g_muTextCacheMisses = 0;
+                    }
+                    if (g_muSplitFrames > 0)
+                    {
+                        __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
+                            "split inside=%.0fms (update=%.0f render=%.0f) outside=%.0fms (avg over %d frames)",
+                            g_muInsideMsAccum / g_muSplitFrames,
+                            s_muUpdateMs / g_muSplitFrames,
+                            s_muRenderMs / g_muSplitFrames,
+                            g_muOutsideMsAccum / g_muSplitFrames,
+                            g_muSplitFrames);
+                        g_muInsideMsAccum = 0.0;
+                        g_muOutsideMsAccum = 0.0;
+                        s_muUpdateMs = 0.0;
+                        s_muRenderMs = 0.0;
+                        g_muSplitFrames = 0;
                     }
                     __android_log_print(ANDROID_LOG_INFO, "MuMainGL",
                         "tot gl=%u draw=%u bufUp=%u orphan=%u prog=%u tex=%u uni=%u",

--- a/src/source/UI/Legacy/UIControls.cpp
+++ b/src/source/UI/Legacy/UIControls.cpp
@@ -27,6 +27,7 @@
 #include "GameLogic/Items/InventoryUtils.h"
 #include "UI/NewUI/NewUISystem.h"
 #include <vector>
+#include <unordered_map>
 
 extern BYTE m_CrywolfState;
 
@@ -2700,7 +2701,13 @@ void CUIRenderTextOriginal::SetBgColor(BYTE byRed, BYTE byGreen, BYTE byBlue, BY
 }
 void CUIRenderTextOriginal::SetBgColor(DWORD dwColor) { m_dwBackColor = dwColor; }
 
-void CUIRenderTextOriginal::SetFont(HFONT hFont) { SelectObject(m_hFontDC, hFont); }
+void CUIRenderTextOriginal::SetFont(HFONT hFont)
+{
+    SelectObject(m_hFontDC, hFont);
+#ifdef __ANDROID__
+    m_hCurrentFont = hFont;
+#endif
+}
 
 /// \brief Reads the Picture created by GDI and copies it to the texture bitmap.
 void CUIRenderTextOriginal::WriteText(int iOffset, int iWidth, int iHeight)
@@ -2832,6 +2839,54 @@ void CUIRenderTextOriginal::UploadText(int sx, int sy, int Width, int Height)
     }
 }
 
+#ifdef __ANDROID__
+// AH-1118: string-texture cache. The stock path re-rasterizes every string with
+// stb_truetype, colorizes it pixel-by-pixel, and respecifies the one shared
+// 256x32 BITMAP_FONT texture per <=256px chunk -- per string, per frame. On a
+// tiled-GPU driver each mid-frame respecify of a texture still referenced by an
+// earlier draw forces a ghost copy, and the UI pass alone measured 35 ms/frame
+// in-game. Each distinct (font, text, color, clip, size) instead rasterizes
+// once into its own exactly-sized texture; repeat frames bind and draw a quad.
+// Draws go through the stock RenderBitmap via its negative-index raw-texture
+// convention, so IR batching/flush semantics stay identical.
+namespace
+{
+    struct MuTextCacheEntry
+    {
+        unsigned int texId = 0;
+        int w = 0, h = 0;
+        uint64_t lastUse = 0;
+    };
+    std::unordered_map<std::wstring, MuTextCacheEntry> g_muTextCache;
+    uint64_t g_muTextUseCounter = 0;
+    constexpr size_t kMuTextCacheCap = 512;
+
+    void MuTextCacheEvictOldest();
+}
+
+// Read+reset by the SceneManager stats dump: how much of the UI pass is still
+// rasterizing (misses) versus drawing cached quads (hits). Non-static on purpose.
+unsigned int g_muTextCacheHits = 0;
+unsigned int g_muTextCacheMisses = 0;
+
+namespace
+{
+    void MuTextCacheEvictOldest()
+    {
+        auto oldest = g_muTextCache.begin();
+        for (auto it = g_muTextCache.begin(); it != g_muTextCache.end(); ++it)
+        {
+            if (it->second.lastUse < oldest->second.lastUse) oldest = it;
+        }
+        if (oldest != g_muTextCache.end())
+        {
+            RHI::DestroyTexture(RHI::TextureHandle{ oldest->second.texId });
+            g_muTextCache.erase(oldest);
+        }
+    }
+}
+#endif
+
 /// \brief Renders the text with GDI to the location of m_hFontDC/m_pFontBuffer as black/white picture. Text is white.
 void CUIRenderTextOriginal::RenderText(int iPos_x, int iPos_y, const wchar_t* pszText,
                                        int iBoxWidth /* = 0 */, int iBoxHeight /* = 0 */,
@@ -2935,6 +2990,85 @@ void CUIRenderTextOriginal::RenderText(int iPos_x, int iPos_y, const wchar_t* ps
         EndRenderColor();
     }
 
+#ifdef __ANDROID__
+    if (pszText[0] != '\0' && pszText[0] != 0x0a &&
+        RealRenderingSize.cx > 0 && RealRenderingSize.cy > 0)
+    {
+        // Key: font | text color | clip | rendered size | the text itself. The
+        // background quad above stays live-rendered, so bg color is not keyed.
+        std::wstring key;
+        key.reserve(wcslen(pszText) + 48);
+        wchar_t hdr[48];
+        mu_swprintf(hdr, L"%p|%08X|%d|%dx%d|",
+                    (void*)m_hCurrentFont, m_dwTextColor, iClipMove,
+                    RealRenderingSize.cx, RealRenderingSize.cy);
+        key.append(hdr);
+        key.append(pszText);
+
+        auto it = g_muTextCache.find(key);
+        if (it != g_muTextCache.end()) ++g_muTextCacheHits; else ++g_muTextCacheMisses;
+        if (it == g_muTextCache.end())
+        {
+            ::SetBkColor(m_hFontDC, RGB(0, 0, 0));
+            ::SetTextColor(m_hFontDC, RGB(255, 255, 255));
+            TextOut(m_hFontDC, 0, 0, pszText, lstrlen(pszText));
+
+            // Colorize straight from the DIB into an exactly-sized RGBA buffer --
+            // same per-pixel rules as WriteText(), minus the 256x32 atlas bound.
+            const int w = RealRenderingSize.cx;
+            const int h = RealRenderingSize.cy;
+            const SIZE dcSize = { (int)(REFERENCE_WIDTH * g_fScreenRate_x), (int)(REFERENCE_HEIGHT * g_fScreenRate_y) };
+            const int pitch = ((dcSize.cx * 24 + 31) & ~31) >> 3;
+            std::vector<unsigned char> rgba((size_t)w * h * 4, 0);
+            for (int y = 0; y < h && y < dcSize.cy; ++y)
+            {
+                int srcIndex = y * pitch + iClipMove * 3;
+                unsigned int* dst = reinterpret_cast<unsigned int*>(rgba.data() + (size_t)y * w * 4);
+                for (int x = 0; x < w && srcIndex + 2 < pitch * dcSize.cy; ++x, srcIndex += 3)
+                {
+                    const BYTE lum = m_pFontBuffer[srcIndex];
+                    if (lum == 255)
+                    {
+                        dst[x] = m_dwTextColor;
+                    }
+                    else if (lum != 0)
+                    {
+                        DWORD alpha = (DWORD)m_pFontBuffer[srcIndex] +
+                                      m_pFontBuffer[srcIndex + 1] +
+                                      m_pFontBuffer[srcIndex + 2];
+                        alpha /= 3;
+                        alpha <<= 24;
+                        alpha |= 0x00FFFFFF;
+                        dst[x] = m_dwTextColor & alpha;
+                    }
+                }
+            }
+
+            RHI::TextureDesc desc{ w, h, RHI::TexFilter::Nearest, RHI::TexWrap::Clamp };
+            const RHI::TextureHandle tex = RHI::CreateTexture(desc, rgba.data());
+            if (!tex.IsValid())
+            {
+                // Texture creation failed -- draw nothing this frame rather than
+                // falling into the shared-atlas path with a half-updated DIB.
+                if (lpTextSize)
+                {
+                    lpTextSize->cx = RealRenderingSize.cx / g_fScreenRate_x;
+                    lpTextSize->cy = RealRenderingSize.cy / g_fScreenRate_y;
+                }
+                return;
+            }
+            if (g_muTextCache.size() >= kMuTextCacheCap) MuTextCacheEvictOldest();
+            it = g_muTextCache.emplace(std::move(key), MuTextCacheEntry{ tex.id, w, h, 0 }).first;
+        }
+
+        it->second.lastUse = ++g_muTextUseCounter;
+        EnableAlphaTest();
+        RenderBitmap(-(int)it->second.texId,
+                     RealBoxPos.x + iTab, RealBoxPos.y,
+                     (float)it->second.w, (float)it->second.h,
+                     0.0f, 0.0f, 1.0f, 1.0f, false, false);
+    }
+#else
     if (pszText[0] != 0x0a)
     {
         ::SetBkColor(m_hFontDC, RGB(0, 0, 0));
@@ -2953,6 +3087,7 @@ void CUIRenderTextOriginal::RenderText(int iPos_x, int iPos_y, const wchar_t* ps
         WriteText(LIMIT_WIDTH * i * 3 + iClipMove, RealSectionLine.cx, RealSectionLine.cy);
         UploadText(RealBoxPos.x + LIMIT_WIDTH * i + iTab, RealBoxPos.y, RealSectionLine.cx, RealSectionLine.cy);
     }
+#endif
 
     if (lpTextSize)
     {

--- a/src/source/UI/Legacy/UIControls.h
+++ b/src/source/UI/Legacy/UIControls.h
@@ -767,6 +767,11 @@ class CUIRenderTextOriginal : public IUIRenderText
     BYTE* m_pFontBuffer;
     DWORD m_dwTextColor, m_dwBackColor;
     std::vector<BYTE> m_tightUploadBuffer;
+#ifdef __ANDROID__
+    // AH-1118: identifies the selected font in the string-texture cache key --
+    // the DC's selected font is not otherwise readable through the GDI shim.
+    HFONT m_hCurrentFont = nullptr;
+#endif
 public:
     CUIRenderTextOriginal();
     virtual ~CUIRenderTextOriginal();

--- a/src/source/UI/NewUI/Character/NewUICharacterInfoWindow.cpp
+++ b/src/source/UI/NewUI/Character/NewUICharacterInfoWindow.cpp
@@ -254,21 +254,27 @@ void SEASON3B::CNewUICharacterInfoWindow::RenderFrame()
     RenderImage(IMAGE_CHAINFO_TABLE_BOTTOM_LEFT, m_Pos.x + 12, m_Pos.y + 119 - 14, 14, 14);
     RenderImage(IMAGE_CHAINFO_TABLE_BOTTOM_RIGHT, m_Pos.x + 12 + 165 - 14, m_Pos.y + 119 - 14, 14, 14);
 
-    for (int x = m_Pos.x + 12 + 14; x < m_Pos.x + 12 + 165 - 14; ++x)
+    // AH-1118: stretched quads instead of 1px-strip loops -- identical texels,
+    // two draws instead of two texture rebinds per pixel column (see
+    // NewUIInventoryCtrl.cpp's border rendering for the measurement).
     {
-        RenderImage(IMAGE_CHAINFO_TABLE_TOP_PIXEL, x, m_Pos.y + 48, 1, 14);
-        RenderImage(IMAGE_CHAINFO_TABLE_BOTTOM_PIXEL, x, m_Pos.y + 119 - 14, 1, 14);
+        const float x0 = m_Pos.x + 12 + 14;
+        const float xw = (m_Pos.x + 12 + 165 - 14) - x0;
+        RenderImage(IMAGE_CHAINFO_TABLE_TOP_PIXEL, x0, m_Pos.y + 48, xw, 14);
+        RenderImage(IMAGE_CHAINFO_TABLE_BOTTOM_PIXEL, x0, m_Pos.y + 119 - 14, xw, 14);
     }
 
-    for (int x = m_Pos.x + 14; x < m_Pos.x + 12 + 165 - 4; ++x)
     {
-        RenderImage(IMAGE_CHAINFO_TABLE_BOTTOM_PIXEL, x, m_Pos.y + 48 + 12, 1, 14);
+        const float x0 = m_Pos.x + 14;
+        const float xw = (m_Pos.x + 12 + 165 - 4) - x0;
+        RenderImage(IMAGE_CHAINFO_TABLE_BOTTOM_PIXEL, x0, m_Pos.y + 48 + 12, xw, 14);
     }
 
-    for (int y = m_Pos.y + 48 + 14; y < m_Pos.y + 119 - 14; y++)
     {
-        RenderImage(IMAGE_CHAINFO_TABLE_LEFT_PIXEL, m_Pos.x + 12, y, 14, 1);
-        RenderImage(IMAGE_CHAINFO_TABLE_RIGHT_PIXEL, m_Pos.x + 12 + 165 - 14, y, 14, 1);
+        const float y0 = m_Pos.y + 48 + 14;
+        const float yh = (m_Pos.y + 119 - 14) - y0;
+        RenderImage(IMAGE_CHAINFO_TABLE_LEFT_PIXEL, m_Pos.x + 12, y0, 14, yh);
+        RenderImage(IMAGE_CHAINFO_TABLE_RIGHT_PIXEL, m_Pos.x + 12 + 165 - 14, y0, 14, yh);
     }
 
     RenderImage(IMAGE_CHAINFO_TEXTBOX, m_Pos.x + 11, m_Pos.y + HEIGHT_STRENGTH, 170.f, 21.f);

--- a/src/source/UI/NewUI/Inventory/NewUIInventoryCtrl.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIInventoryCtrl.cpp
@@ -1023,15 +1023,26 @@ void SEASON3B::CNewUIInventoryCtrl::Render()
     RenderImage(IMAGE_ITEM_TABLE_BOTTOM_LEFT, m_Pos.x - WND_LEFT_EDGE, m_Pos.y + m_Size.cy - WND_BOTTOM_EDGE, 14, 14);
     RenderImage(IMAGE_ITEM_TABLE_BOTTOM_RIGHT, m_Pos.x + m_Size.cx - WND_RIGHT_EDGE, m_Pos.y + m_Size.cy - WND_BOTTOM_EDGE, 14, 14);
 
-    for (x = m_Pos.x - WND_LEFT_EDGE + 14; x < m_Pos.x + m_Size.cx - WND_RIGHT_EDGE; x++)
+    // AH-1118: one stretched quad per edge instead of a 1px-strip loop. The
+    // strip textures are 1px wide/tall, so stretching samples the identical
+    // texel column/row -- but the loop alternated two textures per iteration,
+    // breaking the batch on every pixel (~270 texture binds per frame for one
+    // open window, measured on Adreno 730).
     {
-        RenderImage(IMAGE_ITEM_TABLE_TOP_PIXEL, x, m_Pos.y - WND_TOP_EDGE, 1, 14);
-        RenderImage(IMAGE_ITEM_TABLE_BOTTOM_PIXEL, x, m_Pos.y + m_Size.cy - WND_BOTTOM_EDGE, 1, 14);
-    }
-    for (y = m_Pos.y - WND_TOP_EDGE + 14; y < m_Pos.y + m_Size.cy - WND_BOTTOM_EDGE; y++)
-    {
-        RenderImage(IMAGE_ITEM_TABLE_LEFT_PIXEL, m_Pos.x - WND_LEFT_EDGE, y, 14, 1);
-        RenderImage(IMAGE_ITEM_TABLE_RIGHT_PIXEL, m_Pos.x + m_Size.cx - WND_RIGHT_EDGE, y, 14, 1);
+        const float xStart = m_Pos.x - WND_LEFT_EDGE + 14;
+        const float xSpan = (m_Pos.x + m_Size.cx - WND_RIGHT_EDGE) - xStart;
+        if (xSpan > 0)
+        {
+            RenderImage(IMAGE_ITEM_TABLE_TOP_PIXEL, xStart, m_Pos.y - WND_TOP_EDGE, xSpan, 14);
+            RenderImage(IMAGE_ITEM_TABLE_BOTTOM_PIXEL, xStart, m_Pos.y + m_Size.cy - WND_BOTTOM_EDGE, xSpan, 14);
+        }
+        const float yStart = m_Pos.y - WND_TOP_EDGE + 14;
+        const float ySpan = (m_Pos.y + m_Size.cy - WND_BOTTOM_EDGE) - yStart;
+        if (ySpan > 0)
+        {
+            RenderImage(IMAGE_ITEM_TABLE_LEFT_PIXEL, m_Pos.x - WND_LEFT_EDGE, yStart, 14, ySpan);
+            RenderImage(IMAGE_ITEM_TABLE_RIGHT_PIXEL, m_Pos.x + m_Size.cx - WND_RIGHT_EDGE, yStart, 14, ySpan);
+        }
     }
 
     if (ms_pPickedItem)

--- a/tools/android/build-native.sh
+++ b/tools/android/build-native.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly GL4ES_REV="81547d986798e876de8b434193920b606a72363f"
+readonly CURL_REV="5d6dc816785358f505ba6922ceb507b4521c5421"
+readonly LIBJPEG_TURBO_REV="2646fa33f8d67373c27b558b47e77b2d8d517e31"
+readonly ANDROID_API="29"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+output_root="${MU_ANDROID_OUTPUT_DIR:-${repo_root}/out/android}"
+abi="${MU_ANDROID_ABI:-arm64-v8a}"
+ndk_root="${ANDROID_NDK_ROOT:-${ANDROID_NDK_HOME:-}}"
+
+if [[ -z "${ndk_root}" || ! -f "${ndk_root}/build/cmake/android.toolchain.cmake" ]]; then
+    echo "Set ANDROID_NDK_ROOT to Android NDK r28 or newer." >&2
+    exit 1
+fi
+
+case "${abi}" in
+    arm64-v8a|x86_64) ;;
+    *)
+        echo "Unsupported MU_ANDROID_ABI='${abi}'; use arm64-v8a or x86_64." >&2
+        exit 1
+        ;;
+esac
+
+readonly toolchain="${ndk_root}/build/cmake/android.toolchain.cmake"
+readonly dependency_root="${output_root}/dependencies"
+readonly build_root="${output_root}/build/${abi}"
+readonly native_output="${output_root}/native/${abi}"
+
+prepare_source()
+{
+    local name="$1"
+    local url="$2"
+    local revision="$3"
+    local source_dir="${dependency_root}/${name}"
+
+    if [[ ! -d "${source_dir}/.git" ]]; then
+        mkdir -p "${dependency_root}"
+        git clone --filter=blob:none "${url}" "${source_dir}"
+    fi
+
+    git -C "${source_dir}" fetch --depth=1 origin "${revision}" >&2
+    git -C "${source_dir}" checkout --detach "${revision}" >&2
+    printf '%s\n' "${source_dir}"
+}
+
+configure_dependency()
+{
+    local source_dir="$1"
+    local binary_dir="$2"
+    shift 2
+
+    cmake -S "${source_dir}" -B "${binary_dir}" -G Ninja \
+        -DCMAKE_TOOLCHAIN_FILE="${toolchain}" \
+        -DANDROID_ABI="${abi}" \
+        -DANDROID_PLATFORM="android-${ANDROID_API}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        "$@"
+}
+
+gl4es_source="$(prepare_source gl4es https://github.com/ptitSeb/gl4es.git "${GL4ES_REV}")"
+curl_source="$(prepare_source curl https://github.com/curl/curl.git "${CURL_REV}")"
+jpeg_source="$(prepare_source libjpeg-turbo https://github.com/libjpeg-turbo/libjpeg-turbo.git "${LIBJPEG_TURBO_REV}")"
+
+gl4es_build="${build_root}/gl4es"
+configure_dependency "${gl4es_source}" "${gl4es_build}" \
+    -DNOX11=ON \
+    -DGBM=OFF \
+    -DDEFAULT_ES=2
+cmake --build "${gl4es_build}" --parallel
+
+mkdir -p "${native_output}"
+cp "${gl4es_source}/lib/libGL.so.1" "${native_output}/libGL.so"
+patchelf --set-soname libGL.so "${native_output}/libGL.so"
+
+curl_build="${build_root}/curl"
+configure_dependency "${curl_source}" "${curl_build}" \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_STATIC_LIBS=OFF \
+    -DBUILD_CURL_EXE=OFF \
+    -DBUILD_TESTING=OFF \
+    -DCURL_USE_OPENSSL=OFF \
+    -DCURL_USE_LIBPSL=OFF \
+    -DUSE_LIBIDN2=OFF \
+    -DCURL_USE_LIBSSH=OFF \
+    -DCURL_USE_LIBSSH2=OFF \
+    -DCURL_USE_GSSAPI=OFF
+cmake --build "${curl_build}" --target libcurl_shared --parallel
+
+jpeg_build="${build_root}/libjpeg-turbo"
+configure_dependency "${jpeg_source}" "${jpeg_build}" \
+    -DENABLE_SHARED=ON \
+    -DENABLE_STATIC=OFF \
+    -DWITH_TURBOJPEG=ON \
+    -DWITH_JAVA=OFF \
+    -DWITH_TESTS=OFF
+cmake --build "${jpeg_build}" --target turbojpeg --parallel
+
+main_build="${build_root}/mumain"
+cmake -S "${repo_root}" -B "${main_build}" -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE="${toolchain}" \
+    -DANDROID_ABI="${abi}" \
+    -DANDROID_PLATFORM="android-${ANDROID_API}" \
+    -DANDROID_ALLOW_UNDEFINED_SYMBOLS=ON \
+    -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=TRUE \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_EDITOR=OFF \
+    -DBUILD_TESTING=OFF \
+    -DMU_RENDER_BACKEND=OpenGL \
+    -DMU_ANDROID_GL4ES_ROOT="${gl4es_source}" \
+    -DMU_ANDROID_GL4ES_LIBRARY="${native_output}/libGL.so" \
+    -DCURL_INCLUDE_DIR="${curl_source}/include" \
+    -DCURL_LIBRARY="${curl_build}/lib/libcurl.so" \
+    -DTURBOJPEG_LIBRARY="${jpeg_build}/libturbojpeg.so"
+cmake --build "${main_build}" --target Main --parallel
+
+strip_tool="${ndk_root}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip"
+cp "${main_build}/src/libmain.so" "${native_output}/libmain.so"
+cp "${curl_build}/lib/libcurl.so" "${native_output}/libcurl.so"
+cp "${jpeg_build}/libturbojpeg.so" "${native_output}/libturbojpeg.so"
+cp "${main_build}/src/Release/MUnique.Client.Library.so" \
+    "${native_output}/libMUniqueClient.so"
+
+"${strip_tool}" "${native_output}/libmain.so"
+"${strip_tool}" "${native_output}/libcurl.so"
+"${strip_tool}" "${native_output}/libturbojpeg.so"
+"${strip_tool}" "${native_output}/libMUniqueClient.so"
+
+printf 'renderer=OpenGL\nabi=%s\napi=%s\n' "${abi}" "${ANDROID_API}" \
+    > "${native_output}/build.properties"
+sha256sum "${native_output}"/*.so > "${native_output}/sha256sums.txt"
+
+echo "Android native libraries are ready in ${native_output}"

--- a/tools/android/capture-performance.ps1
+++ b/tools/android/capture-performance.ps1
@@ -1,0 +1,49 @@
+param(
+    [int]$DurationSeconds = 120,
+    [string]$Device,
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+if (-not $OutputPath) {
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $OutputPath = Join-Path $repositoryRoot "out\android\captures\mumain-$timestamp.log"
+}
+$OutputPath = [IO.Path]::GetFullPath($OutputPath)
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $OutputPath) | Out-Null
+
+$adbArguments = @()
+if ($Device) {
+    $adbArguments += @('-s', $Device)
+}
+
+& adb @adbArguments get-state | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw 'No usable Android device is connected.'
+}
+
+& adb @adbArguments logcat -c
+& adb @adbArguments shell am start -n com.alin.mumain/.LoadingActivity | Out-Null
+
+$logProcess = Start-Process adb `
+    -ArgumentList ($adbArguments + @(
+        'logcat', '-v', 'threadtime',
+        'MuMainFPS:I', 'MuMainGL:I', 'MuMainPace:I', 'MuMainInput:I', '*:S')) `
+    -RedirectStandardOutput $OutputPath `
+    -NoNewWindow `
+    -PassThru
+
+try {
+    Write-Host "Capturing renderer telemetry for $DurationSeconds seconds to $OutputPath"
+    Start-Sleep -Seconds $DurationSeconds
+}
+finally {
+    if (-not $logProcess.HasExited) {
+        $logProcess.Kill()
+        $logProcess.WaitForExit()
+    }
+}
+
+Write-Host "Capture complete: $OutputPath"

--- a/tools/android/package-apk.ps1
+++ b/tools/android/package-apk.ps1
@@ -1,0 +1,113 @@
+param(
+    [string]$NativeLibraryDirectory,
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+
+if (-not $NativeLibraryDirectory) {
+    $NativeLibraryDirectory = Join-Path $repositoryRoot 'out\android\native'
+}
+$NativeLibraryDirectory = [IO.Path]::GetFullPath($NativeLibraryDirectory)
+
+if (-not $OutputPath) {
+    $OutputPath = Join-Path $repositoryRoot 'out\android\MuMain-debug.apk'
+}
+$OutputPath = [IO.Path]::GetFullPath($OutputPath)
+
+$sourceGradleWrapper = Join-Path $repositoryRoot 'src\ThirdParty\SDL\android-project\gradlew.bat'
+if (-not (Test-Path -LiteralPath $sourceGradleWrapper)) {
+    throw 'SDL Gradle wrapper is missing. Run git submodule update --init --recursive.'
+}
+if (-not (Test-Path -LiteralPath $NativeLibraryDirectory)) {
+    throw "Native library directory does not exist: $NativeLibraryDirectory"
+}
+
+if (-not $env:JAVA_HOME) {
+    $androidStudioJbr = 'C:\Program Files\Android\Android Studio\jbr'
+    if (Test-Path -LiteralPath $androidStudioJbr) {
+        $env:JAVA_HOME = $androidStudioJbr
+    }
+}
+if (-not $env:ANDROID_HOME -and -not $env:ANDROID_SDK_ROOT) {
+    $defaultAndroidSdk = Join-Path $env:LOCALAPPDATA 'Android\Sdk'
+    if (Test-Path -LiteralPath $defaultAndroidSdk) {
+        $env:ANDROID_HOME = $defaultAndroidSdk
+    }
+}
+
+$buildRoot = $repositoryRoot
+$buildNativeLibraryDirectory = $NativeLibraryDirectory
+$stagingRoot = $null
+
+try {
+    if ($repositoryRoot.StartsWith('\\')) {
+        $stagingRoot = Join-Path ([IO.Path]::GetTempPath()) `
+            ("mumain-android-package-{0}" -f [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $stagingRoot | Out-Null
+
+        Copy-Item -LiteralPath (Join-Path $repositoryRoot 'android') `
+            -Destination $stagingRoot -Recurse
+
+        $stagedSdlProject = Join-Path $stagingRoot 'src\ThirdParty\SDL\android-project'
+        New-Item -ItemType Directory -Path $stagedSdlProject -Force | Out-Null
+        Copy-Item -LiteralPath $sourceGradleWrapper -Destination $stagedSdlProject
+        Copy-Item -LiteralPath (Join-Path $repositoryRoot `
+                'src\ThirdParty\SDL\android-project\gradle') `
+            -Destination $stagedSdlProject -Recurse
+
+        $stagedSdlMain = Join-Path $stagedSdlProject 'app\src\main'
+        New-Item -ItemType Directory -Path $stagedSdlMain -Force | Out-Null
+        Copy-Item -LiteralPath (Join-Path $repositoryRoot `
+                'src\ThirdParty\SDL\android-project\app\src\main\java') `
+            -Destination $stagedSdlMain -Recurse
+
+        $stagedNativeParent = Join-Path $stagingRoot 'out\android'
+        New-Item -ItemType Directory -Path $stagedNativeParent -Force | Out-Null
+        Copy-Item -LiteralPath $NativeLibraryDirectory `
+            -Destination $stagedNativeParent -Recurse
+
+        $buildRoot = $stagingRoot
+        $buildNativeLibraryDirectory = Join-Path $stagedNativeParent 'native'
+    }
+
+    $androidProject = Join-Path $buildRoot 'android'
+    $gradleWrapper = Join-Path $buildRoot `
+        'src\ThirdParty\SDL\android-project\gradlew.bat'
+
+    & $gradleWrapper `
+        --project-dir $androidProject `
+        "-PmuNativeLibDir=$buildNativeLibraryDirectory" `
+        :app:assembleDebug
+    if ($LASTEXITCODE -ne 0) {
+        throw "Gradle APK build failed with exit code $LASTEXITCODE."
+    }
+
+    $builtApk = Join-Path $androidProject `
+        'app\build\outputs\apk\debug\app-debug.apk'
+    if (-not (Test-Path -LiteralPath $builtApk)) {
+        throw "Gradle completed without producing $builtApk"
+    }
+
+    $outputDirectory = Split-Path -Parent $OutputPath
+    New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
+    Copy-Item -LiteralPath $builtApk -Destination $OutputPath -Force
+}
+finally {
+    if ($stagingRoot -and (Test-Path -LiteralPath $stagingRoot)) {
+        $resolvedStaging = [IO.Path]::GetFullPath($stagingRoot)
+        $resolvedTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+        if ($resolvedStaging.StartsWith($resolvedTemp) -and
+            (Split-Path -Leaf $resolvedStaging).StartsWith('mumain-android-package-')) {
+            Remove-Item -LiteralPath $resolvedStaging -Recurse -Force
+        }
+    }
+}
+
+$apk = Get-Item -LiteralPath $OutputPath
+$hash = Get-FileHash -LiteralPath $OutputPath -Algorithm SHA256
+Write-Host "APK ready: $($apk.FullName)"
+Write-Host "Size: $($apk.Length) bytes"
+Write-Host "SHA-256: $($hash.Hash)"


### PR DESCRIPTION
## Summary
- land the working SDL/GL4ES Android port and its existing performance/compatibility fixes
- add a pinned, clean arm64/x86_64 native build plus tracked Gradle APK packaging
- make renderer selection explicit and log the selected backend
- document the repeatable Fold4 production baseline and 60 FPS gate

Closes AH-1307

## Verification
- cmake --build build-linux --parallel 4
- ctest --test-dir build-linux --output-on-failure (25/25 passed)
- clean arm64 build: ANDROID_NDK_ROOT=/home/ghrunner/android-ndk-r28b tools/android/build-native.sh
- APK package: 10,050,941 bytes, SHA-256 CF52119189DC014B5BE8AFBA5C44799049B83A62860CB88D0558AE4FBE499CFD
- Fold4 SM-F936B: db install -r passed; production login, character select, and in-game Lorencia rendering verified
- 120-second GL4ES recapture: settled in-game average 1.93 FPS (1.2-2.5), confirming the migration baseline

No deploy: native client source/build tooling only.