### PR TITLE
Add macOS (arm64) support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,7 +211,12 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "iOS")
     "Store restricted. When that work starts, add source/App/Platform/iOS/ "
     "and replace this branch.")
 elseif (APPLE)
-  set(MU_APP_ENTRY "source/App/Platform/macOS/main.mm")
+  # macOS entry (main.mm) plus the shared bootstrap/game-loop from Winmain.cpp,
+  # which compiles off Windows (issue #462) - the same pairing the UNIX branch
+  # below uses. Listing main.mm alone leaves WinMain undefined at link time.
+  set(MU_APP_ENTRY
+    "source/App/Platform/macOS/main.mm"
+    "source/App/Platform/Windows/Winmain.cpp")
 elseif (ANDROID)
   message(FATAL_ERROR "Android is not a supported build target yet: it needs "
     "an OpenGL ES renderer port, and its entry point is android_main via "
@@ -237,7 +242,13 @@ target_link_libraries(Main PRIVATE MuClient::MuClient)
 
 if (NOT MSVC)
   set(MU_MAIN_MAP_FILE "${CMAKE_CURRENT_BINARY_DIR}/Main.map")
-  target_link_options(Main PRIVATE "-Wl,-Map,${MU_MAIN_MAP_FILE}")
+  if (APPLE)
+    # Apple's ld64 spells the link-map flag -map, not GNU ld's -Map, and
+    # rejects the latter outright with "ld: unknown options: -Map".
+    target_link_options(Main PRIVATE "-Wl,-map,${MU_MAIN_MAP_FILE}")
+  else()
+    target_link_options(Main PRIVATE "-Wl,-Map,${MU_MAIN_MAP_FILE}")
+  endif()
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -316,6 +327,30 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     OpenGL::GL
     OpenGL::GLU
     ${GLEW_LIBRARY}
+    ${TURBOJPEG_LIBRARY}
+  )
+endif()
+
+# macOS-native linkage, mirroring the Linux block above. OpenGL and GLU come
+# from the system OpenGL.framework (deprecated by Apple but still present and
+# what the fixed-function engine needs). libjpeg-turbo is keg-only under
+# Homebrew, so it is not on the default search path and needs an explicit hint;
+# the vendored headers in src/dependencies/include are used for both.
+if (APPLE)
+  find_package(OpenGL REQUIRED)
+  find_library(TURBOJPEG_LIBRARY
+    NAMES turbojpeg
+    HINTS
+      /opt/homebrew/opt/jpeg-turbo/lib   # Apple Silicon Homebrew
+      /usr/local/opt/jpeg-turbo/lib      # Intel Homebrew
+      /opt/local/lib                     # MacPorts
+    REQUIRED)
+  message(STATUS "Using libturbojpeg: ${TURBOJPEG_LIBRARY}")
+  target_link_libraries(MuClient PUBLIC
+    pthread
+    m
+    OpenGL::GL
+    OpenGL::GLU
     ${TURBOJPEG_LIBRARY}
   )
 endif()
@@ -544,6 +579,11 @@ if (DOTNET_EXECUTABLE)
   # this name).
   if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(DOTNET_LIB_NAME "MUnique.Client.Library.so")
+  elseif (APPLE)
+    # Native AOT names the shared library after the platform convention, so on
+    # macOS it publishes a .dylib. Falling through to the .dll default here made
+    # the publish succeed and then fail on the copy, because no such file exists.
+    set(DOTNET_LIB_NAME "MUnique.Client.Library.dylib")
   else()
     set(DOTNET_LIB_NAME "MUnique.Client.Library.dll")
   endif()
@@ -590,6 +630,27 @@ if (DOTNET_EXECUTABLE)
     # skip it (ci=true) and use the checked-in output.
     set(DOTNET_EXTRA_ARGS "-p:ci=true")
     message(STATUS ".NET Client Library will build for linux-x64")
+  elseif (APPLE)
+    # Native AOT cannot cross-compile between operating systems, so macOS must
+    # publish an osx-* RID; falling through to the pointer-width branches below
+    # picks win-x64 and fails with "Cross-OS native compilation is not
+    # supported". Match the architecture actually being built rather than the
+    # host, so an explicit -DCMAKE_OSX_ARCHITECTURES=x86_64 still resolves.
+    if (CMAKE_OSX_ARCHITECTURES)
+      set(_mu_dotnet_arch "${CMAKE_OSX_ARCHITECTURES}")
+    else()
+      set(_mu_dotnet_arch "${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+    if (_mu_dotnet_arch MATCHES "arm64|aarch64")
+      set(DOTNET_RID "osx-arm64")
+      set(DOTNET_PLATFORM "arm64")
+    else()
+      set(DOTNET_RID "osx-x64")
+      set(DOTNET_PLATFORM "x64")
+    endif()
+    # Same Windows-path XSLT problem as Linux; use the checked-in generated code.
+    set(DOTNET_EXTRA_ARGS "-p:ci=true")
+    message(STATUS ".NET Client Library will build for ${DOTNET_RID}")
   elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(DOTNET_RID "win-x64")
     set(DOTNET_PLATFORM "x64")

--- a/src/source/App/Platform/macOS/main.mm
+++ b/src/source/App/Platform/macOS/main.mm
@@ -1,0 +1,26 @@
+// macOS entry point, the Apple arm of the per-platform entry seam that already
+// carries source/App/Platform/Linux/main.cpp and .../Windows/Winmain.cpp.
+//
+// The CMake APPLE branch has referenced this file for a while, but the file was
+// never added, so configuring for macOS failed on a missing source. This is that
+// file.
+//
+// As on Linux, the game bootstrap lives in Winmain.cpp: off Windows its WinMain
+// is a plain function rather than the Win32 entry contract, so the platform entry
+// only has to forward into it. The HINSTANCE and command-line parameters are
+// Win32 artifacts which the portable code path never reads.
+//
+// This is Objective-C++ (.mm) rather than .cpp because a macOS app needs a Cocoa
+// application object to exist before it can own a window, take keyboard focus, or
+// appear in the Dock. SDL creates and activates one from SDL_Init, so nothing has
+// to be done here yet; keeping the translation unit Objective-C++ means the Cocoa
+// work can land here without changing the build when it is needed.
+
+#include "Core/Platform/WinCompat.h"
+
+int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int nCmdShow);
+
+int main(int /*argc*/, char* /*argv*/[])
+{
+    return WinMain(nullptr, nullptr, nullptr, SW_SHOW);
+}

--- a/src/source/App/stdafx.h
+++ b/src/source/App/stdafx.h
@@ -91,7 +91,14 @@
 //c runtime
 #include <stdio.h>
 #include <stdlib.h>
+// macOS ships no <malloc.h>: the allocator introspection lives in
+// <malloc/malloc.h>, and alloca() has its own header there.
+#ifdef __APPLE__
+#include <malloc/malloc.h>
+#include <alloca.h>
+#else
 #include <malloc.h>
+#endif
 #include <memory.h>
 #include <assert.h>
 #include <time.h>

--- a/src/source/Core/Input/Input.h
+++ b/src/source/Core/Input/Input.h
@@ -85,8 +85,13 @@ public:
     bool IsMBtnUp() { return m_bMBtnUp; }
     bool IsMBtnDbl() { return m_bMBtnDbl; }
 
-    long GetScreenWidth() { return m_lScreenWidth; }
-    long GetScreenHeight() { return m_lScreenHeight; }
+    // LONG, not long: these feed RECT/POINT fields, which are LONG (32-bit).
+    // Windows makes long 32-bit so the two coincide there, but on LP64 targets
+    // long is 64-bit and every `RECT rc = { 0, 0, GetScreenWidth(), ... }`
+    // becomes a narrowing conversion that clang rejects. A screen dimension
+    // never needs more than 32 bits.
+    LONG GetScreenWidth() { return static_cast<LONG>(m_lScreenWidth); }
+    LONG GetScreenHeight() { return static_cast<LONG>(m_lScreenHeight); }
     void SetLeftHandMode(bool bLeftHand) { m_bLeftHand = bLeftHand; }
     bool IsLeftHandMode() { return m_bLeftHand; }
     void SetTextEditMode(bool bTextEditMode) { m_bTextEditMode = bTextEditMode; }

--- a/src/source/Core/Utilities/_GlobalFunctions.h
+++ b/src/source/Core/Utilities/_GlobalFunctions.h
@@ -84,9 +84,14 @@ BuffStateValueControl& TheBuffStateValueControl();
 #define g_BuffStateValueString( outstr, type ) \
 	TheBuffStateValueControl().GetBuffValueString( outstr, type )
 
-inline unsigned long RGBA(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
+// Returns DWORD rather than unsigned long: a packed RGBA colour is exactly 32
+// bits, and callers store it in DWORD (e.g. `DWORD adwColor[4] = { RGBA(...) }`).
+// On Windows unsigned long is 32-bit so the two agree, but on LP64 targets such
+// as macOS unsigned long is 64-bit and those initialisers become narrowing
+// conversions, which clang rejects outright.
+inline DWORD RGBA(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
 {
-    return (r)+(g << 8) + (b << 16) + (a << 24);
+    return static_cast<DWORD>((r)+(g << 8) + (b << 16) + (a << 24));
 }
 inline unsigned char GetAlpha(unsigned long rgba)
 {

--- a/src/source/Dotnet/Connection.h
+++ b/src/source/Dotnet/Connection.h
@@ -17,7 +17,25 @@
 #include "dlfcn.h"
 #include <unistd.h>   // readlink
 #include <string>
+#ifdef __APPLE__
+#include <cstdint>
+// Deliberately NOT <mach-o/dyld.h>: that header defines
+// `enum DYLD_BOOL { FALSE, TRUE };`, which would redefine the Win32 FALSE/TRUE
+// this codebase relies on in every translation unit that reaches this header -
+// e.g. `BOOL* pbEqual = FALSE` in UI/Legacy/UIWindows.cpp stops compiling.
+// Only one symbol is needed, so declare it directly.
+extern "C" int _NSGetExecutablePath(char* buf, std::uint32_t* bufsize);
+#endif
 #define symLoad dlsym
+#endif
+
+// Native AOT names its shared library after the platform convention: .dll on
+// Windows, .dylib on macOS, .so elsewhere. The build copies it next to the
+// executable under this name, and the loader below opens it by that name.
+#ifdef __APPLE__
+#define MUNIQUE_CLIENT_LIBRARY_NAME "MUnique.Client.Library.dylib"
+#else
+#define MUNIQUE_CLIENT_LIBRARY_NAME "MUnique.Client.Library.so"
 #endif
 
 // Construct-on-first-use: the library handle is loaded lazily on first access.
@@ -35,28 +53,42 @@ inline HINSTANCE get_munique_client_library_handle()
 #else
 inline void* get_munique_client_library_handle()
 {
-    // Native AOT emits a platform-native shared object on Linux (.so), not the
-    // Windows .dll, and the build copies it next to the executable. Resolve the
-    // executable's real directory (via /proc/self/exe) and load by absolute
+    // Native AOT emits a platform-native shared object (.so on Linux, .dylib on
+    // macOS), not the Windows .dll, and the build copies it next to the
+    // executable. Resolve the executable's real directory and load by absolute
     // path, so it works regardless of the working directory the client was
     // launched from; fall back to the loader search path.
+    //
+    // The directory lookup is platform-specific: /proc/self/exe does not exist
+    // on macOS, so Darwin uses _NSGetExecutablePath instead. Without this the
+    // absolute-path branch silently fails there and the fallback dlopen has to
+    // find the library on the loader path, which usually does not include the
+    // executable's own directory.
     // Not const-qualified return: dlsym() takes a non-const void* handle.
     static void* const handle = []() -> void* {
         char exe[4096];
+        std::string path;
+#ifdef __APPLE__
+        uint32_t size = sizeof(exe);
+        if (_NSGetExecutablePath(exe, &size) == 0)
+            path.assign(exe);
+#else
         const ssize_t n = ::readlink("/proc/self/exe", exe, sizeof(exe) - 1);
         if (n > 0)
+            path.assign(exe, static_cast<size_t>(n));
+#endif
+        if (!path.empty())
         {
-            std::string path(exe, static_cast<size_t>(n));
             const std::string::size_type slash = path.find_last_of('/');
             if (slash != std::string::npos)
             {
                 path.resize(slash + 1);
-                path += "MUnique.Client.Library.so";
+                path += MUNIQUE_CLIENT_LIBRARY_NAME;
                 if (void* h = dlopen(path.c_str(), RTLD_LAZY))
                     return h;
             }
         }
-        return dlopen("MUnique.Client.Library.so", RTLD_LAZY);
+        return dlopen(MUNIQUE_CLIENT_LIBRARY_NAME, RTLD_LAZY);
     }();
     return handle;
 }

--- a/src/source/GameLogic/Items/PersonalShopTitleImp.h
+++ b/src/source/GameLogic/Items/PersonalShopTitleImp.h
@@ -10,7 +10,12 @@
 
 inline POINT MakePos(long x, long y)
 {
-    POINT pos = { x, y };
+    // POINT::x/y are LONG, which the Win32 compatibility layer defines as int
+    // (Windows keeps long at 32 bits). On LP64 targets such as macOS and Linux
+    // plain long is 64-bit, so brace initialisation here is a narrowing
+    // conversion and is ill-formed. The values are screen coordinates and
+    // always fit, so cast explicitly.
+    POINT pos = { static_cast<LONG>(x), static_cast<LONG>(y) };
     return pos;
 }
 inline SIZE MakeSize(int cx, int cy)

--- a/src/source/Render/Sprites/Sprite.cpp
+++ b/src/source/Render/Sprites/Sprite.cpp
@@ -200,13 +200,17 @@ BOOL CSprite::PtInSprite(long lXPos, long lYPos)
     if (!m_bShow)
         return FALSE;
 
-    POINT pt = { lXPos, lYPos };
+    // POINT/RECT fields are LONG (32-bit). The parameters and the functional
+    // casts below are plain long, which is 64-bit on LP64 targets such as
+    // macOS, so these initialisers narrow and clang rejects them. Screen
+    // coordinates always fit in 32 bits.
+    POINT pt = { static_cast<LONG>(lXPos), static_cast<LONG>(lYPos) };
 
     RECT rc = {
-        long(m_aScrCoord[LT].fX * m_fScaleX),
-        long((m_fScrHeight - m_aScrCoord[LT].fY) * m_fScaleY),
-        long(m_aScrCoord[RB].fX * m_fScaleX),
-        long((m_fScrHeight - m_aScrCoord[RB].fY) * m_fScaleY)
+        LONG(m_aScrCoord[LT].fX * m_fScaleX),
+        LONG((m_fScrHeight - m_aScrCoord[LT].fY) * m_fScaleY),
+        LONG(m_aScrCoord[RB].fX * m_fScaleX),
+        LONG((m_fScrHeight - m_aScrCoord[RB].fY) * m_fScaleY)
     };
 
     return ::PtInRect(&rc, pt);

--- a/src/source/Render/Terrain/ZzzLodTerrain.cpp
+++ b/src/source/Render/Terrain/ZzzLodTerrain.cpp
@@ -3,8 +3,15 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+// Apple ships the OpenGL headers under an OpenGL/ framework directory rather
+// than the GL/ path used on Windows and Linux.
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#else
 #include <GL/gl.h>
 #include <GL/glu.h>
+#endif
 #include <math.h>
 #include <iterator>
 #include "Render/Textures/ZzzOpenglUtil.h"

--- a/src/source/UI/Legacy/UIControls.cpp
+++ b/src/source/UI/Legacy/UIControls.cpp
@@ -2946,7 +2946,7 @@ void CUIRenderTextOriginal::RenderText(int iPos_x, int iPos_y, const wchar_t* ps
     int iNumberOfSections = (RealRenderingSize.cx / LIMIT_WIDTH) + ((iRealRenderWidth % LIMIT_WIDTH >= 0) ? 1 : 0);
     for (int i = 0; i < iNumberOfSections; i++)
     {
-        SIZE RealSectionLine = { (long)LIMIT_WIDTH, (long)RealRenderingSize.cy };
+        SIZE RealSectionLine = { (LONG)LIMIT_WIDTH, (LONG)RealRenderingSize.cy };
         if (i == iNumberOfSections - 1)
             RealSectionLine.cx = iRealRenderWidth % LIMIT_WIDTH;
 

--- a/src/source/UI/NewUI/Combat/NewUICastleWindow.cpp
+++ b/src/source/UI/NewUI/Combat/NewUICastleWindow.cpp
@@ -513,7 +513,7 @@ void CNewUICastleWindow::UpdateTaxManagingTab()
 
 void CNewUICastleWindow::RenderOutlineUpper(float fPos_x, float fPos_y, float fWidth, float fHeight)
 {
-    POINT ptOrigin = { (long)fPos_x, (long)fPos_y };
+    POINT ptOrigin = { (LONG)fPos_x, (LONG)fPos_y };
     float fBoxWidth = fWidth;
 
     RenderImage(IMAGE_CASTLEWINDOW_TABLE_TOP_LEFT, ptOrigin.x + 12, ptOrigin.y - 4, 14, 14);
@@ -526,7 +526,7 @@ void CNewUICastleWindow::RenderOutlineUpper(float fPos_x, float fPos_y, float fW
 
 void CNewUICastleWindow::RenderOutlineLower(float fPos_x, float fPos_y, float fWidth, float fHeight)
 {
-    POINT ptOrigin = { (long)fPos_x, (long)fPos_y };
+    POINT ptOrigin = { (LONG)fPos_x, (LONG)fPos_y };
     float fBoxWidth = fWidth;
     float fBoxHeight = fHeight;
 

--- a/src/source/UI/NewUI/Combat/NewUIDuelWatchUserListWindow.cpp
+++ b/src/source/UI/NewUI/Combat/NewUIDuelWatchUserListWindow.cpp
@@ -93,7 +93,7 @@ bool CNewUIDuelWatchUserListWindow::Render()
     float fFontHeight = TextSize.cy / g_fScreenRate_y;
 
     POINT ptSize = { 57, 17 };
-    POINT ptOrigin = { m_Pos.x, m_Pos.y - (ptSize.y + 1) * (long)g_DuelMgr.GetDuelWatchUserCount() + (ptSize.y - (long)fFontHeight) / 2 + 1 };
+    POINT ptOrigin = { m_Pos.x, m_Pos.y - (ptSize.y + 1) * (LONG)g_DuelMgr.GetDuelWatchUserCount() + (ptSize.y - (LONG)fFontHeight) / 2 + 1 };
 
     for (int i = 0; i < g_DuelMgr.GetDuelWatchUserCount(); ++i)
     {

--- a/src/source/UI/NewUI/Events/NewUICatapultWindow.cpp
+++ b/src/source/UI/NewUI/Events/NewUICatapultWindow.cpp
@@ -313,7 +313,7 @@ void SEASON3B::CNewUICatapultWindow::RenderButtons()
 
 void SEASON3B::CNewUICatapultWindow::RenderOutlineUpper(float fPos_x, float fPos_y, float fWidth, float fHeight)
 {
-    POINT ptOrigin = { (long)fPos_x, (long)fPos_y };
+    POINT ptOrigin = { (LONG)fPos_x, (LONG)fPos_y };
     float fBoxWidth = fWidth;
 
     RenderImage(IMAGE_CATAPULT_TABLE_TOP_LEFT, ptOrigin.x + 12, ptOrigin.y - 4, 14, 14);
@@ -323,7 +323,7 @@ void SEASON3B::CNewUICatapultWindow::RenderOutlineUpper(float fPos_x, float fPos
 
 void SEASON3B::CNewUICatapultWindow::RenderOutlineLower(float fPos_x, float fPos_y, float fWidth, float fHeight)
 {
-    POINT ptOrigin = { (long)fPos_x, (long)fPos_y };
+    POINT ptOrigin = { (LONG)fPos_x, (LONG)fPos_y };
     float fBoxWidth = fWidth;
     float fBoxHeight = fHeight;
 

--- a/src/source/UI/NewUI/Events/NewUIGateSwitchWindow.cpp
+++ b/src/source/UI/NewUI/Events/NewUIGateSwitchWindow.cpp
@@ -232,7 +232,7 @@ bool CNewUIGateSwitchWindow::BtnProcess()
 
 void CNewUIGateSwitchWindow::RenderOutlineUpper(float fPos_x, float fPos_y, float fWidth, float fHeight)
 {
-    POINT ptOrigin = { (long)fPos_x, (long)fPos_y };
+    POINT ptOrigin = { (LONG)fPos_x, (LONG)fPos_y };
     float fBoxWidth = fWidth;
 
     RenderImage(IMAGE_GATESWITCHWINDOW_TABLE_TOP_LEFT, ptOrigin.x + 12, ptOrigin.y - 4, 14, 14);
@@ -242,7 +242,7 @@ void CNewUIGateSwitchWindow::RenderOutlineUpper(float fPos_x, float fPos_y, floa
 
 void CNewUIGateSwitchWindow::RenderOutlineLower(float fPos_x, float fPos_y, float fWidth, float fHeight)
 {
-    POINT ptOrigin = { (long)fPos_x, (long)fPos_y };
+    POINT ptOrigin = { (LONG)fPos_x, (LONG)fPos_y };
     float fBoxWidth = fWidth;
     float fBoxHeight = fHeight;
 

--- a/src/source/UI/NewUI/HUD/NewUIChatLogWindow.cpp
+++ b/src/source/UI/NewUI/HUD/NewUIChatLogWindow.cpp
@@ -166,7 +166,7 @@ bool SEASON3B::CNewUIChatLogWindow::RenderMessages()
 
         if (bRenderMessage && !pMsgText->GetText().empty())
         {
-            POINT ptRenderPos = { (long)fRenderPosX + (long)WND_LEFT_RIGHT_EDGE, (long)fRenderPosY + (long)FONT_LEADING + ((long)SCROLL_MIDDLE_PART_HEIGHT * (long)s) };
+            POINT ptRenderPos = { (LONG)fRenderPosX + (LONG)WND_LEFT_RIGHT_EDGE, (LONG)fRenderPosY + (LONG)FONT_LEADING + ((LONG)SCROLL_MIDDLE_PART_HEIGHT * (LONG)s) };
             if (!pMsgText->GetID().empty())
             {
                 if (m_bPointedMessage == true && m_iPointedMessageIndex == i)

--- a/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
+++ b/src/source/UI/NewUI/Inventory/NewUIMixInventory.cpp
@@ -50,7 +50,7 @@ bool CNewUIMixInventory::Create(CNewUIManager* pNewUIMng, int x, int y)
 
     LoadImages();
 
-    POINT ptBtn = { m_Pos.x + (long)INVENTORY_WIDTH * (long)0.5f - (long)22.f, m_Pos.y + (long)380 };
+    POINT ptBtn = { m_Pos.x + (LONG)INVENTORY_WIDTH * (LONG)0.5f - (LONG)22.f, m_Pos.y + (LONG)380 };
 
     m_BtnMix.ChangeButtonImgState(true, IMAGE_MIXINVENTORY_MIXBTN, false);
     m_BtnMix.ChangeButtonInfo(m_Pos.x + INVENTORY_WIDTH * 0.5f - 22.f, m_Pos.y + 380, 44.f, 35.f);


### PR DESCRIPTION
The `APPLE` branch in `src/CMakeLists.txt` already points at
`source/App/Platform/macOS/main.mm`, but that file isn't in the tree, so
configuring for macOS stops on a missing source. I wanted to see how far the
client actually was from running there, so I added it and worked through what
came next. It turned out to be closer than I expected — the RHI/SDL3 work has
done most of the heavy lifting, and everything here is small platform plumbing
rather than anything structural.

Builds and runs on an M4 (macOS 26.5.1, arm64). It reaches the server list from
an OpenMU server and gets into the world.

### Entry point and build

- Added `App/Platform/macOS/main.mm`, mirroring the Linux entry — off Windows
  `WinMain` is an ordinary function, so the platform entry only forwards into
  it. It's Objective-C++ so Cocoa work can land there later without touching
  the build, though nothing needs it yet since SDL sets up `NSApplication`.
- The `APPLE` branch listed only `main.mm` and not `Winmain.cpp`, so `WinMain`
  was undefined at link. It now pairs them the way the `UNIX` branch does.
- The .NET client library RID came from pointer width alone, which resolves to
  `win-x64` on macOS. Native AOT rejects that outright with *"Cross-OS native
  compilation is not supported"*. Picks an `osx-*` RID from the architecture
  being built, and passes `-p:ci=true` for the same PreBuild XSLT reason Linux
  already does.
- Native AOT publishes a `.dylib` on macOS, but the copy step looked for a
  `.dll` — so the publish succeeded and the build then failed copying a file
  that never existed.
- `ld64` spells the link map flag `-map`; GNU `ld`'s `-Map` is rejected with
  *"ld: unknown options: -Map"*.
- GL, GLU and turbojpeg were linked under a Linux-only guard. Added an Apple
  branch using `OpenGL.framework`, with an explicit hint for libjpeg-turbo
  since it's keg-only under Homebrew and off the default search path.

### Platform headers

- macOS has no `<malloc.h>`; the allocator lives in `<malloc/malloc.h>`.
- GL headers are under `OpenGL/` rather than `GL/`.
- `Dotnet/Connection.h` loaded the library by a hardcoded `.so` name and
  resolved its directory through `/proc/self/exe`, neither of which exists on
  macOS. Uses the platform library name and `_NSGetExecutablePath`.

  Worth a note: `_NSGetExecutablePath` is declared directly rather than by
  including `<mach-o/dyld.h>`. That header defines
  `enum DYLD_BOOL { FALSE, TRUE }`, which redefines the Win32 `FALSE`/`TRUE`
  this codebase relies on in every translation unit that reaches it — I hit it
  as `BOOL* pbEqual = FALSE` failing to compile in `UI/Legacy/UIWindows.cpp`,
  a file with no obvious connection to the change.

### Data model (LP64)

Windows keeps `long` at 32 bits, so casting to `long` to fill a `LONG` field is
correct there. On LP64 `long` is 64-bit while `LONG` stays 32-bit, making those
brace initialisers narrowing conversions. GCC only warns, which is presumably
why the Linux build hasn't tripped over it; clang treats it as an error.

Fixed at the two definitions responsible rather than at ~30 call sites:
`RGBA()` now returns `DWORD` (a packed colour is 32 bits by definition) and
`CInput::GetScreenWidth/Height()` return `LONG` (they feed `RECT` and `POINT`).
The handful left are local casts. **This likely also affects a clang-based
Linux build**, so it may be worth having regardless of the macOS side.

### Testing

Built and ran `Debug` and `Release` on macOS 26.5.1 / arm64. The core context
loop lands on GL 3.3 (macOS caps at 4.1, so the 4.5 and 4.3 rungs fail and it
descends as designed). Logged in against OpenMU and played.

I have no Windows or Linux toolchain here, so I have **not** verified those
builds. The changes are inside `if (APPLE)` / `__APPLE__` guards except the two
return-type changes above, which are the ones worth a second look.
