### PR TITLE
Only shake the camera for a nearby source

### DIFF
--- a/src/source/Engine/AI/GOBoid.cpp
+++ b/src/source/Engine/AI/GOBoid.cpp
@@ -759,7 +759,7 @@ void RenderDarkHorseSkill(OBJECT* o, BMD* b)
                 CreateEffect(MODEL_GROUND_STONE + rand() % 2, Position, o->Angle, o->Light);
             }
         }
-        EarthQuake = (rand() % 3 - 3) * 0.7f;
+        SetEarthQuakeAt(o->Position, (rand() % 3 - 3) * 0.7f);
     }
     else if (o->WeaponLevel == (BYTE)(19.f / FPS_ANIMATION_FACTOR))
     {
@@ -802,7 +802,7 @@ void RenderSkillEarthQuake(CHARACTER* c, OBJECT* o, BMD* b, int iMaxSkill)
 
     if (o->WeaponLevel == iMaxSkill - 1)
     {
-        EarthQuake = (rand() % 3 - 3) * 0.7f;
+        SetEarthQuakeAt(o->Position, (rand() % 3 - 3) * 0.7f);
         CreateEffect(MODEL_SKILL_FURY_STRIKE, TargetO.Position, TargetO.Angle, TargetO.Light, 0, o, -1, 0, 2);
     }
 

--- a/src/source/Engine/Object/ZzzObject.cpp
+++ b/src/source/Engine/Object/ZzzObject.cpp
@@ -69,6 +69,22 @@ OPERATE      Operates[MAX_OPERATES];
 //int   World = -1;
 float EarthQuake;
 
+void SetEarthQuakeAt(const vec3_t sourcePosition, float magnitude)
+{
+    if (Hero == nullptr) return;
+
+    // ~12 tiles: roughly what fits on screen, so anything that can shake the view
+    // is something the player can actually see happening.
+    const float kShakeRadius = TERRAIN_SCALE * 12.f;
+
+    const float dx = sourcePosition[0] - Hero->Object.Position[0];
+    const float dy = sourcePosition[1] - Hero->Object.Position[1];
+    const float distSq = dx * dx + dy * dy;
+    if (distSq >= kShakeRadius * kShakeRadius) return;
+
+    EarthQuake = magnitude * (1.f - sqrtf(distSq) / kShakeRadius);
+}
+
 static  int g_iThunderTime = 0;
 int g_iActionObjectType = -1;
 int g_iActionWorld = -1;

--- a/src/source/Engine/Object/ZzzObject.h
+++ b/src/source/Engine/Object/ZzzObject.h
@@ -7,6 +7,20 @@ extern OBJECT       Boids[];
 extern OBJECT       Fishs[];
 
 extern float EarthQuake;
+
+// EarthQuake is a single global that DefaultCamera adds straight onto the camera
+// pitch, so writing it unconditionally from an effect shakes the local player's
+// screen for any caster in render scope -- however far away, and even off-screen.
+// On a populated map that reads as a permanent camera judder caused by strangers.
+//
+// Use this for shakes that belong to a specific world object: it applies the shake
+// only when that object is close enough for it to read as "this happened here",
+// scaling linearly to zero at the cutoff. Magnitude at zero distance is unchanged,
+// so the effect keeps its original feel for whoever is standing on top of it.
+//
+// Scripted, map-wide event shakes (Raklion, Hellas, Kanturu, Chaos Castle) are
+// deliberately NOT routed through this -- they are meant to shake the whole map.
+void SetEarthQuakeAt(const vec3_t sourcePosition, float magnitude);
 extern bool EnableShadow;
 extern float AmbientShadowAngle;
 extern float RainTarget;

--- a/src/source/Render/Effects/Behaviors/EffectBehaviors.cpp
+++ b/src/source/Render/Effects/Behaviors/EffectBehaviors.cpp
@@ -170,7 +170,7 @@ namespace Render::Effects::Behaviors
         }
         o->Scale += (sinf(WorldTime * 0.005f) * 2.0f) * FPS_ANIMATION_FACTOR;
         o->Angle[1] += (10.0f) * FPS_ANIMATION_FACTOR;
-        EarthQuake = (float)(rand() % 6 - 6) * 0.5f;
+        SetEarthQuakeAt(o->Position, (float)(rand() % 6 - 6) * 0.5f);
         return true;
     }
 }

--- a/src/source/Render/Effects/Behaviors/MoveHandlers.cpp
+++ b/src/source/Render/Effects/Behaviors/MoveHandlers.cpp
@@ -2908,7 +2908,7 @@ namespace Render::Effects::Behaviors
         Vector(fLevel, fLevel, fLevel + 0.1f, Light);
         AddTerrainLight(o->Position[0], o->Position[1], Light, 10, PrimaryTerrainLight);
 
-        EarthQuake = (float)(rand() % 4 - 2) * 0.1f;
+        SetEarthQuakeAt(o->Position, (float)(rand() % 4 - 2) * 0.1f);
 
         if (rand_fps_check(2)) {
             Vector(0.f, (float)(rand() % 150) + 300.f, 0.f, p);
@@ -3460,7 +3460,7 @@ namespace Render::Effects::Behaviors
         case 5:
         case 6:
         case 7:
-            EarthQuake = (float)(rand() % 8 - 4) * 0.1f;
+            SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 4) * 0.1f);
             CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 28);
             CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 29);
             CreateParticleFpsChecked(BITMAP_SMOKE, o->Position, o->Angle, o->Light, 30);
@@ -3845,7 +3845,11 @@ namespace Render::Effects::Behaviors
             else
                 o->BlendMeshLight = o->LifeTime * 0.1f;
             o->BlendMeshTexCoordU = -(float)o->LifeTime * 0.01f;
-            EarthQuake = (float)(rand() % 6 - 6) * 0.1f;
+
+            // Hellfire (AT_SKILL_HELL_FIRE) is the common SubType-0 source of this
+            // effect, and before the distance check a single caster anywhere in scope
+            // shook every nearby player's camera continuously.
+            SetEarthQuakeAt(o->Position, (float)(rand() % 6 - 6) * 0.1f);
 
             if (rand_fps_check(value))
             {
@@ -4220,7 +4224,7 @@ namespace Render::Effects::Behaviors
             o->Direction[0] = 0;
             o->Direction[1] = 0;
             o->Direction[2] = 0;
-            EarthQuake = (float)(rand() % 4 + 1) * 0.1f;
+            SetEarthQuakeAt(o->Position, (float)(rand() % 4 + 1) * 0.1f);
         }
         else
         {
@@ -6032,7 +6036,7 @@ namespace Render::Effects::Behaviors
 
             o->Scale += (0.02f) * FPS_ANIMATION_FACTOR;
             //				o->Position[2] -= 0.5f;
-            EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
+            SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 8) * 0.1f);
         }
         return true;
     }
@@ -6130,7 +6134,7 @@ namespace Render::Effects::Behaviors
                 CreateEffectFpsChecked(BITMAP_CRATER, o->Position, o->Angle, o->Light);
             }
 
-            EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
+            SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 8) * 0.1f);
             EarthQuake *= pow(1.0f / (2.f), FPS_ANIMATION_FACTOR);
 
             o->HiddenMesh = 99;
@@ -6331,7 +6335,7 @@ namespace Render::Effects::Behaviors
                         int CollisionX = (int)(o->Position[0] / TERRAIN_SCALE);
                         int CollisionY = (int)(o->Position[1] / TERRAIN_SCALE);
 
-                        EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
+                        SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 8) * 0.1f);
                         if (CollisionY < 104 && o->Visible)
                         {
                             AddTerrainHeight(o->Position[0], o->Position[1], -30.f, 2, BackTerrainHeight);
@@ -6488,7 +6492,7 @@ namespace Render::Effects::Behaviors
                     int CollisionX = (int)(o->Position[0] / TERRAIN_SCALE);
                     int CollisionY = (int)(o->Position[1] / TERRAIN_SCALE);
 
-                    EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
+                    SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 8) * 0.1f);
                     if (CollisionY < 104 && o->Visible)
                     {
                         AddTerrainHeight(o->Position[0], o->Position[1], -30.f, 2, BackTerrainHeight);
@@ -7539,7 +7543,7 @@ namespace Render::Effects::Behaviors
             {
                 if (o->LifeTime >= 15.f)
                 {
-                    EarthQuake = (float)(rand() % 8 - 4) * 0.1f;
+                    SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 4) * 0.1f);
                 }
                 else
                 {
@@ -7640,7 +7644,7 @@ namespace Render::Effects::Behaviors
             vec3_t vLight;
             if (o->LifeTime <= 35.0f && o->LifeTime >= 15.0f)
             {
-                EarthQuake = (float)(rand() % 8 - 4) * 0.1f;
+                SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 4) * 0.1f);
             }
             else
             {
@@ -8737,7 +8741,7 @@ namespace Render::Effects::Behaviors
             int	iSwordOnTheLand = (o->ExtState / 2) + 5;
             if (o->LifeTime <= iSwordOnTheLand && o->LifeTime > 10)
             {
-                EarthQuake = (float)(rand() % 2 - 2) * 0.5f;
+                SetEarthQuakeAt(o->Position, (float)(rand() % 2 - 2) * 0.5f);
             }
 
             if ((int)o->LifeTime == o->ExtState)
@@ -8969,7 +8973,7 @@ namespace Render::Effects::Behaviors
             {
                 if (o->LifeTime >= 15.f)
                 {
-                    EarthQuake = (float)(rand() % 8 - 4) * 0.1f;
+                    SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 4) * 0.1f);
                 }
                 else
                 {

--- a/src/source/Render/Effects/ZzzEffect.cpp
+++ b/src/source/Render/Effects/ZzzEffect.cpp
@@ -7084,7 +7084,7 @@ void MoveEffect(OBJECT* o, int iIndex)
             {
                 o->Position[2] = Height;
                 o->Live = false;
-                EarthQuake = (float)(rand() % 8 - 8) * 0.1f;
+                SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 8) * 0.1f);
                 for (int j = 0; j < 5; j++)
                 {
                     if (rand_fps_check(1))
@@ -7108,7 +7108,7 @@ void MoveEffect(OBJECT* o, int iIndex)
         }
         if (o->LifeTime > 15 && ((int)o->LifeTime % 3) == 0)
         {
-            EarthQuake = (float)(rand() % 8 - 4) * 0.1f;
+            SetEarthQuakeAt(o->Position, (float)(rand() % 8 - 4) * 0.1f);
         }
         break;
     case MODEL_SKILL_FURY_STRIKE + 3:
@@ -7747,7 +7747,7 @@ void MoveEffect(OBJECT* o, int iIndex)
                     if (o->Position[2] < Height)
                     {
                         success = true;
-                        EarthQuake = (float)(rand() % 4 - 4) * 0.1f;
+                        SetEarthQuakeAt(o->Position, (float)(rand() % 4 - 4) * 0.1f);
 
                         for (int i = 0; i < MAX_CHARACTERS_CLIENT; i++)
                         {


### PR DESCRIPTION
### What I saw

Playing in **Lorencia**, walking around town, the camera would start juddering
hard — like a constant earthquake — for a few seconds, stop, then start again a
little later somewhere else in the city. It was bad enough to be unplayable in
places, and it didn't happen out on the hunting maps.

Setup was the MuMain client on macOS against a local **OpenMU** server with its
bot population enabled (50 bot characters), which is what made it so obvious:
bots warp into Lorencia to shop and fight, so there was almost always somebody
casting something nearby.

### Tracking it down

I logged `EarthQuake` where `DefaultCamera` applies it, along with the hero's
tile. It fired around tiles (139–144, 131–137) with values between `-0.6` and
`-0.1` in `0.1` steps. That range identifies the source exactly — it's
`(rand() % 6 - 6) * 0.1f` in `Move_MODEL_CIRCLE_LIGHT`, and across 88 samples I
never saw `-0.7` or `-0.8`, which rules out the similar-looking
`(rand() % 8 - 8) * 0.1f` sites in `ZzzEffect.cpp`.

Working back from there: `MODEL_CIRCLE_LIGHT` at `SubType` 0 comes from
`AT_SKILL_HELL_FIRE` in `ZzzCharacter.cpp`. So it was other players' Hellfire
casts. The handler sets `EarthQuake` on every frame the effect is alive, and
`EarthQuake` is a single global that `DefaultCamera` adds straight onto the
camera pitch — with no distance test anywhere in that path. A caster shakes
every nearby player's view at full strength no matter how far away they are,
including sources off-screen entirely.

Decay is `EarthQuake *= 0.2f` once per frame in `InitializeSceneFrame`, so it
dies quickly on its own; the problem is purely that something in scope keeps
re-setting it.

### The change

`SetEarthQuakeAt()`, declared next to the global it writes, applies the shake
only when its source is within about twelve tiles — roughly a screen — and
scales it linearly to zero at that edge. Magnitude at zero distance is
unchanged, so an effect feels exactly the same to whoever is standing in it;
what stops is strangers across the map shaking your camera.

Routed the seventeen object-driven sites in `ZzzEffect`, `EffectBehaviors`,
`MoveHandlers` and `GOBoid` through it. The scripted map-wide shakes in
Raklion, Hellas, Kanturu, Chaos Castle and Cursed Temple are deliberately left
alone — those are meant to shake the whole map during an event, and several
have no local object to measure a distance from.

### On whether you want this

This is a **behaviour change**, not a port fix, so it's entirely your call. The
argument for it is that a screen shake from a caster you can't see is hard to
defend on any reading. The argument against is that it's long-standing
behaviour and someone may consider the current feel correct — it's only really
punishing when a map is busy, which a bot-populated test server exaggerates far
beyond a normal server.

Happy to drop it, narrow it to fewer effects, or make the radius configurable
if you'd rather.

### Also noticed, deliberately not changed

`(rand() % 6 - 6) * 0.1f` yields `-0.6 … -0.1` — always negative, never zero or
positive. So it isn't a shake around a centre, it's a persistent downward pitch
with jitter on top, and every one of my 88 samples was negative. Several other
sites share the shape (`% 8 - 8`, `% 4 - 4`). It looks like an off-by-one, but
fixing it would change how every one of those effects looks, so I left it well
alone.

### Testing

macOS 26.5.1 / arm64, GL 3.3 core, against OpenMU with 50 bots. No Windows or
Linux toolchain here, so those builds are unverified — this touches shared
files rather than sitting behind a platform guard.
