### PR TITLE
Avoid a GPU sync per vertex append in AppendBuffer

### DIFF
--- a/src/source/Render/RHI/RHI_GL.cpp
+++ b/src/source/Render/RHI/RHI_GL.cpp
@@ -225,6 +225,11 @@ typedef void (APIENTRY* PFNGLBUFFERDATAPROC)(GLenum target, GLsizeiptr size, con
 typedef void (APIENTRY* PFNGLBUFFERSUBDATAPROC)(GLenum target, GLintptr offset, GLsizeiptr size, const void* data);
 typedef void (APIENTRY* PFNGLDELETEBUFFERSPROC)(GLsizei n, const GLuint* buffers);
 typedef void (APIENTRY* PFNGLBINDBUFFERBASEPROC)(GLenum target, GLuint index, GLuint buffer);
+// Declared here rather than with the UBO-ring group further down because
+// AppendBuffer (above that group) streams through them on the unsynchronised
+// path; the UBO ring's loader assigns the same pointers.
+typedef void*     (APIENTRY* PFNGLMAPBUFFERRANGEPROC)(GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
+typedef GLboolean (APIENTRY* PFNGLUNMAPBUFFERPROC)(GLenum target);
 
 namespace {
     PFNGLGENBUFFERSPROC     fn_glGenBuffers     = nullptr;
@@ -233,6 +238,8 @@ namespace {
     PFNGLBUFFERSUBDATAPROC  fn_glBufferSubData  = nullptr;
     PFNGLDELETEBUFFERSPROC  fn_glDeleteBuffers  = nullptr;
     PFNGLBINDBUFFERBASEPROC fn_glBindBufferBase = nullptr;
+    PFNGLMAPBUFFERRANGEPROC fn_glMapBufferRange = nullptr;
+    PFNGLUNMAPBUFFERPROC    fn_glUnmapBuffer    = nullptr;
 
     bool LoadBufferGLFunctions()
     {
@@ -244,6 +251,10 @@ namespace {
         fn_glBufferSubData  = (PFNGLBUFFERSUBDATAPROC)SDL_GL_GetProcAddress("glBufferSubData");
         fn_glDeleteBuffers  = (PFNGLDELETEBUFFERSPROC)SDL_GL_GetProcAddress("glDeleteBuffers");
         fn_glBindBufferBase = (PFNGLBINDBUFFERBASEPROC)SDL_GL_GetProcAddress("glBindBufferBase");
+        // Core since GL 3.0, so guaranteed present given GLP-08's GL >= 3.3 floor. Not part of
+        // the `loaded` predicate: AppendBuffer falls back to glBufferSubData if they are null.
+        fn_glMapBufferRange = (PFNGLMAPBUFFERRANGEPROC)SDL_GL_GetProcAddress("glMapBufferRange");
+        fn_glUnmapBuffer    = (PFNGLUNMAPBUFFERPROC)SDL_GL_GetProcAddress("glUnmapBuffer");
         loaded = (fn_glGenBuffers != nullptr && fn_glBindBuffer != nullptr &&
                   fn_glBufferData != nullptr && fn_glBufferSubData != nullptr &&
                   fn_glDeleteBuffers != nullptr && fn_glBindBufferBase != nullptr);
@@ -374,7 +385,40 @@ size_t AppendBuffer(BufferHandle handle, const void* data, size_t sizeBytes)
         writeOffset = 0;
     }
 
-    fn_glBufferSubData(GL_ARRAY_BUFFER, writeOffset, neededSize, data);
+    // Write the append with an UNSYNCHRONIZED mapped range rather than glBufferSubData.
+    //
+    // The ring bookkeeping above already guarantees this byte range is not one the GPU can
+    // still be reading: writeOffset only ever moves forward, and the wrap/grow branches
+    // orphan the whole buffer before restarting at 0. glBufferSubData cannot be told that,
+    // so a driver is free to synchronise defensively -- and Apple's GL driver does exactly
+    // that, taking every append through GLDContextRec::flushResource -> flushContext and
+    // blocking on a semaphore until the GPU drains. Profiling the macOS client put ~53% of
+    // all main-thread samples inside that one call (RenderParticles -> EnableAlphaBlend ->
+    // IR::Flush -> AppendBuffer), which is what made the frame rate collapse as scene
+    // complexity rose. Desktop NVIDIA/AMD drivers hide the same hazard with implicit
+    // buffer renaming, which is why this only ever showed up on macOS.
+    //
+    // GL_MAP_UNSYNCHRONIZED_BIT states the no-overlap invariant explicitly, so the driver
+    // skips the wait. Core since GL 3.0 and therefore always present at GLP-08's GL >= 3.3
+    // floor; the glBufferSubData path is kept as a fallback for a driver that fails the map.
+    bool wrote = false;
+    if (fn_glMapBufferRange && fn_glUnmapBuffer)
+    {
+        void* dst = fn_glMapBufferRange(GL_ARRAY_BUFFER, writeOffset, neededSize,
+                                        GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT |
+                                        GL_MAP_INVALIDATE_RANGE_BIT);
+        if (dst)
+        {
+            memcpy(dst, data, sizeBytes);
+            wrote = (fn_glUnmapBuffer(GL_ARRAY_BUFFER) != GL_FALSE);
+            // A false unmap means the driver discarded the store (a GPU reset or memory
+            // event); fall through and respecify so the draw does not read stale bytes.
+        }
+    }
+    if (!wrote)
+    {
+        fn_glBufferSubData(GL_ARRAY_BUFFER, writeOffset, neededSize, data);
+    }
     FrameProfiler::CountGLCall(FrameProfiler::Counter::BufferUpdates);
     fn_glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -407,8 +451,6 @@ typedef GLsync    (APIENTRY* PFNGLFENCESYNCPROC)(GLenum condition, GLbitfield fl
 typedef GLenum    (APIENTRY* PFNGLCLIENTWAITSYNCPROC)(GLsync sync, GLbitfield flags, GLuint64 timeout);
 typedef void      (APIENTRY* PFNGLDELETESYNCPROC)(GLsync sync);
 typedef void      (APIENTRY* PFNGLBUFFERSTORAGEPROC)(GLenum target, GLsizeiptr size, const void* data, GLbitfield flags);
-typedef void*     (APIENTRY* PFNGLMAPBUFFERRANGEPROC)(GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
-typedef GLboolean (APIENTRY* PFNGLUNMAPBUFFERPROC)(GLenum target);
 typedef void      (APIENTRY* PFNGLBINDBUFFERRANGEPROC)(GLenum target, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size);
 
 namespace {
@@ -416,8 +458,6 @@ namespace {
     PFNGLCLIENTWAITSYNCPROC  fn_glClientWaitSync  = nullptr;
     PFNGLDELETESYNCPROC      fn_glDeleteSync      = nullptr;
     PFNGLBUFFERSTORAGEPROC   fn_glBufferStorage   = nullptr;
-    PFNGLMAPBUFFERRANGEPROC  fn_glMapBufferRange  = nullptr;
-    PFNGLUNMAPBUFFERPROC     fn_glUnmapBuffer     = nullptr;
     PFNGLBINDBUFFERRANGEPROC fn_glBindBufferRange = nullptr;
 
     // Sync objects + glMapBufferRange/glBindBufferRange are core since GL 3.0/3.2, always


### PR DESCRIPTION
While profiling the client on macOS I found the main thread spending about 53%
of its samples inside a single `glBufferSubData` call, blocked on a semaphore:

```
MainLoop -> RenderScene -> MainScene -> RenderMainScene -> RenderParticles
  -> EnableAlphaBlend -> IR::Flush -> RHI_GL_Impl::AppendBuffer
    -> glBufferSubData -> gldBufferSubData
      -> GLDContextRec::flushResource -> GLDContextRec::flushContext
        -> _dispatch_semaphore_wait_slow -> semaphore_wait_trap
```

`AppendBuffer`'s ring bookkeeping already guarantees the target range isn't one
the GPU can still be reading — `writeOffset` only moves forward, and the wrap
and grow branches orphan the buffer before restarting at zero. The comments
around DXP-26 and GLP-25 make that invariant explicit.

The problem is that `glBufferSubData` has no way to *express* it, so a driver is
free to synchronise defensively, and Apple's does: every append flushes the
context and waits for the GPU to drain. Because the cost scales with the number
of alpha-blended draws, it got worse as scene complexity rose — around 2 fps in
town degrading toward 0.5 as more effects came into view.

Writing the append through `glMapBufferRange` with `GL_MAP_UNSYNCHRONIZED_BIT`
states the invariant explicitly and the driver skips the wait. Same profile
after the change: `flushResource` and `flushContext` at zero samples,
`glBufferSubData` at one, and the main thread dominated by
`Cocoa_GL_SwapWindow` waiting on vsync — which is what a frame-limited renderer
should look like. Subjectively it went from a slideshow to smooth.

`glMapBufferRange` and `glUnmapBuffer` are core since GL 3.0 and so always
available at the GL >= 3.3 floor from GLP-08. Their declarations move above
`AppendBuffer` so it can reach them, which is why the UBO ring group no longer
declares them itself. `glBufferSubData` stays as a fallback if the map fails or
reports a discarded store.

**This isn't macOS-specific.** Desktop NVIDIA and AMD drivers hide the same
hazard with implicit buffer renaming, which is probably why it hasn't shown up
before, but nothing about the change is Apple-gated and any driver that
synchronises here should benefit. I'd expect it to be worth measuring on the
Intel HD 530 mentioned in the GLP-25 comments, since that's exactly the kind of
driver that tends not to rename.

### Testing

Profiled and ran on macOS 26.5.1 / arm64 (GL 3.3 core context), before and
after, using `sample(1)`. I don't have a Windows or Linux toolchain here, so I
have **not** verified those builds or measured the change there — worth a look
before merging, since this is a shared code path rather than a platform guard.

### Not addressed

The same pattern remains in text rendering:
`CUIRenderTextOriginal::UploadText` -> `RHI_GL_Impl::UpdateTexture` ->
`glTexSubImage2D` -> `prepareResourceForCPUAccess` -> `flushContext`, about 12%
of main-thread samples after this fix. Left alone here to keep the change
focused, but it's the same class of problem if someone wants it.
